### PR TITLE
refactor: Fix remaining DumbContracts references missed in rebrand

### DIFF
--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -1,5 +1,5 @@
 /-
-  Dumb Contracts: Minimal EDSL Core
+  Verity: Minimal EDSL Core
 
   This module defines the essential types and primitives for smart contracts.
   Philosophy: Keep it minimal - only add what examples actually need.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -87,13 +87,13 @@ The GitHub Actions workflow validates:
 
 ## Documentation URLs
 
-- Main: https://dumbcontracts.thomasm.ar/
-- Verification: https://dumbcontracts.thomasm.ar/verification
-- Research: https://dumbcontracts.thomasm.ar/research
-- Examples: https://dumbcontracts.thomasm.ar/examples
-- Core: https://dumbcontracts.thomasm.ar/core
-- Compiler: https://dumbcontracts.thomasm.ar/compiler
-- Guides: https://dumbcontracts.thomasm.ar/guides/first-contract
+- Main: https://verity.thomasm.ar/
+- Verification: https://verity.thomasm.ar/verification
+- Research: https://verity.thomasm.ar/research
+- Examples: https://verity.thomasm.ar/examples
+- Core: https://verity.thomasm.ar/core
+- Compiler: https://verity.thomasm.ar/compiler
+- Guides: https://verity.thomasm.ar/guides/first-contract
 
 Add `.md` to any URL for raw markdown (saves tokens).
 

--- a/examples/solidity/ReentrancyExample.sol
+++ b/examples/solidity/ReentrancyExample.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 /// @notice Demonstrates a reentrancy vulnerability where totalSupply is
 ///         decremented twice (modeling a reentrant callback) before the
 ///         balance is updated once. This breaks the supply invariant.
