### PR TITLE
Add Linker name collision detection and expand FiniteSet operations

### DIFF
--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -29,6 +29,12 @@ private def writeContract (outDir : String) (contract : IRContract) (libraryPath
     | .error err => throw (IO.userError err)
     | .ok () => pure ()
 
+  -- Validate: library functions don't shadow generated code or builtins
+  if !allLibFunctions.isEmpty then
+    match validateNoNameCollisions yulObj allLibFunctions with
+    | .error err => throw (IO.userError err)
+    | .ok () => pure ()
+
   -- Validate: all external calls in the contract are provided by libraries
   match validateExternalReferences yulObj allLibFunctions with
   | .error err => throw (IO.userError err)


### PR DESCRIPTION
## Summary

Two high-leverage improvements that address open issues #173 and #144:

### 1. Linker: Name collision detection (refs #173)

Added `validateNoNameCollisions` that catches library functions shadowing:
- **Generated code helpers** (e.g. `mappingSlot`) — a library redefining this would silently break mapping storage
- **Yul builtins** (e.g. `add`, `sstore`) — a library redefining these would produce unpredictable behavior

Previously, `validateNoDuplicateNames` only checked for duplicates *within* libraries. A library could shadow any generated function or builtin without warning. This is a real safety gap since the Linker operates outside the formal verification boundary.

Also refactored the duplicate-finding logic into a shared `findDuplicate` helper.

### 2. FiniteSet: Essential operations and theorems (refs #144)

Added **7 new operations** and **8 proven theorems** to `FiniteSet`, directly needed for Ledger sum proofs (#65):

**New operations:**
- `contains` — check membership (Bool)
- `remove` — remove an element (preserves Nodup via filter_sublist)
- `filter` — filter by predicate
- `union` — set union
- `inter` — set intersection
- `toList` / `fromList` — conversions

**Proven theorems (no sorry):**
- `elements_empty` — empty set has no elements
- `insert_of_mem` — inserting existing element is identity
- `insert_of_not_mem` — inserting new element prepends
- `mem_elements_insert_self` — element is in its own insert
- `mem_elements_insert` — membership after insert (iff)
- `card_empty` — empty set has cardinality 0
- `card_insert_of_not_mem` — fresh insert increases card by 1
- `card_insert_of_mem` — duplicate insert preserves card

Also added `contains` and `remove` to `FiniteAddressSet`.

## Verification

- All 76 Lean modules build successfully
- All existing proofs pass unchanged
- No new `sorry` statements (still 12, all in Ledger sum proofs)
- Doc count check passes
- Contract structure check passes
- Compiler generates all 7 contracts successfully

## Test plan

- [x] `lake build` — all proofs pass
- [x] `lake exe verity-compiler` — all contracts compile
- [x] `python3 scripts/check_doc_counts.py` — passes
- [x] `python3 scripts/check_contract_structure.py` — passes
- [x] `python3 scripts/check_property_coverage.py` — passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new linker validation that can newly fail builds when external libraries shadow generated Yul helpers or Yul builtins, impacting compilation/linking behavior. The FiniteSet expansion is additive and proof-backed but could affect downstream code via new APIs and lemmas.
> 
> **Overview**
> **Linking/compilation now rejects unsafe external libraries.** The compiler runs a new `validateNoNameCollisions` pass so linked library functions cannot shadow **generated Yul function defs** or **Yul builtins**, and duplicate-name detection is refactored via a shared `findDuplicate` helper.
> 
> **`FiniteSet` is expanded for upcoming proof work.** Adds core set operations (`contains`, `remove`, `filter`, `union`, `inter`, `toList`, `fromList`) plus several supporting theorems about `empty`, `insert`, membership, and `card`, and wires `contains`/`remove` through `FiniteAddressSet`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 010cadf02dc7c84d044fda4cea0259621390c20b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->