### PR TITLE
fix: Align IR calldataload(0) with Yul semantics, closing soundness gap (closes #186)

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -26,7 +26,7 @@ In these cases, we use axioms with strong soundness arguments.
 
 ### 1. `evalIRExpr_eq_evalYulExpr`
 
-**Location**: `Compiler/Proofs/YulGeneration/StatementEquivalence.lean:43`
+**Location**: `Compiler/Proofs/YulGeneration/StatementEquivalence.lean:48`
 
 **Statement**:
 ```lean
@@ -45,8 +45,8 @@ axiom evalIRExpr_eq_evalYulExpr (selector : Nat) (irState : IRState) (expr : Yul
 **Soundness Argument**:
 1. **Source code inspection**: Both functions have structurally identical implementations
 2. **Asymmetry**: Only the IR side is `partial`; the Yul side is already total
-3. **State translation**: `yulStateOfIR` simply copies all fields from IRState to YulState
-4. **Selector field**: Only difference is the `selector` field, which doesn't affect expression evaluation
+3. **State translation**: `yulStateOfIR` copies all fields from IRState to YulState (including `selector`)
+4. **calldataload(0)**: Both evaluators return `selectorWord(state.selector)` for offset=0 (fixed in PR #205)
 5. **Differential testing**: 70,000+ property tests validate this equivalence holds in practice
 
 **Alternative Approach**:
@@ -68,7 +68,7 @@ To eliminate this axiom, only the IR evaluator needs refactoring:
 
 ### 2. `evalIRExprs_eq_evalYulExprs`
 
-**Location**: `Compiler/Proofs/YulGeneration/StatementEquivalence.lean:47`
+**Location**: `Compiler/Proofs/YulGeneration/StatementEquivalence.lean:52`
 
 **Statement**:
 ```lean

--- a/Compiler/Proofs/IRGeneration/Conversions.lean
+++ b/Compiler/Proofs/IRGeneration/Conversions.lean
@@ -138,7 +138,8 @@ def specStorageToIRState (storage : SpecStorage) (sender : Address) : IRState :=
     memory := fun _ => 0
     calldata := []
     returnValue := none
-    sender := addressToNat sender }
+    sender := addressToNat sender
+    selector := 0 }
 
 @[simp] theorem specStorageToIRState_storage (storage : SpecStorage) (sender : Address) (slot : Nat) :
     (specStorageToIRState storage sender).storage slot = storage.getSlot slot := by

--- a/Compiler/Proofs/YulGeneration/Equivalence.lean
+++ b/Compiler/Proofs/YulGeneration/Equivalence.lean
@@ -13,13 +13,13 @@ attribute [local reducible] execIRStmt execIRStmts
 
 /-! ## IR ↔ Yul State Alignment -/
 
-def yulStateOfIR (selector : Nat) (state : IRState) : YulState :=
+def yulStateOfIR (_selector : Nat) (state : IRState) : YulState :=
   { vars := state.vars
     storage := state.storage
     mappings := state.mappings
     memory := state.memory
     calldata := state.calldata
-    selector := selector
+    selector := state.selector
     returnValue := state.returnValue
     sender := state.sender }
 
@@ -186,15 +186,15 @@ def ir_yul_function_equiv_goal
     (fn : IRFunction) (tx : IRTransaction) (state : IRState) : Prop :=
     tx.functionSelector < selectorModulus →
     resultsMatch
-      (execIRFunction fn tx.args { state with sender := tx.sender, calldata := tx.args })
-      (interpretYulBody fn tx { state with sender := tx.sender, calldata := tx.args })
+      (execIRFunction fn tx.args { state with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })
+      (interpretYulBody fn tx { state with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })
 
 theorem ir_yul_function_equiv_goal_of_resultsMatch
     (fn : IRFunction) (tx : IRTransaction) (state : IRState)
     (hMatch :
       resultsMatch
-        (execIRFunction fn tx.args { state with sender := tx.sender, calldata := tx.args })
-        (interpretYulBody fn tx { state with sender := tx.sender, calldata := tx.args })) :
+        (execIRFunction fn tx.args { state with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })
+        (interpretYulBody fn tx { state with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })) :
     ir_yul_function_equiv_goal fn tx state := by
   intro _
   simpa [ir_yul_function_equiv_goal] using hMatch

--- a/Compiler/Proofs/YulGeneration/Preservation.lean
+++ b/Compiler/Proofs/YulGeneration/Preservation.lean
@@ -38,13 +38,13 @@ theorem yulCodegen_preserves_semantics
     (hselector : tx.functionSelector < selectorModulus)
     (hbody : ∀ fn, fn ∈ contract.functions →
       resultsMatch
-        (execIRFunction fn tx.args { initialState with sender := tx.sender, calldata := tx.args })
-        (interpretYulBody fn tx { initialState with sender := tx.sender, calldata := tx.args })) :
+        (execIRFunction fn tx.args { initialState with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })
+        (interpretYulBody fn tx { initialState with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })) :
     resultsMatch
       (interpretIR contract tx initialState)
       (interpretYulFromIR contract tx initialState) := by
