### PR TITLE
docs: Fix stale issue refs, yul-new paths, test count, and CI paths

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,6 +13,7 @@ on:
       - 'scripts/**'
       - 'lakefile.lean'
       - 'lean-toolchain'
+      - 'AXIOMS.md'
   pull_request:
     paths:
       - 'DumbContracts/**'
@@ -24,6 +25,7 @@ on:
       - 'scripts/**'
       - 'lakefile.lean'
       - 'lean-toolchain'
+      - 'AXIOMS.md'
   workflow_dispatch:
 
 jobs:

--- a/Compiler/Proofs/README.md
+++ b/Compiler/Proofs/README.md
@@ -23,7 +23,7 @@ lake build                                           # Build everything
 lake build DumbContracts.Specs.SimpleStorage.Proofs  # Build one contract's proofs
 ```
 
-Expected warnings: `sorry` from `DumbContracts.Specs.Ledger.SumProofs` and `DumbContracts.Specs.Common.Sum` (WIP sum properties, Issue #39).
+Expected warnings: `sorry` from `DumbContracts.Specs.Ledger.SumProofs` and `DumbContracts.Specs.Common.Sum` (sum property proofs, Issue #65).
 
 ## Infrastructure
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -266,7 +266,7 @@ lake build dumbcontracts-compiler
 # Generate Yul for all contracts
 lake exe dumbcontracts-compiler
 
-# Output: compiler/yul-new/*.yul
+# Output: compiler/yul/*.yul
 ```
 
 ### Test Compiled Contracts
@@ -303,7 +303,7 @@ lake build dumbcontracts-compiler
 lake exe dumbcontracts-compiler
 ```
 
-3. **Done!** Contract generated in `compiler/yul-new/MyContract.yul`
+3. **Done!** Contract generated in `compiler/yul/MyContract.yul`
 
 Time: **~5 minutes** (vs ~30 minutes manual IR)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,7 @@
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
 - ✅ **Property Testing**: 70% coverage (207/296), all testable properties covered
-- ✅ **Differential Testing**: Production-ready with 10k+ tests
+- ✅ **Differential Testing**: Production-ready with 70k+ tests
 - ✅ **Trust Reduction Phase 1**: keccak256 axiom + CI validation (PR #43, #46)
 - ✅ **External Linking**: Cryptographic library support (PR #49)
 
@@ -35,7 +35,7 @@
 
 ### 🟢 **Ledger Sum Properties** (7 Properties)
 **What**: Prove total supply equals sum of all balances
-**Status**: Infrastructure complete (PR #47, #51), proofs pending (Issue #39)
+**Status**: Infrastructure complete (PR #47, #51, Issue #39 closed), proofs pending (Issue #65)
 **Remaining**: Complete 7 theorem proofs (~10-14 days Lean expertise)
 
 | # | Property | Description |
@@ -114,7 +114,7 @@
 - ✅ Complete Layer 3 statement-level proofs (PR #42)
 - ✅ Function selector verification (PR #43, #46)
 - ✅ Ledger sum properties infrastructure (PR #47, #51)
-- 🔄 Complete sum property proofs (Issue #39 - requires Lean expertise)
+- 🔄 Complete sum property proofs (Issue #65 - requires Lean expertise)
 - 🔄 Yul → EVM bridge investigation
 
 **Success Metrics**:

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -235,7 +235,8 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ### Short Term (1-2 months)
 
-- [ ] Add finite address set modeling for Ledger sum properties (Issue #39)
+- [x] Add finite address set modeling for Ledger sum properties (Issue #39, closed)
+- [ ] Complete Ledger sum property proofs — 12 `sorry` remaining (Issue #65)
 
 ### Medium Term (3-6 months)
 


### PR DESCRIPTION
## Summary
- **Issue #39 references (4 files)**: Issue #39 (finite address set modeling) was closed, but docs still referenced it as pending/WIP. Updated VERIFICATION_STATUS.md, ROADMAP.md, and Compiler/Proofs/README.md to point to Issue #65 (the actual remaining work: sum property proofs with 12 `sorry`)
- **compiler.mdx**: Fixed 2 stale references to `compiler/yul-new/` directory (removed in PR #109) → `compiler/yul/`
- **ROADMAP.md**: Fixed differential test count claim (10k+ → 70k+) to match README
- **verify.yml**: Added `AXIOMS.md` to CI path filters so `check_axiom_locations.py` runs when AXIOMS.md is modified directly

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] `python3 scripts/check_axiom_locations.py` passes (5/5 axioms)
- [x] `python3 scripts/check_contract_structure.py` passes (7/7 contracts)
- [x] All changes are documentation fixes + CI config — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation corrections and a CI path-filter tweak; no runtime or proof logic changes.
> 
> **Overview**
> Updates documentation to remove stale references: points Ledger sum-property work to Issue #65 (and marks Issue #39 as closed), corrects the generated Yul output path from `compiler/yul-new/` to `compiler/yul/`, and updates the differential testing claim to 70k+ tests.
> 
> Adjusts the `verify` GitHub Actions workflow path filters to include `AXIOMS.md`, ensuring CI verification jobs run when the axiom documentation is edited.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab92e028c43e2bc14dd8f11f6cb2e393b16141b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->