### PR TITLE
fix: Widen CI sorry scope, fix doc counts, add linker docs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -61,11 +61,23 @@ jobs:
 
       - name: Check for sorry
         run: |
-          if grep -r "sorry" Verity/Proofs/ --include="*.lean" | grep -v "^--" | grep -v "zero sorry" | grep -v "Summary"; then
-            echo "ERROR: Found 'sorry' in proof files"
+          # Count sorry across all Lean files (matching both 'sorry' and '· sorry')
+          EXPECTED_SORRY=12  # Tracked in issue #65 (Ledger sum proofs)
+          ACTUAL_SORRY=$(grep -rn "sorry" Verity/ Compiler/ --include="*.lean" \
+            | grep -v "^--" | grep -v "zero sorry" | grep -v "Summary" \
+            | grep -v "SORRY" | grep -v "sorry_count" | grep -v "sorry placeholder" \
+            | grep -v "No sorry" | grep -v "all proofs are complete" \
+            | wc -l)
+          echo "Found $ACTUAL_SORRY sorry statement(s) (expected $EXPECTED_SORRY)"
+          if [ "$ACTUAL_SORRY" -gt "$EXPECTED_SORRY" ]; then
+            echo "ERROR: New sorry introduced ($ACTUAL_SORRY found, $EXPECTED_SORRY expected)"
+            grep -rn "sorry" Verity/ Compiler/ --include="*.lean" \
+              | grep -v "^--" | grep -v "zero sorry" | grep -v "Summary" \
+              | grep -v "SORRY" | grep -v "sorry_count" | grep -v "sorry placeholder" \
+              | grep -v "No sorry" | grep -v "all proofs are complete"
             exit 1
           fi
-          echo "No sorry found — all proofs are complete"
+          echo "✓ Sorry count ($ACTUAL_SORRY) within expected limit ($EXPECTED_SORRY)"
 
       - name: Check for axioms in proof files
         run: |

--- a/Compiler/Linker.lean
+++ b/Compiler/Linker.lean
@@ -6,10 +6,10 @@
   to be used with formally verified contract logic.
 
   Usage:
-    lake exec compiler --target yul \
-        --link libs/PoseidonT4.yul \
-        --link libs/Groth16.yul \
-        -o output.yul
+    lake exe verity-compiler \
+        --link examples/external-libs/PoseidonT3.yul \
+        --link examples/external-libs/PoseidonT4.yul \
+        -o compiler/yul
 -/
 
 import Compiler.Yul.Ast

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ One spec can have many competing implementations - naive, gas-optimized, packed 
 | ReentrancyExample | 4 | Reentrancy vulnerability vs safe withdrawal |
 | CryptoHash | - | External cryptographic library linking |
 
-**296 theorems** across 9 categories. **299 Foundry tests** across 23 suites. 5 documented axioms, 10 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)).
+296 theorems across 9 categories. 299 Foundry tests across 23 test suites. 216 covered by property tests (73% coverage, 80 proof-only exclusions). 5 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
@@ -94,7 +94,7 @@ forge test
 <details>
 <summary><strong>Testing</strong></summary>
 
