### PR TITLE
refactor: fix stale verification docs, deduplicate manifest extraction

### DIFF
--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -5,9 +5,9 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 # Formal Verification
 
-The compiler is additionally verified with IR preservation proofs in `Compiler/Proofs/`. Yul preservation is in progress (semantics + scaffolding exist, full equivalence theorems pending). No `sorry`, no axioms. All proofs are checked by `lake build`.
+The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete — no `sorry`, no axioms. All proofs are checked by `lake build`.
 
-## Snapshot (2026-02-13)
+## Snapshot (2026-02-14)
 
 - EDSL theorems: 252 across 7 contracts and a math stdlib.
 - SimpleStorage: 19 total (Basic 12, Correctness 7).
@@ -23,7 +23,7 @@ The compiler is additionally verified with IR preservation proofs in `Compiler/P
 
 - **Spec semantics**: `DumbContracts/Proofs/Stdlib/SpecInterpreter.lean`
 - **IR generation**: `Compiler/Proofs/IRGeneration/` (complete for all 7 contracts)
-- **Yul semantics + preservation**: `Compiler/Proofs/YulGeneration/` (in progress)
+- **Yul semantics + preservation**: `Compiler/Proofs/YulGeneration/` (complete — PR #42)
 
 ## Structure
 
@@ -346,9 +346,8 @@ Transfer proofs now handle self-transfer by modeling it as a no-op (preloading b
 
 ## Known limitations
 
-1. Transfer proofs require `sender != to` (implementation write ordering)
-2. Uint256 is a dedicated 256-bit modular type; `+`, `-`, `*`, `/`, and `%` wrap at `2^256`
-3. No multi-contract interaction
-4. No reentrancy modeling
-5. `supply_bounds_balances` not preserved for lists with duplicates; exact sum equations are proven instead
-6. No Mathlib: `set`, `ring`, `linarith` unavailable
+1. Uint256 is a dedicated 256-bit modular type; `+`, `-`, `*`, `/`, and `%` wrap at `2^256`
+2. No multi-contract interaction
+3. No reentrancy modeling
+4. `supply_bounds_balances` not preserved for lists with duplicates; exact sum equations are proven instead
+5. No Mathlib: `set`, `ring`, `linarith` unavailable

--- a/scripts/check_property_manifest_sync.py
+++ b/scripts/check_property_manifest_sync.py
@@ -5,28 +5,7 @@ from __future__ import annotations
 
 import sys
 
-from property_utils import MANIFEST, PROOFS_DIR, collect_theorems, load_manifest
-
-
-def extract_manifest_from_proofs() -> dict[str, list[str]]:
-    """Extract theorem names from Lean proof files.
-
-    Returns:
-        Dictionary mapping contract names to lists of theorem names.
-    """
-    if not PROOFS_DIR.exists():
-        raise SystemExit(f"Missing proofs dir: {PROOFS_DIR}")
-    manifest: dict[str, list[str]] = {}
-    for contract_dir in sorted(PROOFS_DIR.iterdir()):
-        if not contract_dir.is_dir():
-            continue
-        contract = contract_dir.name
-        theorems: list[str] = []
-        for lean in sorted(contract_dir.rglob("*.lean")):
-            theorems.extend(collect_theorems(lean))
-        if theorems:
-            manifest[contract] = sorted(dict.fromkeys(theorems))
-    return manifest
+from property_utils import extract_manifest_from_proofs, load_manifest
 
 
 def main() -> None:

--- a/scripts/extract_property_manifest.py
+++ b/scripts/extract_property_manifest.py
@@ -4,26 +4,14 @@
 import json
 from pathlib import Path
 
-from property_utils import PROOFS_DIR, collect_theorems
+from property_utils import extract_manifest_from_proofs
 
 ROOT = Path(__file__).resolve().parents[1]
 OUTPUT = ROOT / "test" / "property_manifest.json"
 
 
 def main() -> None:
-    manifest = {}
-    if not PROOFS_DIR.exists():
-        raise SystemExit(f"Missing proofs dir: {PROOFS_DIR}")
-    for contract_dir in sorted(PROOFS_DIR.iterdir()):
-        if not contract_dir.is_dir():
-            continue
-        contract = contract_dir.name
-        theorems = []
-        for lean in sorted(contract_dir.rglob("*.lean")):
-            theorems.extend(collect_theorems(lean))
-        if theorems:
-            # stable ordering + unique
-            manifest[contract] = sorted(dict.fromkeys(theorems))
+    manifest = extract_manifest_from_proofs()
     OUTPUT.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 

--- a/scripts/property_utils.py
+++ b/scripts/property_utils.py
@@ -127,6 +127,27 @@ def collect_theorems(path: Path) -> list[str]:
     return names
 
 
+def extract_manifest_from_proofs() -> dict[str, list[str]]:
+    """Extract theorem names from Lean proof files.
+
+    Returns:
+        Dictionary mapping contract names to sorted, deduplicated lists of theorem names.
+    """
+    if not PROOFS_DIR.exists():
+        raise SystemExit(f"Missing proofs dir: {PROOFS_DIR}")
+    manifest: dict[str, list[str]] = {}
+    for contract_dir in sorted(PROOFS_DIR.iterdir()):
+        if not contract_dir.is_dir():
+            continue
+        contract = contract_dir.name
+        theorems: list[str] = []
+        for lean in sorted(contract_dir.rglob("*.lean")):
+            theorems.extend(collect_theorems(lean))
+        if theorems:
+            manifest[contract] = sorted(dict.fromkeys(theorems))
+    return manifest
+
+
 def die(msg: str) -> None:
     """Print error message and exit with status 1.
 


### PR DESCRIPTION
## Summary
- **verification.mdx**: Fixed 3 stale claims — Layer 3 was listed as "in progress" (complete since PR #42), Yul preservation marked incomplete, and "sender != to" listed as a limitation (removed in earlier PRs)
- **Python scripts**: Extracted `extract_manifest_from_proofs()` to shared `property_utils.py`, eliminating identical 17-line functions duplicated between `extract_property_manifest.py` and `check_property_manifest_sync.py`

Net: -13 lines across 4 files. `lake build` passes (80/80 modules). Both Python scripts verified working with shared function.

## Test plan
- [x] `lake build` passes (80/80 modules)
- [x] `python3 scripts/extract_property_manifest.py` succeeds
- [x] `python3 scripts/check_property_manifest_sync.py` passes sync check
- [ ] CI checks pass (build, verify, foundry shards, bugbot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only updates plus a small refactor that centralizes existing manifest extraction logic, with minimal behavioral change and limited blast radius.
> 
> **Overview**
> Updates `verification.mdx` to remove stale claims (marks Yul layer as complete, updates snapshot date, and drops the outdated self-transfer limitation).
> 
> Refactors the property-manifest tooling by moving proof-manifest extraction into a shared `extract_manifest_from_proofs()` helper in `property_utils.py`, and reusing it from both `extract_property_manifest.py` and `check_property_manifest_sync.py` to eliminate duplicated logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4359f786598291d1633660113a2ccfcd4cd32f68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->