### PR TITLE
[Documentation] Fix stale theorem count (252→296) and contract count (7→9)

### DIFF
--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -311,7 +311,7 @@ Time: **~5 minutes** (vs ~30 minutes manual IR)
 
 ### All Tests Pass ✅
 
-**Lean Proofs**: 252/252 verified (100%)
+**Lean Proofs**: All proofs verified (296 EDSL theorems, 100%)
 ```bash
 $ lake build
 Build completed successfully.
@@ -422,6 +422,6 @@ def ownedSpec : ContractSpec := {
 ## Links
 
 - [Research & Development](/research) — Design decisions and proof techniques
-- [Examples](/examples) — 7 verified contracts
-- [Verification](/verification) — 252 proven theorems
+- [Examples](/examples) — 9 example contracts
+- [Verification](/verification) — 296 proven theorems
 - [GitHub Repository](https://github.com/Th0rgal/dumbcontracts) — Source code

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -132,7 +132,7 @@ theorem store_retrieve : store 42 >> retrieve = pure 42 := by
 ## Documentation
 
 - **[Verification](/verification)** — Full theorem list by contract
-- **[Examples](/examples)** — The 7 contracts and what they demonstrate
+- **[Examples](/examples)** — The 9 contracts and what they demonstrate
 - **[Core](/core)** — How the 234-line EDSL works
 - **[Research](/research)** — Design decisions and proof techniques
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -172,7 +172,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (290/290 as of 2026-02-15), Lean proofs verify (252/252 as of 2026-02-13)
+- Test results: Foundry tests pass (290/290 as of 2026-02-15), Lean proofs verify (296 EDSL theorems as of 2026-02-15)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -136,6 +136,26 @@ def main() -> None:
         )
     )
 
+    # Check compiler.mdx
+    compiler_mdx = ROOT / "docs-site" / "content" / "compiler.mdx"
+    errors.extend(
+        check_file(
+            compiler_mdx,
+            [
+                (
+                    "theorem count",
+                    re.compile(r"(\d+) EDSL theorems"),
+                    str(total_theorems),
+                ),
+                (
+                    "theorem count in links",
+                    re.compile(r"Verification.+ — (\d+) proven theorems"),
+                    str(total_theorems),
+                ),
+            ],
+        )
+    )
+
     # Check TRUST_ASSUMPTIONS.md
     trust = ROOT / "TRUST_ASSUMPTIONS.md"
     errors.extend(


### PR DESCRIPTION
## Summary
- Fix **stale theorem count** "252" → **296** in `compiler.mdx` and `research.mdx` — the 252 was never updated after ReentrancyExample, Stdlib, and other theorems were added
- Fix **stale contract count** "7" → **9** in `index.mdx` navigation link and `compiler.mdx` links section (ReentrancyExample and CryptoHash were missing)
- **Extend `check_doc_counts.py`** to validate theorem counts in `compiler.mdx`, preventing this category of drift in the future

## Details
The "252/252 verified" number in `compiler.mdx` was from an early development phase. The actual count is 296 EDSL theorems (validated by `check_doc_counts.py` against `property_manifest.json`). The "7 contracts" references didn't account for ReentrancyExample and CryptoHash which were added later.

## Files changed
- `docs-site/content/compiler.mdx` — 3 count fixes
- `docs-site/content/research.mdx` — 1 count fix
- `docs-site/content/index.mdx` — 1 count fix
- `scripts/check_doc_counts.py` — Add compiler.mdx validation

## Test Plan
- `python3 scripts/check_doc_counts.py` passes: `296 theorems, 9 categories, 5 axioms, 290 tests, 23 suites`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a small regex-based validation addition; no runtime or protocol logic is affected.
> 
> **Overview**
> Updates docs to reflect current verification metrics: replaces stale Lean proof counts (`252`→`296` EDSL theorems) in `compiler.mdx`/`research.mdx`, and updates the examples/contract count (`7`→`9`) in `index.mdx` and `compiler.mdx` links.
> 
> Extends `scripts/check_doc_counts.py` to validate the theorem count references in `compiler.mdx`, helping prevent future documentation drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89de5a9a20d360a3547b9e4af3f9c3f08348b786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->