-**Property tests** (290 tests) validate EDSL = Yul = EVM execution:
+**Property tests** (299 tests) validate EDSL = Yul = EVM execution:
 
 ```bash
 forge test                                          # run all

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -73,7 +73,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: 207 properties tested across 9 contracts (70% coverage, 296 total theorems)
+**Coverage**: 216 properties tested across 9 contracts (73% coverage, 296 total theorems)
 
 **What this guarantees**:
 - Contract behavior matches specification
@@ -441,7 +441,7 @@ Verity provides **strong formal verification** with a **small trusted computing 
 ✅ Contract implementations match specifications (Layer 1)
 ✅ Specifications preserved through compilation (Layer 2)
 ✅ IR semantics equivalent to Yul semantics (Layer 3)
-✅ 296 theorems across 9 contracts (207 covered by property tests)
+✅ 296 theorems across 9 contracts (216 covered by property tests)
 
 ### What is Trusted (Validated but Not Proven)
 ⚠️ Solidity compiler (solc) - Validated by 70k+ differential tests

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -21,7 +21,7 @@ The Verity compiler transforms high-level, verified contract specifications into
 
 ### What's Verified (Zero Trust Required)
 - **EDSL + compiler proofs**: Lean theorems for contract specs, IR generation, and Yul codegen
-- **Machine-checked proofs**: 5 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 10 sorry in Ledger sum proofs
+- **Machine-checked proofs**: 5 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 12 sorry in Ledger sum proofs
 - **Interpreter semantics**: Spec, IR, and Yul semantics defined and linked in Lean
 
 ### What's Tested (High Confidence)
@@ -177,6 +177,12 @@ forge create SimpleStorage --from 0x... --private-key ...
 - Mapping slot computation helper
 - Deploy code + runtime code separation
 
+**`Compiler/Linker.lean`**
+- External Yul library linking
+- Line-based parser for extracting function definitions from `.yul` files
+- Injection of library functions into runtime code section
+- Validation of external references (`validateExternalReferences`)
+
 **`Compiler/Yul/*.lean`** (Yul AST + pretty printer)
 - Yul abstract syntax tree
 - Pretty printer (Yul → text)
@@ -253,6 +259,31 @@ sstore(0, add(sload(0), 1))
 
 Automatic expression inlining reduces bytecode size and gas costs.
 
+### External Library Linking ✅
+
+Link production cryptographic libraries (or any external Yul functions) into compiled contracts using the `--link` flag:
+
+```bash
+lake exe verity-compiler \
+    --link examples/external-libs/PoseidonT3.yul \
+    --link examples/external-libs/PoseidonT4.yul \
+    -o compiler/yul
+```
+
+**How it works**: The linker parses `.yul` files, extracts function definitions, and injects them into the runtime `code {}` section of each compiled contract. This lets you prove properties about contract logic using simple placeholder functions in Lean, then swap in production-grade implementations at compile time.
+
+**Library file format**: External libraries should contain plain Yul function definitions (no `object` wrapper):
+```yul
+function PoseidonT3_hash(a, b) -> result {
+    // Production implementation here
+    result := /* ... */
+}
+```
+
+**Validation**: The `validateExternalReferences` function checks that all non-builtin function calls in the contract are satisfied by linked libraries, catching missing dependencies at compile time.
+
+See [`examples/external-libs/`](https://github.com/Th0rgal/verity/tree/main/examples/external-libs) for example library files.
+
 ## Usage
 
 ### Compile All Contracts
@@ -274,7 +305,7 @@ lake exe verity-compiler
 # Run all Foundry tests
 forge test
 
-# Expected: 290/290 tests pass (as of 2026-02-15)
+# Expected: 299/299 tests pass (as of 2026-02-15)
 ```
 
 ### Add New Contract
@@ -317,10 +348,10 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 290/290 passing (100%, as of 2026-02-15)
+**Foundry Tests**: 299/299 passing (100%, as of 2026-02-15)
 ```bash
 $ forge test
-Ran 23 test suites: 290 tests passed, 0 failed, 0 skipped (290 total tests)
+Ran 23 test suites: 299 tests passed, 0 failed, 0 skipped (299 total tests)
 ```
 
 **Coverage**: Unit, property, and differential tests across EDSL and compiled Yul. See `test/` for suites.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -17,7 +17,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Language**: Lean 4.15.0
 - **Core Size**: 249 lines
 - **Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, CryptoHash, ReentrancyExample
