### PR TITLE
refactor: extract shared transferBody in Specs.lean

### DIFF
--- a/Compiler/Specs.lean
+++ b/Compiler/Specs.lean
@@ -20,6 +20,26 @@ open Compiler.ContractSpec
 def requireOwner : Stmt :=
   Stmt.require (Expr.eq Expr.caller (Expr.storage "owner")) "Not owner"
 
+/-- Transfer body for mapping-based balance contracts.
+    Handles self-transfer safely by computing a zero delta when caller == to. -/
+@[reducible] def transferBody (mappingName : String) : List Stmt := [
+  -- Pre-load both balances to match EDSL semantics (prevents self-transfer bug)
+  Stmt.letVar "senderBal" (Expr.mapping mappingName Expr.caller),
+  Stmt.letVar "recipientBal" (Expr.mapping mappingName (Expr.param "to")),
+  Stmt.require
+    (Expr.ge (Expr.localVar "senderBal") (Expr.param "amount"))
+    "Insufficient balance",
+  -- If caller == to, delta = 0 so both updates become no-ops.
+  Stmt.letVar "sameAddr" (Expr.eq Expr.caller (Expr.param "to")),
+  Stmt.letVar "delta" (Expr.sub (Expr.literal 1) (Expr.localVar "sameAddr")),
+  Stmt.letVar "amountDelta" (Expr.mul (Expr.param "amount") (Expr.localVar "delta")),
+  Stmt.setMapping mappingName Expr.caller
+    (Expr.sub (Expr.localVar "senderBal") (Expr.localVar "amountDelta")),
+  Stmt.setMapping mappingName (Expr.param "to")
+    (Expr.add (Expr.localVar "recipientBal") (Expr.localVar "amountDelta")),
+  Stmt.stop
+]
+
 /-!
 ## SimpleStorage Specification
 -/
@@ -164,23 +184,7 @@ def ledgerSpec : ContractSpec := {
         { name := "amount", ty := ParamType.uint256 }
       ]
       returnType := none
-      body := [
-        -- Pre-load both balances to match EDSL semantics (prevents self-transfer bug)
-        Stmt.letVar "senderBal" (Expr.mapping "balances" Expr.caller),
-        Stmt.letVar "recipientBal" (Expr.mapping "balances" (Expr.param "to")),
-        Stmt.require
-          (Expr.ge (Expr.localVar "senderBal") (Expr.param "amount"))
-          "Insufficient balance",
-        -- If caller == to, delta = 0 so both updates become no-ops.
-        Stmt.letVar "sameAddr" (Expr.eq Expr.caller (Expr.param "to")),
-        Stmt.letVar "delta" (Expr.sub (Expr.literal 1) (Expr.localVar "sameAddr")),
-        Stmt.letVar "amountDelta" (Expr.mul (Expr.param "amount") (Expr.localVar "delta")),
-        Stmt.setMapping "balances" Expr.caller
-          (Expr.sub (Expr.localVar "senderBal") (Expr.localVar "amountDelta")),
-        Stmt.setMapping "balances" (Expr.param "to")
-          (Expr.add (Expr.localVar "recipientBal") (Expr.localVar "amountDelta")),
-        Stmt.stop
-      ]
+      body := transferBody "balances"
     },
     { name := "getBalance"
       params := [{ name := "addr", ty := ParamType.address }]
@@ -297,23 +301,7 @@ def simpleTokenSpec : ContractSpec := {
         { name := "amount", ty := ParamType.uint256 }
       ]
       returnType := none
-      body := [
-        -- Pre-load both balances to match EDSL semantics (prevents self-transfer bug)
-        Stmt.letVar "senderBal" (Expr.mapping "balances" Expr.caller),
-        Stmt.letVar "recipientBal" (Expr.mapping "balances" (Expr.param "to")),
-        Stmt.require
-          (Expr.ge (Expr.localVar "senderBal") (Expr.param "amount"))
-          "Insufficient balance",
-        -- If caller == to, delta = 0 so both updates become no-ops.
-        Stmt.letVar "sameAddr" (Expr.eq Expr.caller (Expr.param "to")),
-        Stmt.letVar "delta" (Expr.sub (Expr.literal 1) (Expr.localVar "sameAddr")),
-        Stmt.letVar "amountDelta" (Expr.mul (Expr.param "amount") (Expr.localVar "delta")),
-        Stmt.setMapping "balances" Expr.caller
-          (Expr.sub (Expr.localVar "senderBal") (Expr.localVar "amountDelta")),
-        Stmt.setMapping "balances" (Expr.param "to")
-          (Expr.add (Expr.localVar "recipientBal") (Expr.localVar "amountDelta")),
-        Stmt.stop
-      ]
+      body := transferBody "balances"
     },
     { name := "balanceOf"
       params := [{ name := "addr", ty := ParamType.address }]


### PR DESCRIPTION
## Summary
- **Compiler/Specs.lean**: Extracted `transferBody` helper for the self-transfer-safe balance update pattern used identically in both `ledgerSpec.transfer` and `simpleTokenSpec.transfer`. Both functions now delegate to the shared helper with `body := transferBody "balances"` instead of duplicating 16 lines each.
- Marked `@[reducible]` so existing proofs in `SpecCorrectness/Ledger.lean` and `SpecCorrectness/SimpleToken.lean` unfold it transparently — no proof changes needed.
- Follows the existing `requireOwner` pattern already used for shared spec logic.

Net: -12 lines, 1 file. `lake build` passes (80/80 modules).

## Test plan
- [x] `lake build` passes (80/80 modules, including all SpecCorrectness proofs)
- [x] `lake build dumbcontracts-compiler` passes
- [ ] CI checks pass (build, verify, foundry shards, bugbot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor that centralizes identical spec logic; behavioral intent stays the same, with minimal risk limited to potential unfolding/EDSL semantic differences if the helper is misused.
> 
> **Overview**
> Refactors `Compiler/Specs.lean` by extracting the duplicated, self-transfer-safe `transfer` implementation for mapping-based balances into a shared `@[reducible]` helper `transferBody`.
> 
> Both `ledgerSpec.transfer` and `simpleTokenSpec.transfer` now delegate to `body := transferBody "balances"` instead of inlining the same balance preloading, require check, and mapping updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f17650316b18bba2b99220718b5e93816ce1890c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->