### PR TITLE
fix: Discharge hbody hypothesis via fuel adequacy axiom (closes #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ One spec can have many competing implementations - naive, gas-optimized, packed 
 | ReentrancyExample | 4 | Reentrancy vulnerability vs safe withdrawal |
 | CryptoHash | - | External cryptographic library linking |
 
-300 theorems across 9 categories. 349 Foundry tests across 25 test suites. 220 covered by property tests (73% coverage, 80 proof-only exclusions). 4 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)).
+300 theorems across 9 categories. 349 Foundry tests across 25 test suites. 220 covered by property tests (73% coverage, 80 proof-only exclusions). 5 documented axioms, 12 `sorry` in Ledger sum proofs ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
 - **EDSL correctness** - each contract satisfies its spec in Lean (Layer 1)
 - **Compiler correctness** - IR generation preserves semantics (Layer 2), Yul codegen preserves IR (Layer 3)
-- **End-to-end pipeline** - EDSL -> ContractSpec -> IR -> Yul, fully verified with 4 axioms
+- **End-to-end pipeline** - EDSL -> ContractSpec -> IR -> Yul, fully verified with 5 axioms
 - **Trust boundary** - Yul -> EVM bytecode via solc (validated by 70k+ differential tests)
 
 See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for trust boundaries, [`AXIOMS.md`](AXIOMS.md) for axiom documentation, and [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) for full status.
@@ -134,7 +134,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for conventions and workflow.
 | | |
 |---|---|
 | [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) | What's verified, what's trusted, trust reduction roadmap |
-| [`AXIOMS.md`](AXIOMS.md) | All 4 axioms with soundness justifications |
+| [`AXIOMS.md`](AXIOMS.md) | All 5 axioms with soundness justifications |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Coding conventions, workflow, PR guidelines |
 | [`docs/ROADMAP.md`](docs/ROADMAP.md) | Verification progress, planned features |
 | [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) | Per-theorem status |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -25,7 +25,7 @@ User's Contract Code (EDSL)
 ContractSpec (High-level specification)
     ↓ [Layer 2: FULLY VERIFIED]
 IR (Intermediate representation)
-    ↓ [Layer 3: FULLY VERIFIED, 4 axioms]
+    ↓ [Layer 3: FULLY VERIFIED, 5 axioms]
 Yul (Ethereum intermediate language)
     ↓ [TRUSTED: Solidity compiler]
 EVM Bytecode
@@ -37,7 +37,7 @@ EVM Bytecode
 |-----------|--------|------------|
 | Layer 1 (EDSL → Spec) | ✅ Verified | None |
 | Layer 2 (Spec → IR) | ✅ Verified | None |
-| Layer 3 (IR → Yul) | ✅ Verified (4 axioms) | Very Low |
+| Layer 3 (IR → Yul) | ✅ Verified (5 axioms) | Very Low |
 | Axioms | ⚠️ Documented | Low |
 | Solidity Compiler (solc) | ⚠️ Trusted | Medium |
 | Keccak256 Hashing | ⚠️ Trusted | Low |
@@ -116,7 +116,7 @@ theorem execStmt_preserves_properties :
 
 ### Layer 3: IR → Yul
 
-**Status**: ✅ **Verified (with 4 axioms)**
+**Status**: ✅ **Verified (with 5 axioms)**
 
 **What is proven**: IR execution is equivalent to Yul execution when states are properly aligned.
 
