### PR TITLE
Fix ContractResult safety comments, sync doc counts, add Linker guide

### DIFF
--- a/docs-site/content/_meta.js
+++ b/docs-site/content/_meta.js
@@ -6,4 +6,5 @@ export default {
   guides: 'Guides',
   'add-contract': 'Add a Contract',
   core: 'Core Architecture',
+  compiler: 'Compiler',
 };

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -1,6 +1,6 @@
 ---
 title: Core Architecture
-description: How the 249-line core works
+description: How the 257-line core works
 ---
 
 # Core Architecture

--- a/docs-site/content/guides/_meta.js
+++ b/docs-site/content/guides/_meta.js
@@ -1,4 +1,5 @@
 export default {
   'first-contract': 'Adding Your First Contract',
+  'linking-libraries': 'Linking External Libraries',
   'debugging-proofs': 'Proof Debugging Handbook',
 };

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -1,0 +1,226 @@
+---
+title: Linking External Libraries
+description: How to use external Yul libraries (Poseidon, Groth16, etc.) with verified contracts
+---
+
+# Linking External Libraries
+
+**Time Required**: 30 minutes
+**Prerequisites**: Verity project builds (`lake build` passes)
+
+Use the Linker to inject production cryptographic libraries (or any Yul functions) into your verified contracts. You prove properties against simple placeholders in Lean, then swap in real implementations at compile time.
+
+---
+
+## When to Use This
+
+- You need **cryptographic primitives** (Poseidon hash, Groth16 verification, etc.) that are impractical to implement in Lean
+- You want to **reuse audited Yul libraries** without re-implementing them
+- You want to **prove contract logic** independently of complex library internals
+
+## Quick Start
+
+### 1. Write your library as a `.yul` file
+
+Create a file with plain Yul function definitions (no `object` wrapper):
+
+```yul
+// libs/MyHash.yul
+function myHash(a, b) -> result {
+    // Your implementation here
+    result := add(xor(a, b), 0x42)
+}
+```
+
+### 2. Write a placeholder in your Lean contract
+
+In your EDSL contract, define a placeholder that models the same interface:
+
+```lean
+-- Placeholder for proofs: models the hash as addition
+-- At compile time, replaced by the real myHash from MyHash.yul
+def myHash (a b : Uint256) : Contract Uint256 := do
+  return add a b
+```
+
+### 3. Add the external call to your ContractSpec
+
+In `Compiler/Specs.lean`, use `Expr.externalCall` to reference the library function:
+
+```lean
+-- Inside your contract spec's function body:
+Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param 0, Expr.param 1])
+```
+
+The compiler generates a Yul `myHash(arg0, arg1)` call that will be resolved by the linked library.
+
+### 4. Compile with `--link`
+
+```bash
+lake exe verity-compiler --link libs/MyHash.yul -o compiler/yul
+```
+
+The compiler validates that:
+- No duplicate function names across libraries
+- Library functions don't shadow generated code or Yul builtins
+- All external calls in contracts are satisfied by linked libraries
+
+If validation fails, you get a clear error message:
+
+```
+Unresolved external references: myHash
+```
+
+This means you forgot to pass `--link libs/MyHash.yul`.
+
+---
+
+## Complete Example: CryptoHash Contract
+
+Verity includes a working example in [`Verity/Examples/CryptoHash.lean`](https://github.com/Th0rgal/verity/blob/main/Verity/Examples/CryptoHash.lean) with libraries in [`examples/external-libs/`](https://github.com/Th0rgal/verity/tree/main/examples/external-libs).
+
+**EDSL placeholder** (`Verity/Examples/CryptoHash.lean`):
+```lean
+-- Placeholder: just adds the inputs (for proving logic)
+def hashTwo (a b : Uint256) : Contract Uint256 := do
+  return add a b
+
+def storeHashTwo (a b : Uint256) : Contract Unit := do
+  let h <- hashTwo a b
+  setStorage lastHash h
+```
+
+**External library** (`examples/external-libs/PoseidonT3.yul`):
+```yul
+function PoseidonT3_hash(a, b) -> result {
+    result := add(xor(a, b), 0x1234...)
+}
+```
+
+**Compile with linking**:
+```bash
+lake exe verity-compiler \
+    --link examples/external-libs/PoseidonT3.yul \
+    --link examples/external-libs/PoseidonT4.yul \
+    -o compiler/yul
+```
+
+---
+
+## How the Linker Works
+
+The linking process has three stages:
+
+### Stage 1: Parse libraries
+
+The linker reads each `.yul` file and extracts function definitions using a line-based parser. It tracks brace depth to capture complete function bodies:
+
+```
+Input file:           Parsed output:
+function foo() {  ->  LibraryFunction { name: "foo", body: [...] }
+    sstore(0, 1)
+}
+```
+
+### Stage 2: Validate
+
+Three safety checks run before any code is injected:
+
+| Check | What it catches |
+|-------|-----------------|
+| `validateNoDuplicateNames` | Two libraries defining the same function |
+| `validateNoNameCollisions` | Library function shadowing `mappingSlot` or Yul builtins like `add`, `sstore` |
+| `validateExternalReferences` | Contract calling a function not provided by any library |
+
+### Stage 3: Inject
+
+Library functions are injected into the runtime `code {}` section of each compiled Yul contract, with proper indentation:
+
+```yul
+object "MyContract" {
+    code { /* deploy */ }
+    object "runtime" {
+        code {
+            // ... generated contract code ...
+
+            // Injected from MyHash.yul:
+            function myHash(a, b) -> result {
+                result := add(xor(a, b), 0x42)
+            }
+        }
+    }
+}
+```
+
+---
+
+## Library File Format
+
+External library files must contain **plain Yul function definitions**:
+
+```yul
+// Good: plain function definitions
+function foo(x) -> y {
+    y := add(x, 1)
+}
+
+function bar(a, b) -> c {
+    c := mul(a, b)
+}
+```
+
+Do **not** wrap them in an `object` block:
+
+```yul
+// Bad: object wrapper not supported
+object "MyLib" {
+    code {
+        function foo(x) -> y { y := add(x, 1) }
+    }
+}
+```
+
+---
+
+## Trust Model
+
+External libraries are **outside the formal verification boundary**. The Linker validates structural properties (no shadowing, all references resolved) but does not verify the library's correctness.
+
+Your proofs establish: *"If the library functions behave like the placeholders, then the contract is correct."*
+
+To increase confidence in linked libraries:
+- Use audited, battle-tested implementations
+- Add Foundry fuzz tests that exercise the linked contract end-to-end
+- Document the trust assumption explicitly (see [`TRUST_ASSUMPTIONS.md`](https://github.com/Th0rgal/verity/blob/main/TRUST_ASSUMPTIONS.md))
+
+---
+
+## CLI Reference
+
+```bash
+lake exe verity-compiler [options]
+
+Options:
+  --link <path>      Link external Yul library (can be used multiple times)
+  --output <dir>     Output directory (default: compiler/yul)
+  -o <dir>           Short form of --output
+  --verbose          Enable verbose output
+  -v                 Short form of --verbose
+  --help             Show help message
+```
+
+**Examples**:
+```bash
+# Compile without libraries
+lake exe verity-compiler
+
+# Compile with one library
+lake exe verity-compiler --link libs/Poseidon.yul
+
+# Compile with multiple libraries, verbose output
+lake exe verity-compiler \
+    --link libs/PoseidonT3.yul \
+    --link libs/PoseidonT4.yul \
+    --link libs/Groth16.yul \
+    -v -o output/
+```

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -120,7 +120,7 @@ See [/verification](/verification) for the complete, always-current theorem list
 
 **What's a proof?** A step-by-step logical argument that shows why a theorem must be true. Lean checks every step.
 
-**What's `sorry`?** A placeholder in Lean that says "I'll prove this later." It's how incomplete proofs compile. This project has 10 `sorry` in Ledger sum proofs — all other claims are fully proven.
+**What's `sorry`?** A placeholder in Lean that says "I'll prove this later." It's how incomplete proofs compile. This project has 12 `sorry` in Ledger sum proofs — all other claims are fully proven.
 
 **What are axioms?** Statements assumed true without proof. This project uses 5 documented axioms for keccak256 hashing, expression evaluation equivalence, and address injectivity — each with soundness justification in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
@@ -137,7 +137,7 @@ theorem store_retrieve : store 42 >> retrieve = pure 42 := by
 
 - **[Verification](/verification)** — Full theorem list by contract
 - **[Examples](/examples)** — The 9 contracts and what they demonstrate
-- **[Core](/core)** — How the 249-line EDSL works
+- **[Core](/core)** — How the 257-line EDSL works
 - **[Research](/research)** — Design decisions and proof techniques
 
 ## Learning Resources

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 296 theorems, 5 documented axioms, 10 sorry remaining in Ledger sum proofs.**
+**Compact core, built across 7 iterations. 300 theorems, 5 documented axioms, 12 sorry remaining in Ledger sum proofs.**
 
 ## Evolution
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -15,7 +15,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 ## Quick Facts
 
 - **Language**: Lean 4.15.0
-- **Core Size**: 249 lines
+- **Core Size**: 257 lines
 - **Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, CryptoHash, ReentrancyExample
 - **Theorems**: 300 across 9 categories (288 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
 - **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, fuel adequacy, address injectivity


### PR DESCRIPTION
## Summary

Three improvements bundled together because they share the doc-count update:

### 1. ContractResult safety comments (refs #175, #143)

Added `WARNING` comments to `ContractResult.fst`, `snd`, and `getState` explaining:
- `fst` returns `default` on revert — proofs must independently establish success
- `snd` returns the state at the point of revert (which may include prior mutations), not the pre-call state — this differs from EVM semantics where REVERT discards all changes
- Current contracts are safe because `require` precedes all state mutations

This is the same change as PR #212, but with the doc count updates that PR was missing (which caused its CI to fail).

### 2. Doc count fixes

- Updated `core.mdx`, `index.mdx`, `llms.txt` to reflect new `Core.lean` line count (249 → 257)
- Fixed `sorry` count inconsistency in `index.mdx` (was `10`, actual is `12`)
- Fixed `research.mdx` (was `296 theorems / 10 sorry`, now `300 / 12`)
- Added `compiler` to docs-site navigation (page existed but wasn't linked)

### 3. Linker quickstart guide (new)

Added a dedicated **Linking External Libraries** guide at `docs-site/content/guides/linking-libraries.mdx` covering:
- When to use external libraries
- 4-step quickstart (write .yul file → add placeholder → add ContractSpec call → compile with `--link`)
- Complete CryptoHash walkthrough with code examples
- How the Linker works (parse → validate → inject)
- Library file format requirements
- Trust model explanation
- CLI reference

This makes the Linker feature much more discoverable and practical for developers who want to use production crypto libraries with verified contract logic.

## Verification

- All 76 Lean modules build successfully
- `check_doc_counts.py` passes
- `check_contract_structure.py` passes
- `check_property_coverage.py` passes
- No new `sorry` statements
- No functional code changes (only comments and docs)

## Test plan

- [x] `lake build` — all proofs pass
- [x] `python3 scripts/check_doc_counts.py` — passes
- [x] `python3 scripts/check_contract_structure.py` — passes
- [x] `python3 scripts/check_property_coverage.py` — passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: no functional Lean/compiler changes, only warning comments and documentation/navigation updates. Main risk is documentation drift or confusion if the described revert/state semantics change later.
> 
> **Overview**
> Clarifies `ContractResult` safety semantics by adding explicit WARNING comments on `fst`, `snd`, and `getState`, highlighting that `fst` yields `default` on revert and that revert state reflects mutations up to the failure (not EVM-style rollback).
> 
> Updates docs counts/metadata to match current core line count and proof stats (theorem and `sorry` counts), adds `compiler` to top-level docs navigation, and introduces a new guide on linking external Yul libraries via the compiler’s `--link` flow (including validation, injection behavior, and trust model).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c331afbb69cd46a81474e256e87a6a4967f9aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->