### PR TITLE
ci: Add sorry/coverage/exclusion validation and fix stale counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ theorem v3_correct : semantics transfer_v3 = transfer_spec
 | ReentrancyExample | 4 | Reentrancy vulnerability vs safe withdrawal (inline proofs) |
 | CryptoHash | — | External cryptographic library linking (no specs, no tests) |
 
-**Verification snapshot**: 296 theorems across 9 categories, 216 covered by property tests (73% coverage), 80 proof-only exclusions. 5 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 299 Foundry tests across 23 test suites.
+**Verification snapshot**: 296 theorems across 9 categories, 216 covered by property tests (73% coverage), 80 proof-only exclusions. 5 documented axioms, 10 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 299 Foundry tests across 23 test suites.
 
 ## What's Verified
 

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 
 const banner = (
   <Banner storageKey="verification-status">
-    284/296 theorems proven — 96% formal verification (12 sorry in Ledger sum proofs)
+    286/296 theorems proven — 97% formal verification (10 sorry in Ledger sum proofs)
   </Banner>
 )
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -21,7 +21,7 @@ The Verity compiler transforms high-level, verified contract specifications into
 
 ### What's Verified (Zero Trust Required)
 - **EDSL + compiler proofs**: Lean theorems for contract specs, IR generation, and Yul codegen
-- **Machine-checked proofs**: 5 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 12 sorry in Ledger sum proofs
+- **Machine-checked proofs**: 5 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 10 sorry in Ledger sum proofs
 - **Interpreter semantics**: Spec, IR, and Yul semantics defined and linked in Lean
 
 ### What's Tested (High Confidence)

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 296 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 5 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 12 `sorry` placeholders remaining in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 296 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 5 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 10 `sorry` placeholders remaining in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 
@@ -120,7 +120,7 @@ See [/verification](/verification) for the complete, always-current theorem list
 
 **What's a proof?** A step-by-step logical argument that shows why a theorem must be true. Lean checks every step.
 
-**What's `sorry`?** A placeholder in Lean that says "I'll prove this later." It's how incomplete proofs compile. This project has 12 `sorry` in Ledger sum proofs — all other claims are fully proven.
+**What's `sorry`?** A placeholder in Lean that says "I'll prove this later." It's how incomplete proofs compile. This project has 10 `sorry` in Ledger sum proofs — all other claims are fully proven.
 
 **What are axioms?** Statements assumed true without proof. This project uses 5 documented axioms for keccak256 hashing, expression evaluation equivalence, and address injectivity — each with soundness justification in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 296 theorems, 5 documented axioms, 12 sorry remaining in Ledger sum proofs.**
+**Compact core, built across 7 iterations. 296 theorems, 5 documented axioms, 10 sorry remaining in Ledger sum proofs.**
 
 ## Evolution
 

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,7 +7,7 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 296 theorems across 9 categories. 284 fully proven, 12 `sorry` placeholders in Ledger sum property proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 5 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 296 theorems across 9 categories. 286 fully proven, 10 `sorry` placeholders in Ledger sum property proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 5 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-15)
 
@@ -17,7 +17,7 @@ The compiler is verified with IR preservation proofs and Yul equivalence proofs 
 - Owned: 22 total (Basic 18, Correctness 4).
 - SimpleToken: 56 total (Basic 34, Correctness 12, Supply 6, Isolation 9).
 - OwnedCounter: 45 total (Basic 29, Correctness 6, Isolation 14).
-- Ledger: 32 total (Basic 21, Correctness 6, Conservation 13 — 12 sorry).
+- Ledger: 32 total (Basic 21, Correctness 6, Conservation 13 — 10 sorry).
 - SafeCounter: 25 total (Basic 22, Correctness 9).
 - ReentrancyExample: 4 total (inline proofs: vulnerability existence, supply invariant).
 - Stdlib: 64 theorems (Math 25, Automation 39).

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -17,7 +17,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Language**: Lean 4.15.0
 - **Core Size**: 249 lines
 - **Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, CryptoHash, ReentrancyExample
-- **Theorems**: 296 across 9 categories (284 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
+- **Theorems**: 296 across 9 categories (286 fully proven, 10 `sorry` placeholders in Ledger sum proofs)
 - **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, address injectivity
 - **Tests**: 299 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
@@ -107,7 +107,7 @@ See TRUST_ASSUMPTIONS.md for full analysis. Key trust boundaries:
 
 ## Known Limitations
 
-- 12 `sorry` placeholders in Ledger sum property proofs (issue #65)
+- 10 `sorry` placeholders in Ledger sum property proofs (issue #65)
 - No events, no gas modeling
 - No nested mappings (can't express ERC-20 allowances yet)
 - Self-transfer handled via delta-zero pattern (not separate logic)


### PR DESCRIPTION
## Summary

- **Enhances `check_doc_counts.py`** with three new CI validations that prevent documentation drift:
  - **sorry count**: Counts `sorry` statements in Lean files, validates against README.md and llms.txt
  - **coverage stats**: Computes covered/total properties from `property_utils`, validates coverage % and exclusion count in README.md
  - **proven count**: Validates `total - sorry` math in llms.txt
- **Fixes stale sorry count** (`12` → `10`) and proven count (`284` → `286`) across 7 documentation files:
  - `README.md`, `llms.txt`, `layout.tsx`, `verification.mdx`, `compiler.mdx`, `research.mdx`, `index.mdx`

This directly prevents the kind of doc drift that PR #136 had to fix manually. Going forward, any change to sorry counts, property test coverage, or exclusions will be caught by CI automatically.

## Test plan

- [x] `check_doc_counts.py` passes with all new validations
- [x] `check_property_manifest.py` passes
- [x] `check_property_manifest_sync.py` passes
- [x] `check_property_coverage.py` passes
- [x] All stale `12 sorry` and `284 proven` references eliminated (verified with grep)
- [ ] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation and CI validation changes; the only behavioral risk is potential false CI failures if the new regex-based `sorry` counting or coverage collection diverges from project conventions.
> 
> **Overview**
> Updates documentation metrics to reflect improved proof progress (**Ledger `sorry` 12→10; proven theorems 284→286**) across the README, docs pages, and `llms.txt`, including the site banner.
> 
> Enhances `scripts/check_doc_counts.py` to prevent future doc drift by computing and validating **`sorry` count**, **property-test covered count + coverage %**, and **exclusion count**, and by cross-checking derived **proven** counts against `llms.txt`; CI now fails with a richer “actual counts” report when these stats don’t match the docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87ba8c5f21a692d017872496f39e91a626c812f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->