@@ -139,7 +139,7 @@ theorem storageStore_equiv : ...
 theorem if_equiv : ...
 ```
 
-**Dependencies**: Relies on 4 axioms (see [Axioms](#axioms) section)
+**Dependencies**: Relies on 5 axioms (see [Axioms](#axioms) section)
 
 **What this guarantees**:
 - Yul code correctly implements IR semantics
@@ -353,7 +353,7 @@ Two files use `set_option allowUnsafeReducibility true`:
 
 ## Axioms
 
-Verity uses **4 axioms** across the verification codebase. All axioms are documented with soundness justifications.
+Verity uses **5 axioms** across the verification codebase. All axioms are documented with soundness justifications.
 
 **See**: [AXIOMS.md](AXIOMS.md) for complete details.
 
@@ -453,8 +453,8 @@ Use this checklist when performing security audits of Verity-verified contracts.
    - Effort: 3-4 months
 
 2. **Axiom Elimination**
-   - Refactor expression evaluation to fuel-based
-   - Removes 2 of 4 axioms
+   - Refactor IR execution to fuel-based (expressions + statements)
+   - Removes 3 of 5 axioms (evalIRExpr, evalIRExprs, execIRStmtsFuel adequacy)
    - Effort: ~500 LOC refactoring
 
 3. **Gas Cost Verification** (Issue #80)
@@ -494,7 +494,7 @@ Verity provides **strong formal verification** with a **small trusted computing 
 ⚠️ Solidity compiler (solc) - Validated by 70k+ differential tests
 ⚠️ Keccak256 hashing - Validated against solc
 ⚠️ EVM semantics - Industry standard, billions in TVL
-⚠️ 4 axioms - Low risk, extensively validated (see AXIOMS.md)
+⚠️ 5 axioms - Low risk, extensively validated (see AXIOMS.md)
 
 ### Risk Profile
 - **Overall**: Low to Medium risk

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -21,7 +21,7 @@ The Verity compiler transforms high-level, verified contract specifications into
 
 ### What's Verified (Zero Trust Required)
 - **EDSL + compiler proofs**: Lean theorems for contract specs, IR generation, and Yul codegen
-- **Machine-checked proofs**: 4 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 12 sorry in Ledger sum proofs
+- **Machine-checked proofs**: 5 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 12 sorry in Ledger sum proofs
 - **Interpreter semantics**: Spec, IR, and Yul semantics defined and linked in Lean
 
 ### What's Tested (High Confidence)

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,7 +7,7 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 296 theorems across 9 categories. 286 fully proven, 10 `sorry` placeholders in Ledger sum property proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 4 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 296 theorems across 9 categories. 286 fully proven, 10 `sorry` placeholders in Ledger sum property proofs ([#65](https://github.com/Th0rgal/verity/issues/65)). 5 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-15)
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -18,7 +18,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Core Size**: 249 lines
 - **Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, CryptoHash, ReentrancyExample
 - **Theorems**: 300 across 9 categories (288 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
-- **Axioms**: 4 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, address injectivity
+- **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, fuel adequacy, address injectivity
 - **Tests**: 349 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity


### PR DESCRIPTION
## Summary

- Add `ir_function_body_equiv` theorem that fully instantiates the proof chain from `all_stmts_equiv` through fuel adequacy to function-level IR↔Yul equivalence
- Add `execIRStmtsFuel_adequate` axiom to bridge the `partial` IR evaluator with the fuel-parametric version used in proofs
- The Layer 3 preservation theorem's `hbody` hypothesis is now dischargeable for any contract
- Axiom count increases from 4→5 (all 3 new IR axioms are eliminable by a single ~500 LOC refactor)

## Details

**Issue**: #159 — Layer 3 preservation theorem has undischarged `hbody` hypothesis

**Problem**: `yulCodegen_preserves_semantics` required `hbody : ∀ fn, fn ∈ contract.functions → resultsMatch (execIRFunction fn ...) (interpretYulBody fn ...)` but no theorem supplied this proof. The existing statement-level equivalence proofs (`all_stmts_equiv`) couldn't bridge to `hbody` because of two gaps:
1. `execIRFunction` uses `partial` `execIRStmts`, while proofs use fuel-parametric `execIRStmtsFuel`
2. No adequacy proof connected these two execution modes

**Fix**: Add `execIRStmtsFuel_adequate` axiom (standard fuel adequacy pattern) and compose it with the proven statement equivalence chain to produce `ir_function_body_equiv`.

**Proof chain**:
```
all_stmts_equiv (proven, 8 statement types)
    ↓
execIRStmtsFuel_equiv_execYulStmtsFuel_of_stmt_equiv (proven, list composition)
    ↓
ir_yul_function_equiv_fuel_goal_of_stmt_equiv (proven, function-level fuel equiv)
    ↓
execIRStmtsFuel_adequate (NEW AXIOM, bridges partial ↔ fuel)
    ↓
ir_function_body_equiv (NEW THEOREM, fully instantiated)
```

**Files changed**:
| File | Change |
|------|--------|
| `Equivalence.lean` | Add `execIRStmtsFuel_adequate` axiom + `execIRFunctionFuel_adequate` theorem |
| `Preservation.lean` | Add `ir_function_body_equiv` theorem, import StatementEquivalence |
| `AXIOMS.md` | Document new axiom #3, renumber #3→#4, #4→#5 |
| `README.md`, `TRUST_ASSUMPTIONS.md`, `compiler.mdx`, `verification.mdx`, `llms.txt` | Update axiom count 4→5 |

## Test plan

- [x] Lean build passes (76/76 modules, no new sorry)
- [x] `check_doc_counts.py` passes (5 axioms)
- [x] `check_axiom_locations.py` passes (all 5 axiom locations correct)
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new axiom bridging `partial` and fuel-based IR execution; while localized to proofs/docs, it expands the trusted base for core compiler-correctness results.
> 
> **Overview**
> Discharges Layer 3 `yulCodegen_preserves_semantics`’s previously external `hbody` assumption by introducing a fuel-adequacy bridge from total `execIRStmtsFuel` to `partial` `execIRStmts`, and composing it with existing statement equivalence to produce a self-contained `ir_function_body_equiv` theorem.
> 
> Adds a new axiom `execIRStmtsFuel_adequate` (plus `execIRFunctionFuel_adequate`) and updates axiom/trust-model documentation across `AXIOMS.md`, `README.md`, `TRUST_ASSUMPTIONS.md`, and docs to reflect the axiom count increase from 4→5.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bac89aabf2ec3d775bfb7c8bc6f1db5b3cefe09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->