### PR TITLE
fix: Split console.log calls in _reportRandomSeed to avoid Solidity compilation error

### DIFF
--- a/test/DiffTestConfig.sol
+++ b/test/DiffTestConfig.sol
@@ -12,7 +12,8 @@ abstract contract DiffTestConfig is Test {
         uint256 shardCount = _diffShardCount();
 
         if (shardCount > 1) {
-            console.log("DIFFTEST_RANDOM_SEED:", seed, "(shard", shardIndex, "/", shardCount, ")");
+            console.log("DIFFTEST_RANDOM_SEED:", seed);
+            console.log("Shard:", shardIndex, "/", shardCount);
         } else {
             console.log("DIFFTEST_RANDOM_SEED:", seed);
         }


### PR DESCRIPTION
## Summary
Fixes Solidity compilation errors in  that were blocking all foundry tests.

## Problem
PR #92 introduced  helper with a console.log call using 6+ mixed-type arguments:
```solidity
console.log("DIFFTEST_RANDOM_SEED:", seed, "(shard", shardIndex, "/", shardCount, ")");
```

This exceeded Solidity's console.log overload limits, causing compilation errors:
```
Error (9582): Member "log" not found or not visible after argument-dependent lookup in type(library console).
  --> test/DiffTestConfig.sol:15:13:
```

This blocked:
- All foundry test shards (0-7)
- All foundry-multi-seed tests (6 seeds)
- PR #93 and any future PRs

## Solution
Split into two console.log calls that work within Solidity constraints:
```solidity
if (shardCount > 1) {
    console.log("DIFFTEST_RANDOM_SEED:", seed);
    console.log("Shard:", shardIndex, "/", shardCount);
} else {
    console.log("DIFFTEST_RANDOM_SEED:", seed);
}
```

## Test Plan
- ✅ `forge build` succeeds (previously failed)
- ✅ Maintains same information output
- ✅ No semantic changes

## Impact
Unblocks:
- All CI foundry tests
- PR #93 (currently failing due to this issue)
- Future PRs with test changes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only logging change with no runtime/protocol impact; main risk is minor changes to log formatting relied on by CI parsers.
> 
> **Overview**
> Fixes a Solidity/Foundry compilation issue in `test/DiffTestConfig.sol` by replacing a single `console.log` call (with too many mixed-type arguments) with two separate logs when sharding is enabled.
> 
> The seed output is unchanged, but shard details now print on a second line (`"Shard:" shardIndex "/" shardCount`), unblocking sharded/multi-seed test runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73c5b78277138875adf994d5f66b68d8fb3606e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->