### PR TITLE
[Infrastructure] Add CI path filters for tests/scripts, fix docs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,6 +9,8 @@ on:
       - 'Compiler/**'
       - 'Compiler.lean'
       - 'examples/solidity/**'
+      - 'test/**'
+      - 'scripts/**'
       - 'lakefile.lean'
       - 'lean-toolchain'
   pull_request:
@@ -18,6 +20,8 @@ on:
       - 'Compiler/**'
       - 'Compiler.lean'
       - 'examples/solidity/**'
+      - 'test/**'
+      - 'scripts/**'
       - 'lakefile.lean'
       - 'lean-toolchain'
   workflow_dispatch:

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -92,17 +92,19 @@ The Lean compiler verifies every proof. If a proof is wrong, compilation fails.
 
 ## Example Contracts
 
-Seven contracts are implemented and verified:
+Nine contracts are implemented and verified:
 
 | Contract | Demonstrates |
 |----------|--------------|
 | SimpleStorage | Basic storage read/write, state isolation |
 | Counter | Arithmetic operations, composition |
+| SafeCounter | Overflow/underflow prevention with checked arithmetic |
 | Owned | Access control patterns, ownership transfer |
-| SimpleToken | Token minting/transfer, supply conservation, storage isolation |
 | OwnedCounter | Combining patterns (owned + counter) |
 | Ledger | Balance tracking, deposit/withdraw/transfer, conservation laws |
-| SafeCounter | Overflow/underflow prevention with checked arithmetic |
+| SimpleToken | Token minting/transfer, supply conservation, storage isolation |
+| ReentrancyExample | Reentrancy vulnerability vs safe withdrawal patterns |
+| CryptoHash | External cryptographic library linking |
 
 Plus a math standard library with safe arithmetic theorems (`safeMul`, `safeDiv`, etc.).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,6 +72,25 @@ Properties are excluded in `test/property_exclusions.json` for valid reasons:
 - **Sum equations**: Properties requiring finite address set modeling (e.g., total supply invariants)
 - **Internal helpers**: Functions like `isOwner_*` that are tested implicitly through other operations
 
+## Validation Scripts
+
+These CI-critical scripts validate cross-layer consistency:
+
+- **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
+- **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, and Compiler layers; detects intra-contract slot collisions
+- **`check_doc_counts.py`** - Validates theorem, axiom, category, test, and suite counts in README.md, llms.txt, and TRUST_ASSUMPTIONS.md against actual codebase data
+
+```bash
+# Run locally before submitting documentation changes
+python3 scripts/check_doc_counts.py
+
+# Run locally after modifying storage slots or adding contracts
+python3 scripts/check_storage_layout.py
+
+# Run locally after adding/removing theorems
+python3 scripts/check_property_manifest_sync.py
+```
+
 ## Selector & Yul Scripts
 
 - **`check_selectors.py`** - Verifies function selector hashes match between Lean and generated Yul
@@ -82,14 +101,19 @@ Properties are excluded in `test/property_exclusions.json` for valid reasons:
 
 - **`property_utils.py`** - Shared utilities for loading manifests, exclusions, and test coverage
 - **`keccak256.py`** - Keccak-256 hashing implementation for selector verification
+- **`extract_property_manifest.py`** - Extracts theorem names from Lean proofs to regenerate `property_manifest.json`
+- **`test_multiple_seeds.sh`** - Runs Foundry tests with multiple random seeds to detect flakiness
 
 ## CI Integration
 
-All verification scripts run automatically in GitHub Actions:
-1. Property coverage is checked on every PR
-2. Coverage reports are displayed in the workflow summary
-3. Selector hashes are verified against both Lean specs and solc output
-4. Generated Yul code must compile successfully
+All verification scripts run automatically in GitHub Actions (`verify.yml`):
+1. Property manifest sync check
+2. Property coverage validation
+3. Selector hash verification (against Lean specs and solc output)
+4. Yul compilation check
+5. Storage layout consistency validation
+6. Documentation count validation
+7. Coverage reports in workflow summary
 
 ## Adding New Property Tests
 
@@ -118,4 +142,4 @@ To add test coverage for a proven theorem:
   - Text/Markdown/JSON output formats
   - Per-contract and overall statistics
   - CI integration with GitHub workflow summaries
-  - Coverage improved from 53.1% (155/292) to 69.9% (207/296) — all testable properties covered
+  - Coverage improved from 53.1% (155/292) to 70% (207/296) — all testable properties covered

--- a/test/DifferentialTestBase.sol
+++ b/test/DifferentialTestBase.sol
@@ -216,7 +216,7 @@ abstract contract DifferentialTestBase {
      * @dev Used for deterministic random test generation
      */
     function _prng(uint256 seed) internal pure returns (uint256) {
-        // LCG parameters (same as used in DiffTestConfig)
+        // LCG parameters (Glibc-style; DiffTestConfig._lcg uses different constants)
         uint256 a = 1664525;
         uint256 c = 1013904223;
         uint256 m = 2 ** 31;


### PR DESCRIPTION
## Summary
- **Add `test/**` and `scripts/**` to CI path filters** in verify.yml — previously, changes to test files and validation scripts did not trigger CI, creating a silent failure mode where test changes could be merged without validation
- **Fix misleading PRNG comment** in `DifferentialTestBase.sol` — comment claimed LCG parameters were "same as used in DiffTestConfig" but they use different constants (Glibc-style 1664525/1013904223 vs MINSTD-style 1103515245/12345)
- **Document 3 undocumented CI scripts** in `scripts/README.md`: `check_doc_counts.py`, `check_property_manifest_sync.py`, `check_storage_layout.py` — these run in CI but had no developer-facing documentation
- **Update `index.mdx` contract table** from 7 → 9 contracts (add ReentrancyExample and CryptoHash, matching README.md)

## Test Plan
- `python3 scripts/check_doc_counts.py` passes (296 theorems, 9 categories, 5 axioms, 290 tests, 23 suites)
- CI path filters are additive — no existing triggers are removed, only new paths added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI path filters and documentation/comment updates; they should only affect when CI runs and reduce confusion, with minimal runtime impact.
> 
> **Overview**
> CI `verify.yml` now triggers when `test/**` or `scripts/**` change, preventing merges of test/script updates without running verification.
> 
> Docs are updated to reflect current project state: `scripts/README.md` documents CI-critical validation scripts and CI integration order, and the docs site index updates the example contract list/count (now 9, adding `ReentrancyExample` and `CryptoHash`).
> 
> A small test clarity fix updates the `_prng` comment in `test/DifferentialTestBase.sol` to note its LCG constants differ from `DiffTestConfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f1afb46f8d6cf4636f415571ca4273c423c8524. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->