### PR TITLE
Thread msgValue and blockTimestamp through Transaction type

### DIFF
--- a/Compiler/DiffTestTypes.lean
+++ b/Compiler/DiffTestTypes.lean
@@ -21,6 +21,8 @@ structure Transaction where
   sender : Address
   functionName : String
   args : List Nat  -- Simplified: all args as uint256 for now
+  msgValue : Nat := 0
+  blockTimestamp : Nat := 0
 
 /-!
 ## Contract Type

--- a/Compiler/Interpreter.lean
+++ b/Compiler/Interpreter.lean
@@ -631,6 +631,8 @@ def main (args : List String) : IO Unit := do
       sender := normalizeAddress senderAddr
       functionName := functionName
       args := argsNat
+      msgValue := valueOpt.getD 0
+      blockTimestamp := timestampOpt.getD 0
     }
     -- Parse storage from optional arg (format: "slot:value,...")
     let storageState := match storageOpt with

--- a/Verity/Proofs/Stdlib/SpecInterpreter.lean
+++ b/Verity/Proofs/Stdlib/SpecInterpreter.lean
@@ -326,8 +326,8 @@ def interpretSpec (spec : ContractSpec) (initialStorage : SpecStorage) (tx : Tra
     -- Constructor execution
     let ctx : EvalContext := {
       sender := tx.sender
-      msgValue := 0
-      blockTimestamp := 0
+      msgValue := tx.msgValue
+      blockTimestamp := tx.blockTimestamp
       params := []
       paramTypes := []
       constructorArgs := tx.args  -- Constructor args go here
@@ -349,8 +349,8 @@ def interpretSpec (spec : ContractSpec) (initialStorage : SpecStorage) (tx : Tra
     -- Regular function execution
     let ctx : EvalContext := {
       sender := tx.sender
-      msgValue := 0  -- Not exposed in current specs
-      blockTimestamp := 0  -- Not exposed in current specs
+      msgValue := tx.msgValue
+      blockTimestamp := tx.blockTimestamp
       params := tx.args
       paramTypes := []
       constructorArgs := []  -- Not used for regular functions


### PR DESCRIPTION
## Summary
- Add `msgValue : Nat := 0` and `blockTimestamp : Nat := 0` to the `Transaction` struct
- Replace hardcoded `0` values in `SpecInterpreter.interpretSpec` with `tx.msgValue`/`tx.blockTimestamp`
- Pass CLI-parsed value/timestamp into Transaction in `Interpreter.lean`
- Generate random `blockTimestamp` per transaction in `RandomGen.lean`
- Include `msgValue` and `blockTimestamp` in RandomGen JSON output

## Motivation
The SpecInterpreter hardcoded `msgValue := 0` and `blockTimestamp := 0`, meaning any contract behavior that depends on `msg.value` or `block.timestamp` was untested through the spec interpreter path. Meanwhile, the compiled-side interpreter already supported these via CLI arguments. This asymmetry meant the two sides of differential testing were using different context values — the compiled side used `block.timestamp` from the EVM while the spec side always used 0.

This PR closes the gap by:
1. Adding the fields to `Transaction` (shared between both interpreters)
2. Using them consistently in both the spec and compiled interpreters
3. Generating random timestamps in the test generator

## Backward compatibility
All fields have `:= 0` defaults, so every existing `Transaction` construction site (including all SpecCorrectness proofs) compiles unchanged with identical behavior.

Addresses #169

## Test plan
- [x] `lake build` — all 76 modules, all proofs verified
- [x] `lake build difftest-interpreter` — passes
- [x] `check_doc_counts.py`, `check_axiom_locations.py` pass
- [ ] CI build + Foundry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the execution context used by the spec interpreter and diff-test harness; contracts/specs that reference `msg.value`/`block.timestamp` may now behave differently and expose new mismatches.
> 
> **Overview**
> Differential testing transactions now carry `msgValue` and `blockTimestamp` (defaulting to `0`) via new fields on `Transaction`.
> 
> The CLI interpreter now populates these fields from parsed `value=`/`timestamp=` args, and the spec-side `interpretSpec` uses `tx.msgValue`/`tx.blockTimestamp` instead of hardcoded `0`, aligning context between spec and compiled execution.
> 
> Random test generation now assigns a per-transaction random `blockTimestamp` and includes both context fields in the emitted JSON.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c922015870ae172de6a66602d52044dcd0fb6a6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->