### PR TITLE
test: Add sum conservation property tests for Ledger and SimpleToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ theorem v3_correct : semantics transfer_v3 = transfer_spec
 | ReentrancyExample | 4 | Reentrancy vulnerability vs safe withdrawal (inline proofs) |
 | CryptoHash | — | External cryptographic library linking (no specs, no tests) |
 
-**Verification snapshot**: 296 theorems across 9 categories, 207 covered by property tests (70% coverage), 89 proof-only exclusions. 5 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 290 Foundry tests across 23 test suites.
+**Verification snapshot**: 296 theorems across 9 categories, 216 covered by property tests (73% coverage), 80 proof-only exclusions. 5 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 299 Foundry tests across 23 test suites.
 
 ## What's Verified
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -19,7 +19,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, CryptoHash, ReentrancyExample
 - **Theorems**: 296 across 9 categories (284 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
 - **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, address injectivity
-- **Tests**: 290 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
+- **Tests**: 299 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
 

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -6,15 +6,7 @@
     "setStorage_preserves_map_storage",
     "setStorage_updates_count"
   ],
-  "Ledger": [
-    "deposit_sum_equation",
-    "deposit_sum_singleton_sender",
-    "deposit_withdraw_sum_cancel",
-    "transfer_sum_equation",
-    "transfer_sum_preserved_unique",
-    "withdraw_sum_equation",
-    "withdraw_sum_singleton_sender"
-  ],
+  "Ledger": [],
   "Owned": [
     "isOwner_meets_spec",
     "isOwner_returns_correct_value"
@@ -29,12 +21,10 @@
     "getMapping_reads_balance",
     "getStorageAddr_reads_owner",
     "getStorage_reads_supply",
-    "mint_sum_equation",
     "setMapping_preserves_other_addresses",
     "setMapping_updates_balance",
     "setStorageAddr_updates_owner",
-    "setStorage_updates_supply",
-    "transfer_sum_equation"
+    "setStorage_updates_supply"
   ],
   "Stdlib": [
     "SpecStorage_getMapping_setMapping_diff_slot",


### PR DESCRIPTION
## Summary

- Add **9 new fuzz tests** covering balance sum conservation theorems previously excluded from testing
- Remove 9 entries from `property_exclusions.json` (7 Ledger, 2 SimpleToken)
- **Ledger reaches 100% coverage** (all 32 theorems now have property tests)

## What these theorems prove

The Lean conservation theorems (in `Conservation.lean` and `Supply.lean`) prove that operations **predictably change the total balance sum** across any set of addresses:

| Theorem | What it proves |
|---------|---------------|
| `deposit_sum_equation` | Deposit increases sum by exactly `amount` |
| `withdraw_sum_equation` | Withdraw decreases sum by exactly `amount` |
| `transfer_sum_preserved_unique` | Transfer preserves total sum exactly |
| `deposit_withdraw_sum_cancel` | Deposit+withdraw round-trip restores sum |
| `mint_sum_equation` | Mint increases balance sum by `amount` |

The Solidity tests validate these at the EVM level by tracking balances across 2-3 addresses through operations and asserting the exact sum relationship.

## Coverage impact

| Contract | Before | After |
|----------|--------|-------|
| Ledger | 78% (25/32) | **100% (32/32)** |
| SimpleToken | 83.9% (47/56) | 87.5% (49/56) |
| **Overall** | **70% (207/296)** | **73% (216/296)** |
| Exclusions | 89 | 80 |
| Test count | 290 | 299 |

## Test plan

- [x] All 9 new tests pass locally with 256 fuzz runs each
- [x] `check_property_coverage.py` passes
- [x] `check_doc_counts.py` passes (README.md and llms.txt updated)
- [ ] CI passes (build, foundry shards, multi-seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test- and documentation-only changes; main risk is added fuzz tests being flaky or overly constrained in CI.
> 
> **Overview**
> Adds **9 new Foundry property/fuzz tests** for previously excluded sum-conservation theorems: 7 for `Ledger` (deposit/withdraw/transfer sum equations and deposit→withdraw sum cancel) and 2 for `SimpleToken` (mint/transfer total balance sum preservation).
> 
> Removes these theorems from `test/property_exclusions.json` (leaving `Ledger` with no exclusions) and updates documentation snapshots in `README.md` and `docs-site/public/llms.txt` to reflect higher property-test coverage and total test counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feafc5ef39459575bfc379f63220074ba98f0026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->