### PR TITLE
docs: Fix stale claims and add scaffold generator references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ lake build  # Must pass
 - `docs/VERIFICATION_STATUS.md` — Contract table and coverage stats
 - `docs-site/public/llms.txt` — Quick Facts and theorem breakdown table
 - `docs-site/content/verification.mdx` — Snapshot section
+- Run `python3 scripts/check_contract_structure.py` to verify file structure is complete
 - Run `python3 scripts/check_doc_counts.py` to verify all counts are synchronized
 
 ## Code Style
@@ -199,7 +200,7 @@ Tag format: `/// Property: exact_theorem_name`
 
 **Layer 3 proofs**: Read [Compiler/Proofs/README.md](Compiler/Proofs/README.md), study completed proofs (`assign_equiv`, `storageLoad_equiv`), use templates
 
-**New contracts**: Follow `SimpleStorage` pattern: Spec → Invariants → Implementation → Proofs → Tests
+**New contracts**: Use `python3 scripts/generate_contract.py <Name>` to scaffold all boilerplate files, then follow the `SimpleStorage` pattern: Spec → Invariants → Implementation → Proofs → Tests
 
 **Compiler changes**: Check [Compiler/Specs.lean](Compiler/Specs.lean), ensure proofs still build
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ def retrieve_spec (result : Uint256) (s : ContractState) : Prop :=
 | Ledger | 32 | Deposit/withdraw/transfer with balance conservation |
 | SimpleToken | 56 | Mint/transfer, supply conservation, storage isolation |
 | ReentrancyExample | 4 | Reentrancy vulnerability vs safe withdrawal (inline proofs) |
-| CryptoHash | — | External cryptographic library linking (no specs) |
+| CryptoHash | — | External cryptographic library linking (no specs, no tests) |
 
 **Verification snapshot**: 296 theorems across 9 categories, 207 covered by property tests (70% coverage), 89 proof-only exclusions. 5 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/dumbcontracts/issues/65)). 290 Foundry tests across 23 test suites.
 
@@ -83,6 +83,12 @@ test/                                # Foundry tests (unit, property, differenti
 ```
 
 ## Adding a Contract
+
+Use the scaffold generator to create all boilerplate files:
+```bash
+python3 scripts/generate_contract.py MyContract
+python3 scripts/generate_contract.py MyToken --fields "balances:mapping,totalSupply:uint256,owner:address"
+```
 
 **File Layout (Spec → Impl → Proof):**
 1. **Spec**: `DumbContracts/Specs/<Name>/Spec.lean` — Human-readable function specifications
@@ -137,6 +143,8 @@ python3 scripts/check_property_coverage.py       # Ensure all theorems have test
 python3 scripts/check_property_manifest_sync.py  # Verify manifest matches proofs
 python3 scripts/check_selectors.py               # Verify keccak256 selector hashing
 python3 scripts/check_storage_layout.py          # Verify storage slot consistency across layers
+python3 scripts/check_contract_structure.py      # Verify contract file structure is complete
+python3 scripts/check_doc_counts.py              # Verify documentation counts match codebase
 ```
 
 ## Documentation

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -83,12 +83,16 @@ The Lean compiler verifies every proof. If a proof is wrong, compilation fails.
 
 ## Adding a Contract (Checklist)
 
+Use `python3 scripts/generate_contract.py <Name>` to scaffold all boilerplate files, then:
+
 1. Write a small, human-readable spec in `DumbContracts/Specs/<Name>/Spec.lean`.
 2. Add any invariants in `DumbContracts/Specs/<Name>/Invariants.lean` (optional but encouraged).
 3. Implement the contract in `DumbContracts/Examples/<Name>.lean` using the EDSL.
 4. Prove the implementation meets the spec in `DumbContracts/Specs/<Name>/Proofs.lean`.
 5. Add compiler-level spec glue in `Compiler/Specs.lean` and any IR/Yul proofs in `Compiler/Proofs/` if new patterns are introduced.
 6. Add tests in `test/` (unit + property + differential if applicable).
+
+See [Add a Contract](/add-contract) for the full guide.
 
 ## Example Contracts
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -82,7 +82,8 @@ The GitHub Actions workflow validates:
 - Storage layout consistency across EDSL/Spec/Compiler layers
 - Selector hashes match specs
 - Generated Yul compiles with solc
-- Foundry tests pass (8 shards, 6 seeds)
+- Contract file structure validation
+- Foundry tests pass (8 shards, 7 seeds)
 
 ## Documentation URLs
 
@@ -100,7 +101,7 @@ Add `.md` to any URL for raw markdown (saves tokens).
 
 See TRUST_ASSUMPTIONS.md for full analysis. Key trust boundaries:
 - **Verified**: EDSL -> ContractSpec -> IR -> Yul
-- **Trusted**: Yul -> Bytecode (via solc, validated by 10,000+ differential tests)
+- **Trusted**: Yul -> Bytecode (via solc, validated by 70k+ differential tests)
 - **Axioms**: 5 documented, all with soundness justification
 - **External**: Lean 4 kernel, EVM specification alignment
 


### PR DESCRIPTION
## Summary
- **llms.txt**: Fix seed count (6→7), differential test count (10,000+→70k+), add contract structure validation to CI checklist
- **CONTRIBUTING.md**: Add scaffold generator to new-contract workflow, add `check_contract_structure.py` to validation checklist
- **README.md**: CryptoHash description "(no specs)" → "(no specs, no tests)", add scaffold generator usage to "Adding a Contract" section, add missing validation scripts to checklist
- **index.mdx**: Add scaffold generator to contract checklist, link to add-contract guide

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes (296 theorems, 9 categories, 5 axioms, 290 tests, 23 suites)
- [x] `python3 scripts/check_contract_structure.py` passes (7/7 contracts OK)
- [x] All changes are documentation-only — no code/logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; low risk aside from potentially confusing contributors if any referenced scripts/URLs are incorrect.
> 
> **Overview**
> Updates contributor and user docs to standardize the **new-contract workflow** around `scripts/generate_contract.py`, and adds/mentions the validation steps `check_contract_structure.py` and `check_doc_counts.py` in the relevant checklists.
> 
> Fixes a few stale documentation claims: clarifies `CryptoHash` has *no specs and no tests*, updates `llms.txt` CI/testing numbers (7 seeds, 70k+ differential tests), and adds a pointer from the docs landing page to the full “Add a Contract” guide.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7076e0a8215684ee8fe4d974039e29ed9718f40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->