-  -- Normalize the initial IR state with sender/calldata.
-  let irState := { initialState with sender := tx.sender, calldata := tx.args }
+  -- Normalize the initial IR state with sender/calldata/selector.
+  let irState := { initialState with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector }
   let yulTx : YulTransaction := {
     sender := tx.sender
     functionSelector := tx.functionSelector

--- a/Compiler/Proofs/YulGeneration/README.md
+++ b/Compiler/Proofs/YulGeneration/README.md
@@ -39,7 +39,7 @@ Two expression evaluation axioms in `StatementEquivalence.lean`:
 1. `evalIRExpr_eq_evalYulExpr` - IR and Yul expression evaluation are identical when states are aligned
 2. `evalIRExprs_eq_evalYulExprs` - List version of the above
 
-These are sound because both eval functions have identical source code and `yulStateOfIR` copies all fields. The axiom exists because `evalIRExpr` is `partial` (opaque to Lean's kernel) while `evalYulExpr` is total. Eliminating the axiom requires only refactoring the IR evaluator to use fuel parameters (~300 lines).
+These are sound because both eval functions have identical source code and `yulStateOfIR` copies all fields (including `selector`). Both handle `calldataload(0)` identically via `selectorWord(state.selector)`. The axiom exists because `evalIRExpr` is `partial` (opaque to Lean's kernel) while `evalYulExpr` is total. Eliminating the axiom requires only refactoring the IR evaluator to use fuel parameters (~300 lines).
 
 ## References
 


### PR DESCRIPTION
## Summary

- Fix provably unsound `evalIRExpr_eq_evalYulExpr` axiom: the IR evaluator returned 0 for `calldataload(0)` while the Yul evaluator returned `selectorWord(selector)`
- Add `selector` field to `IRState` so both evaluators compute `calldataload(0)` identically
- Update `yulStateOfIR` to copy `state.selector` instead of using a separate parameter
- Update all `IRState` construction sites and proof-side state patterns

## Details

**Issue**: #186 — `evalIRExpr` axiom is provably unsound for `calldataload(0)`

**Problem**: The axiom `evalIRExpr_eq_evalYulExpr` asserts that IR and Yul expression evaluation are identical for ALL expressions. But for `calldataload(0)`:
- IR evaluator: `if offset < 4 then some 0` → returns **0**
- Yul evaluator: `if offset = 0 then some (selectorWord state.selector)` → returns **selector << 224**

This made the axiom provably false, which is a soundness vulnerability. While no current compiled code invokes `calldataload(0)` inside function bodies (the switch dispatcher is handled separately), any future compiler feature emitting `calldataload(0)` in a function body would inherit a false assumption.

**Fix**: Add `selector : Nat` to `IRState` and update the IR evaluator's calldataload to:
```lean
if offset = 0 then
  some ((state.selector % (2 ^ 32)) * (2 ^ 224))
```
This matches the Yul evaluator's `selectorWord state.selector` computation exactly.

**Files changed**:
| File | Change |
|------|--------|
| `IRInterpreter.lean` | Add `selector` field to `IRState`, fix calldataload(0) |
| `Conversions.lean` | Add `selector := 0` to `specStorageToIRState` |
| `Equivalence.lean` | Use `state.selector` in `yulStateOfIR`, update equiv goals |
| `Preservation.lean` | Add `selector := tx.functionSelector` to state patterns |
| `StatementEquivalence.lean` | Update axiom documentation |
| `AXIOMS.md` | Update soundness argument and line references |
| `README.md` (YulGeneration) | Update axiom description |

## Test plan

- [x] Lean build passes (76/76 modules)
- [x] All 375 Foundry tests pass (2 known OOG in Random10000, excluded in CI)
- [x] `check_doc_counts.py` passes
- [x] `check_axiom_locations.py` passes
- [x] All CI validation scripts pass
- [ ] Full CI green (build + 8 foundry shards + 7 multi-seed runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core IR interpreter state and calldata semantics, which can affect execution results and downstream equivalence proofs if any call sites weren’t updated. Scope is contained to selector plumbing and documentation, but it touches multiple proof layers.
> 
> **Overview**
> Fixes a semantic mismatch between IR and Yul evaluation of `calldataload(0)` by adding a `selector` field to `IRState` and making the IR interpreter return the selector word (selector << 224) for offset 0.
> 
> Threads the selector through IR execution (`IRState.initial`, `interpretIR`, `specStorageToIRState`) and proof scaffolding (`yulStateOfIR` now copies `state.selector`; preservation/equivalence lemmas updated accordingly), and updates axiom documentation (`AXIOMS.md`, `StatementEquivalence.lean`, Layer 3 README) to reflect the now-sound equivalence assumptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38f9d6f11f96d03a900e8f5813a2b19ef7412221. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->