### PR TITLE
fix: Update package-lock.json name to verity-docs

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dumbcontracts-docs",
+  "name": "verity-docs",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dumbcontracts-docs",
+      "name": "verity-docs",
       "version": "0.1.0",
       "dependencies": {
         "@mdx-js/loader": "^3.1.1",


### PR DESCRIPTION
Completes the Verity rebrand by regenerating `package-lock.json` to match the updated `package.json` name.

## Changes
- Regenerated `docs-site/package-lock.json` via `npm install`
- Updates package name from `dumbcontracts-docs` to `verity-docs`

## Context
The main rebrand PRs (#125, #129, #130) updated `package.json` but `package-lock.json` retained the old name. This regenerates the lockfile to complete the transition.

## Verification
```bash
grep '"name"' docs-site/package-lock.json
# Shows: "name": "verity-docs"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile metadata-only change; minimal risk aside from potential noise if the regenerated lockfile differs unexpectedly.
> 
> **Overview**
> Updates `docs-site/package-lock.json` to rename the root package from `dumbcontracts-docs` to `verity-docs`, aligning the lockfile with the rebranded `package.json`.
> 
> No dependency graph or runtime code changes are introduced beyond the lockfile metadata update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5758c44a31b105c7cd66be2ba0a7ba42420cbb48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->