-- **Theorems**: 296 across 9 categories (286 fully proven, 10 `sorry` placeholders in Ledger sum proofs)
+- **Theorems**: 296 across 9 categories (284 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
 - **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, address injectivity
 - **Tests**: 299 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
@@ -107,7 +107,7 @@ See TRUST_ASSUMPTIONS.md for full analysis. Key trust boundaries:
 
 ## Known Limitations
 
-- 10 `sorry` placeholders in Ledger sum property proofs (issue #65)
+- 12 `sorry` placeholders in Ledger sum property proofs (issue #65)
 - No events, no gas modeling
 - No nested mappings (can't express ERC-20 allowances yet)
 - Self-transfer handled via delta-zero pattern (not separate logic)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@
 - ✅ **Layer 1 Complete**: 296 theorems across 9 contracts (EDSL ≡ ContractSpec)
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
-- ✅ **Property Testing**: 70% coverage (207/296), all testable properties covered
+- ✅ **Property Testing**: 73% coverage (216/296), all testable properties covered
 - ✅ **Differential Testing**: Production-ready with 70k+ tests
 - ✅ **Trust Reduction Phase 1**: keccak256 axiom + CI validation (PR #43, #46)
 - ✅ **External Linking**: Cryptographic library support (PR #49)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -234,7 +234,7 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 ### Short Term (1-2 months)
 
 - [x] Add finite address set modeling for Ledger sum properties (Issue #39, closed)
-- [ ] Complete Ledger sum property proofs — 10 `sorry` remaining (Issue #65)
+- [ ] Complete Ledger sum property proofs — 12 `sorry` remaining (Issue #65)
 
 ### Medium Term (3-6 months)
 

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -59,7 +59,10 @@ def get_core_line_count() -> int:
 
 
 def get_sorry_count() -> int:
-    """Count sorry statements in Lean proof files."""
+    """Count sorry statements in Lean proof files.
+
+    Matches both plain ``sorry`` and focus-bullet ``· sorry`` syntax.
+    """
     count = 0
     for d in [ROOT / "Compiler", ROOT / "Verity"]:
         if not d.exists():
@@ -67,7 +70,7 @@ def get_sorry_count() -> int:
         for lean in d.rglob("*.lean"):
             text = lean.read_text(encoding="utf-8")
             for line in text.splitlines():
-                if re.match(r"^\s*sorry\b", line):
+                if re.match(r"^\s*(·\s*)?sorry\b", line):
                     count += 1
     return count
 


### PR DESCRIPTION
## Summary

This PR addresses three interrelated issues and adds missing documentation:

- **Fix CI sorry check scope** (fixes #139): The CI sorry check only scanned `Verity/Proofs/`, but all 12 sorry statements live in `Verity/Specs/` (Sum.lean and SumProofs.lean). New sorry could be introduced anywhere outside `Verity/Proofs/` without CI catching it. Now scans all of `Verity/` and `Compiler/`, and fails if the sorry count exceeds the expected 12.

- **Fix sorry regex** in `check_doc_counts.py`: The `^\s*sorry\b` regex missed the `· sorry` (focus-bullet) syntax used on lines 103-104 of SumProofs.lean, undercounting sorry as 10 instead of the actual 12.

- **Sync doc counts across 8 files** (fixes #140, #152):
  | Metric | Before | After | Files |
  |--------|--------|-------|-------|
  | sorry count | 10 | 12 | README, llms.txt, compiler.mdx, VERIFICATION_STATUS |
  | proven count | 286 | 284 | llms.txt |
  | coverage | 70% (207/296) | 73% (216/296) | ROADMAP, TRUST_ASSUMPTIONS |
  | test count | 290 | 299 | compiler.mdx, README |

- **Add External Library Linking docs** to compiler.mdx: The `--link` flag was completely undocumented in the docs site. Added a feature section explaining usage, library file format, and validation.

- **Fix stale Linker.lean docstring**: Referenced nonexistent `--target yul` CLI flag.

## Test plan

- [x] `python3 scripts/check_doc_counts.py` passes with all correct counts
- [x] CI sorry grep matches expected 12 locally
- [ ] CI verify workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI scripting and documentation updates; the main behavior change is stricter/expanded `sorry` detection which could only affect PR gating, not runtime or proof logic.
> 
> **Overview**
> CI proof verification now scans all `Compiler/` and `Verity/` Lean files for `sorry` and enforces a fixed budget (12), failing only when new `sorry` are introduced and printing the offending matches.
> 
> Documentation-count automation is corrected to count both `sorry` and focus-bullet `· sorry`, and project docs are synced to updated metrics (tests, coverage, proven/sorry counts) while adding/refreshing documentation for external Yul library linking (`--link`) and updating the `Compiler/Linker.lean` usage snippet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8613af28fa3bbe02d716058cfb76b67300b4c8c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->