### PR TITLE
fix: Update stale coverage docs and add missing CI path triggers

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/verify.yml'
       - 'Verity/**'
       - 'Verity.lean'
       - 'Compiler/**'
@@ -13,9 +14,11 @@ on:
       - 'scripts/**'
       - 'lakefile.lean'
       - 'lean-toolchain'
+      - 'foundry.toml'
       - 'AXIOMS.md'
   pull_request:
     paths:
+      - '.github/workflows/verify.yml'
       - 'Verity/**'
       - 'Verity.lean'
       - 'Compiler/**'
@@ -25,6 +28,7 @@ on:
       - 'scripts/**'
       - 'lakefile.lean'
       - 'lean-toolchain'
+      - 'foundry.toml'
       - 'AXIOMS.md'
   workflow_dispatch:
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -153,13 +153,13 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ## Property Test Coverage 🎯 **NEAR COMPLETE**
 
-**Status**: 70% coverage (207/296), 89 remaining exclusions all proof-only
+**Status**: 73% coverage (216/296), 80 remaining exclusions all proof-only
 
 ### Current Coverage
 
 - **Total Properties**: 296
-- **Covered**: 207 (70%)
-- **Excluded**: 89 (all proof-only)
+- **Covered**: 216 (73%)
+- **Excluded**: 80 (all proof-only)
 - **Missing**: 0
 
 ### Coverage by Contract
@@ -171,21 +171,19 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 | SimpleStorage | 95% (19/20) | 1 proof-only | ✅ Near-complete |
 | Owned | 91% (20/22) | 2 proof-only | ✅ Near-complete |
 | OwnedCounter | 98% (44/45) | 1 proof-only | ✅ Near-complete |
-| SimpleToken | 84% (47/56) | 9 proof-only | ✅ High coverage |
+| SimpleToken | 88% (49/56) | 7 proof-only | ✅ High coverage |
 | Counter | 82% (23/28) | 5 proof-only | ✅ High coverage |
-| Ledger | 78% (25/32) | 7 modeling limit | ⚠️ Limited |
+| Ledger | 100% (32/32) | 0 | ✅ Complete |
 | Stdlib | 0% (0/64) | 64 proof-only | — Internal |
 
 ### Exclusion Categories
 
-**Proof-Only Properties (82 exclusions)**: Internal proof machinery that cannot be tested in Foundry
+**Proof-Only Properties (80 exclusions)**: Internal proof machinery that cannot be tested in Foundry
 - Storage helpers: `setStorage_*`, `getStorage_*`, `setMapping_*`, `getMapping_*`
 - Internal helpers: `isOwner_*` functions tested implicitly
 - Low-level operations used only in proofs
 
-**Modeling Limitations (7 exclusions)**: Properties requiring features not yet modeled
-- Sum equations: Require finite address set modeling (e.g., total supply invariants)
-- Currently affects Ledger contract
+> **Note**: Sum conservation properties (previously excluded as "modeling limitations") were resolved in PR #135 by testing with fixed address sets.
 
 ## Differential Testing ✅ **PRODUCTION READY**
 
@@ -236,7 +234,7 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 ### Short Term (1-2 months)
 
 - [x] Add finite address set modeling for Ledger sum properties (Issue #39, closed)
-- [ ] Complete Ledger sum property proofs — 12 `sorry` remaining (Issue #65)
+- [ ] Complete Ledger sum property proofs — 10 `sorry` remaining (Issue #65)
 
 ### Medium Term (3-6 months)
 


### PR DESCRIPTION
## Summary

- **Updates stale `docs/VERIFICATION_STATUS.md`** coverage numbers that were outdated after PR #135 added sum conservation tests:
  - Overall: 70% (207/296) → 73% (216/296), exclusions 89 → 80
  - Ledger: 78% (25/32) → 100% (32/32) — fully covered now
  - SimpleToken: 84% (47/56) → 88% (49/56)
  - Removed "Modeling Limitations" exclusion category (resolved by PR #135)
  - Updated sorry count: 12 → 10
- **Adds missing CI path triggers** in `verify.yml`:
  - `.github/workflows/verify.yml` — so workflow changes themselves trigger CI
  - `foundry.toml` — so Foundry config changes (solc version, optimizer settings, etc.) trigger CI

## Test plan

- [x] All local CI validation scripts pass (`check_property_manifest.py`, `check_property_manifest_sync.py`, `check_property_coverage.py`, `check_doc_counts.py`)
- [x] YAML structure validated
- [ ] CI runs on this PR (the new path triggers will take effect after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only updates plus a small CI trigger tweak; risk is limited to potentially increased/changed CI execution on PRs and pushes.
> 
> **Overview**
> Updates CI path filters in `.github/workflows/verify.yml` so the verification workflow runs when the workflow file itself or `foundry.toml` changes.
> 
> Refreshes `docs/VERIFICATION_STATUS.md` to reflect current property-test coverage and exclusions (overall coverage 70%→73%, `Ledger` now 100%, `SimpleToken` improved), removes the prior “modeling limitations” narrative in favor of a note about PR #135’s fixed-address-set tests, and adjusts the remaining Ledger `sorry` count (12→10).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5ee36698333aba5f65d76ef073dbd7a4b901573. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->