### PR TITLE
[Documentation] Add contracts table, doc-count CI validation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Check storage layout consistency
         run: python3 scripts/check_storage_layout.py
 
+      - name: Check documentation counts
+        run: python3 scripts/check_doc_counts.py
+
       - name: Generate property coverage report
         run: python3 scripts/report_property_coverage.py --format=markdown >> $GITHUB_STEP_SUMMARY
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,15 @@ lake build  # Must pass
 # No new `sorry` without documentation
 # No new `axiom` without documenting in AXIOMS.md
 # Update docs/ROADMAP.md if architectural changes
+# If adding a new contract, run the checklist below
 ```
+
+**When adding a new contract**, also update:
+- `test/property_manifest.json` — Run `python3 scripts/extract_property_manifest.py`
+- `README.md` — Contracts table (theorem count and description)
+- `docs/VERIFICATION_STATUS.md` — Contract table and coverage stats
+- `docs-site/public/llms.txt` — Quick Facts and theorem breakdown table
+- `docs-site/content/verification.mdx` — Snapshot section
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -43,18 +43,30 @@ def retrieve_spec (result : Uint256) (s : ContractState) : Prop :=
   result = s.storage 0
 ```
 
+## Contracts
+
+| Contract | Theorems | Description |
+|----------|----------|-------------|
+| SimpleStorage | 20 | Store/retrieve with roundtrip proof |
+| Counter | 28 | Increment/decrement with wrapping, composition proofs |
+| SafeCounter | 25 | Overflow/underflow revert proofs |
+| Owned | 22 | Access control and ownership transfer |
+| OwnedCounter | 45 | Cross-pattern composition, lockout proofs |
+| Ledger | 32 | Deposit/withdraw/transfer with balance conservation |
+| SimpleToken | 56 | Mint/transfer, supply conservation, storage isolation |
+| ReentrancyExample | 4 | Reentrancy vulnerability vs safe withdrawal (inline proofs) |
+| CryptoHash | — | External cryptographic library linking (no specs) |
+
+**Verification snapshot**: 296 theorems across 9 categories, 207 covered by property tests (70% coverage), 89 proof-only exclusions. 5 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/dumbcontracts/issues/65)). 311 Foundry tests across 30 test suites.
+
 ## What's Verified
 
-- **EDSL correctness**: Each example contract satisfies its specification in Lean.
-- **Spec semantics**: ContractSpec execution matches the intended DSL behavior.
-- **Compiler correctness**: IR generation and Yul codegen fully proven (Layers 1-3 complete).
-- **Automation**: Common proof patterns are captured in reusable lemmas.
+- **EDSL correctness**: Each contract satisfies its specification in Lean (Layer 1).
+- **Compiler correctness**: IR generation preserves ContractSpec semantics (Layer 2). Yul codegen preserves IR semantics (Layer 3).
+- **End-to-end pipeline**: EDSL → ContractSpec → IR → Yul fully verified with 5 axioms.
+- **Trust boundary**: Yul → EVM bytecode via solc (validated by 70k+ differential tests).
 
-See [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) for detailed verification status and [`Compiler/Proofs/README.md`](Compiler/Proofs/README.md) for proof inventory.
-
-## Trust Model
-
-See [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) for detailed trust assumptions and semantics definitions.
+See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for detailed trust boundaries, [`AXIOMS.md`](AXIOMS.md) for axiom documentation, and [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) for full status.
 
 ## Repository Structure
 
@@ -80,12 +92,19 @@ test/                                # Foundry tests (unit, property, differenti
 5. **Compiler Spec**: `Compiler/Specs.lean` — ContractSpec for code generation
 6. **Tests**: `test/Property<Name>.t.sol` + differential tests
 
+**Documentation Checklist:**
+After adding a contract, update these files to keep counts in sync:
+- `test/property_manifest.json` — Run `python3 scripts/extract_property_manifest.py`
+- Contracts table in this README
+- `docs/VERIFICATION_STATUS.md` — Contract table and coverage stats
+- `docs-site/public/llms.txt` — Quick Facts and theorem breakdown
+
 **Common Pitfalls:**
 - Storage slot mismatches between spec, EDSL, and compiler
 - Mapping conversions assuming simple slots instead of typed storage
 - Stale proofs when specs change
 
