### PR TITLE
docs: Fix stale axiom line numbers and core size, add CI validation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -147,6 +147,9 @@ jobs:
       - name: Check contract file structure
         run: python3 scripts/check_contract_structure.py
 
+      - name: Check axiom locations in AXIOMS.md
+        run: python3 scripts/check_axiom_locations.py
+
       - name: Check documentation counts
         run: python3 scripts/check_doc_counts.py
 

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -26,7 +26,7 @@ In these cases, we use axioms with strong soundness arguments.
 
 ### 1. `evalIRExpr_eq_evalYulExpr`
 
-**Location**: `Compiler/Proofs/YulGeneration/StatementEquivalence.lean:107`
+**Location**: `Compiler/Proofs/YulGeneration/StatementEquivalence.lean:43`
 
 **Statement**:
 ```lean
@@ -66,7 +66,7 @@ To eliminate this axiom, we would need to:
 
 ### 2. `evalIRExprs_eq_evalYulExprs`
 
-**Location**: `Compiler/Proofs/YulGeneration/StatementEquivalence.lean:111`
+**Location**: `Compiler/Proofs/YulGeneration/StatementEquivalence.lean:47`
 
 **Statement**:
 ```lean

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -1,6 +1,6 @@
 ---
 title: Core Architecture
-description: How the 234-line core works
+description: How the 249-line core works
 ---
 
 # Core Architecture

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -137,7 +137,7 @@ theorem store_retrieve : store 42 >> retrieve = pure 42 := by
 
 - **[Verification](/verification)** — Full theorem list by contract
 - **[Examples](/examples)** — The 9 contracts and what they demonstrate
-- **[Core](/core)** — How the 234-line EDSL works
+- **[Core](/core)** — How the 249-line EDSL works
 - **[Research](/research)** — Design decisions and proof techniques
 
 ## Learning Resources

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,7 +78,8 @@ These CI-critical scripts validate cross-layer consistency:
 
 - **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
 - **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, and Compiler layers; detects intra-contract slot collisions
