### PR TITLE
[Documentation] Simplify and deduplicate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,26 +50,15 @@ def retrieve_spec (result : Uint256) (s : ContractState) : Prop :=
 - **Compiler correctness**: IR generation is proven; Yul codegen proofs are in progress (semantics + scaffolding in place).
 - **Automation**: Common proof patterns are captured in reusable lemmas.
 
-**Verification Status**: Layers 1-2 complete (100%), Layer 3 in progress (92/100 overall). See:
+**Verification Status**: Layers 1-2 complete (100%), Layer 3 in progress (97/100 overall). See:
 - [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) - Comprehensive verification status
 - [`docs/ROADMAP.md`](docs/ROADMAP.md) - Roadmap to completion (2-3 months to production-ready)
 
 See `Compiler/Proofs/README.md` for the proof inventory and layout across layers.
 
-## Assumptions and Trust Model
+## Trust Model
 
-These are the remaining trusted components outside Lean:
-
-- **`solc` Yul compiler**: The Solidity compiler is trusted to compile Yul to EVM bytecode (CI now compiles generated Yul as a sanity check).
-- **EVM semantics**: The EVM execution model is assumed to match the specification used in proofs.
-- **Function selectors**: Precomputed `keccak256` hashes in `Compiler/Selector.lean` are assumed correct (CI checks fixtures against `solc --hashes`).
-
-Semantics are defined in Lean here:
-
-- EDSL semantics: `DumbContracts/Core.lean`
-- Spec semantics: `DumbContracts/Proofs/Stdlib/SpecInterpreter.lean`
-- IR semantics: `Compiler/Proofs/IRGeneration/IRInterpreter.lean`
-- Yul semantics: `Compiler/Proofs/YulGeneration/Semantics.lean`
+See [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) for detailed trust assumptions and semantics definitions.
 
 ## Repository Structure
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,38 +107,7 @@ Here's what stands between current state (97%) and full completion (100%):
 
 **Status**: ✅ COMPLETE - All statement proofs now possible!
 
-**What Was Done**:
-- ✅ Implemented `execIRStmtFuel` and `execIRStmtsFuel` as **mutual definitions** (~95 lines)
-- ✅ Mirrors structure of `execYulStmtFuel` from `Semantics.lean`
-- ✅ Handles ALL statement types: comment, let, assign, expr (sstore/sload/return/revert/etc), if, switch, block, funcDef
-- ✅ Fuel parameter ensures termination (total functions, provable in Lean)
-- ✅ Project builds successfully with mutual definitions
-
-**Location**: `Compiler/Proofs/YulGeneration/Equivalence.lean:247-333`
-
-**Key Implementation Details**:
-```lean
-mutual
-  def execIRStmtFuel : Nat → IRState → YulStmt → IRExecResult
-    | 0, state, _ => .revert state  -- Out of fuel
-    | Nat.succ fuel, state, stmt =>
-        match stmt with
-        | .comment _ => .continue state
-        | .let_ name value => ... -- All cases implemented
-        | .if_ cond body => ... -- Calls execIRStmtsFuel
-        | .switch expr cases default => ... -- Calls execIRStmtsFuel
-
-  def execIRStmtsFuel (fuel : Nat) (state : IRState) (stmts : List YulStmt) : IRExecResult :=
-    match stmts with
-    | [] => .continue state
-    | stmt :: rest =>
-        match execIRStmtFuel fuel state stmt with
-        | .continue s' => execIRStmtsFuel fuel s' rest
-        | other => other  -- propagate return/stop/revert
-end
-```
-
-**Impact**: Enabled ALL statement-level proofs!
+Implemented `execIRStmtFuel` and `execIRStmtsFuel` as mutual definitions (~95 lines) with fuel parameter ensuring termination. See `Compiler/Proofs/YulGeneration/Equivalence.lean:247-333`.
 
 ### Required Theorems
 
@@ -157,23 +126,7 @@ theorem stmt_equiv :
 
 ### Statement Equivalence Proofs (7/8 Complete!)
 
-Progress tracked in `Compiler/Proofs/YulGeneration/StatementEquivalence.lean`:
-
-| # | Statement Type | Theorem | Lines | Status | Notes |
-|---|----------------|---------|-------|--------|-------|
-| 1 | Variable Assignment | `assign_equiv` | 27 | ✅ **PROVEN** | No sorries! |
-| 2 | Storage Load | `storageLoad_equiv` | 14 | ✅ **PROVEN** | No sorries! |
-| 3 | Storage Store | `storageStore_equiv` | 12 | ✅ **PROVEN** | No sorries! |
-| 4 | Mapping Load | `mappingLoad_equiv` | 14 | ✅ **PROVEN** | No sorries! |
-| 5 | Mapping Store | `mappingStore_equiv` | 12 | ✅ **PROVEN** | No sorries! |
-| 6 | Return | `return_equiv` | 12 | ✅ **PROVEN** | No sorries! |
-| 7 | Revert | `revert_equiv` | 11 | ✅ **PROVEN** | No sorries! |
-| 8 | Conditional (if) | `conditional_equiv` | 25 | 🔵 **PARTIAL** | 1 sorry in recursive case |
-| 9 | **Composition** | EXISTS at Equivalence.lean:403 | 89 | ✅ **PROVEN** | `execIRStmtsFuel_equiv_execYulStmtsFuel_of_stmt_equiv` |
-
-**Legend**: ✅ Complete (no sorries) | 🔵 Partial (has sorry) | ⚪ Not started
-
-**Achievement**: 7/8 individual proofs complete! All follow the same clean pattern using the helper axiom.
+**Achievement**: 7/8 individual proofs complete! All follow the same clean pattern using the helper axiom. See `Compiler/Proofs/YulGeneration/StatementEquivalence.lean` for detailed progress.
 
 ### ✅ Composition Theorem (ALREADY PROVEN!)
 
