### PR TITLE
fix: Add calldatasize guard to all compiled functions (closes #176)

### DIFF
--- a/Compiler/Proofs/YulGeneration/Codegen.lean
+++ b/Compiler/Proofs/YulGeneration/Codegen.lean
@@ -84,7 +84,8 @@ by
 /-- Switch cases generated from IR functions. -/
 def switchCases (fns : List IRFunction) : List (Prod Nat (List YulStmt)) :=
   fns.map (fun f =>
-    let body := [YulStmt.comment s!"{f.name}()"] ++ [Compiler.callvalueGuard] ++ f.body
+    let body := [YulStmt.comment s!"{f.name}()"] ++
+      [Compiler.callvalueGuard] ++ [Compiler.calldatasizeGuard f.params.length] ++ f.body
     (f.selector, body)
   )
 
@@ -136,7 +137,8 @@ theorem find_switch_case_of_find_function
     (fns : List IRFunction) (sel : Nat) (fn : IRFunction)
     (hFind : fns.find? (fun f => f.selector == sel) = some fn) :
     (switchCases fns).find? (fun (c, _) => c = sel) =
-      some (fn.selector, [YulStmt.comment s!"{fn.name}()"] ++ [Compiler.callvalueGuard] ++ fn.body) := by
+      some (fn.selector, [YulStmt.comment s!"{fn.name}()"] ++
+        [Compiler.callvalueGuard] ++ [Compiler.calldatasizeGuard fn.params.length] ++ fn.body) := by
   induction fns with
   | nil =>
       simp at hFind

--- a/Compiler/Proofs/YulGeneration/Preservation.lean
+++ b/Compiler/Proofs/YulGeneration/Preservation.lean
@@ -73,7 +73,8 @@ theorem yulCodegen_preserves_semantics
       -- The switch cases align with `find?` on selectors.
       have hcase :
           (switchCases contract.functions).find? (fun (c, _) => c = tx.functionSelector) =
-            some (fn.selector, [YulStmt.comment s!"{fn.name}()"] ++ [Compiler.callvalueGuard] ++ fn.body) := by
+            some (fn.selector, [YulStmt.comment s!"{fn.name}()"] ++
+              [Compiler.callvalueGuard] ++ [Compiler.calldatasizeGuard fn.params.length] ++ fn.body) := by
         exact find_switch_case_of_find_function contract.functions tx.functionSelector fn hFind
       -- Apply switch rule.
       have hsel :

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ One spec can have many competing implementations - naive, gas-optimized, packed 
 | ReentrancyExample | 4 | Reentrancy vulnerability vs safe withdrawal |
 | CryptoHash | - | External cryptographic library linking |
 
-300 theorems across 9 categories. 325 Foundry tests across 24 test suites. 220 covered by property tests (73% coverage, 80 proof-only exclusions). 4 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)).
+300 theorems across 9 categories. 349 Foundry tests across 25 test suites. 220 covered by property tests (73% coverage, 80 proof-only exclusions). 4 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
@@ -94,7 +94,7 @@ FOUNDRY_PROFILE=difftest forge test
 <details>
 <summary><strong>Testing</strong></summary>
 
