### PR TITLE
feat: Add reentrancy property tests (issue #85)

### DIFF
--- a/examples/solidity/ReentrancyExample.sol
+++ b/examples/solidity/ReentrancyExample.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title VulnerableBank
+/// @notice Demonstrates a reentrancy vulnerability where totalSupply is
+///         decremented twice (modeling a reentrant callback) before the
+///         balance is updated once. This breaks the supply invariant.
+/// @dev Matches the Lean EDSL model in DumbContracts/Examples/ReentrancyExample.lean
+contract VulnerableBank {
+    // Storage layout matches EDSL:
+    // slot 0: reentrancyLock (unused in vulnerable version)
+    // slot 1: totalSupply
+    // slot 2: balances mapping base slot
+    uint256 public reentrancyLock;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balances;
+
+    /// @notice Deposit amount to caller's balance
+    function deposit(uint256 amount) external {
+        balances[msg.sender] += amount;
+        totalSupply += amount;
+    }
+
+    /// @notice Vulnerable withdraw: models reentrancy by decrementing
+    ///         totalSupply twice (simulating reentrant callback) before
+    ///         updating balance once.
+    /// @dev This mirrors the Lean model where the external call effect is
+    ///      inlined as a second totalSupply decrement.
+    function withdraw(uint256 amount) external {
+        require(balances[msg.sender] >= amount, "Insufficient balance");
+
+        // Unchecked to match Lean's wrapping sub semantics (Uint256.sub wraps at 2^256)
+        unchecked {
+            // First totalSupply decrement (before "external call")
+            totalSupply -= amount;
+
+            // Reentrant call effect: totalSupply decremented again
+            totalSupply -= amount;
+        }
+
+        // Balance updated once (using original balance check)
+        balances[msg.sender] -= amount;
+    }
+
+    function getBalance(address addr) external view returns (uint256) {
+        return balances[addr];
+    }
+}
+
+/// @title SafeBank
+/// @notice Demonstrates the fix: state is updated before any external
+///         interaction. The supply invariant is provably maintained.
+/// @dev Matches the Lean EDSL SafeBank model
+contract SafeBank {
+    uint256 public reentrancyLock;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balances;
+
+    /// @notice Deposit amount to caller's balance
+    function deposit(uint256 amount) external {
+        balances[msg.sender] += amount;
+        totalSupply += amount;
+    }
+
+    /// @notice Safe withdraw: updates balance and totalSupply atomically
+    ///         before any external interaction would occur.
+    function withdraw(uint256 amount) external {
+        require(balances[msg.sender] >= amount, "Insufficient balance");
+
+        // State updates BEFORE external interaction
+        balances[msg.sender] -= amount;
+        totalSupply -= amount;
+    }
+
+    function getBalance(address addr) external view returns (uint256) {
+        return balances[addr];
+    }
+}

--- a/scripts/property_utils.py
+++ b/scripts/property_utils.py
@@ -14,6 +14,7 @@ MANIFEST = ROOT / "test" / "property_manifest.json"
 EXCLUSIONS = ROOT / "test" / "property_exclusions.json"
 TEST_DIR = ROOT / "test"
 PROOFS_DIR = ROOT / "DumbContracts" / "Proofs"
+EXAMPLES_DIR = ROOT / "DumbContracts" / "Examples"
 
 # Regex patterns for extracting property tags from test files
 PROPERTY_WITH_NUM_RE = re.compile(
@@ -130,6 +131,9 @@ def collect_theorems(path: Path) -> list[str]:
 def extract_manifest_from_proofs() -> dict[str, list[str]]:
     """Extract theorem names from Lean proof files.
 
+    Scans DumbContracts/Proofs/ directories and DumbContracts/Examples/ files
+    that contain inline theorems (e.g., ReentrancyExample).
+
     Returns:
         Dictionary mapping contract names to sorted, deduplicated lists of theorem names.
     """
@@ -145,6 +149,17 @@ def extract_manifest_from_proofs() -> dict[str, list[str]]:
             theorems.extend(collect_theorems(lean))
         if theorems:
             manifest[contract] = sorted(dict.fromkeys(theorems))
+
+    # Also scan Examples/ for contracts with inline theorems (no separate Proofs dir)
+    if EXAMPLES_DIR.exists():
+        for lean in sorted(EXAMPLES_DIR.glob("*.lean")):
+            contract = lean.stem
+            if contract in manifest:
+                continue  # Already found via Proofs/
+            theorems = collect_theorems(lean)
+            if theorems:
+                manifest[contract] = sorted(dict.fromkeys(theorems))
+
     return manifest
 
 

--- a/test/PropertyReentrancyExample.t.sol
+++ b/test/PropertyReentrancyExample.t.sol
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "forge-std/Test.sol";
+import "../examples/solidity/ReentrancyExample.sol";
+
+/**
+ * @title PropertyReentrancyExampleTest
+ * @notice Property-based tests for the reentrancy example contracts
+ * @dev Maps theorems from DumbContracts/Examples/ReentrancyExample.lean to executable tests
+ *
+ * These tests validate proven Lean theorems against Solidity implementations:
+ *
+ * VulnerableBank (namespace VulnerableBank):
+ * 1. vulnerable_attack_exists         — Supply invariant breaks after withdraw
+ * 2. withdraw_maintains_supply_UNPROVABLE — Universal invariant is false
+ *
+ * SafeBank (namespace SafeBank):
+ * 3. withdraw_maintains_supply        — Withdraw preserves supply invariant
+ * 4. deposit_maintains_supply         — Deposit preserves supply invariant
+ */
+contract PropertyReentrancyExampleTest is Test {
+    VulnerableBank vulnerable;
+    SafeBank safe;
+
+    address alice = address(0xA11CE);
+    address bob = address(0xB0B);
+
+    function setUp() public {
+        vulnerable = new VulnerableBank();
+        safe = new SafeBank();
+    }
+
+    //═══════════════════════════════════════════════════════════════════════════
+    // VulnerableBank: Proven vulnerability properties
+    //═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Property 1: vulnerable_attack_exists
+     * Theorem: There exists a state where the supply invariant holds before
+     *          withdraw but breaks after withdraw (due to double totalSupply
+     *          decrement modeling reentrancy).
+     *
+     * The Lean proof constructs a concrete counterexample with MAX_UINT256
+     * balance and supply. After withdraw, totalSupply wraps to 1 while
+     * balance wraps to 0, breaking totalSupply == sum(balances).
+     */
+    function testProperty_VulnerableBank_AttackExists() public {
+        // Setup: Establish invariant (totalSupply == alice's balance)
+        vm.prank(alice);
+        vulnerable.deposit(100);
+
+        // Verify invariant holds before withdraw
+        assertEq(
+            vulnerable.totalSupply(),
+            vulnerable.balances(alice),
+            "Invariant should hold before withdraw"
+        );
+
+        // Action: Withdraw (triggers double totalSupply decrement)
+        vm.prank(alice);
+        vulnerable.withdraw(50);
+
+        // Assert: Invariant BROKEN (totalSupply decremented twice, balance once)
+        // totalSupply = 100 - 50 - 50 = 0
+        // balances[alice] = 100 - 50 = 50
+        assertEq(vulnerable.totalSupply(), 0, "totalSupply should be 0 (decremented twice)");
+        assertEq(vulnerable.balances(alice), 50, "Balance should be 50 (decremented once)");
+        assertTrue(
+            vulnerable.totalSupply() != vulnerable.balances(alice),
+            "Invariant should be broken: totalSupply != balance"
+        );
+    }
+
+    /**
+     * Property 2: withdraw_maintains_supply_UNPROVABLE
+     * Theorem: The universal supply preservation property is FALSE for
+     *          VulnerableBank. For any amount > 0, the invariant breaks.
+     *
+     * This is a fuzz test that demonstrates the invariant breaks for
+     * arbitrary (non-zero) deposit and withdrawal amounts.
+     */
+    function testFuzz_VulnerableBank_InvariantBreaks(uint256 depositAmt, uint256 withdrawAmt) public {
+        // Constrain inputs to avoid trivial cases
+        vm.assume(depositAmt > 0 && depositAmt < type(uint128).max);
+        vm.assume(withdrawAmt > 0 && withdrawAmt <= depositAmt);
+
+        // Setup: Establish invariant
+        vm.prank(alice);
+        vulnerable.deposit(depositAmt);
+        assertEq(vulnerable.totalSupply(), vulnerable.balances(alice));
+
+        // Action: Withdraw (uses unchecked wrapping arithmetic like Lean's sub)
+        vm.prank(alice);
+        vulnerable.withdraw(withdrawAmt);
+
+        // Assert: Invariant broken (totalSupply short by withdrawAmt)
+        // totalSupply = depositAmt - 2*withdrawAmt (wrapping at 2^256)
+        // balance = depositAmt - withdrawAmt
+        uint256 expectedSupply;
+        unchecked {
+            expectedSupply = depositAmt - 2 * withdrawAmt;
+        }
+        assertEq(
+            vulnerable.totalSupply(),
+            expectedSupply,
+            "totalSupply decremented twice (wrapping)"
+        );
+        assertEq(
+            vulnerable.balances(alice),
+            depositAmt - withdrawAmt,
+            "Balance decremented once"
+        );
+    }
+
+    /**
+     * Property: Vulnerable withdraw reverts on insufficient balance
+     * Matches the EDSL: revert "Insufficient balance" when bal < amount
+     */
+    function testProperty_VulnerableBank_RevertsInsufficientBalance() public {
+        vm.prank(alice);
+        vulnerable.deposit(100);
+
+        // Withdraw more than balance should revert
+        vm.expectRevert("Insufficient balance");
+        vm.prank(alice);
+        vulnerable.withdraw(101);
+    }
+
+    //═══════════════════════════════════════════════════════════════════════════
+    // SafeBank: Proven safety properties
+    //═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Property 3: withdraw_maintains_supply
+     * Theorem: For all states where the supply invariant holds and the
+     *          sender has sufficient balance, withdraw preserves the invariant.
+     *
+     * supplyInvariant s [s.sender] →
+     * s.storageMap balances.slot s.sender ≥ amount →
+     * supplyInvariant (withdraw amount).runState s) [s.sender]
+     */
+    function testProperty_SafeBank_WithdrawMaintainsSupply() public {
+        // Setup: Establish invariant
+        vm.prank(alice);
+        safe.deposit(100);
+        assertEq(safe.totalSupply(), safe.balances(alice), "Pre: invariant");
+
+        // Action: Withdraw
+        vm.prank(alice);
+        safe.withdraw(50);
+
+        // Assert: Invariant preserved
+        assertEq(
+            safe.totalSupply(),
+            safe.balances(alice),
+            "Post: supply invariant should hold after withdraw"
+        );
+    }
+
+    /**
+     * Property 3 (fuzz): withdraw_maintains_supply
+     * Fuzz version that tests with arbitrary amounts.
+     */
+    function testFuzz_SafeBank_WithdrawMaintainsSupply(uint256 depositAmt, uint256 withdrawAmt) public {
+        vm.assume(depositAmt > 0 && depositAmt < type(uint128).max);
+        vm.assume(withdrawAmt > 0 && withdrawAmt <= depositAmt);
+
+        // Setup: Establish invariant
+        vm.prank(alice);
+        safe.deposit(depositAmt);
+        assertEq(safe.totalSupply(), safe.balances(alice));
+
+        // Action: Withdraw
+        vm.prank(alice);
+        safe.withdraw(withdrawAmt);
+
+        // Assert: Invariant preserved
+        assertEq(
+            safe.totalSupply(),
+            safe.balances(alice),
+            "Supply invariant must hold after withdraw"
+        );
+        assertEq(safe.totalSupply(), depositAmt - withdrawAmt);
+    }
+
+    /**
+     * Property 4: deposit_maintains_supply
+     * Theorem: For all states where the supply invariant holds,
+     *          deposit preserves the invariant.
+     *
+     * supplyInvariant s [s.sender] →
+     * supplyInvariant ((deposit amount).runState s) [s.sender]
+     */
+    function testProperty_SafeBank_DepositMaintainsSupply() public {
+        // Multiple deposits should maintain invariant
+        vm.prank(alice);
+        safe.deposit(100);
+        assertEq(safe.totalSupply(), safe.balances(alice), "After deposit 1");
+
+        vm.prank(alice);
+        safe.deposit(200);
+        assertEq(safe.totalSupply(), safe.balances(alice), "After deposit 2");
+    }
+
+    /**
+     * Property 4 (fuzz): deposit_maintains_supply
+     * Fuzz version that tests with arbitrary amounts.
+     */
+    function testFuzz_SafeBank_DepositMaintainsSupply(uint256 amount1, uint256 amount2) public {
+        vm.assume(amount1 < type(uint128).max);
+        vm.assume(amount2 < type(uint128).max);
+
+        vm.prank(alice);
+        safe.deposit(amount1);
+        assertEq(safe.totalSupply(), safe.balances(alice), "After first deposit");
+
+        vm.prank(alice);
+        safe.deposit(amount2);
+        assertEq(safe.totalSupply(), safe.balances(alice), "After second deposit");
+        assertEq(safe.totalSupply(), amount1 + amount2);
+    }
+
+    /**
+     * Property: Safe withdraw reverts on insufficient balance
+     */
+    function testProperty_SafeBank_RevertsInsufficientBalance() public {
+        vm.prank(alice);
+        safe.deposit(100);
+
+        vm.expectRevert("Insufficient balance");
+        vm.prank(alice);
+        safe.withdraw(101);
+    }
+
+    /**
+     * Property: Deposit then withdraw cancels out (SafeBank)
+     * Combined property showing full lifecycle preserves invariant
+     */
+    function testFuzz_SafeBank_DepositWithdrawCancel(uint256 amount) public {
+        vm.assume(amount > 0 && amount < type(uint128).max);
+
+        vm.prank(alice);
+        safe.deposit(amount);
+
+        vm.prank(alice);
+        safe.withdraw(amount);
+
+        assertEq(safe.totalSupply(), 0, "Supply should return to 0");
+        assertEq(safe.balances(alice), 0, "Balance should return to 0");
+        assertEq(safe.totalSupply(), safe.balances(alice), "Invariant holds");
+    }
+
+    //═══════════════════════════════════════════════════════════════════════════
+    // Multi-user invariant tests
+    //═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Property: SafeBank supply invariant holds with multiple users
+     * Extension of the single-user invariant to multi-user scenarios
+     */
+    function testProperty_SafeBank_MultiUserInvariant() public {
+        vm.prank(alice);
+        safe.deposit(100);
+
+        vm.prank(bob);
+        safe.deposit(200);
+
+        assertEq(
+            safe.totalSupply(),
+            safe.balances(alice) + safe.balances(bob),
+            "Supply should equal sum of all balances"
+        );
+
+        vm.prank(alice);
+        safe.withdraw(30);
+
+        assertEq(
+            safe.totalSupply(),
+            safe.balances(alice) + safe.balances(bob),
+            "Invariant holds after partial withdrawal"
+        );
+    }
+
+    /**
+     * Property: VulnerableBank invariant breaks with multiple users
+     */
+    function testProperty_VulnerableBank_MultiUserInvariantBreaks() public {
+        vm.prank(alice);
+        vulnerable.deposit(100);
+
+        vm.prank(bob);
+        vulnerable.deposit(200);
+
+        assertEq(
+            vulnerable.totalSupply(),
+            vulnerable.balances(alice) + vulnerable.balances(bob),
+            "Invariant holds before attack"
+        );
+
+        // Alice withdraws — triggers vulnerability
+        vm.prank(alice);
+        vulnerable.withdraw(50);
+
+        // Invariant is now broken
+        assertTrue(
+            vulnerable.totalSupply() !=
+                vulnerable.balances(alice) + vulnerable.balances(bob),
+            "Invariant should be broken"
+        );
+    }
+
+    //═══════════════════════════════════════════════════════════════════════════
+    // Comparative tests: VulnerableBank vs SafeBank
+    //═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Property: Same operations produce different invariant outcomes
+     * Demonstrates that the ordering of state updates matters
+     */
+    function testFuzz_Comparison_SameOps_DifferentOutcome(uint256 depositAmt, uint256 withdrawAmt) public {
+        vm.assume(depositAmt > 0 && depositAmt < type(uint128).max);
+        vm.assume(withdrawAmt > 0 && withdrawAmt <= depositAmt);
+
+        // Same operations on both contracts
+        vm.prank(alice);
+        vulnerable.deposit(depositAmt);
+        vm.prank(alice);
+        safe.deposit(depositAmt);
+
+        vm.prank(alice);
+        vulnerable.withdraw(withdrawAmt);
+        vm.prank(alice);
+        safe.withdraw(withdrawAmt);
+
+        // SafeBank invariant holds
+        assertEq(
+            safe.totalSupply(),
+            safe.balances(alice),
+            "SafeBank invariant should hold"
+        );
+
+        // VulnerableBank invariant broken
+        assertTrue(
+            vulnerable.totalSupply() != vulnerable.balances(alice),
+            "VulnerableBank invariant should be broken"
+        );
+    }
+}

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -63,6 +63,12 @@
     "withdraw_sum_equation",
     "withdraw_sum_singleton_sender"
   ],
