### PR TITLE
fix: Standardize PRNG across differential tests, fix doc typos

### DIFF
--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -15,7 +15,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 ## Quick Facts
 
 - **Language**: Lean 4.15.0
-- **Core Size**: Small (few hundred lines)
+- **Core Size**: 249 lines
 - **Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, CryptoHash, ReentrancyExample
 - **Theorems**: 296 across 9 categories (284 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
 - **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, address injectivity

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -139,7 +139,7 @@ All verification scripts run automatically in GitHub Actions (`verify.yml`):
 6. Contract file structure validation
 7. Axiom location validation
 8. Documentation count validation
-8. Coverage reports in workflow summary
+9. Coverage reports in workflow summary
 
 ## Adding New Property Tests
 

--- a/test/DifferentialOwned.t.sol
+++ b/test/DifferentialOwned.t.sol
@@ -435,7 +435,7 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig {
 
         seed = _skipRandom(seed, startIndex);
         for (uint256 i = 0; i < numTransactions; i++) {
-            seed = _prng(seed);
+            seed = _lcg(seed);
             uint256 txType = seed % 100;
 
             address sender;
@@ -444,14 +444,14 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig {
             if (txType < 60) {
                 // 60% transferOwnership
                 sender = edslStorageAddr[0];  // Current owner
-                seed = _prng(seed);
+                seed = _lcg(seed);
                 arg0 = uint256(uint160(testAddresses[seed % testAddresses.length]));
 
                 bool success = executeDifferentialTest("transferOwnership", sender, arg0);
                 _assertRandomSuccess(success, startIndex + i);
             } else {
                 // 40% getOwner
-                seed = _prng(seed);
+                seed = _lcg(seed);
                 sender = testAddresses[seed % testAddresses.length];
                 arg0 = 0;
 
@@ -483,7 +483,7 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig {
 
         seed = _skipRandom(seed, startIndex);
         for (uint256 i = 0; i < numTransactions; i++) {
-            seed = _prng(seed);
+            seed = _lcg(seed);
             uint256 txType = seed % 100;
 
             address sender;
@@ -492,14 +492,14 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig {
             if (txType < 60) {
                 // 60% transferOwnership
                 sender = edslStorageAddr[0];  // Current owner
-                seed = _prng(seed);
+                seed = _lcg(seed);
                 arg0 = uint256(uint160(testAddresses[seed % testAddresses.length]));
 
                 bool success = executeDifferentialTest("transferOwnership", sender, arg0);
                 _assertRandomSuccess(success, startIndex + i);
             } else {
                 // 40% getOwner
-                seed = _prng(seed);
+                seed = _lcg(seed);
                 sender = testAddresses[seed % testAddresses.length];
                 arg0 = 0;
 
@@ -516,17 +516,10 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig {
 
     // ========== Helper Functions ==========
 
-    /**
-     * @notice Simple PRNG for reproducible random testing
-     */
-    function _prng(uint256 seed) internal pure returns (uint256) {
-        return uint256(keccak256(abi.encodePacked(seed))) % (2**32);
-    }
-
     function _skipRandom(uint256 seed, uint256 iterations) internal pure returns (uint256) {
         for (uint256 i = 0; i < iterations; i++) {
-            seed = _prng(seed);
-            seed = _prng(seed);
+            seed = _lcg(seed);
+            seed = _lcg(seed);
         }
         return seed;
     }

--- a/test/DifferentialTestBase.sol
+++ b/test/DifferentialTestBase.sol
@@ -216,11 +216,8 @@ abstract contract DifferentialTestBase {
      * @dev Used for deterministic random test generation
      */
     function _prng(uint256 seed) internal pure returns (uint256) {
-        // LCG parameters (Glibc-style; DiffTestConfig._lcg uses different constants)
-        uint256 a = 1664525;
-        uint256 c = 1013904223;
-        uint256 m = 2 ** 31;
-        return (a * seed + c) % m;
+        // LCG parameters — matches DiffTestConfig._lcg() for consistency
+        return (1103515245 * seed + 12345) % (2 ** 31);
     }
 
     /**


### PR DESCRIPTION
## Summary
- **DifferentialOwned.t.sol**: Replaced local keccak256-based `_prng()` with `_lcg()` from `DiffTestConfig`. Previously, DifferentialOwned used `keccak256(seed) % 2^32` while all other differential tests (Counter, SafeCounter, SimpleStorage, Ledger, OwnedCounter, SimpleToken) use the shared LCG from DiffTestConfig (`(1103515245 * seed + 12345) % 2^31`). This caused inconsistent random sequences with the same seed across test suites.
- **DifferentialTestBase.sol**: Aligned `_prng()` LCG constants with `DiffTestConfig._lcg()`. Was using different Glibc-style constants (`a=1664525, c=1013904223`) while DiffTestConfig uses POSIX constants (`a=1103515245, c=12345`). Now both produce identical sequences.
- **scripts/README.md**: Fixed duplicate item "8" in CI Integration list (→ "9")
- **llms.txt**: Replaced vague "Small (few hundred lines)" core size with precise "249 lines" matching `core.mdx` and `check_doc_counts.py` validation

## Test plan
- [x] `forge build` compiles without errors
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] PRNG change produces different random sequences but all tests are seed-independent (they validate EVM↔EDSL equivalence, not specific values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation-only changes; the main impact is different (but still deterministic) random sequences, which could expose latent test flakiness but doesn’t affect production code.
> 
> **Overview**
> Standardizes deterministic random generation in differential tests by switching `DifferentialOwned.t.sol` from a bespoke keccak-based `_prng` to the shared `_lcg`, and by updating `DifferentialTestBase._prng` to use the same LCG constants as `DiffTestConfig` so seeds produce consistent sequences across suites.
> 
> Fixes minor documentation inconsistencies: corrects the CI integration step numbering in `scripts/README.md` and replaces an imprecise core size description with an exact value in `docs-site/public/llms.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cefc119e162e90744036f87faa565f28859c09c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->