### PR TITLE
fix: Document all 5 axioms and expand CI axiom check scope

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,13 +55,13 @@ jobs:
 
       - name: Check for axioms in proof files
         run: |
-          echo "Checking for axioms in proof files..."
+          echo "Checking for axioms in Compiler/ and DumbContracts/..."
 
-          # Find all axioms (excluding commented lines)
-          grep -r "axiom " Compiler/Proofs/ --include="*.lean" | grep -v "^--" | grep -v "TRUST ASSUMPTION" | grep -v "This is an axiom" | grep -v "List version" | grep -v "Usage.*axiom" | tee axioms.txt || true
+          # Find all axioms across both directories (excluding commented lines)
+          grep -rn "^axiom " Compiler/ DumbContracts/ --include="*.lean" | tee axioms.txt || true
 
-          # Count axioms (look for actual axiom declarations)
-          AXIOM_COUNT=$(grep -c "^[^:]*:axiom " axioms.txt 2>/dev/null || echo 0)
+          # Count axioms
+          AXIOM_COUNT=$(wc -l < axioms.txt 2>/dev/null | tr -d ' ')
 
           echo "Found $AXIOM_COUNT axiom declaration(s)"
 
@@ -79,7 +79,7 @@ jobs:
             echo "Verifying all axioms are documented..."
 
             # Extract axiom names from grep output
-            AXIOM_NAMES=$(grep "^[^:]*:axiom " axioms.txt | sed 's/.*:axiom \([a-zA-Z0-9_]*\).*/\1/' | sort -u)
+            AXIOM_NAMES=$(sed 's/.*:axiom \([a-zA-Z0-9_]*\).*/\1/' axioms.txt | sort -u)
 
             UNDOCUMENTED=""
             for axiom_name in $AXIOM_NAMES; do


### PR DESCRIPTION
## Summary
- Adds documentation for 2 previously undocumented axioms in AXIOMS.md
- Expands CI axiom check to scan all Lean files, not just `Compiler/Proofs/`

## Problem
The CI axiom check (added in PR #88) only scanned `Compiler/Proofs/` for axiom declarations, missing 2 axioms in other locations:

| Axiom | Location | Previously Detected |
|-------|----------|-------------------|
| `evalIRExpr_eq_evalYulExpr` | `Compiler/Proofs/YulGeneration/` | Yes |
| `evalIRExprs_eq_evalYulExprs` | `Compiler/Proofs/YulGeneration/` | Yes |
| `addressToNat_injective_valid` | `Compiler/Proofs/IRGeneration/` | Yes |
| `keccak256_first_4_bytes` | `Compiler/Selectors.lean` | **No** |
| `addressToNat_injective` | `DumbContracts/Proofs/Stdlib/Automation.lean` | **No** |

## Changes

**AXIOMS.md**:
- Added axiom #4 (`keccak256_first_4_bytes`) with soundness argument (validated by CI selector checks + solc)
- Added axiom #5 (`addressToNat_injective`) with soundness argument (consistent with axiom #3)
- Updated summary table: 3 -> 5 axioms
- Updated trust model diagram to show axiom distribution across layers
- Updated local check commands

**verify.yml**:
- Expanded grep from `Compiler/Proofs/` to `Compiler/ DumbContracts/`
- Uses `^axiom` anchor for more precise matching
- Simplified axiom name extraction

## Test plan
- [x] Local simulation finds all 5 axioms and validates all are documented
- [x] No false positives from comments or documentation strings


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and documentation-only changes; no prover/compiler semantics are modified, with the main risk being CI false positives/negatives in axiom detection.
> 
> **Overview**
> **CI now enforces full axiom coverage across the repo.** The verify workflow’s axiom check is expanded from `Compiler/Proofs/` to scanning all `*.lean` files under `Compiler/` and `DumbContracts/`, and simplifies counting/name extraction based on `^axiom` matches.
> 
> **Axiom documentation is updated to match enforcement.** `AXIOMS.md` adds full entries for two previously undocumented axioms (`keccak256_first_4_bytes` and `addressToNat_injective`), updates the summary table/total count (3→5), and refreshes the trust-model/CI instructions accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7e6b83b3a8962d46b7bb84a7a1a3b2fabe610ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->