+  "ReentrancyExample": [
+    "deposit_maintains_supply",
+    "vulnerable_attack_exists",
+    "withdraw_maintains_supply",
+    "withdraw_maintains_supply_UNPROVABLE"
+  ],
   "Owned": [
     "constructor_getOwner_correct",
     "constructor_meets_spec",


### PR DESCRIPTION
## Summary

- Adds Solidity implementations of `VulnerableBank` and `SafeBank` contracts matching the Lean EDSL model in `DumbContracts/Examples/ReentrancyExample.lean`
- Creates 12 property-based tests mapping to 4 proven Lean theorems: `vulnerable_attack_exists`, `withdraw_maintains_supply_UNPROVABLE`, `withdraw_maintains_supply`, `deposit_maintains_supply`
- Updates property manifest and extends `property_utils.py` to scan `DumbContracts/Examples/` for contracts with inline theorems (no separate Proofs directory)

### Key design decisions

- **Unchecked arithmetic**: `VulnerableBank.withdraw()` uses `unchecked` blocks for the double `totalSupply -= amount` to match Lean's wrapping `sub` semantics (Uint256.sub wraps at 2^256, while Solidity 0.8+ reverts on underflow)
- **Standalone contracts**: Since `ReentrancyExample` has no compiler spec, no Yul output, and no existing Solidity reference, standalone Solidity contracts were created to test the proven properties
- **Reentrancy modeling**: The vulnerable contract inlines the reentrant callback effect as a second `totalSupply` decrement, matching the Lean model exactly

### Test coverage

| Theorem | Test Type | Description |
|---------|-----------|-------------|
| `vulnerable_attack_exists` | Concrete | Concrete counterexample showing invariant breaks |
| `withdraw_maintains_supply_UNPROVABLE` | Fuzz | Fuzz test demonstrating invariant failure for arbitrary amounts |
| `withdraw_maintains_supply` | Concrete + Fuzz | SafeBank withdraw preserves supply invariant |
| `deposit_maintains_supply` | Concrete + Fuzz | SafeBank deposit preserves supply invariant |
| (additional) | Multi-user | Multi-user invariant tests for both contracts |
| (additional) | Comparative | Same operations, different invariant outcomes |

## Test plan

- [x] All 12 reentrancy tests pass (`forge test --match-contract PropertyReentrancyExampleTest`)
- [x] Full non-differential test suite passes (259 tests, 0 failures)
- [x] Property manifest sync check passes
- [x] Property coverage check passes
- [x] Property manifest check passes

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new example contracts and tests; the only behavioral change is widening manifest extraction to include `DumbContracts/Examples`, which should be low-risk but could affect CI sync/coverage checks if additional example theorems are present.
> 
> **Overview**
> Adds a new `ReentrancyExample` Solidity reference implementation (`VulnerableBank` + `SafeBank`) plus a comprehensive Foundry property test suite (`PropertyReentrancyExample.t.sol`) that exercises supply-invariant behavior, including fuzzing and multi-user scenarios.
> 
> Extends the property-manifest tooling (`property_utils.py`) to also extract Lean theorem names from `DumbContracts/Examples/*.lean` (not just `DumbContracts/Proofs/`), and updates `test/property_manifest.json` to include the four `ReentrancyExample` theorem names so sync/coverage checks recognize the new example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bba16ca6a1308452e53fc2038b7cd32fe1bc9338. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->