### PR TITLE
docs: Fix misleading axiom justification — only IR eval is partial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ All axioms **must** be documented inline **and** in AXIOMS.md:
 ```lean
 /-- AXIOM: Expression evaluation equivalence
 
-This is an axiom because both evalIRExpr and evalYulExpr are partial functions.
+This is an axiom because evalIRExpr is partial (evalYulExpr is total).
 See AXIOMS.md for full soundness justification.
 -/
 axiom evalIRExpr_eq_evalYulExpr : ...

--- a/Compiler/Proofs/YulGeneration/README.md
+++ b/Compiler/Proofs/YulGeneration/README.md
@@ -39,7 +39,7 @@ Two expression evaluation axioms in `StatementEquivalence.lean`:
 1. `evalIRExpr_eq_evalYulExpr` - IR and Yul expression evaluation are identical when states are aligned
 2. `evalIRExprs_eq_evalYulExprs` - List version of the above
 
-These are sound because both eval functions have identical source code and `yulStateOfIR` copies all fields. Making them theorems would require refactoring both `partial` functions to use fuel parameters (~500+ lines).
+These are sound because both eval functions have identical source code and `yulStateOfIR` copies all fields. The axiom exists because `evalIRExpr` is `partial` (opaque to Lean's kernel) while `evalYulExpr` is total. Eliminating the axiom requires only refactoring the IR evaluator to use fuel parameters (~300 lines).
 
 ## References
 

--- a/Compiler/Proofs/YulGeneration/StatementEquivalence.lean
+++ b/Compiler/Proofs/YulGeneration/StatementEquivalence.lean
@@ -24,18 +24,18 @@ Individual statement proofs compose via `execIRStmtsFuel_equiv_execYulStmtsFuel_
 
 /-- IR and Yul expression evaluation are identical when states are aligned.
 
-This is an axiom because both `evalIRExpr` and `evalYulExpr` are defined as `partial`
-functions, making them unprovable in Lean's logic. However, this axiom is sound because:
+This is an axiom because `evalIRExpr` is defined as `partial` (not provably terminating),
+making it opaque to Lean's kernel. `evalYulExpr` is total (structural recursion), but
+Lean cannot unfold the `partial` IR side to prove equality. This axiom is sound because:
 
 1. Both functions have **identical** source code (see IRInterpreter.lean and Semantics.lean)
 2. `yulStateOfIR` just copies all IRState fields to YulState
 3. The only difference is the `selector` field, which doesn't affect expression evaluation
 4. This is a structural equality, not a semantic one
 
-**Alternative**: To avoid this axiom, we would need to refactor both eval functions
-to use fuel parameters (similar to what we did for execIRStmtFuel). This would be
-a significant undertaking (~500+ lines of code) for relatively little benefit, since
-the functions are already known to be identical by inspection.
+**Alternative**: To avoid this axiom, only the IR evaluator needs refactoring to use
+fuel parameters (matching the pattern already used by `evalYulExpr`). The Yul side is
+already total and requires no changes. Estimated effort: ~300 lines.
 
 **Usage**: This axiom is used by all statement equivalence proofs to show that
 evaluating expressions gives the same results in both IR and Yul contexts.


### PR DESCRIPTION
## Summary

- **AXIOMS.md**: Correct axiom #1 and #2 descriptions — `evalIRExpr` is `partial`, but `evalYulExpr` is **total** (structural recursion). The previous claim that "both are partial" was wrong.
- **StatementEquivalence.lean**: Fix inline axiom docstring with accurate partiality description
- **CONTRIBUTING.md**: Fix example axiom comment
- **YulGeneration/README.md**: Fix axiom summary paragraph

## Why this matters

The misleading documentation overstated the difficulty of eliminating these axioms. Since only the IR evaluator needs refactoring (the Yul side is already total), the elimination effort is ~300 LOC instead of the previously estimated ~500+. This is important for anyone planning trust-reduction work on the codebase.

Addresses issue #160.

## Test plan

- [ ] CI build passes (docs-only change, no code modifications)
- [ ] Verify the factual claim: `grep -n "partial def evalYulExpr" Compiler/` should return nothing (confirming evalYulExpr is total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that don’t affect proof logic or runtime behavior; risk is limited to potential inaccuracies in the updated explanations.
> 
> **Overview**
> Updates axiom documentation (in `AXIOMS.md`, `Compiler/Proofs/YulGeneration/StatementEquivalence.lean`, `Compiler/Proofs/YulGeneration/README.md`, and `CONTRIBUTING.md`) to fix a factual error: only `evalIRExpr`/`evalIRExprs` are `partial`/opaque to Lean, while `evalYulExpr`/`evalYulExprs` are total via well-founded recursion.
> 
> Reframes the soundness and *axiom-elimination* guidance accordingly, stating that removing the axioms would require refactoring only the IR evaluator (and related helpers like `evalIRCall`) and revising the estimated effort from ~500 LOC to ~300 LOC.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e5c6e7b745a122f46a20600431c825fc17ec4cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->