### PR TITLE
fix: Improve test generator, fix self-transfer refs, add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# CODEOWNERS — Require review on proof-critical paths
+#
+# Changes to axioms, trusted compiler code, and CI pipeline require
+# explicit approval to prevent accidental weakening of the trust base.
+
+# Global fallback
+* @Th0rgal
+
+# Axioms and trust assumptions — any change weakens guarantees
+AXIOMS.md @Th0rgal
+TRUST_ASSUMPTIONS.md @Th0rgal
+
+# Lean proof files — ensure no sorry regressions
+Verity/Proofs/ @Th0rgal
+
+# Formal specs — changes alter what is being verified
+Verity/Specs/ @Th0rgal
+
+# Core EDSL — the trusted base all proofs build on
+Verity/Core.lean @Th0rgal
+
+# Compiler trusted code — bugs here break soundness
+Compiler/Specs.lean @Th0rgal
+Compiler/IRGen.lean @Th0rgal
+Compiler/YulGen.lean @Th0rgal
+Compiler/Interpreter.lean @Th0rgal
+
+# CI pipeline — governs what gets checked
+.github/workflows/ @Th0rgal
+scripts/ @Th0rgal

--- a/Verity/Examples/ReentrancyExample.lean
+++ b/Verity/Examples/ReentrancyExample.lean
@@ -58,6 +58,14 @@ by subtracting totalSupply twice while only decrementing balance once.
 
 namespace VulnerableBank
 
+-- Deposit (mirrors SafeBank — reentrancy is only relevant on withdraw)
+def deposit (amount : Uint256) : Contract Unit := fun s =>
+  let bal := s.storageMap balances.slot s.sender
+  let supply := s.storage totalSupply.slot
+  let s1 := setMappingSlot balances s.sender (bal + amount) s
+  let s2 := setStorageSlot totalSupply (supply + amount) s1
+  ContractResult.success () s2
+
 -- Vulnerable withdraw (single reentrant attempt modeled inline)
 def withdraw (amount : Uint256) : Contract Unit := fun s =>
   let bal := s.storageMap balances.slot s.sender

--- a/examples/solidity/Ledger.sol
+++ b/examples/solidity/Ledger.sol
@@ -33,8 +33,10 @@ contract Ledger {
         if (balances[msg.sender] < amount) {
             revert InsufficientBalance();
         }
-        balances[msg.sender] -= amount;
-        balances[to] += amount;
+        if (msg.sender != to) {
+            balances[msg.sender] -= amount;
+            balances[to] += amount;
+        }
     }
 
     /// @notice Get balance of any address

--- a/examples/solidity/SimpleToken.sol
+++ b/examples/solidity/SimpleToken.sol
@@ -43,8 +43,10 @@ contract SimpleToken {
         if (balances[msg.sender] < amount) {
             revert InsufficientBalance();
         }
-        balances[msg.sender] -= amount;
-        balances[to] += amount;
+        if (msg.sender != to) {
+            balances[msg.sender] -= amount;
+            balances[to] += amount;
+        }
     }
 
     /// @notice Get balance of an address


### PR DESCRIPTION
## Summary

- **RandomGen.lean**: Edge-case value injection (0, 1, 2^128, 2^255, MAX-1, MAX) ~44% of the time + expanded address pool with zero/max/address(1) — strengthens the 70k+ differential test runs that validate all 5 axioms (issue #168)
- **Ledger.sol / SimpleToken.sol**: Add `if (msg.sender != to)` self-transfer guard to match the EDSL's `pure ()` short-circuit, eliminating the semantic mismatch between reference contracts and verified models (issue #165)
- **ReentrancyExample.lean**: Add missing `VulnerableBank.deposit` function matching the Solidity reference — the Lean model was incomplete (issue #164)
- **.github/CODEOWNERS**: Require owner review on proof-critical paths (axioms, specs, proofs, compiler core, CI) to prevent accidental weakening of the trust base (issue #192)

## Test plan

- [ ] CI build passes (Lean compilation, sorry check, axiom validation)
- [ ] Foundry property tests pass — the Solidity self-transfer fix should not break any existing tests since the compiled Yul already handles self-transfer correctly via branchless delta computation
- [ ] Verify `PropertyReentrancyExample.t.sol` tests still pass — they already call `vulnerable.deposit()` which now has a matching Lean definition
- [ ] CODEOWNERS file triggers required reviews on future PRs touching proof-critical paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the distribution of generated test inputs and adjusts reference contract semantics, which can shift differential-test expectations and uncover new failures. No production runtime/auth changes; primarily affects testing and verification scaffolding.
> 
> **Overview**
> Improves differential test coverage by updating `Compiler/RandomGen.lean` to *inject high-impact uint256 edge values* (e.g., 0/1/powers-of-two/MAX) and to draw addresses from an expanded pool including zero/max/address(1).
> 
> Aligns the Solidity reference contracts with the EDSL by making `Ledger.sol` and `SimpleToken.sol` `transfer` a no-op on self-transfer (`msg.sender == to`), avoiding semantic mismatches during differential testing.
> 
> Completes the Lean reentrancy example by adding the missing `VulnerableBank.deposit` definition, and adds `.github/CODEOWNERS` to require review for changes to axioms/proofs/specs/compiler-trusted code and CI-related paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be054e6e640779f0c7e58b3230f92d939a8be707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->