### PR TITLE
fix: Eliminate redundant address axiom (5→4 axioms)

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -105,54 +105,7 @@ theorem evalIRExprs_eq_evalYulExprs : ... := by
 
 ---
 
-### 3. `addressToNat_injective_valid`
-
-**Location**: `Compiler/Proofs/IRGeneration/Conversions.lean:83`
-
-**Statement**:
-```lean
-axiom addressToNat_injective_valid :
-  ∀ {a b : Address}, isValidAddress a → isValidAddress b →
-    addressToNat a = addressToNat b → a = b
-```
-
-**Purpose**: Asserts that the address-to-number conversion is injective for valid Ethereum addresses.
-
-**Why Axiom?**:
-- Models external Ethereum behavior (address space)
-- Addresses are 20-byte hex strings (0x + 40 hex chars)
-- Conversion involves string parsing and normalization
-- Full formalization of hex parsing would be substantial
-
-**Soundness Argument**:
-1. **Valid address format**: Valid Ethereum addresses are exactly 20 bytes (160 bits)
-2. **Normalization**: Address normalization removes case-based collisions (EIP-55 checksums)
-3. **Hex parsing injectivity**: For normalized addresses, hex string → number conversion is injective up to 2^160
-4. **Matches Ethereum**: This precisely models the actual Ethereum address space
-5. **Differential testing**: Validated by 70,000+ differential tests against real EVM execution
-
-**Trust Assumption**:
-This axiom assumes that:
-- Valid addresses have unique numerical representations
-- Normalization is correctly implemented
-- This matches Ethereum's actual address semantics
-
-**Validation**:
-- `isValidAddress` predicate ensures format correctness
-- Differential testing validates against Solidity/EVM behavior
-- Address normalization tested independently
-
-**Risk**: **Low** - Ethereum address injectivity is a fundamental assumption of the EVM itself.
-
-**Future Work**:
-- [ ] Formalize hex string parsing in Lean (substantial effort)
-- [ ] Prove injectivity from first principles
-- [ ] Consider using verified hex parsing library
-- [ ] Issue tracking: #82
-
----
-
-### 4. `keccak256_first_4_bytes`
+### 3. `keccak256_first_4_bytes`
 
 **Location**: `Compiler/Selectors.lean:43`
 
@@ -178,7 +131,7 @@ axiom keccak256_first_4_bytes (sig : String) : Nat
 
 ---
 
-### 5. `addressToNat_injective`
+### 4. `addressToNat_injective`
 
 **Location**: `Verity/Proofs/Stdlib/Automation.lean:155`
 
@@ -197,14 +150,42 @@ axiom addressToNat_injective :
 
 **Soundness Argument**:
 1. **Ethereum model**: Addresses are 20-byte values with unique numeric encodings
-2. **Consistent with axiom #3**: Same property as `addressToNat_injective_valid` but without the `isValidAddress` precondition
-3. **Differential testing**: Validated by 70,000+ tests against EVM execution
-4. **Mathematical foundation**: String-to-number conversion on fixed-width encodings is inherently injective
+2. **Differential testing**: Validated by 70,000+ tests against EVM execution
+3. **Mathematical foundation**: String-to-number conversion on fixed-width encodings is inherently injective
 
 **Risk**: **Low** - Standard assumption about Ethereum address encoding.
 
 **Future Work**:
