### PR TITLE
ci: Centralize solc version and cache binary across jobs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,6 +28,10 @@ on:
       - 'AXIOMS.md'
   workflow_dispatch:
 
+env:
+  SOLC_VERSION: "0.8.33"
+  SOLC_URL: "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -122,11 +126,21 @@ jobs:
       - name: Validate Selectors.lean axiom definitions
         run: python3 scripts/validate_selectors.py
 
+      - name: Cache solc binary
+        id: cache-solc
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/solc
+          key: solc-${{ env.SOLC_VERSION }}
+
       - name: Install solc
+        if: steps.cache-solc.outputs.cache-hit != 'true'
         run: |
-          sudo curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21 -o /usr/local/bin/solc
+          sudo curl -L "$SOLC_URL" -o /usr/local/bin/solc
           sudo chmod +x /usr/local/bin/solc
-          solc --version
+
+      - name: Verify solc
+        run: solc --version
 
       - name: Compile generated Yul with solc
         run: python3 scripts/check_yul_compiles.py
@@ -207,11 +221,21 @@ jobs:
         with:
           version: v1.5.0
 
+      - name: Cache solc binary
+        id: cache-solc
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/solc
+          key: solc-${{ env.SOLC_VERSION }}
+
       - name: Install solc
+        if: steps.cache-solc.outputs.cache-hit != 'true'
         run: |
-          sudo curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21 -o /usr/local/bin/solc
+          sudo curl -L "$SOLC_URL" -o /usr/local/bin/solc
           sudo chmod +x /usr/local/bin/solc
-          solc --version
+
+      - name: Verify solc
+        run: solc --version
 
       - name: Run Foundry tests with seed 42
         env:
@@ -259,11 +283,21 @@ jobs:
         with:
           version: v1.5.0
 
+      - name: Cache solc binary
+        id: cache-solc
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/solc
+          key: solc-${{ env.SOLC_VERSION }}
+
       - name: Install solc
+        if: steps.cache-solc.outputs.cache-hit != 'true'
         run: |
-          sudo curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21 -o /usr/local/bin/solc
+          sudo curl -L "$SOLC_URL" -o /usr/local/bin/solc
           sudo chmod +x /usr/local/bin/solc
-          solc --version
+
+      - name: Verify solc
+        run: solc --version
 
       - name: Run tests with seed ${{ matrix.seed }}
         env:


### PR DESCRIPTION
## Summary

- Eliminate triple duplication of solc installation across 3 CI jobs (build, foundry, foundry-multi-seed)
- Add top-level `env` block with `SOLC_VERSION` and `SOLC_URL` — upgrading solc now requires changing **1 line** instead of 3
- Cache the solc binary via `actions/cache@v4` keyed by version — on cache hit, skip the download entirely
- Separate "Install solc" (conditional) from "Verify solc" (always runs) for clearer CI logs

## Before

```yaml
# Repeated identically in build, foundry, foundry-multi-seed jobs:
- name: Install solc
  run: |
    sudo curl -L https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21 -o /usr/local/bin/solc
    sudo chmod +x /usr/local/bin/solc
    solc --version
```

**Problems**: 3 identical downloads per CI run, hardcoded URL in 3 places, version upgrade requires 3 edits.

## After

```yaml
env:
  SOLC_VERSION: "0.8.33"
  SOLC_URL: "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21"

# In each job:
- name: Cache solc binary
  uses: actions/cache@v4
  with:
    path: /usr/local/bin/solc
    key: solc-${{ env.SOLC_VERSION }}

- name: Install solc
  if: steps.cache-solc.outputs.cache-hit != 'true'
  run: sudo curl -L "$SOLC_URL" -o /usr/local/bin/solc && sudo chmod +x /usr/local/bin/solc
```

**Benefits**: Single source of truth for version, cache eliminates redundant downloads, cleaner CI logs.

## Test plan

- [ ] All CI jobs pass (build, foundry shards, multi-seed)
- [ ] solc version correctly reported in all 3 jobs
- [ ] Cache hit on subsequent runs (verify in Actions logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that mainly affect CI speed and logging; risk is limited to potential cache/path misconfiguration causing CI failures.
> 
> **Overview**
> Centralizes Solidity compiler configuration in `verify.yml` by adding top-level `SOLC_VERSION`/`SOLC_URL` env vars and replacing hardcoded download URLs across jobs.
> 
> Adds an `actions/cache@v4` step to cache `/usr/local/bin/solc` keyed by version, makes installation conditional on cache misses, and splits out an always-run `Verify solc` step for clearer logs in `build`, `foundry`, and `foundry-multi-seed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcc5fa1ccef7fbfe9e389eb67c0a244fa60df9f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->