### PR TITLE
Add SVG logo and redesign README

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Thomas Marchand
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/verity.svg
+++ b/verity.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 507 441" width="507" height="441">
+  <g shape-rendering="crispEdges">
+    <!-- Left arm outer -->
+    <polygon points="0,0 169,0 84.5,147" fill="#6e6e6e" stroke="#6e6e6e" stroke-width="1" stroke-linejoin="round"/>
+    <!-- Left arm inner -->
+    <polygon points="169,0 84.5,147 253.5,147" fill="#3c3c3c" stroke="#3c3c3c" stroke-width="1" stroke-linejoin="round"/>
+    <!-- Right arm outer -->
+    <polygon points="338,0 507,0 422.5,147" fill="#5c5c5c" stroke="#5c5c5c" stroke-width="1" stroke-linejoin="round"/>
+    <!-- Right arm inner -->
+    <polygon points="338,0 422.5,147 253.5,147" fill="#666666" stroke="#666666" stroke-width="1" stroke-linejoin="round"/>
+    <!-- Bottom left -->
+    <polygon points="84.5,147 253.5,147 169,294" fill="#1c1c1c" stroke="#1c1c1c" stroke-width="1" stroke-linejoin="round"/>
+    <!-- Bottom right -->
+    <polygon points="253.5,147 422.5,147 338,294" fill="#525252" stroke="#525252" stroke-width="1" stroke-linejoin="round"/>
+    <!-- Bottom center (up-pointing gap fill) - blends with bottom point -->
+    <polygon points="253.5,147 169,294 338,294" fill="#2e2e2e" stroke="#2e2e2e" stroke-width="1" stroke-linejoin="round"/>
+    <!-- Bottom point -->
+    <polygon points="169,294 338,294 253.5,441" fill="#2e2e2e" stroke="#2e2e2e" stroke-width="1" stroke-linejoin="round"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add `verity.svg`: faceted V logo recreated as SVG (no raster PNG in history)
- Redesign README with centered hero block, tagline, and shields.io badges
- Consolidate vision/philosophy sections into a concise intro
- Collapse build/test/scaffold instructions behind `<details>` tags
- Convert docs links to clean table layout
- Single code example showing the full spec → impl → proof flow

## Test plan
- [ ] Verify SVG logo renders correctly and is centered on GitHub
- [ ] Verify badges load (license, Lean 4, theorems, CI)
- [ ] Verify `<details>` sections expand/collapse properly
- [ ] Verify docs table links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus new static assets; no runtime/code-path impact beyond ensuring links/rendering work on GitHub.
> 
> **Overview**
> Adds an MIT license file (`LICENSE.md`) and introduces a new `verity.svg` logo referenced at the top of the README.
> 
> Redesigns `README.md` with a centered hero section (logo/tagline/badges), consolidates the narrative into a single spec→implementation→proof example, and reorganizes build/test/contract-scaffolding instructions into collapsible `<details>` blocks; updates the license link to point to `LICENSE.md` and refreshes contract/docs tables copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 476f923e400dac041a58e1655992741cc0c06638. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->