-**Property tests** (325 tests) validate EDSL = Yul = EVM execution:
+**Property tests** (349 tests) validate EDSL = Yul = EVM execution:
 
 ```bash
 FOUNDRY_PROFILE=difftest forge test                                          # run all

--- a/compiler/yul/Counter.yul
+++ b/compiler/yul/Counter.yul
@@ -11,6 +11,9 @@ object "Counter" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 4) {
+                    revert(0, 0)
+                }
                 sstore(0, add(sload(0), 1))
                 stop()
             }
@@ -19,12 +22,18 @@ object "Counter" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 4) {
+                    revert(0, 0)
+                }
                 sstore(0, sub(sload(0), 1))
                 stop()
             }
             case 0xa87d942c {
                 /* getCount() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 4) {
                     revert(0, 0)
                 }
                 mstore(0, sload(0))

--- a/compiler/yul/Ledger.yul
+++ b/compiler/yul/Ledger.yul
@@ -16,6 +16,9 @@ object "Ledger" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 36) {
+                    revert(0, 0)
+                }
                 let amount := calldataload(4)
                 let senderBal := sload(mappingSlot(0, caller()))
                 sstore(mappingSlot(0, caller()), add(senderBal, amount))
@@ -24,6 +27,9 @@ object "Ledger" {
             case 0x2e1a7d4d {
                 /* withdraw() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 36) {
                     revert(0, 0)
                 }
                 let amount := calldataload(4)
@@ -41,6 +47,9 @@ object "Ledger" {
             case 0xa9059cbb {
                 /* transfer() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 68) {
                     revert(0, 0)
                 }
                 let to := and(calldataload(4), 0xffffffffffffffffffffffffffffffffffffffff)
@@ -72,6 +81,9 @@ object "Ledger" {
             case 0xf8b2cb4f {
                 /* getBalance() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 36) {
                     revert(0, 0)
                 }
                 let addr := and(calldataload(4), 0xffffffffffffffffffffffffffffffffffffffff)

--- a/compiler/yul/Owned.yul
+++ b/compiler/yul/Owned.yul
@@ -15,6 +15,9 @@ object "Owned" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 36) {
+                    revert(0, 0)
+                }
                 let newOwner := and(calldataload(4), 0xffffffffffffffffffffffffffffffffffffffff)
                 if iszero(eq(caller(), sload(0))) {
                     mstore(0, 0x8c379a000000000000000000000000000000000000000000000000000000000)
@@ -29,6 +32,9 @@ object "Owned" {
             case 0x893d20e8 {
                 /* getOwner() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 4) {
                     revert(0, 0)
                 }
                 mstore(0, sload(0))

--- a/compiler/yul/OwnedCounter.yul
+++ b/compiler/yul/OwnedCounter.yul
@@ -15,6 +15,9 @@ object "OwnedCounter" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 4) {
+                    revert(0, 0)
+                }
                 if iszero(eq(caller(), sload(0))) {
                     mstore(0, 0x8c379a000000000000000000000000000000000000000000000000000000000)
                     mstore(4, 32)
@@ -28,6 +31,9 @@ object "OwnedCounter" {
             case 0x2baeceb7 {
                 /* decrement() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 4) {
                     revert(0, 0)
                 }
                 if iszero(eq(caller(), sload(0))) {
@@ -45,6 +51,9 @@ object "OwnedCounter" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 4) {
+                    revert(0, 0)
+                }
                 mstore(0, sload(1))
                 return(0, 32)
             }
@@ -53,12 +62,18 @@ object "OwnedCounter" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 4) {
+                    revert(0, 0)
+                }
                 mstore(0, sload(0))
                 return(0, 32)
             }
             case 0xf2fde38b {
                 /* transferOwnership() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 36) {
                     revert(0, 0)
                 }
                 let newOwner := and(calldataload(4), 0xffffffffffffffffffffffffffffffffffffffff)

--- a/compiler/yul/SafeCounter.yul
+++ b/compiler/yul/SafeCounter.yul
@@ -11,6 +11,9 @@ object "SafeCounter" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 4) {
+                    revert(0, 0)
+                }
                 let count := sload(0)
                 let newCount := add(count, 1)
                 if iszero(gt(newCount, count)) {
@@ -28,6 +31,9 @@ object "SafeCounter" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 4) {
+                    revert(0, 0)
+                }
                 let count := sload(0)
                 if lt(count, 1) {
                     mstore(0, 0x8c379a000000000000000000000000000000000000000000000000000000000)
@@ -42,6 +48,9 @@ object "SafeCounter" {
             case 0xa87d942c {
                 /* getCount() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 4) {
                     revert(0, 0)
                 }
                 mstore(0, sload(0))

--- a/compiler/yul/SimpleStorage.yul
+++ b/compiler/yul/SimpleStorage.yul
@@ -11,6 +11,9 @@ object "SimpleStorage" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 36) {
+                    revert(0, 0)
+                }
                 let value := calldataload(4)
                 sstore(0, value)
                 stop()
@@ -18,6 +21,9 @@ object "SimpleStorage" {
             case 0x2e64cec1 {
                 /* retrieve() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 4) {
                     revert(0, 0)
                 }
                 mstore(0, sload(0))

--- a/compiler/yul/SimpleToken.yul
+++ b/compiler/yul/SimpleToken.yul
@@ -21,6 +21,9 @@ object "SimpleToken" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 68) {
+                    revert(0, 0)
+                }
                 let to := and(calldataload(4), 0xffffffffffffffffffffffffffffffffffffffff)
                 let amount := calldataload(36)
                 if iszero(eq(caller(), sload(0))) {
@@ -57,6 +60,9 @@ object "SimpleToken" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 68) {
+                    revert(0, 0)
+                }
                 let to := and(calldataload(4), 0xffffffffffffffffffffffffffffffffffffffff)
                 let amount := calldataload(36)
                 let senderBal := sload(mappingSlot(1, caller()))
@@ -88,6 +94,9 @@ object "SimpleToken" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 36) {
+                    revert(0, 0)
+                }
                 let addr := and(calldataload(4), 0xffffffffffffffffffffffffffffffffffffffff)
                 mstore(0, sload(mappingSlot(1, addr)))
                 return(0, 32)
@@ -97,12 +106,18 @@ object "SimpleToken" {
                 if callvalue() {
                     revert(0, 0)
                 }
+                if lt(calldatasize(), 4) {
+                    revert(0, 0)
+                }
                 mstore(0, sload(2))
                 return(0, 32)
             }
             case 0x8da5cb5b {
                 /* owner() */
                 if callvalue() {
+                    revert(0, 0)
+                }
+                if lt(calldatasize(), 4) {
                     revert(0, 0)
                 }
                 mstore(0, sload(0))

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -305,7 +305,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 325/325 tests pass (as of 2026-02-16)
+# Expected: 349/349 tests pass (as of 2026-02-16)
 ```
 
 ### Add New Contract
