### PR TITLE
fix: Add keccak256 self-tests and CI validation (issue #167)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Generate Yul
         run: ./.lake/build/bin/verity-compiler
 
+      - name: Keccak-256 self-test (validate hash implementation)
+        run: python3 scripts/keccak256.py --self-test
+
       - name: Check selector hashing against specs
         run: python3 scripts/check_selectors.py
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -200,25 +200,32 @@ These components are **not formally verified** but are trusted based on testing,
 - **Standard**: EIP-20 function selector specification
 
 **Mitigation Strategies**:
-1. **Cross-Validation**: `scripts/check_selectors.py`
+1. **Self-Test**: `python3 scripts/keccak256.py --self-test`
+   - 14 test vectors: 4 full 32-byte digests + 10 selector-only checks
+   - Full digests verified against Ethereum Yellow Paper and ethers.js
+   - Selector vectors verified against `solc --hashes`
+   - Runs in CI before any dependent script
+
+2. **Cross-Validation**: `scripts/check_selectors.py`
    - Compares Python output against solc-generated selectors
    - Runs in CI on every build
    - Ensures consistency
 
-2. **Fixture Testing**: `scripts/check_selector_fixtures.py`
-   - Tests against known correct selector values
+3. **Fixture Testing**: `scripts/check_selector_fixtures.py`
+   - Tests against known correct selector values via `solc --hashes`
    - Prevents regression
 
 **Risk Assessment**: **Low**
 - Keccak256 is a deterministic algorithm
-- Validated against multiple implementations
-- Extensively tested in CI
+- Validated against multiple independent implementations (solc, ethers.js)
+- 14 test vectors catch round-constant, padding, or rotation bugs
 - Any mismatch would fail differential tests
 
 **Files**:
 - `Compiler/Selectors.lean` - Selector definitions
-- `scripts/keccak256.py` - Implementation
-- `scripts/check_selectors.py` - Validation
+- `scripts/keccak256.py` - Implementation (with `--self-test` mode)
+- `scripts/check_selectors.py` - Cross-validation against specs
+- `scripts/check_selector_fixtures.py` - Cross-validation against solc
 
 ---
 


### PR DESCRIPTION
## Summary

- **keccak256.py**: Add `--self-test` flag with 14 test vectors (4 full 32-byte digests + 10 selector-only checks) that validate the hand-rolled Keccak-256 implementation against known-good values from the Ethereum Yellow Paper, ethers.js, and `solc --hashes`
- **verify.yml**: Add CI step that runs `--self-test` before all dependent selector scripts, catching any hash implementation regression before it can produce broken selectors
- **TRUST_ASSUMPTIONS.md**: Document the self-test as a mitigation strategy in the keccak trust surface section

## Context

The `scripts/keccak256.py` file implements the full Keccak-f[1600] permutation from scratch (116 lines of cryptographic code) with zero tests. It is in the trust boundary of the verification pipeline — if it computes wrong selectors, compiled contracts silently break. While `check_selector_fixtures.py` cross-validates against `solc`, the self-test provides a faster, independent check that catches bugs in round constants, rotation offsets, or padding before any dependent script runs.

## Test plan

- [x] `python3 scripts/keccak256.py --self-test` passes locally (14/14 vectors)
- [ ] CI build passes with new self-test step
- [ ] All existing selector validation scripts still pass
- [ ] Foundry tests unaffected (no code changes to compiler or contracts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a CI gate and a pure-Python self-test harness around an existing hashing implementation; failure mode is limited to CI breaks rather than runtime behavior changes.
> 
> **Overview**
> Adds a `--self-test` mode to `scripts/keccak256.py` that validates the hand-rolled Keccak-256 implementation against 14 known-good vectors (full 32-byte digests plus selector-only checks) and returns a non-zero exit code on mismatch.
> 
> Updates the `verify.yml` GitHub Actions workflow to run this self-test before selector validation scripts, and expands `TRUST_ASSUMPTIONS.md` to document the self-test as an additional mitigation for the Keccak256 trust boundary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4050e5e2596205fb4d66629a3f8e1fee67aace43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->