-**Reference**: Use `SimpleStorage` as the minimal end-to-end example.
+**Reference**: Use `SimpleStorage` as the minimal end-to-end example (full spec pipeline). Use `ReentrancyExample` as a reference for proof-only contracts (inline theorems, no compiler spec).
 
 **Infrastructure:**
 - **Proof automation**: `DumbContracts/Proofs/Stdlib/` (SpecInterpreter + automation lemmas)

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Check that documentation files have accurate theorem/test/axiom counts.
+
+Validates counts in README.md, VERIFICATION_STATUS.md, llms.txt, and other
+documentation against the actual property manifest and codebase.
+
+Usage:
+    python3 scripts/check_doc_counts.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def get_manifest_counts() -> tuple[int, int, dict[str, int]]:
+    """Return (total_theorems, num_categories, per_contract_counts)."""
+    manifest = ROOT / "test" / "property_manifest.json"
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    per_contract = {k: len(v) for k, v in data.items()}
+    total = sum(per_contract.values())
+    return total, len(data), per_contract
+
+
+def get_axiom_count() -> int:
+    """Count axiom declarations in Lean files."""
+    count = 0
+    for d in [ROOT / "Compiler", ROOT / "DumbContracts"]:
+        if not d.exists():
+            continue
+        for lean in d.rglob("*.lean"):
+            text = lean.read_text(encoding="utf-8")
+            for line in text.splitlines():
+                if re.match(r"^axiom\s+", line):
+                    count += 1
+    return count
+
+
+def check_file(path: Path, checks: list[tuple[str, re.Pattern, str]]) -> list[str]:
+    """Check a file for expected patterns. Returns list of errors."""
+    if not path.exists():
+        return [f"{path.name}: file not found"]
+    text = path.read_text(encoding="utf-8")
+    errors = []
+    for desc, pattern, expected in checks:
+        match = pattern.search(text)
+        if not match:
+            errors.append(f"{path.name}: missing expected pattern for {desc}")
+        elif match.group(1) != expected:
+            errors.append(
+                f"{path.name}: {desc} says '{match.group(1)}' but expected '{expected}'"
+            )
+    return errors
+
+
+def main() -> None:
+    total_theorems, num_categories, _ = get_manifest_counts()
+    axiom_count = get_axiom_count()
+
+    errors: list[str] = []
+
+    # Check README.md
+    readme = ROOT / "README.md"
+    errors.extend(
+        check_file(
+            readme,
+            [
+                (
+                    "theorem count",
+                    re.compile(r"(\d+) theorems across"),
+                    str(total_theorems),
+                ),
+                (
+                    "category count",
+                    re.compile(r"theorems across (\d+) categor"),
+                    str(num_categories),
+                ),
+                (
+                    "axiom count in What's Verified",
+                    re.compile(r"verified with (\d+) axioms"),
+                    str(axiom_count),
+                ),
+            ],
+        )
+    )
+
+    # Check llms.txt
+    llms = ROOT / "docs-site" / "public" / "llms.txt"
+    errors.extend(
+        check_file(
+            llms,
+            [
+                (
+                    "theorem count",
+                    re.compile(r"\*\*Theorems\*\*: (\d+) across"),
+                    str(total_theorems),
+                ),
+                (
+                    "category count",
+                    re.compile(r"Theorems\*\*: \d+ across (\d+) categor"),
+                    str(num_categories),
+                ),
+            ],
+        )
+    )
+
+    # Check TRUST_ASSUMPTIONS.md
+    trust = ROOT / "TRUST_ASSUMPTIONS.md"
+    errors.extend(
+        check_file(
+            trust,
+            [
+                (
+                    "axiom count in verification chain",
+                    re.compile(r"FULLY VERIFIED, (\d+) axioms"),
+                    str(axiom_count),
+                ),
+            ],
+        )
+    )
+
+    if errors:
+        print("Documentation count check FAILED:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(
+            f"Actual counts: {total_theorems} theorems, "
+            f"{num_categories} categories, {axiom_count} axioms",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    print(
+        f"Documentation count check passed "
+        f"({total_theorems} theorems, {num_categories} categories, "
+        f"{axiom_count} axioms)."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add **Contracts table** to README.md listing all 9 contracts with theorem counts and descriptions
- Add **verification snapshot** line with accurate counts (296 theorems, 311 tests, 9 categories, 5 axioms)
- Improve **What's Verified** section with layer-specific descriptions and links to TRUST_ASSUMPTIONS.md/AXIOMS.md
- Add **documentation checklist** to both README.md and CONTRIBUTING.md for new contract additions
- Create `scripts/check_doc_counts.py` — **CI validation script** that checks README.md, llms.txt, and TRUST_ASSUMPTIONS.md for accurate theorem/axiom/category counts
- Add CI step to run doc-count validation on every build

## Motivation
After PRs #103 and #104 fixed stale counts across docs, this PR prevents future drift by:
1. Making the README the canonical source for contract overview (previously scattered)
2. Adding automated CI validation of documentation counts against actual codebase data
3. Providing a checklist so contributors know which docs to update when adding contracts

## Test Plan
- `python3 scripts/check_doc_counts.py` passes locally (validates 296 theorems, 9 categories, 5 axioms)
- CI will run the new check step after storage layout validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI validation only; primary risk is new CI failures due to regex/pattern mismatches or unexpected doc formatting changes.
> 
> **Overview**
> Adds a new **Contracts** table and a single-line **verification snapshot** to `README.md`, and refines the “What’s Verified” section with more explicit layer/trust-boundary wording plus links to `TRUST_ASSUMPTIONS.md`/`AXIOMS.md`.
> 
> Introduces `scripts/check_doc_counts.py` and wires it into the `verify.yml` workflow to **fail CI when documented theorem/category/axiom counts drift** from `test/property_manifest.json` and Lean `axiom` declarations; also updates `CONTRIBUTING.md` and the README with a checklist of docs to update when adding a new contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d868c12f7520c8cd7e6337f3ee2a9dc86689ce9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->