### PR TITLE
fix: remove unused variable warnings in Spec definitions

### DIFF
--- a/DumbContracts/Specs/Ledger/Spec.lean
+++ b/DumbContracts/Specs/Ledger/Spec.lean
@@ -70,7 +70,7 @@ def Spec_withdraw_sum_equation (amount : Uint256) (s s' : ContractState) : Prop 
   totalBalance s' = sub (totalBalance s) amount
 
 /-- Spec: transfer preserves total balance -/
-def Spec_transfer_sum_preservation (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
+def Spec_transfer_sum_preservation (_to : Address) (_amount : Uint256) (s s' : ContractState) : Prop :=
   totalBalance s' = totalBalance s
 
 /-- Spec: Sum of balances for singleton set containing only sender after deposit -/
@@ -92,7 +92,7 @@ def Spec_withdraw_sum_singleton_sender (amount : Uint256) (s s' : ContractState)
     totalBalance s' = sub (s.storageMap 0 s.sender) amount
 
 /-- Spec: Transfer preserves sum for unique addresses -/
-def Spec_transfer_sum_preserved_unique (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
+def Spec_transfer_sum_preserved_unique (to : Address) (_amount : Uint256) (s s' : ContractState) : Prop :=
   s.sender ≠ to →
   totalBalance s' = totalBalance s
 


### PR DESCRIPTION
## Summary

This PR eliminates linter warnings about unused variables in sum property specifications by marking unused parameters with underscore prefix.

## Changes

- `Spec_transfer_sum_preservation`: Mark `to` and `amount` parameters as unused (\_to, \_amount)
- `Spec_transfer_sum_preserved_unique`: Mark `amount` parameter as unused (\_amount)

## Rationale

These parameters are part of the function signature for API consistency but aren't used in the property definitions. Marking them with underscore prefix is the idiomatic Lean way to indicate intentionally unused parameters.

## Build Verification

✅ Build completes successfully
✅ No functional changes
✅ Linter warnings eliminated

```
lake build DumbContracts.Specs.Ledger.Spec
```

## Impact

- Cleaner build output
- No functional changes
- Better code quality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature-only naming tweaks in specification definitions; no behavioral or proof logic changes expected beyond improved lint/build output.
> 
> **Overview**
> Removes Lean unused-variable warnings in ledger sum-property specs by marking unused parameters with underscore-prefixed names.
> 
> Specifically updates `Spec_transfer_sum_preservation` to `_to`/`_amount` and `Spec_transfer_sum_preserved_unique` to `_amount`, without changing the stated propositions or their call sites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65ab51972653d2a04c06bf2c3bf4fd0972999383. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->