### PR TITLE
Eliminate partial functions from trusted compiler code (15→5)

### DIFF
--- a/Compiler/RandomGen.lean
+++ b/Compiler/RandomGen.lean
@@ -196,14 +196,14 @@ def genTransaction (contractType : ContractType) (rng : RNG) : Except String (RN
 -/
 
 -- Generate N random transactions
-partial def genTransactions (contractType : ContractType) (count : Nat) (rng : RNG) : Except String (List Transaction) :=
-  if count == 0 then
-    Except.ok []
-  else
+def genTransactions (contractType : ContractType) (count : Nat) (rng : RNG) : Except String (List Transaction) :=
+  match count with
+  | 0 => Except.ok []
+  | n + 1 =>
     match genTransaction contractType rng with
     | Except.error msg => Except.error msg
     | Except.ok (rng', tx) =>
-        match genTransactions contractType (count - 1) rng' with
+        match genTransactions contractType n rng' with
         | Except.ok rest => Except.ok (tx :: rest)
         | Except.error msg => Except.error msg
 


### PR DESCRIPTION
## Summary
- Remove all 10 `partial` annotations from the trusted compilation pipeline
- Remaining 5 `partial def` are in `IRInterpreter.lean` (proof layer, inherently unbounded)

## Changes

**`Compiler/Yul/PrettyPrint.lean`** (4 functions made total):
- `toHex`: Add `termination_by x` + `Nat.div_lt_self` proof for the inner loop
- `ppExpr`, `ppStmt`: Replace `List.map`/`List.flatMap` with explicit `ppExprs`, `ppStmts`, `ppCases` list helpers in a `mutual` block, enabling structural recursion on the Yul AST
- `render`: Now total (delegates to total `ppStmts`)

**`Compiler/ContractSpec.lean`** (2 functions made total):
- `compileExpr`/`compileExprList`: Convert `compileExprList` from `List.mapM` to explicit cons-recursion within the `mutual` block, enabling Lean to verify structural termination on `Expr`

**`Compiler/Linker.lean`** (4 functions made total):
- `extractFunction`: Was already non-recursive; just remove `partial`
- `extractAllFunctions`: Use fuel bounded by `lines.length` for guaranteed termination
- `collectAllCalls`/`collectFuncDefs`: Replace `let rec` with mutual `callsFrom*`/`defsFrom*` helpers (structural recursion on `YulStmt`/`YulExpr`)

**`Compiler/RandomGen.lean`** (1 function made total):
- `genTransactions`: Match on `n + 1` pattern instead of `if count == 0`

## Why this matters
`partial` in Lean means the function bypasses the termination checker. For the compiler itself, this means:
1. No termination guarantee — the compiler could theoretically loop forever
2. Lean treats `partial` definitions as opaque — proofs cannot inspect inside them
3. This blocks any future compiler correctness proofs for the compilation pipeline

By making these functions total, Lean's kernel verifies termination and the functions become transparent to the proof system.

## Verification
- `lake build` passes (all 76 modules, all proofs verified)
- `lake build verity-compiler` passes
- Generated Yul for all 7 contracts compiles with solc
- `check_doc_counts.py`, `check_axiom_locations.py`, `check_selectors.py` all pass

Addresses #170

## Test plan
- [x] `lake build` — all proofs verified
- [x] Yul generation produces identical output
- [x] `python3 scripts/check_yul_compiles.py` — all 7 files compile
- [ ] CI build + Foundry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compiler/linker/pretty-printer code paths to restructure recursion for termination proofs; intended to be behavior-preserving but could subtly change output formatting or library reference validation if a traversal differs.
> 
> **Overview**
> Removes several `partial` definitions in the trusted compiler pipeline by rewriting list/AST traversals into structurally recursive helpers and adding explicit termination arguments/proofs.
> 
> Key changes: `ContractSpec.compileExprList`, `RandomGen.genTransactions`, `Linker.extractAllFunctions` (fuel-bounded), `Linker` call/def collection traversals, and Yul pretty-printing (`toHex`, `ppExpr`/`ppStmt`, `render`) are rewritten to satisfy Lean’s termination checker while preserving the same rendered/compiled output shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 926f3b0387a15bc09a8c199a20a988ecb788ac93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->