### PR TITLE
[Infrastructure] Fix CI seed consistency and stale documentation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -218,7 +218,7 @@ jobs:
     strategy:
       fail-fast: false  # Test all seeds even if one fails
       matrix:
-        seed: [0, 1, 123, 999, 12345, 67890]
+        seed: [0, 1, 42, 123, 999, 12345, 67890]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ lake build  # Must pass
 - `docs/VERIFICATION_STATUS.md` — Contract table and coverage stats
 - `docs-site/public/llms.txt` — Quick Facts and theorem breakdown table
 - `docs-site/content/verification.mdx` — Snapshot section
+- Run `python3 scripts/check_doc_counts.py` to verify all counts are synchronized
 
 ## Code Style
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -186,7 +186,7 @@ def ownedSpec : ContractSpec := {
 ```bash
 lake build dumbcontracts-compiler    # Build compiler
 lake exe dumbcontracts-compiler      # Generate all contracts
-forge test  # 264/264 tests pass (as of 2026-02-13)
+forge test  # 311/311 tests pass (as of 2026-02-15)
 ```
 
 ### Differential Testing (Completed 2026-02-10)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -39,6 +39,8 @@ EVM Bytecode
 | ReentrancyExample | 4 | ✅ Complete | `DumbContracts/Examples/ReentrancyExample.lean` |
 | **Total** | **232** | **✅ 100%** | — |
 
+> **Note**: Stdlib (64 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (296 total properties).
+
 ### Example Property
 
 ```lean

--- a/scripts/test_multiple_seeds.sh
+++ b/scripts/test_multiple_seeds.sh
@@ -34,7 +34,8 @@ for seed in "${SEEDS[@]}"; do
     echo "Testing seed: $seed"
     echo "--------------------------------------"
 
-    if DIFFTEST_RANDOM_SEED=$seed forge test; then
+    # Skip Random10000 tests to avoid out-of-gas errors (see issue #96)
+    if DIFFTEST_RANDOM_SEED=$seed forge test --no-match-test "Random10000"; then
         echo "✅ Seed $seed: PASSED"
     else
         echo "❌ Seed $seed: FAILED"


### PR DESCRIPTION
## Summary
- **Fix CI seed matrix**: Add seed 42 to multi-seed job matrix (was missing despite being used in the primary foundry job and the local test script)
- **Fix local test script**: Add `--no-match-test "Random10000"` to `test_multiple_seeds.sh` to match CI behavior and avoid OutOfGas errors locally (see issue #96)
- **Fix stale test count**: Update `research.mdx` from 264 → 311 tests (missed in PR #103)
- **Improve CONTRIBUTING.md**: Add `check_doc_counts.py` validation step to new-contract checklist
- **Clarify VERIFICATION_STATUS.md**: Add footnote explaining Stdlib's 64 properties are excluded from Layer 1 table (232) but included in overall count (296)

## Test Plan
- Verified seed 42 is already in local script defaults (line 14) — now matches CI
- `--no-match-test "Random10000"` matches the CI workflow (line 267)
- Doc count check passes: `python3 scripts/check_doc_counts.py`

## Related Issues
Addresses remaining items from #87 (codebase audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow/script and documentation-only changes; main risk is inadvertently reducing test coverage or masking failures due to the `Random10000` exclusion.
> 
> **Overview**
> CI’s `foundry-multi-seed` job now includes seed `42` in its matrix to match the primary Foundry job and local defaults.
> 
> The local `scripts/test_multiple_seeds.sh` script is updated to skip `Random10000` tests (via `--no-match-test "Random10000"`) to mirror CI and avoid OOG failures.
> 
> Docs are refreshed: `research.mdx` test counts are updated, `CONTRIBUTING.md` adds a `check_doc_counts.py` step to the new-contract checklist, and `VERIFICATION_STATUS.md` clarifies that Stdlib properties are excluded from the Layer 1 table but included in overall totals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f771dbb46834bf130e21d422537f162f1be27774. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->