@@ -551,39 +504,7 @@ theorem mint_preserves_supply_sum (s : FiniteAddressSet) :
 
 ## Contributing
 
-### High-Impact Contribution Opportunities
-
-1. **Layer 3 Statement Proofs** (🔴 Critical, Lean expertise required)
-   - **NEW**: We've created skeleton file `StatementEquivalence.lean` with theorem stubs!
-   - Pick a statement type from the progress table (8 theorems + composition)
-   - Study the worked example (variable assignment)
-   - Replace `sorry` with your proof
-   - See: `Compiler/Proofs/YulGeneration/StatementEquivalence.lean`
-   - **Quick Start**:
-     1. Start with low-difficulty proofs (storageLoad, storageStore, return)
-     2. Work up to medium (mappingLoad, mappingStore)
-     3. Tackle conditional (requires recursion/induction)
-     4. Final boss: composition theorem (depends on all others)
-
-2. **Property Test Expansion** (🟢 Low priority, Solidity/Foundry skills)
-   - Add more differential tests for edge cases
-   - Improve property test coverage reporting
-   - See: `test/Property*.t.sol`, `scripts/`
-
-3. **Documentation** (🔵 Medium priority, technical writing)
-   - Tutorial: "Verifying Your First Contract"
-   - Proof patterns guide
-   - Architecture deep-dive
-   - See: `docs/`, `docs-site/`
-
-4. **Example Contracts** (🔵 Medium priority, smart contract expertise)
-   - Implement and verify ERC721, Governance, or AMM
-   - Document verification process
-   - See: `DumbContracts/Examples/`
-
-### Getting Started
-
-See `VERIFICATION_STATUS.md` for current project state and `Compiler/Proofs/README.md` for proof development guide.
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for contribution guidelines and [`VERIFICATION_STATUS.md`](VERIFICATION_STATUS.md) for current project state.
 
 ---
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -199,19 +199,12 @@ If fuel-parametric approach proves too complex:
 
 ## Property Test Coverage 🎯 **NEAR COMPLETE**
 
-**Status**: 63% coverage (after pending PRs), 89 remaining exclusions all proof-only
+**Status**: 70% coverage (203/292), 89 remaining exclusions all proof-only
 
-### Current Coverage (Main Branch)
-
-- **Total Properties**: 292
-- **Covered**: 155 (53.1%)
-- **Excluded**: 137 (proof-only)
-- **Missing**: 0
-
-### After Pending PRs (#20, #21)
+### Current Coverage
 
 - **Total Properties**: 292
-- **Covered**: 185 (63.4%)
+- **Covered**: 203 (70%)
 - **Excluded**: 89 (all proof-only)
 - **Missing**: 0
 


### PR DESCRIPTION
## Summary

Simplified and deduplicated documentation across README, ROADMAP, and VERIFICATION_STATUS to improve clarity and maintainability:

### Changes Made

1. **Fixed critical progress inconsistency**: Updated README.md from 92% → 97% to match ROADMAP
2. **Removed duplicate trust model documentation**: README now references VERIFICATION_STATUS for trust assumptions and semantics definitions (reduced 14 lines)
3. **Consolidated verbose ROADMAP sections**: 
   - Removed redundant contribution section (now references CONTRIBUTING.md)
   - Simplified statement equivalence table (now references source file)
   - Condensed execIRStmtFuel implementation details
   - Total reduction: 592 → 513 lines (79 lines removed)
4. **Updated property coverage numbers**: Synced to current state (70%, 203/292 properties)
5. **Removed outdated references**: Cleaned up mentions of "pending PRs" that have since merged

### Impact

- **Total reduction**: ~91 lines of redundant documentation
- **Improved maintainability**: Single sources of truth for key information
- **Better clarity**: No conflicting numbers or duplicate sections
- **Easier navigation**: Clear cross-references between documents

### Files Changed

- `README.md`: 142 → 130 lines (-12)
- `docs/ROADMAP.md`: 592 → 513 lines (-79)
- `docs/VERIFICATION_STATUS.md`: Updated property coverage numbers

## Test Plan

- ✅ All documentation cross-references verified
- ✅ No broken links introduced
- ✅ Progress numbers now consistent across all files (97/100)
- ✅ Property coverage reflects current state (70%, 203/292)

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that mainly adjust reported progress/coverage numbers and cross-references; low risk aside from potential link/number typos.
> 
> **Overview**
> Updates public docs to remove duplicated content and keep project metrics consistent.
> 
> `README.md` bumps Layer 3 progress from **92% → 97%** and replaces the inline *Assumptions and Trust Model* section with a link to `docs/VERIFICATION_STATUS.md` as the single source of truth. `docs/ROADMAP.md` is condensed by removing verbose implementation/progress detail and replacing the long contribution guidance with links to `CONTRIBUTING.md` and `VERIFICATION_STATUS.md`.
> 
> `docs/VERIFICATION_STATUS.md` updates property test coverage to **70% (203/292)** and drops outdated “pending PR” wording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8183e66a46ab7ed04f271e27df6fd7bbb0a28e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->