@@ -348,10 +348,10 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 325/325 passing (100%, as of 2026-02-16)
+**Foundry Tests**: 349/349 passing (100%, as of 2026-02-16)
 ```bash
 $ forge test
-Ran 24 test suites: 325 tests passed, 0 failed, 0 skipped (325 total tests)
+Ran 25 test suites: 349 tests passed, 0 failed, 0 skipped (349 total tests)
 ```
 
 **Coverage**: Unit, property, and differential tests across EDSL and compiled Yul. See `test/` for suites.

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -19,7 +19,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, CryptoHash, ReentrancyExample
 - **Theorems**: 300 across 9 categories (288 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
 - **Axioms**: 4 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, address injectivity
-- **Tests**: 325 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
+- **Tests**: 349 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
 

--- a/test/CalldataSizeGuard.t.sol
+++ b/test/CalldataSizeGuard.t.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title CalldataSizeGuardTest
+ * @notice Tests that all compiled contracts reject calls with truncated calldata.
+ * @dev Validates fix for issue #176: generated Yul must check calldatasize()
+ *      and revert when calldata is shorter than expected.
+ *
+ *      Expected minimum calldatasize per param count:
+ *      - 0 params: 4 bytes (selector only)
+ *      - 1 param:  36 bytes (4 + 32)
+ *      - 2 params: 68 bytes (4 + 64)
+ */
+contract CalldataSizeGuardTest is YulTestBase {
+    address counter;
+    address ledger;
+    address simpleStorage;
+    address safeCounter;
+    address owned;
+    address ownedCounter;
+    address simpleToken;
+
+    address alice = address(0xA11CE);
+    address bob = address(0xB0B);
+
+    function setUp() public {
+        counter = deployYul("Counter");
+        ledger = deployYul("Ledger");
+        simpleStorage = deployYul("SimpleStorage");
+        safeCounter = deployYul("SafeCounter");
+        owned = deployYulWithArgs("Owned", abi.encode(alice));
+        ownedCounter = deployYulWithArgs("OwnedCounter", abi.encode(alice));
+        simpleToken = deployYulWithArgs("SimpleToken", abi.encode(alice));
+    }
+
+    //═══════════════════════════════════════════════════════════════════════════
+    // Helper: send raw calldata to a contract
+    //═══════════════════════════════════════════════════════════════════════════
+
+    function _callRaw(address target, bytes memory data) internal returns (bool) {
+        (bool success,) = target.call(data);
+        return success;
+    }
+
+    //═══════════════════════════════════════════════════════════════════════════
+    // 0-param functions: require exactly 4 bytes (selector)
+    //═══════════════════════════════════════════════════════════════════════════
+
+    function testCalldataSize_Counter_Increment_TooShort() public {
+        // 3 bytes: too short for selector
+        assertFalse(_callRaw(counter, hex"d09de0"), "3 bytes should revert");
+    }
+
+    function testCalldataSize_Counter_Increment_Exact() public {
+        // 4 bytes: exact selector
+        assertTrue(_callRaw(counter, abi.encodeWithSignature("increment()")), "4 bytes should succeed");
+    }
+
+    function testCalldataSize_Counter_GetCount_TooShort() public {
+        assertFalse(_callRaw(counter, hex"a87d94"), "3 bytes should revert");
+    }
+
+    function testCalldataSize_Counter_GetCount_Exact() public {
+        assertTrue(_callRaw(counter, abi.encodeWithSignature("getCount()")), "4 bytes should succeed");
+    }
+
+    function testCalldataSize_SafeCounter_Decrement_TooShort() public {
+        assertFalse(_callRaw(safeCounter, hex"2baece"), "3 bytes should revert");
+    }
+
+    function testCalldataSize_SafeCounter_Decrement_Exact() public {
+        // First increment so decrement doesn't underflow
+        _callRaw(safeCounter, abi.encodeWithSignature("increment()"));
+        assertTrue(_callRaw(safeCounter, abi.encodeWithSignature("decrement()")), "4 bytes should succeed");
+    }
+
+    //═══════════════════════════════════════════════════════════════════════════
+    // 1-param functions: require 36 bytes (4 + 32)
+    //═══════════════════════════════════════════════════════════════════════════
+
+    function testCalldataSize_SimpleStorage_Store_TooShort() public {
+        // 35 bytes: selector + 31 bytes (missing last byte of param)
+        bytes memory short = new bytes(35);
+        short[0] = 0x60; short[1] = 0x57; short[2] = 0x36; short[3] = 0x1d; // store selector
+        assertFalse(_callRaw(simpleStorage, short), "35 bytes should revert for 1-param function");
+    }
+
+    function testCalldataSize_SimpleStorage_Store_Exact() public {
+        assertTrue(
+            _callRaw(simpleStorage, abi.encodeWithSignature("store(uint256)", 42)),
+            "36 bytes should succeed"
+        );
+    }
+
+    function testCalldataSize_SimpleStorage_Store_SelectorOnly() public {
+        // Just 4 bytes (selector only, no param)
+        assertFalse(_callRaw(simpleStorage, hex"6057361d"), "4 bytes should revert for 1-param function");
+    }
+
+    function testCalldataSize_Owned_TransferOwnership_TooShort() public {
+        bytes memory short = new bytes(20); // selector + partial address
+        short[0] = 0xf2; short[1] = 0xfd; short[2] = 0xe3; short[3] = 0x8b; // transferOwnership selector
+        vm.prank(alice);
+        assertFalse(_callRaw(owned, short), "20 bytes should revert for 1-param function");
+    }
+
+    function testCalldataSize_Owned_TransferOwnership_Exact() public {
+        vm.prank(alice);
+        assertTrue(
+            _callRaw(owned, abi.encodeWithSignature("transferOwnership(address)", bob)),
+            "36 bytes should succeed"
+        );
+    }
+
+    function testCalldataSize_Ledger_Deposit_SelectorOnly() public {
+        assertFalse(_callRaw(ledger, hex"b6b55f25"), "4 bytes should revert for 1-param function");
+    }
+
+    function testCalldataSize_Ledger_Deposit_Exact() public {
+        assertTrue(
+            _callRaw(ledger, abi.encodeWithSignature("deposit(uint256)", 100)),
+            "36 bytes should succeed"
+        );
+    }
+
+    function testCalldataSize_Ledger_GetBalance_TooShort() public {
+        assertFalse(_callRaw(ledger, hex"f8b2cb4f"), "4 bytes should revert for 1-param function");
+    }
+
+    function testCalldataSize_Ledger_GetBalance_Exact() public {
+        assertTrue(
+            _callRaw(ledger, abi.encodeWithSignature("getBalance(address)", alice)),
+            "36 bytes should succeed"
+        );
+    }
+
+    //═══════════════════════════════════════════════════════════════════════════
+    // 2-param functions: require 68 bytes (4 + 64)
+    //═══════════════════════════════════════════════════════════════════════════
+
+    function testCalldataSize_Ledger_Transfer_TooShort() public {
+        // 36 bytes: only first param, missing second
+        bytes memory oneParam = abi.encodeWithSignature("transfer(address,uint256)", bob);
+        bytes memory short = new bytes(36);
+        for (uint i = 0; i < 36; i++) short[i] = oneParam[i];
+        assertFalse(_callRaw(ledger, short), "36 bytes should revert for 2-param function");
+    }
+
+    function testCalldataSize_Ledger_Transfer_SelectorOnly() public {
+        assertFalse(_callRaw(ledger, hex"a9059cbb"), "4 bytes should revert for 2-param function");
+    }
+
+    function testCalldataSize_Ledger_Transfer_Exact() public {
+        // First deposit so transfer has balance
+        _callRaw(ledger, abi.encodeWithSignature("deposit(uint256)", 100));
+        assertTrue(
+            _callRaw(ledger, abi.encodeWithSignature("transfer(address,uint256)", bob, 50)),
+            "68 bytes should succeed"
+        );
+    }
+
+    function testCalldataSize_SimpleToken_Mint_SelectorOnly() public {
+        assertFalse(_callRaw(simpleToken, hex"40c10f19"), "4 bytes should revert for 2-param function");
+    }
+
+    function testCalldataSize_SimpleToken_Mint_Exact() public {
+        vm.prank(alice);
+        assertTrue(
+            _callRaw(simpleToken, abi.encodeWithSignature("mint(address,uint256)", bob, 1000)),
+            "68 bytes should succeed"
+        );
+    }
+
+    function testCalldataSize_SimpleToken_Transfer_TooShort() public {
+        bytes memory short = new bytes(67); // 1 byte short of 68
+        short[0] = 0xa9; short[1] = 0x05; short[2] = 0x9c; short[3] = 0xbb; // transfer selector
+        vm.prank(alice);
+        assertFalse(_callRaw(simpleToken, short), "67 bytes should revert for 2-param function");
+    }
+
+    //═══════════════════════════════════════════════════════════════════════════
+    // Empty calldata: should revert for all contracts (hits default case)
+    //═══════════════════════════════════════════════════════════════════════════
+
+    function testCalldataSize_EmptyCalldata_Counter() public {
+        assertFalse(_callRaw(counter, ""), "empty calldata should revert");
+    }
+
+    function testCalldataSize_EmptyCalldata_Ledger() public {
+        assertFalse(_callRaw(ledger, ""), "empty calldata should revert");
+    }
+
+    function testCalldataSize_EmptyCalldata_SimpleToken() public {
+        assertFalse(_callRaw(simpleToken, ""), "empty calldata should revert");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `calldatasizeGuard` to the Yul codegen pipeline — generated Yul now checks `calldatasize()` before reading parameters, reverting when calldata is shorter than `4 + 32 * numParams` bytes
- Prevents `calldataload` from silently zero-padding truncated inputs, fixing a soundness gap where contracts would accept malformed calls
- Update proof-side `switchCases` and `Preservation` theorem to match the new case body pattern
- Add 24 Foundry tests covering 0-param, 1-param, and 2-param functions with exact/truncated/empty calldata

## Details

**Issue**: #176 — Generated Yul does not check `calldatasize()` before reading parameters

**Problem**: EVM's `calldataload` zero-pads when reading beyond actual calldata length. A call with only 4 bytes (selector) to a function expecting `uint256` would silently read `0` instead of reverting.

**Fix**: Each switch case now emits `if lt(calldatasize(), N) { revert(0, 0) }` where N = 4 + 32 × param count, placed after the `callvalue()` guard and before parameter loads.

**Files changed**:
| File | Change |
|------|--------|
| `Compiler/Codegen.lean` | Added `calldatasizeGuard` def, included in `buildSwitch` body |
| `Compiler/Proofs/YulGeneration/Codegen.lean` | Updated `switchCases` and `find_switch_case_of_find_function` |
| `Compiler/Proofs/YulGeneration/Preservation.lean` | Updated `hcase` body pattern |
| `compiler/yul/*.yul` (7 files) | Regenerated with calldatasize checks |
| `test/CalldataSizeGuard.t.sol` | 24 new tests |
| `README.md`, `compiler.mdx`, `llms.txt` | 325→349 tests, 24→25 suites |

## Test plan

- [x] Lean build passes (76/76 modules)
- [x] All 24 new calldatasize tests pass
- [x] All 318 existing non-differential tests pass
- [x] Differential tests pass with `FOUNDRY_PROFILE=difftest`
- [x] `check_doc_counts.py` passes
- [ ] CI green (build + 8 foundry shards + 7 multi-seed runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime dispatch prologue for every compiled function, which can affect on-chain behavior for malformed inputs and must align with the verified semantics/proofs. Risk is mitigated by updated Lean proofs and new end-to-end Foundry tests exercising the new revert conditions.
> 
> **Overview**
> Adds a new Yul precondition, `calldatasizeGuard`, and injects it into every generated runtime switch case so calls revert when calldata is shorter than `4 + 32*numParams`, preventing `calldataload` from zero-padding truncated arguments.
> 
> Updates the Layer-3 Lean codegen/proof scaffolding (`switchCases`, lookup lemmas, and preservation theorem expectations) to match the new guard order, regenerates the example `compiler/yul/*.yul` outputs accordingly, and adds a dedicated Foundry test suite (`CalldataSizeGuard.t.sol`) covering truncated/empty calldata across 0/1/2-param functions; docs/test counts are bumped (325→349 tests, 24→25 suites).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb386ef1217557791b74f26826f4c87d175156ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->