### PR TITLE
refactor: deduplicate context_preserved across 7 Invariants.lean files

### DIFF
--- a/DumbContracts/Proofs/Counter/Correctness.lean
+++ b/DumbContracts/Proofs/Counter/Correctness.lean
@@ -53,7 +53,7 @@ theorem getCount_state_preserved (s : ContractState) :
   state_preserved_except_count s s' := by
   have h := getCount_preserves_state s
   simp [h, state_preserved_except_count, storage_isolated, addr_storage_unchanged,
-    map_storage_unchanged, context_preserved]
+    map_storage_unchanged, Specs.sameContext]
 
 /-! ## Combined Spec Proofs
 

--- a/DumbContracts/Proofs/OwnedCounter/Isolation.lean
+++ b/DumbContracts/Proofs/OwnedCounter/Isolation.lean
@@ -69,14 +69,14 @@ All successful operations preserve sender and thisAddress.
 /-- Constructor preserves context. -/
 theorem constructor_context_preserved (s : ContractState) (initialOwner : Address) :
   context_preserved s ((constructor initialOwner).run s).snd := by
-  unfold context_preserved
+  unfold context_preserved Specs.sameContext
   simp [constructor, setStorageAddr, owner, Contract.run, ContractResult.snd]
 
 /-- Increment preserves context (when authorized). -/
 theorem increment_context_preserved (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   context_preserved s (increment.run s).snd := by
-  unfold context_preserved
+  unfold context_preserved Specs.sameContext
   simp only [increment, onlyOwner, isOwner, owner, count,
     msgSender, getStorageAddr, getStorage, setStorage,
     DumbContracts.require, DumbContracts.pure, DumbContracts.bind, Bind.bind, Pure.pure,
@@ -87,7 +87,7 @@ theorem increment_context_preserved (s : ContractState)
 theorem decrement_context_preserved (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   context_preserved s (decrement.run s).snd := by
-  unfold context_preserved
+  unfold context_preserved Specs.sameContext
   simp only [decrement, onlyOwner, isOwner, owner, count,
     msgSender, getStorageAddr, getStorage, setStorage,
     DumbContracts.require, DumbContracts.pure, DumbContracts.bind, Bind.bind, Pure.pure,
@@ -98,7 +98,7 @@ theorem decrement_context_preserved (s : ContractState)
 theorem transferOwnership_context_preserved (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :
   context_preserved s ((transferOwnership newOwner).run s).snd := by
-  unfold context_preserved
+  unfold context_preserved Specs.sameContext
   simp only [transferOwnership, onlyOwner, isOwner, owner,
     msgSender, getStorageAddr, setStorageAddr,
     DumbContracts.require, DumbContracts.pure, DumbContracts.bind, Bind.bind, Pure.pure,
@@ -108,13 +108,13 @@ theorem transferOwnership_context_preserved (s : ContractState) (newOwner : Addr
 /-- getCount preserves context. -/
 theorem getCount_context_preserved (s : ContractState) :
   context_preserved s (getCount.run s).snd := by
-  unfold context_preserved
+  unfold context_preserved Specs.sameContext
   simp [getCount, getStorage, count, Contract.run, ContractResult.snd]
 
 /-- getOwner preserves context. -/
 theorem getOwner_context_preserved (s : ContractState) :
   context_preserved s (getOwner.run s).snd := by
-  unfold context_preserved
+  unfold context_preserved Specs.sameContext
   simp [getOwner, getStorageAddr, owner, Contract.run, ContractResult.snd]
 
 /-! ## Mapping storage isolation

--- a/DumbContracts/Proofs/SafeCounter/Correctness.lean
+++ b/DumbContracts/Proofs/SafeCounter/Correctness.lean
@@ -71,7 +71,7 @@ theorem getCount_preserves_context (s : ContractState) :
   let s' := ((getCount).run s).snd
   context_preserved s s' := by
   have h := getCount_preserves_state s
-  simp [h, context_preserved]
+  simp [h, Specs.sameContext]
 
 /-- getCount preserves well-formedness. -/
 theorem getCount_preserves_wellformedness (s : ContractState) (h : WellFormedState s) :

--- a/DumbContracts/Proofs/SimpleStorage/Correctness.lean
+++ b/DumbContracts/Proofs/SimpleStorage/Correctness.lean
@@ -81,7 +81,7 @@ theorem retrieve_preserves_context (s : ContractState) :
   let s' := ((retrieve).run s).snd
   context_preserved s s' := by
   have h := retrieve_preserves_state s
-  simp [h, context_preserved]
+  simp [h, Specs.sameContext]
 
 /-- retrieve preserves well-formedness. -/
 theorem retrieve_preserves_wellformedness (s : ContractState) (h : WellFormedState s) :

--- a/DumbContracts/Specs/Counter/Invariants.lean
+++ b/DumbContracts/Specs/Counter/Invariants.lean
@@ -5,6 +5,7 @@
 -/
 
 import DumbContracts.Core
+import DumbContracts.Specs.Common
 
 namespace DumbContracts.Specs.Counter
 
@@ -36,11 +37,7 @@ def map_storage_unchanged (s s' : ContractState) : Prop :=
   s'.storageMap = s.storageMap
 
 /-- Contract context preserved: Operations don't change sender or contract address -/
-def context_preserved (s s' : ContractState) : Prop :=
-  s'.sender = s.sender ∧
-  s'.thisAddress = s.thisAddress ∧
-  s'.msgValue = s.msgValue ∧
-  s'.blockTimestamp = s.blockTimestamp
+abbrev context_preserved := Specs.sameContext
 
 /-- Complete state preservation except for count:
     Everything except slot 0 remains unchanged

--- a/DumbContracts/Specs/Ledger/Invariants.lean
+++ b/DumbContracts/Specs/Ledger/Invariants.lean
@@ -3,6 +3,7 @@
 -/
 
 import DumbContracts.Core
+import DumbContracts.Specs.Common
 
 namespace DumbContracts.Specs.Ledger
 
@@ -16,11 +17,7 @@ structure WellFormedState (s : ContractState) : Prop where
   contract_nonempty : s.thisAddress ≠ ""
 
 /-- Context preserved across operations -/
-def context_preserved (s s' : ContractState) : Prop :=
-  s'.sender = s.sender ∧
-  s'.thisAddress = s.thisAddress ∧
-  s'.msgValue = s.msgValue ∧
-  s'.blockTimestamp = s.blockTimestamp
+abbrev context_preserved := Specs.sameContext
 
 /-- Non-mapping storage unchanged by all Ledger operations -/
 def non_mapping_storage_unchanged (s s' : ContractState) : Prop :=

--- a/DumbContracts/Specs/Owned/Invariants.lean
+++ b/DumbContracts/Specs/Owned/Invariants.lean
@@ -5,6 +5,7 @@
 -/
 
 import DumbContracts.Core
+import DumbContracts.Specs.Common
 
 namespace DumbContracts.Specs.Owned
 
@@ -38,11 +39,7 @@ def map_storage_unchanged (s s' : ContractState) : Prop :=
   s'.storageMap = s.storageMap
 
 /-- Contract context preserved: Operations don't change sender or contract address -/
-def context_preserved (s s' : ContractState) : Prop :=
-  s'.sender = s.sender ∧
-  s'.thisAddress = s.thisAddress ∧
-  s'.msgValue = s.msgValue ∧
-  s'.blockTimestamp = s.blockTimestamp
+abbrev context_preserved := Specs.sameContext
 
 /-- Complete state preservation except for owner:
     Everything except owner slot remains unchanged

--- a/DumbContracts/Specs/OwnedCounter/Invariants.lean
+++ b/DumbContracts/Specs/OwnedCounter/Invariants.lean
@@ -6,6 +6,7 @@
 -/
 
 import DumbContracts.Core
+import DumbContracts.Specs.Common
 
 namespace DumbContracts.Specs.OwnedCounter
 
@@ -28,10 +29,6 @@ def owner_preserves_count (s s' : ContractState) : Prop :=
   s'.storage = s.storage
 
 /-- Context preserved across all operations -/
-def context_preserved (s s' : ContractState) : Prop :=
-  s'.sender = s.sender ∧
-  s'.thisAddress = s.thisAddress ∧
-  s'.msgValue = s.msgValue ∧
-  s'.blockTimestamp = s.blockTimestamp
+abbrev context_preserved := Specs.sameContext
 
 end DumbContracts.Specs.OwnedCounter

--- a/DumbContracts/Specs/SafeCounter/Invariants.lean
+++ b/DumbContracts/Specs/SafeCounter/Invariants.lean
@@ -6,6 +6,7 @@
 -/
 
 import DumbContracts.Core
+import DumbContracts.Specs.Common
 import DumbContracts.Stdlib.Math
 
 namespace DumbContracts.Specs.SafeCounter
@@ -21,11 +22,7 @@ structure WellFormedState (s : ContractState) : Prop where
   contract_nonempty : s.thisAddress ≠ ""
 
 /-- Context preserved: operations don't change sender or contract address -/
-def context_preserved (s s' : ContractState) : Prop :=
-  s'.sender = s.sender ∧
-  s'.thisAddress = s.thisAddress ∧
-  s'.msgValue = s.msgValue ∧
-  s'.blockTimestamp = s.blockTimestamp
+abbrev context_preserved := Specs.sameContext
 
 /-- Storage isolation: operations on slot 0 don't affect other slots -/
 def storage_isolated (s s' : ContractState) : Prop :=

--- a/DumbContracts/Specs/SimpleStorage/Invariants.lean
+++ b/DumbContracts/Specs/SimpleStorage/Invariants.lean
@@ -6,6 +6,7 @@
 -/
 
 import DumbContracts.Core
+import DumbContracts.Specs.Common
 
 namespace DumbContracts.Specs.SimpleStorage
 
@@ -32,10 +33,6 @@ def map_storage_unchanged (s s' : ContractState) : Prop :=
   s'.storageMap = s.storageMap
 
 -- Context preservation: operations don't change sender/address
-def context_preserved (s s' : ContractState) : Prop :=
-  s'.sender = s.sender ∧
-  s'.thisAddress = s.thisAddress ∧
-  s'.msgValue = s.msgValue ∧
-  s'.blockTimestamp = s.blockTimestamp
+abbrev context_preserved := Specs.sameContext
 
 end DumbContracts.Specs.SimpleStorage

--- a/DumbContracts/Specs/SimpleToken/Invariants.lean
+++ b/DumbContracts/Specs/SimpleToken/Invariants.lean
@@ -6,6 +6,7 @@
 -/
 
 import DumbContracts.Core
+import DumbContracts.Specs.Common
 import DumbContracts.EVM.Uint256
 
 namespace DumbContracts.Specs.SimpleToken
@@ -68,11 +69,7 @@ def owner_addr_isolated (s s' : ContractState) (slot : Nat) : Prop :=
   slot ≠ 0 → s'.storageAddr slot = s.storageAddr slot
 
 /-- Context preservation (sender, contract address unchanged) -/
-def context_preserved (s s' : ContractState) : Prop :=
-  s'.sender = s.sender ∧
-  s'.thisAddress = s.thisAddress ∧
-  s'.msgValue = s.msgValue ∧
-  s'.blockTimestamp = s.blockTimestamp
+abbrev context_preserved := Specs.sameContext
 
 /-- State preserved except for specific modifications -/
 def state_preserved_except (s s' : ContractState)


### PR DESCRIPTION
## Summary
- Replace 7 identical 5-line \`context_preserved\` definitions with \`abbrev\` aliases to the existing \`Specs.sameContext\` from \`Common.lean\`
- The definition was copy-pasted across Counter, Ledger, Owned, OwnedCounter, SafeCounter, SimpleStorage, and SimpleToken Invariants.lean files
- Update 4 proof files (Counter/Correctness, SafeCounter/Correctness, SimpleStorage/Correctness, OwnedCounter/Isolation) to reference \`Specs.sameContext\` where the \`abbrev\` transparency changed tactic behavior

## Test plan
- [x] \`lake build\` passes (77/77 modules, only expected \`sorry\` warnings from sum properties)
- [x] All proofs verified — zero new \`sorry\` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor of proof/spec definitions with small proof-script adjustments; no runtime logic or contract semantics are changed.
> 
> **Overview**
> Refactors the various contract `Invariants.lean` modules to **deduplicate** the repeated `context_preserved` predicate by importing `DumbContracts.Specs.Common` and replacing the local field-by-field definition with `abbrev context_preserved := Specs.sameContext`.
> 
> Updates several proof files (e.g. `Counter/Correctness`, `SafeCounter/Correctness`, `SimpleStorage/Correctness`, `OwnedCounter/Isolation`) to unfold/simp against `Specs.sameContext` explicitly where the new abbrev changes tactic behavior, without changing the intended statements of the invariants/proofs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89db928f8f23829b843539822bed9074e846c097. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->