### PR TITLE
fix: Replace inline LCG with _lcg(), remove dead code

### DIFF
--- a/test/DifferentialLedger.t.sol
+++ b/test/DifferentialLedger.t.sol
@@ -566,11 +566,10 @@ contract DifferentialLedger is YulTestBase, DiffTestConfig {
         pure
         returns (string memory funcName, address sender, address recipient, uint256 amount)
     {
-        // PRNG (simple LCG)
-        uint256 rand1 = (seed * 1103515245 + 12345) % (2**31);
-        uint256 rand2 = (rand1 * 1103515245 + 12345) % (2**31);
-        uint256 rand3 = (rand2 * 1103515245 + 12345) % (2**31);
-        uint256 rand4 = (rand3 * 1103515245 + 12345) % (2**31);
+        uint256 rand1 = _lcg(seed);
+        uint256 rand2 = _lcg(rand1);
+        uint256 rand3 = _lcg(rand2);
+        uint256 rand4 = _lcg(rand3);
 
         // Choose function (40% deposit, 20% withdraw, 30% transfer, 10% getBalance)
         uint256 funcChoice = rand1 % 100;

--- a/test/DifferentialOwnedCounter.t.sol
+++ b/test/DifferentialOwnedCounter.t.sol
@@ -614,10 +614,9 @@ contract DifferentialOwnedCounter is YulTestBase, DiffTestConfig {
         view
         returns (string memory funcName, address sender, uint256 arg)
     {
-        // PRNG (simple LCG)
-        uint256 rand1 = (seed * 1103515245 + 12345) % (2**31);
-        uint256 rand2 = (rand1 * 1103515245 + 12345) % (2**31);
-        uint256 rand3 = (rand2 * 1103515245 + 12345) % (2**31);
+        uint256 rand1 = _lcg(seed);
+        uint256 rand2 = _lcg(rand1);
+        uint256 rand3 = _lcg(rand2);
 
         // Choose function (30% increment, 25% decrement, 20% getCount, 15% getOwner, 10% transferOwnership)
         uint256 funcChoice = rand1 % 100;

--- a/test/DifferentialSimpleStorage.t.sol
+++ b/test/DifferentialSimpleStorage.t.sol
@@ -355,27 +355,7 @@ contract DifferentialSimpleStorage is YulTestBase, DiffTestConfig {
      * @notice Execute N random transactions via random-gen
      */
     function _runRandomDifferentialTests(uint256 startIndex, uint256 count, uint256 seed) internal {
-        // Generate random transactions via Lean random-gen (disabled - use inline PRNG for CI)
-        // string[] memory inputs = new string[](3);
-        // inputs[0] = "bash";
-        // inputs[1] = "-c";
-        // inputs[2] = string.concat(
-        //     "export PATH=\"$HOME/.elan/bin:$PATH\" && lake exe random-gen SimpleStorage ",
-        //     vm.toString(count),
-        //     " ",
-        //     vm.toString(seed)
-        // );
-        // bytes memory txJsonBytes = vm.ffi(inputs);
-        // string memory txJson = string(txJsonBytes);
-
         console2.log("Generated", count, "random transactions");
-
-        // Parse JSON array and execute each transaction
-        // JSON format: [{"sender":"0xAlice","function":"store","args":[42]}, ...]
-        // For simplicity, we'll just split by transactions and parse manually
-
-        // For now, execute a simpler approach: generate them one-by-one inline
-        // This avoids complex JSON parsing in Solidity
 
         uint256 prng = _skipRandom(seed, startIndex);
         vm.pauseGasMetering();

--- a/test/DifferentialSimpleToken.t.sol
+++ b/test/DifferentialSimpleToken.t.sol
@@ -816,11 +816,10 @@ contract DifferentialSimpleToken is YulTestBase, DiffTestConfig {
         view
         returns (string memory funcName, address sender, address recipient, uint256 amount)
     {
-        // PRNG (simple LCG)
-        uint256 rand1 = (seed * 1103515245 + 12345) % (2**31);
-        uint256 rand2 = (rand1 * 1103515245 + 12345) % (2**31);
-        uint256 rand3 = (rand2 * 1103515245 + 12345) % (2**31);
-        uint256 rand4 = (rand3 * 1103515245 + 12345) % (2**31);
+        uint256 rand1 = _lcg(seed);
+        uint256 rand2 = _lcg(rand1);
+        uint256 rand3 = _lcg(rand2);
+        uint256 rand4 = _lcg(rand3);
 
         // Choose function (30% mint, 30% transfer, 20% balanceOf, 10% totalSupply, 10% owner)
         uint256 funcChoice = rand1 % 100;

--- a/test/DifferentialTestBase.sol
+++ b/test/DifferentialTestBase.sol
@@ -212,26 +212,6 @@ abstract contract DifferentialTestBase {
     }
 
     /**
-     * @notice Linear congruential generator for pseudo-random numbers
-     * @dev Used for deterministic random test generation
-     */
-    function _prng(uint256 seed) internal pure returns (uint256) {
-        // LCG parameters — matches DiffTestConfig._lcg() for consistency
-        return (1103515245 * seed + 12345) % (2 ** 31);
-    }
-
-    /**
-     * @notice Skip forward N iterations of PRNG
-     */
-    function _skipRandom(uint256 seed, uint256 iterations) internal pure returns (uint256) {
-        uint256 current = seed;
-        for (uint i = 0; i < iterations; i++) {
-            current = _prng(current);
-        }
-        return current;
-    }
-
-    /**
      * @notice Convert index to deterministic address
      */
     function _indexToAddress(uint256 index) internal pure returns (address) {


### PR DESCRIPTION
## Summary
- Replace inline LCG arithmetic (`seed * 1103515245 + 12345) % (2**31)`) with `_lcg()` from `DiffTestConfig` in 3 differential test files, completing the standardization started in PR #119
- Remove dead `_prng()`/`_skipRandom()` from `DifferentialTestBase` (unused — `DifferentialCounter`, the only inheritor, uses its own `_skipRandomLcg()`)
- Remove 20-line commented-out Lean random-gen block from `DifferentialSimpleStorage` (disabled code from old approach)

**Files changed (5), net -43 lines:**
- `test/DifferentialOwnedCounter.t.sol` — inline LCG → `_lcg()`
- `test/DifferentialLedger.t.sol` — inline LCG → `_lcg()`
- `test/DifferentialSimpleToken.t.sol` — inline LCG → `_lcg()`
- `test/DifferentialTestBase.sol` — remove dead `_prng()`/`_skipRandom()`
- `test/DifferentialSimpleStorage.t.sol` — remove commented-out code

## Test plan
- [x] `forge build` compiles successfully
- [x] `check_doc_counts.py` passes (290 tests, 23 suites)
- [x] No remaining inline LCG constants outside `DiffTestConfig._lcg()`
- [ ] CI: 8-shard Foundry + 7-seed multi-seed tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors that consolidate PRNG logic and remove dead/commented code; low risk aside from potentially changing deterministic random sequences if `_lcg()` semantics ever diverge.
> 
> **Overview**
> Standardizes random transaction generation in differential tests by replacing duplicated inline LCG arithmetic with calls to shared `DiffTestConfig._lcg()` in `DifferentialLedger`, `DifferentialOwnedCounter`, and `DifferentialSimpleToken`.
> 
> Cleans up test utilities by deleting unused `_prng()`/`_skipRandom()` helpers from `DifferentialTestBase` and removing a large commented-out (disabled) Lean `random-gen` block from `DifferentialSimpleStorage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f51f645ae33969ffc71627dbfbc751005c90f304. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->