### PR TITLE
refactor: move inline proof comments to doc comments in SumProofs.lean

### DIFF
--- a/DumbContracts/Specs/Ledger/SumProofs.lean
+++ b/DumbContracts/Specs/Ledger/SumProofs.lean
@@ -29,39 +29,38 @@ open DumbContracts.Specs.Common
 
 /-! ## Deposit Sum Properties -/
 
-/-- Deposit increases total balance by the deposited amount -/
+/-- Deposit increases total balance by the deposited amount.
+
+Strategy: Use deposit_increases_balance to show balance increases and
+knownAddresses is updated to include sender. Then show sumBalances increases
+by the deposited amount using FiniteSet.sum properties. -/
 theorem deposit_sum_equation (amount : Uint256) (s : ContractState)
     (h_finite : balancesFinite 0 s) :
     let s' := (deposit amount).runState s
     Spec_deposit_sum_equation amount s s' := by
   unfold Spec_deposit_sum_equation totalBalance
   unfold Contract.runState
-  -- We have:
-  -- - deposit_increases_balance shows balance increases
-  -- - knownAddresses is updated to include sender
-  -- The proof would show:
-  -- sumBalances 0 (s'.knownAddresses 0) s'.storageMap = add (sumBalances 0 (s.knownAddresses 0) s.storageMap) amount
-  -- This follows from the FiniteSet.sum properties
-  sorry  -- Requires completing sumBalances helper lemmas
+  sorry
 
-/-- Deposit on singleton set with only sender -/
+/-- Deposit on singleton set with only sender.
+
+Special case of deposit_sum_equation where only sender has non-zero balance.
+Show totalBalance equals the single address balance, then apply deposit logic. -/
 theorem deposit_sum_singleton_sender (amount : Uint256) (s : ContractState)
     (h_finite : balancesFinite 0 s) :
     let s' := (deposit amount).runState s
     Spec_deposit_sum_singleton_sender amount s s' := by
   unfold Spec_deposit_sum_singleton_sender totalBalance
   intro h_only_sender
-  -- Strategy:
-  -- 1. From h_only_sender: only sender has non-zero balance
-  -- 2. Show totalBalance s = s.storageMap 0 s.sender (sum over singleton)
-  -- 3. After deposit: totalBalance s' = add (s.storageMap 0 s.sender) amount
-  -- 4. Use deposit_increases_balance
-  -- This is a special case of deposit_sum_equation
-  sorry  -- Follows from deposit_sum_equation and singleton sum property
+  sorry
 
 /-! ## Withdraw Sum Properties -/
 
-/-- Withdraw decreases total balance by the withdrawn amount -/
+/-- Withdraw decreases total balance by the withdrawn amount.
+
+Strategy: Use withdraw_decreases_balance to show the sender's balance decreases.
+Since knownAddresses includes sender, apply sumBalances_update_existing to show
+the total sum decreases by the withdrawn amount. -/
 theorem withdraw_sum_equation (amount : Uint256) (s : ContractState)
     (h_balance : s.storageMap 0 s.sender >= amount)
     (h_finite : balancesFinite 0 s) :
@@ -69,15 +68,12 @@ theorem withdraw_sum_equation (amount : Uint256) (s : ContractState)
     Spec_withdraw_sum_equation amount s s' := by
   unfold Spec_withdraw_sum_equation totalBalance
   unfold Contract.runState
-  -- We have:
-  -- - withdraw_decreases_balance: s'.storageMap 0 s.sender = sub (s.storageMap 0 s.sender) amount
-  -- - knownAddresses includes sender (unchanged or already present)
-  -- The proof shows:
-  -- sumBalances 0 (s'.knownAddresses 0) s'.storageMap = sub (sumBalances 0 (s.knownAddresses 0) s.storageMap) amount
-  -- This follows from sumBalances_update_existing
-  sorry  -- Requires completing sumBalances helper lemmas
+  sorry
 
-/-- Withdraw on singleton set with only sender -/
+/-- Withdraw on singleton set with only sender.
+
+Special case of withdraw_sum_equation where only sender has non-zero balance.
+Show totalBalance equals the single address balance, then apply withdraw logic. -/
 theorem withdraw_sum_singleton_sender (amount : Uint256) (s : ContractState)
     (h_balance : s.storageMap 0 s.sender >= amount)
     (h_finite : balancesFinite 0 s) :
@@ -85,17 +81,17 @@ theorem withdraw_sum_singleton_sender (amount : Uint256) (s : ContractState)
     Spec_withdraw_sum_singleton_sender amount s s' := by
   unfold Spec_withdraw_sum_singleton_sender totalBalance
   intro h_only_sender
-  -- Strategy:
-  -- 1. From h_only_sender: only sender has non-zero balance
-  -- 2. Show totalBalance s = s.storageMap 0 s.sender (sum over singleton)
-  -- 3. After withdraw: totalBalance s' = sub (s.storageMap 0 s.sender) amount
-  -- 4. Use withdraw_decreases_balance
-  -- This is a special case of withdraw_sum_equation
-  sorry  -- Follows from withdraw_sum_equation and singleton sum property
+  sorry
 
 /-! ## Transfer Sum Properties -/
 
-/-- Transfer preserves total balance -/
+/-- Transfer preserves total balance.
+
+Strategy: Case split on sender == to.
+- If sender == to: Use transfer_self_preserves_balance (balances unchanged).
+- If sender ≠ to: The amount subtracted from sender is added to recipient,
+  so the net change to totalBalance is zero. Requires sumBalances distributivity
+  and Uint256 arithmetic to show the amounts cancel. -/
 theorem transfer_sum_preservation (to : Address) (amount : Uint256) (s : ContractState)
     (h_balance : s.storageMap 0 s.sender >= amount)
     (h_finite : balancesFinite 0 s) :
@@ -103,22 +99,14 @@ theorem transfer_sum_preservation (to : Address) (amount : Uint256) (s : Contrac
     Spec_transfer_sum_preservation to amount s s' := by
   unfold Spec_transfer_sum_preservation totalBalance
   unfold Contract.runState
-  -- Strategy:
   by_cases h_eq : s.sender = to
-  · -- Case 1: sender == to
-    -- Use transfer_self_preserves_balance
-    -- Show balances unchanged, so sum unchanged
-    -- This is trivial: s'.storageMap = s.storageMap
-    sorry  -- Straightforward equality
-  · -- Case 2: sender ≠ to
-    -- Use transfer_decreases_sender: s'.storageMap 0 sender = sub (s.storageMap 0 sender) amount
-    -- Use transfer_increases_recipient: s'.storageMap 0 to = add (s.storageMap 0 to) amount
-    -- Show: sub balance_sender amount + add balance_to amount + rest = balance_sender + balance_to + rest
-    -- The amount added to recipient cancels the amount subtracted from sender
-    -- Requires: add (sub x amount) amount = x and Uint256 arithmetic lemmas
-    sorry  -- Requires sumBalances distributivity and Uint256 arithmetic
+  · sorry
+  · sorry
 
-/-- Transfer with unique addresses preserves total balance -/
+/-- Transfer with unique addresses preserves total balance.
+
+Specialized version of transfer_sum_preservation with sender ≠ to assumed.
+Follows directly from the main theorem. -/
 theorem transfer_sum_preserved_unique (to : Address) (amount : Uint256) (s : ContractState)
     (h_ne : s.sender ≠ to)
     (h_balance : s.storageMap 0 s.sender >= amount)
@@ -127,33 +115,23 @@ theorem transfer_sum_preserved_unique (to : Address) (amount : Uint256) (s : Con
     Spec_transfer_sum_preserved_unique to amount s s' := by
   unfold Spec_transfer_sum_preserved_unique totalBalance
   intro _
-  -- Strategy:
-  -- This is essentially the same as transfer_sum_preservation with h_ne assumed
-  -- Use transfer_decreases_sender: s'.storageMap 0 sender = sub (s.storageMap 0 sender) amount
-  -- Use transfer_increases_recipient: s'.storageMap 0 to = add (s.storageMap 0 to) amount
-  -- Show: The amount subtracted from sender is added to recipient, preserving the sum
-  sorry  -- Follows directly from transfer_sum_preservation
+  sorry
 
 /-! ## Composition Properties -/
 
-/-- Deposit followed by withdraw cancels out in total balance -/
+/-- Deposit followed by withdraw cancels out in total balance.
+
+Composition property: deposit increases total by amount, withdraw decreases by amount,
+so net change is zero. Uses EVM.Uint256.sub_add_cancel for the arithmetic.
+Requires deposit_sum_equation and withdraw_sum_equation. -/
 theorem deposit_withdraw_sum_cancel (amount : Uint256) (s : ContractState)
-    (h_balance : s.storageMap 0 s.sender >= amount)  -- Need sufficient balance after deposit
+    (h_balance : s.storageMap 0 s.sender >= amount)
     (h_finite : balancesFinite 0 s) :
     let s' := (deposit amount).runState s
     let s'' := (withdraw amount).runState s'
     Spec_deposit_withdraw_sum_cancel amount s s' s'' := by
   unfold Spec_deposit_withdraw_sum_cancel
   intro h_deposit h_withdraw
-  -- Strategy:
-  -- 1. From h_deposit: totalBalance s' = add (totalBalance s) amount
-  -- 2. From h_withdraw: totalBalance s'' = sub (totalBalance s') amount
-  -- 3. Substitute: totalBalance s'' = sub (add (totalBalance s) amount) amount
-  -- 4. Use EVM.Uint256.sub_add_cancel: sub (add x amount) amount = x
-  -- Once deposit_sum_equation and withdraw_sum_equation are proven, this follows by:
-  -- calc totalBalance s'' = sub (totalBalance s') amount := h_withdraw
-  --   _ = sub (add (totalBalance s) amount) amount := by rw [h_deposit]
-  --   _ = totalBalance s := EVM.Uint256.sub_add_cancel (totalBalance s) amount
-  sorry  -- Requires deposit_sum_equation and withdraw_sum_equation to be proven first
+  sorry
 
 end DumbContracts.Specs.Ledger.SumProofs


### PR DESCRIPTION
## Summary
- Move verbose inline strategy comments from `sorry` lines to proper doc comments above each theorem
- Clean up 7 theorems in `SumProofs.lean` (deposit_sum_equation, deposit_sum_singleton_sender, withdraw_sum_equation, withdraw_sum_singleton_sender, transfer_sum_preservation, transfer_sum_preserved_unique, deposit_withdraw_sum_cancel)
- All inline comments that cluttered proof bodies are now structured doc comments

## Changes
- **Before**: Multi-line inline comments (6-13 lines each) explaining proof strategy mixed with code
- **After**: Concise doc comments above theorems, clean proof bodies with just `unfold` + `sorry`

Example:
```lean
-- Before:
theorem foo := by
  unfold bar
  -- Strategy:
  -- 1. Do this
  -- 2. Do that
  -- 3. Show xyz
  sorry  -- Requires helper lemmas

-- After:
/-- Foo does X.

Strategy: Do this, then that, then show xyz. Requires helper lemmas. -/
theorem foo := by
  unfold bar
  sorry
```

## Test plan
- [x] `lake build` passes (77/77 modules, same `sorry` warnings as before)
- [x] No semantic changes to proofs — only moved comments to proper locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only refactor that does not change theorem statements or executable logic; risk is limited to potential formatting/docstring issues.
> 
> **Overview**
> Refactors `SumProofs.lean` by moving verbose, step-by-step proof strategy notes out of theorem bodies and into structured doc comments above each of the 7 `sorry`-stubbed theorems.
> 
> Proof bodies are simplified to the minimal `unfold`/case-split scaffolding (e.g., `transfer_sum_preservation` keeps only the `by_cases`), with no change to theorem statements or proof obligations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b21d5c81b7ceb53d7b1ebb5bcf76d2872b42878. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->