-- [ ] Unify with `addressToNat_injective_valid` (axiom #3) to eliminate redundancy
+- [ ] Formalize hex string parsing in Lean (substantial effort)
+- [ ] Prove injectivity from first principles
+- [ ] Consider using verified hex parsing library
+- [ ] Issue tracking: #82
+
+---
+
+## Eliminated Axioms
+
+### `addressToNat_injective_valid` (formerly axiom #3)
+
+**Eliminated in**: PR #202 (2026-02-16)
+
+**Previous statement**:
+```lean
+axiom addressToNat_injective_valid :
+  ∀ {a b : Address}, isValidAddress a → isValidAddress b →
+    addressToNat a = addressToNat b → a = b
+```
+
+**How eliminated**: This axiom was a strictly weaker version of `addressToNat_injective` (axiom #4), which doesn't require `isValidAddress` preconditions. It was converted to a theorem derived from axiom #4:
+
+```lean
+theorem addressToNat_injective_valid :
+    ∀ {a b : Address}, isValidAddress a → isValidAddress b →
+      addressToNat a = addressToNat b → a = b :=
+  fun _ _ h_eq => addressToNat_injective _ _ h_eq
+```
+
+**Impact**: Reduced axiom count from 5 to 4 with zero changes to proof structure (the axiom had no call sites).
 
 ---
 
@@ -214,11 +195,10 @@ axiom addressToNat_injective :
 |-------|------|------|--------------|-------------|
 | `evalIRExpr_eq_evalYulExpr` | StatementEquivalence.lean | Low | Differential tests (70k+) | Fuel-based refactor |
 | `evalIRExprs_eq_evalYulExprs` | StatementEquivalence.lean | Low | Differential tests (70k+) | Prove from axiom #1 |
-| `addressToNat_injective_valid` | Conversions.lean | Low | Differential tests (70k+) | Formalize hex parsing |
 | `keccak256_first_4_bytes` | Selectors.lean | Low | CI selector checks + solc | Verified keccak FFI |
-| `addressToNat_injective` | Automation.lean | Low | Differential tests (70k+) | Unify with axiom #3 |
+| `addressToNat_injective` | Automation.lean | Low | Differential tests (70k+) | Formalize hex parsing |
 
-**Total Axioms**: 5
+**Total Axioms**: 4
 **Production Blockers**: 0 (all have low risk with strong validation)
 
 ---
@@ -261,7 +241,7 @@ If you need to add an axiom:
 User Code (EDSL)
     ↓ [Proven, 1 axiom: addressToNat_injective]
 ContractSpec
-    ↓ [Proven, 1 axiom: addressToNat_injective_valid]
+    ↓ [Proven, no additional axioms]
 IR
     ↓ [Proven, 2 axioms: evalIRExpr/Exprs equivalence]
 Yul (1 axiom: keccak256_first_4_bytes for selectors)
@@ -271,7 +251,7 @@ EVM Bytecode
 
 **Trust Assumptions**:
 1. Lean 4 type checker is sound (foundational)
-2. The 5 axioms documented above are sound
+2. The 4 axioms documented above are sound
 3. Solidity compiler (solc) correctly compiles Yul → Bytecode
 
 See `TRUST_ASSUMPTIONS.md` (issue #68) for complete trust model.
@@ -296,6 +276,6 @@ cat AXIOMS.md
 
 ---
 
-**Last Updated**: 2026-02-15
+**Last Updated**: 2026-02-16
 **Next Review**: When new axioms added or existing ones eliminated
 **Maintainer**: Document all changes to axioms in git commit messages

--- a/Compiler/Proofs/IRGeneration/Conversions.lean
+++ b/Compiler/Proofs/IRGeneration/Conversions.lean
@@ -10,6 +10,7 @@
 
 import Compiler.Proofs.IRGeneration.IRInterpreter
 import Verity.Proofs.Stdlib.SpecInterpreter
+import Verity.Proofs.Stdlib.Automation
 import Verity.Core
 import Compiler.ContractSpec
 import Compiler.Hex
@@ -68,20 +69,15 @@ def addressKeyMap (addrs : List Address) : List (Nat × Address) :=
 def addressFromNat (addrs : List Address) (key : Nat) : Option Address :=
   (addressKeyMap addrs).lookup key
 
-/-- For valid Ethereum addresses, addressToNat is injective
+/-- For valid Ethereum addresses, addressToNat is injective.
 
-    TRUST ASSUMPTION (Restricted): This axiom only claims injectivity for valid,
-    normalized (lowercase) addresses.
-
-    Why this is sound:
-    - Valid addresses are 20-byte hex strings (0x + 40 hex chars)
-    - Normalization removes case-based collisions
-    - For normalized addresses, hex parsing is injective before mod 2^160
-    - This matches the actual Ethereum address space
-    - Validated by 70,000+ differential tests
+    This was previously an axiom but is now derived from the stronger
+    `addressToNat_injective` (which holds for all addresses, not just valid ones).
+    See AXIOMS.md for the remaining axioms.
 -/
-axiom addressToNat_injective_valid :
-  ∀ {a b : Address}, isValidAddress a → isValidAddress b → addressToNat a = addressToNat b → a = b
+theorem addressToNat_injective_valid :
+    ∀ {a b : Address}, isValidAddress a → isValidAddress b → addressToNat a = addressToNat b → a = b :=
+  fun _ _ h_eq => Verity.Proofs.Stdlib.Automation.addressToNat_injective _ _ h_eq
 
 /-! ## Uint256 Conversion -/
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ One spec can have many competing implementations - naive, gas-optimized, packed 
 | ReentrancyExample | 4 | Reentrancy vulnerability vs safe withdrawal |
 | CryptoHash | - | External cryptographic library linking |
 
-300 theorems across 9 categories. 325 Foundry tests across 24 test suites. 220 covered by property tests (73% coverage, 80 proof-only exclusions). 5 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)).
+300 theorems across 9 categories. 325 Foundry tests across 24 test suites. 220 covered by property tests (73% coverage, 80 proof-only exclusions). 4 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
 - **EDSL correctness** - each contract satisfies its spec in Lean (Layer 1)
 - **Compiler correctness** - IR generation preserves semantics (Layer 2), Yul codegen preserves IR (Layer 3)
-- **End-to-end pipeline** - EDSL -> ContractSpec -> IR -> Yul, fully verified with 5 axioms
+- **End-to-end pipeline** - EDSL -> ContractSpec -> IR -> Yul, fully verified with 4 axioms
 - **Trust boundary** - Yul -> EVM bytecode via solc (validated by 70k+ differential tests)
 
 See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for trust boundaries, [`AXIOMS.md`](AXIOMS.md) for axiom documentation, and [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) for full status.
@@ -132,7 +132,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for conventions and workflow.
 | | |
 |---|---|
 | [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) | What's verified, what's trusted, trust reduction roadmap |
-| [`AXIOMS.md`](AXIOMS.md) | All 5 axioms with soundness justifications |
+| [`AXIOMS.md`](AXIOMS.md) | All 4 axioms with soundness justifications |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Coding conventions, workflow, PR guidelines |
 | [`docs/ROADMAP.md`](docs/ROADMAP.md) | Verification progress, planned features |
 | [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) | Per-theorem status |

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -21,7 +21,7 @@ The Verity compiler transforms high-level, verified contract specifications into
 
 ### What's Verified (Zero Trust Required)
 - **EDSL + compiler proofs**: Lean theorems for contract specs, IR generation, and Yul codegen
-- **Machine-checked proofs**: 5 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 12 sorry in Ledger sum proofs
+- **Machine-checked proofs**: 4 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 12 sorry in Ledger sum proofs
 - **Interpreter semantics**: Spec, IR, and Yul semantics defined and linked in Lean
 
 ### What's Tested (High Confidence)

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,7 +7,7 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 296 theorems across 9 categories. 286 fully proven, 10 `sorry` placeholders in Ledger sum property proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 5 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 296 theorems across 9 categories. 286 fully proven, 10 `sorry` placeholders in Ledger sum property proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 4 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-15)
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -18,7 +18,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Core Size**: 249 lines
 - **Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, CryptoHash, ReentrancyExample
 - **Theorems**: 300 across 9 categories (288 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
-- **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, address injectivity
+- **Axioms**: 4 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, address injectivity
 - **Tests**: 325 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity


### PR DESCRIPTION
## Summary
- Convert \`addressToNat_injective_valid\` from axiom to theorem, derived from the strictly stronger \`addressToNat_injective\` — reduces axiom count from 5 to 4
- Document \`allowUnsafeReducibility\` usage as a trust assumption in TRUST_ASSUMPTIONS.md (addresses #188)
- Add "Eliminated Axioms" section to AXIOMS.md for tracking removed axioms

## Details

**Axiom #3 elimination**: \`addressToNat_injective_valid\` required \`isValidAddress\` preconditions, but \`addressToNat_injective\` (axiom #4, now #4) makes the same claim unconditionally. The weaker axiom had **zero call sites** in the entire codebase, making this zero-risk:

\`\`\`lean
-- Before: axiom (trust required)
axiom addressToNat_injective_valid :
  ∀ {a b : Address}, isValidAddress a → isValidAddress b →
    addressToNat a = addressToNat b → a = b

-- After: theorem (derived from existing axiom)
theorem addressToNat_injective_valid :
    ∀ {a b : Address}, isValidAddress a → isValidAddress b →
      addressToNat a = addressToNat b → a = b :=
  fun _ _ h_eq => addressToNat_injective _ _ h_eq
\`\`\`

**allowUnsafeReducibility documentation**: Two usages in \`Semantics.lean:332\` and \`Equivalence.lean:11\` are now documented in TRUST_ASSUMPTIONS.md with risk assessment and elimination path.

## Files Changed
- \`Compiler/Proofs/IRGeneration/Conversions.lean\` — axiom → theorem
- \`AXIOMS.md\` — Removed axiom #3 section, renumbered, added "Eliminated Axioms"
- \`TRUST_ASSUMPTIONS.md\` — Updated counts, added allowUnsafeReducibility section
- \`README.md\`, \`compiler.mdx\`, \`verification.mdx\`, \`llms.txt\` — 5 → 4 axioms

## Test plan
- [x] \`lake build\` passes (76/76)
- [x] \`check_doc_counts.py\` validates (300 theorems, 4 axioms, 325 tests)
- [x] \`check_axiom_locations.py\` validates all 4 axiom locations

Closes #142
Addresses #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes one trust axiom by deriving it from an existing stronger axiom and updates documentation accordingly; no runtime logic changes and minimal proof surface impact.
> 
> **Overview**
> Eliminates the redundant `addressToNat_injective_valid` trust assumption by converting it from an `axiom` to a `theorem` in `Conversions.lean`, derived directly from the stronger existing `addressToNat_injective` axiom.
> 
> Updates the trust-model docs (`AXIOMS.md`, `TRUST_ASSUMPTIONS.md`, README, and docs-site pages) to reflect **5→4 total axioms**, adds an **“Eliminated Axioms”** tracking section to `AXIOMS.md`, and documents `allowUnsafeReducibility` usage as an explicit (low-risk) trust assumption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41d879ac06a3728f0cf7218b896f79c2abaf6255. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->