### PR TITLE
Pin elan and solc with SHA256 integrity verification

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -35,6 +35,7 @@ on:
 env:
   SOLC_VERSION: "0.8.33"
   SOLC_URL: "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21"
+  SOLC_SHA256: "1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468"
 
 jobs:
   build:
@@ -45,8 +46,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install elan
+        env:
+          ELAN_VERSION: "v4.1.2"
+          ELAN_INIT_SHA256: "4bacca9502cb89736fe63d2685abc2947cfbf34dc87673504f1bb4c43eda9264"
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y --default-toolchain none
+          curl -sSfL "https://raw.githubusercontent.com/leanprover/elan/${ELAN_VERSION}/elan-init.sh" -o elan-init.sh
+          echo "${ELAN_INIT_SHA256}  elan-init.sh" | sha256sum -c -
+          bash elan-init.sh -y --default-toolchain none
+          rm elan-init.sh
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
       - name: Cache Lake packages
@@ -155,7 +162,9 @@ jobs:
       - name: Install solc
         if: steps.cache-solc.outputs.cache-hit != 'true'
         run: |
-          sudo curl -L "$SOLC_URL" -o /usr/local/bin/solc
+          curl -sSfL "$SOLC_URL" -o solc
+          echo "${SOLC_SHA256}  solc" | sha256sum -c -
+          sudo mv solc /usr/local/bin/solc
           sudo chmod +x /usr/local/bin/solc
 
       - name: Verify solc
@@ -250,7 +259,9 @@ jobs:
       - name: Install solc
         if: steps.cache-solc.outputs.cache-hit != 'true'
         run: |
-          sudo curl -L "$SOLC_URL" -o /usr/local/bin/solc
+          curl -sSfL "$SOLC_URL" -o solc
+          echo "${SOLC_SHA256}  solc" | sha256sum -c -
+          sudo mv solc /usr/local/bin/solc
           sudo chmod +x /usr/local/bin/solc
 
       - name: Verify solc
@@ -313,7 +324,9 @@ jobs:
       - name: Install solc
         if: steps.cache-solc.outputs.cache-hit != 'true'
         run: |
-          sudo curl -L "$SOLC_URL" -o /usr/local/bin/solc
+          curl -sSfL "$SOLC_URL" -o solc
+          echo "${SOLC_SHA256}  solc" | sha256sum -c -
+          sudo mv solc /usr/local/bin/solc
           sudo chmod +x /usr/local/bin/solc
 
       - name: Verify solc


### PR DESCRIPTION
## Summary
- **elan**: Pin to `v4.1.2` release tag (instead of `master` branch) and verify SHA256 checksum before executing the install script
- **solc**: Verify SHA256 checksum of downloaded binary before installing (both `build` and `foundry` jobs)

## Motivation
The CI pipeline installs two critical external binaries — elan (which bootstraps the Lean toolchain used to check proofs) and solc (the Solidity compiler used to compile generated Yul). Both were fetched via `curl` without integrity verification:

- **elan**: Fetched from `master` branch, meaning any commit to leanprover/elan could silently modify the install script. A compromised elan could install a backdoored Lean binary that accepts invalid proofs, undermining the entire verification chain.
- **solc**: Downloaded without checksum verification. A compromised solc could generate different bytecode than expected, making differential tests unreliable.

This PR pins both to specific versions and verifies SHA256 checksums before execution.

Closes #193

## Test plan
- [ ] CI passes (elan installs correctly from pinned tag)
- [ ] Foundry tests pass (solc installs and compiles correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that add checksum verification and version pinning; main failure mode is CI breaking if upstream artifacts or checksums change.
> 
> **Overview**
> Hardens the CI `verify.yml` workflow by **pinning and integrity-checking external tool downloads**.
> 
> `elan` installation now fetches `elan-init.sh` from a specific release tag and verifies its SHA256 before execution. `solc` downloads in the `build`, `foundry`, and `foundry-multi-seed` jobs now verify a pinned `SOLC_SHA256` before moving the binary into `/usr/local/bin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81730fb67180e619acfd43630d88128b50d77e75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->