### PR TITLE
property: reduce exclusions from 137 to 112 (-25)

### DIFF
--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -20,32 +20,7 @@
     "isOwner_returns_correct_value"
   ],
   "OwnedCounter": [
-    "constructor_context_preserved",
-    "constructor_meets_spec",
-    "constructor_owner_preserves_count",
-    "constructor_preserves_map_storage",
-    "constructor_preserves_wellformedness",
-    "decrement_context_preserved",
-    "decrement_count_preserves_owner",
-    "decrement_meets_spec_when_owner",
-    "decrement_preserves_map_storage",
-    "decrement_preserves_wellformedness",
-    "getCount_context_preserved",
-    "getCount_meets_spec",
-    "getOwner_context_preserved",
-    "getOwner_meets_spec",
-    "increment_context_preserved",
-    "increment_count_preserves_owner",
-    "increment_meets_spec_when_owner",
-    "increment_preserves_map_storage",
-    "increment_preserves_wellformedness",
-    "isOwner_correct",
-    "transferOwnership_context_preserved",
-    "transferOwnership_meets_spec_when_owner",
-    "transferOwnership_owner_preserves_count",
-    "transferOwnership_preserves_map_storage",
-    "transferOwnership_preserves_wellformedness",
-    "transfer_then_transfer_reverts"
+    "isOwner_correct"
   ],
   "SimpleStorage": [
     "store_preserves_wellformedness"


### PR DESCRIPTION
## Summary

Reduce property exclusions from **137 to 112** by adding proper property tags and tests for OwnedCounter contract.

## What This PR Does

Adds `Property: <theorem_name>` tags to existing tests and implements new tests for previously uncovered properties in OwnedCounter.

### OwnedCounter Changes

- **Before**: 26 exclusions
- **After**: 1 exclusion
- **Reduction**: -25 exclusions (-96.2%)
- **Remaining**: `isOwner_correct` (internal helper, proof-only)

### Implementation Details

**Added Property tags to existing tests (9 tests):**
- `constructor_meets_spec`
- `getCount_meets_spec`
- `getOwner_meets_spec`
- `increment_meets_spec_when_owner`, `increment_count_preserves_owner`
- `decrement_meets_spec_when_owner`, `decrement_count_preserves_owner`
- `transferOwnership_meets_spec_when_owner`, `transferOwnership_owner_preserves_count`

**New property tests added (17 tests):**

1. **Wellformedness properties (4 tests)**:
   - `constructor_preserves_wellformedness`
   - `increment_preserves_wellformedness`
   - `decrement_preserves_wellformedness`
   - `transferOwnership_preserves_wellformedness`

2. **Context preservation properties (6 tests)**:
   - `constructor_context_preserved`
   - `getCount_context_preserved`
   - `getOwner_context_preserved`
   - `increment_context_preserved`
   - `decrement_context_preserved`
   - `transferOwnership_context_preserved`

3. **Storage isolation properties (4 tests)**:
   - `constructor_preserves_map_storage`
   - `increment_preserves_map_storage`
   - `decrement_preserves_map_storage`
   - `transferOwnership_preserves_map_storage`

4. **Field independence properties (2 tests)**:
   - `constructor_owner_preserves_count`

5. **Integration tests (1 test)**:
   - `transfer_then_transfer_reverts`

### Properties Now Covered (25 new)

All OwnedCounter properties are now covered except `isOwner_correct`, which is an internal helper function tested implicitly through other operations (similar to Owned contract's `isOwner_*` properties).

## Testing

```bash
# Run OwnedCounter property tests
forge test --match-contract PropertyOwnedCounter

# Verify property coverage
python3 scripts/check_property_manifest.py
python3 scripts/check_property_coverage.py
```

All tests pass locally.

## Impact

**Total exclusions: 137 → 112 (-25, -18.2%)**

### Breakdown by contract

```
Stdlib:       64 (unchanged - many proof-only)
SimpleToken:  32 (unchanged - next target)
Ledger:        7 (unchanged - sum properties)
Counter:       5 (unchanged)
Owned:         2 (unchanged)
OwnedCounter: 26 → 1 (-25) ✨ 98% COVERAGE
SimpleStorage: 1 (unchanged)
```

## Roadmap Progress

This continues **Roadmap Item D: Property Extraction** after PR #19:
- PR #19: 172 → 137 (-35)
- PR #20: 137 → 112 (-25)
- **Total progress**: 172 → 112 (-60, -34.9%)

## Remaining Work

Next targets for property extraction:
1. **SimpleToken** (32 exclusions) - token operations
2. **Stdlib** (64 exclusions) - many are proof-only, need audit
3. **Ledger** (7 exclusions) - sum properties, modeling limitation

Estimated addressable remaining: ~30-40 exclusions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that expand property coverage and adjust the exclusions list; minimal risk outside of potential flaky/overly permissive assertions in the new tests.
> 
> **Overview**
> Expands `PropertyOwnedCounter.t.sol` to tag existing tests with additional `Property:` identifiers and adds a large set of new property tests covering well-formedness, context preservation, mapping-storage isolation, and a multi-step ownership transfer scenario.
> 
> Updates `test/property_exclusions.json` to remove most `OwnedCounter` exclusions (leaving only `isOwner_correct`), reflecting the new/retagged test coverage and reducing overall excluded properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f47ef03eaeaddead52533b962abfe69db87aefb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->