-/// @dev Matches the Lean EDSL model in DumbContracts/Examples/ReentrancyExample.lean
+/// @dev Matches the Lean EDSL model in Verity/Examples/ReentrancyExample.lean
 contract VulnerableBank {
     // Storage layout matches EDSL:
     // slot 0: reentrancyLock (unused in vulnerable version)

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,5 +1,5 @@
 {"version": "1.1.0",
  "packagesDir": ".lake/packages",
  "packages": [],
- "name": "«dumb-contracts»",
+ "name": "«verity»",
  "lakeDir": ".lake"}

--- a/test/PropertyCounter.t.sol
+++ b/test/PropertyCounter.t.sol
@@ -6,7 +6,7 @@ import "./yul/YulTestBase.sol";
 /**
  * @title PropertyCounterTest
  * @notice Property-based tests extracted from formally verified Lean theorems
- * @dev Maps theorems from DumbContracts/Proofs/Counter/Correctness.lean to executable tests
+ * @dev Maps theorems from Verity/Proofs/Counter/Correctness.lean to executable tests
  *
  * This file contains 10 property tests corresponding to 10 proven theorems:
  * 1. increment_state_preserved_except_count

--- a/test/PropertyLedger.t.sol
+++ b/test/PropertyLedger.t.sol
@@ -6,7 +6,7 @@ import "./yul/YulTestBase.sol";
 /**
  * @title PropertyLedgerTest
  * @notice Property-based tests extracted from formally verified Lean theorems
- * @dev Maps theorems from DumbContracts/Proofs/Ledger/*.lean to executable tests
+ * @dev Maps theorems from Verity/Proofs/Ledger/*.lean to executable tests
  *
  * This file contains property tests for Ledger's 31 proven theorems:
  *

--- a/test/PropertyOwned.t.sol
+++ b/test/PropertyOwned.t.sol
@@ -6,7 +6,7 @@ import "./yul/YulTestBase.sol";
 /**
  * @title PropertyOwnedTest
  * @notice Property-based tests extracted from formally verified Lean theorems
- * @dev Maps theorems from DumbContracts/Proofs/Owned/ to executable tests
+ * @dev Maps theorems from Verity/Proofs/Owned/ to executable tests
  *
  * This file contains property tests corresponding to 22 proven theorems:
  *

--- a/test/PropertyOwnedCounter.t.sol
+++ b/test/PropertyOwnedCounter.t.sol
@@ -6,7 +6,7 @@ import "./yul/YulTestBase.sol";
 /**
  * @title PropertyOwnedCounterTest
  * @notice Property-based tests extracted from formally verified Lean theorems
- * @dev Maps theorems from DumbContracts/Proofs/OwnedCounter/*.lean to executable tests
+ * @dev Maps theorems from Verity/Proofs/OwnedCounter/*.lean to executable tests
  *
  * This file extracts 48 proven theorems into Foundry property tests:
  * - Basic properties (correctness, state preservation)

--- a/test/PropertyReentrancyExample.t.sol
+++ b/test/PropertyReentrancyExample.t.sol
@@ -7,7 +7,7 @@ import "../examples/solidity/ReentrancyExample.sol";
 /**
  * @title PropertyReentrancyExampleTest
  * @notice Property-based tests for the reentrancy example contracts
- * @dev Maps theorems from DumbContracts/Examples/ReentrancyExample.lean to executable tests
+ * @dev Maps theorems from Verity/Examples/ReentrancyExample.lean to executable tests
  *
  * These tests validate proven Lean theorems against Solidity implementations:
  *

--- a/test/PropertySafeCounter.t.sol
+++ b/test/PropertySafeCounter.t.sol
@@ -6,7 +6,7 @@ import "./yul/YulTestBase.sol";
 /**
  * @title PropertySafeCounterTest
  * @notice Property-based tests extracted from formally verified Lean theorems
- * @dev Maps theorems from DumbContracts/Proofs/SafeCounter/*.lean to executable tests
+ * @dev Maps theorems from Verity/Proofs/SafeCounter/*.lean to executable tests
  *
  * This file contains property tests for SafeCounter's 25 proven theorems:
  *

--- a/test/PropertySimpleStorage.t.sol
+++ b/test/PropertySimpleStorage.t.sol
@@ -6,7 +6,7 @@ import "./yul/YulTestBase.sol";
 /**
  * @title PropertySimpleStorageTest
  * @notice Property-based tests extracted from formally verified Lean theorems
- * @dev Maps theorems from DumbContracts/Proofs/SimpleStorage/ to executable tests
+ * @dev Maps theorems from Verity/Proofs/SimpleStorage/ to executable tests
  *
  * This file contains property tests corresponding to 19 proven theorems:
  *

--- a/test/PropertySimpleToken.t.sol
+++ b/test/PropertySimpleToken.t.sol
@@ -6,7 +6,7 @@ import "./yul/YulTestBase.sol";
 /**
  * @title PropertySimpleTokenTest
  * @notice Property-based tests extracted from formally verified Lean theorems
- * @dev Maps theorems from DumbContracts/Proofs/SimpleToken/*.lean to executable tests
+ * @dev Maps theorems from Verity/Proofs/SimpleToken/*.lean to executable tests
  *
  * This file extracts 57 proven theorems into Foundry property tests:
  * - Basic properties (constructor, mint, transfer, getters)


### PR DESCRIPTION
## Summary

- Fix 12 files still referencing the old "DumbContracts" name after the Verity rebrand (#121, #125, #129)
- `lake-manifest.json` package name was still `«dumb-contracts»` (now `«verity»`, matching `lakefile.lean`)
- 8 property test `@dev` comments still referenced `DumbContracts/Proofs/...` paths (now `Verity/Proofs/...`)
- `ReentrancyExample.sol` `@dev` comment still referenced `DumbContracts/Examples/...`
- `llms.txt` documentation URLs still used `dumbcontracts.thomasm.ar` (now `verity.thomasm.ar`)
- `Verity/Core.lean` header still said "Dumb Contracts" (now "Verity")

No code logic changes — only comments, config, and documentation strings.

## Test plan

- [ ] CI passes (no Lean, Solidity, or script changes affect behavior)
- [ ] `grep -ri "dumbcontracts\|dumb-contracts\|DumbContracts" --include="*.lean" --include="*.sol" --include="*.json" --include="*.txt"` returns only the intentional README philosophy section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String/comment and package-metadata updates only; no runtime or proof logic changes, so risk is limited to potential naming/mislinking issues.
> 
> **Overview**
> Updates leftover rebrand references from *DumbContracts* to *Verity* across the repo: the `Verity/Core.lean` header, `lake-manifest.json` package name, documentation URLs in `docs-site/public/llms.txt`, and various `@dev` path comments in Solidity examples and Foundry property tests.
> 
> No functional code or proof logic changes; this is purely documentation/config string cleanup to align with the new project name and site domain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaad50ec0c2f936c97612f5ba7799d019dec4db4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->