-- **`check_doc_counts.py`** - Validates theorem, axiom, category, test, and suite counts in README.md, llms.txt, and TRUST_ASSUMPTIONS.md against actual codebase data
+- **`check_doc_counts.py`** - Validates theorem, axiom, category, test, suite counts and core size in README.md, llms.txt, core.mdx, index.mdx, and TRUST_ASSUMPTIONS.md against actual codebase data
+- **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
 
 ```bash
@@ -136,7 +137,8 @@ All verification scripts run automatically in GitHub Actions (`verify.yml`):
 4. Yul compilation check
 5. Storage layout consistency validation
 6. Contract file structure validation
-7. Documentation count validation
+7. Axiom location validation
+8. Documentation count validation
 8. Coverage reports in workflow summary
 
 ## Adding New Property Tests

--- a/scripts/check_axiom_locations.py
+++ b/scripts/check_axiom_locations.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Check that AXIOMS.md references correct line numbers for axiom declarations.
+
+Parses AXIOMS.md for location patterns like `File.lean:NN` and verifies each
+axiom actually appears at the claimed line number in the source file.
+
+Usage:
+    python3 scripts/check_axiom_locations.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    axioms_md = ROOT / "AXIOMS.md"
+    if not axioms_md.exists():
+        print("AXIOMS.md not found", file=sys.stderr)
+        raise SystemExit(1)
+
+    text = axioms_md.read_text(encoding="utf-8")
+
+    # Match patterns like: ### N. `axiom_name`
+    # followed by **Location**: `path/to/File.lean:NN`
+    axiom_blocks = re.findall(
+        r"### \d+\.\s+`(\w+)`\s*\n\n"
+        r"\*\*Location\*\*:\s*`([^:]+):(\d+)`",
+        text,
+    )
+
+    if not axiom_blocks:
+        print("No axiom location entries found in AXIOMS.md", file=sys.stderr)
+        raise SystemExit(1)
+
+    errors: list[str] = []
+    checked = 0
+
+    for axiom_name, rel_path, claimed_line_str in axiom_blocks:
+        claimed_line = int(claimed_line_str)
+        source_file = ROOT / rel_path
+
+        if not source_file.exists():
+            errors.append(f"{axiom_name}: file {rel_path} not found")
+            continue
+
+        lines = source_file.read_text(encoding="utf-8").splitlines()
+
+        # Find actual line number for this axiom
+        actual_line = None
+        for i, line in enumerate(lines, 1):
+            if re.match(rf"^axiom\s+{re.escape(axiom_name)}\b", line):
+                actual_line = i
+                break
+
+        if actual_line is None:
+            errors.append(
+                f"{axiom_name}: not found in {rel_path} "
+                f"(AXIOMS.md claims line {claimed_line})"
+            )
+        elif actual_line != claimed_line:
+            errors.append(
+                f"{axiom_name}: AXIOMS.md says line {claimed_line} "
+                f"but actually at line {actual_line} in {rel_path}"
+            )
+        else:
+            print(f"  OK {axiom_name} at {rel_path}:{actual_line}")
+            checked += 1
+
+    if errors:
+        print("\nAxiom location check FAILED:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        raise SystemExit(1)
+
+    print(f"\nOK: All {checked} axiom locations in AXIOMS.md are accurate")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -52,6 +52,12 @@ def get_test_counts() -> tuple[int, int]:
     return test_count, suite_count
 
 
+def get_core_line_count() -> int:
+    """Count lines in DumbContracts/Core.lean."""
+    core = ROOT / "DumbContracts" / "Core.lean"
+    return len(core.read_text(encoding="utf-8").splitlines())
+
+
 def check_file(path: Path, checks: list[tuple[str, re.Pattern, str]]) -> list[str]:
     """Check a file for expected patterns. Returns list of errors."""
     if not path.exists():
@@ -73,6 +79,7 @@ def main() -> None:
     total_theorems, num_categories, _ = get_manifest_counts()
     axiom_count = get_axiom_count()
     test_count, suite_count = get_test_counts()
+    core_lines = get_core_line_count()
 
     errors: list[str] = []
 
@@ -166,6 +173,34 @@ def main() -> None:
                     "axiom count in verification chain",
                     re.compile(r"FULLY VERIFIED, (\d+) axioms"),
                     str(axiom_count),
+                ),
+            ],
+        )
+    )
+
+    # Check core size claims
+    core_mdx = ROOT / "docs-site" / "content" / "core.mdx"
+    errors.extend(
+        check_file(
+            core_mdx,
+            [
+                (
+                    "core line count",
+                    re.compile(r"the (\d+)-line core"),
+                    str(core_lines),
+                ),
+            ],
+        )
+    )
+    index_mdx = ROOT / "docs-site" / "content" / "index.mdx"
+    errors.extend(
+        check_file(
+            index_mdx,
+            [
+                (
+                    "core line count",
+                    re.compile(r"the (\d+)-line EDSL"),
+                    str(core_lines),
                 ),
             ],
         )


### PR DESCRIPTION
## Summary
- **AXIOMS.md**: Fix stale line references — `evalIRExpr_eq_evalYulExpr` claimed line 107 but is actually at line 43, `evalIRExprs_eq_evalYulExprs` claimed line 111 but is at line 47
- **core.mdx, index.mdx**: Fix core size claim (234→249 lines) to match actual `DumbContracts/Core.lean`
- **New `scripts/check_axiom_locations.py`**: CI validation that AXIOMS.md line numbers match actual axiom positions — prevents future drift
- **`scripts/check_doc_counts.py`**: Extended to validate core size claims in core.mdx and index.mdx
- **`verify.yml`**: Added axiom location check step
- **`scripts/README.md`**: Documented new validation script

## Test plan
- [x] `python3 scripts/check_axiom_locations.py` passes (5/5 axioms verified)
- [x] `python3 scripts/check_doc_counts.py` passes (296 theorems, 9 categories, 5 axioms, 290 tests, 23 suites)
- [x] `python3 scripts/check_contract_structure.py` passes (7/7 contracts OK)
- [x] All changes are documentation fixes + new validation script — no Lean/Solidity code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI validation-only changes; no Lean/Solidity logic is modified, with the main risk being CI false positives if formats/paths change.
> 
> **Overview**
> Fixes stale `AXIOMS.md` `**Location**` line numbers for the Yul/IR evaluation axioms and updates docs to reflect the current `DumbContracts/Core.lean` size (234→249 lines).
> 
> Adds new `scripts/check_axiom_locations.py` and wires it into `verify.yml` so CI fails if `AXIOMS.md`’s `File.lean:NN` references drift, and extends `scripts/check_doc_counts.py` to also validate the core line-count claims in `core.mdx` and `index.mdx` (with updated script docs in `scripts/README.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1567891e4c6f2df823a5c8e9b469f799875711c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->