### PR TITLE
fix: Restrict FFI to difftest profile (closes #194)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -258,6 +258,7 @@ jobs:
 
       - name: Run Foundry tests with seed 42
         env:
+          FOUNDRY_PROFILE: difftest
           DIFFTEST_RANDOM_SMALL: "100"
           DIFFTEST_RANDOM_LARGE: "10000"
           DIFFTEST_RANDOM_SEED: "42"
@@ -320,6 +321,7 @@ jobs:
 
       - name: Run tests with seed ${{ matrix.seed }}
         env:
+          FOUNDRY_PROFILE: difftest
           DIFFTEST_RANDOM_SMALL: "100"
           DIFFTEST_RANDOM_LARGE: "10000"
           DIFFTEST_RANDOM_SEED: "${{ matrix.seed }}"

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ lake build
 lake build verity-compiler
 lake exe verity-compiler
 
-# Run Foundry tests
-forge test
+# Run Foundry tests (requires difftest profile for FFI access)
+FOUNDRY_PROFILE=difftest forge test
 ```
 
 </details>
@@ -97,10 +97,12 @@ forge test
 **Property tests** (325 tests) validate EDSL = Yul = EVM execution:
 
 ```bash
-forge test                                          # run all
-forge test -vvv                                     # verbose
-forge test --match-path test/PropertyCounter.t.sol  # specific file
+FOUNDRY_PROFILE=difftest forge test                                          # run all
+FOUNDRY_PROFILE=difftest forge test -vvv                                     # verbose
+FOUNDRY_PROFILE=difftest forge test --match-path test/PropertyCounter.t.sol  # specific file
 ```
+
+> **Note**: Tests require `FOUNDRY_PROFILE=difftest` because they compile Yul via `solc` using `vm.ffi()`. The default profile has FFI disabled for security. See [foundry.toml](foundry.toml).
 
 **Differential tests** compare EDSL interpreter output against Solidity-compiled EVM to catch compiler bugs. See [`test/README.md`](test/README.md).
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -302,8 +302,8 @@ lake exe verity-compiler
 
 ### Test Compiled Contracts
 ```bash
-# Run all Foundry tests
-forge test
+# Run all Foundry tests (difftest profile enables FFI for Yul compilation)
+FOUNDRY_PROFILE=difftest forge test
 
 # Expected: 325/325 tests pass (as of 2026-02-16)
 ```

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,11 +4,17 @@ out = "out"
 libs = ["lib"]
 test = "test"
 cache_path = "cache"
-ffi = true
+ffi = false
 solc_version = "0.8.33"
 via_ir = true
 optimizer = true
 optimizer_runs = 200
 fs_permissions = [{ access = "read", path = "./compiler/yul" }]
+
+# Differential testing profile: enables FFI for vm.ffi() calls to difftest-interpreter.
+# Only differential tests (test/Differential*.t.sol) and Yul tests (test/yul/) use FFI.
+# Usage: FOUNDRY_PROFILE=difftest forge test
+[profile.difftest]
+ffi = true
 
 [rpc_endpoints]


### PR DESCRIPTION
## Summary
- Disable \`vm.ffi()\` in the default Foundry profile to prevent unauthorized shell command execution
- Create a \`[profile.difftest]\` profile that enables FFI for tests that need it
- Update CI to use \`FOUNDRY_PROFILE=difftest\` for all test jobs

## Problem
\`foundry.toml\` had \`ffi = true\` globally, allowing any \`.t.sol\` file to execute arbitrary shell commands via \`vm.ffi()\`. A malicious PR adding a test file could exfiltrate CI secrets or modify the build environment.

## Solution
\`\`\`toml
# Default: FFI disabled
[profile.default]
ffi = false

# Differential testing: FFI enabled
[profile.difftest]
ffi = true
\`\`\`

CI now explicitly opts into FFI via \`FOUNDRY_PROFILE=difftest\`. Local development uses \`FOUNDRY_PROFILE=difftest forge test\`.

## Files Changed
- \`foundry.toml\` — Add difftest profile, disable default FFI
- \`.github/workflows/verify.yml\` — Set FOUNDRY_PROFILE=difftest in test jobs
- \`README.md\` — Update forge test commands
- \`docs-site/content/compiler.mdx\` — Update test command

## Test plan
- [x] \`FOUNDRY_PROFILE=difftest forge test --match-path test/PropertyCounter.t.sol\` passes
- [x] Default profile correctly blocks FFI (\`forge test\` fails with FFI disabled error)
- [ ] CI passes with FOUNDRY_PROFILE=difftest

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive test execution settings (`vm.ffi()`) and CI configuration; main risk is CI/test breakage if any suites implicitly relied on default-profile FFI.
> 
> **Overview**
> Disables `ffi` in Foundry’s default profile and introduces a dedicated `profile.difftest` that enables `vm.ffi()` for differential/Yul-related tests.
> 
> Updates CI (`verify.yml`) and developer docs (`README.md`, `docs-site/content/compiler.mdx`) to run `forge test` under `FOUNDRY_PROFILE=difftest`, making FFI usage an explicit opt-in instead of global.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfd6dafd0cb978a8fed737ccf2069bb717fd841c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->