### PR TITLE
Fix edge-value mismatch in differential tests, expand address pools

### DIFF
--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -96,7 +96,7 @@ See [Add a Contract](/add-contract) for the full guide.
 
 ## Example Contracts
 
-Nine contracts are implemented and verified:
+Eight contracts are implemented and verified:
 
 | Contract | Demonstrates |
 |----------|--------------|
@@ -108,7 +108,8 @@ Nine contracts are implemented and verified:
 | Ledger | Balance tracking, deposit/withdraw/transfer, conservation laws |
 | SimpleToken | Token minting/transfer, supply conservation, storage isolation |
 | ReentrancyExample | Reentrancy vulnerability vs safe withdrawal patterns |
-| CryptoHash | External cryptographic library linking |
+
+**Unverified example**: [CryptoHash](/examples#cryptohash) demonstrates external library linking via the Linker but has no specs or proofs.
 
 Plus a math standard library with safe arithmetic theorems (`safeMul`, `safeDiv`, etc.).
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -16,7 +16,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 
 - **Language**: Lean 4.15.0
 - **Core Size**: 257 lines
-- **Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, CryptoHash, ReentrancyExample
+- **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 300 across 9 categories (288 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
 - **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, fuel adequacy, address injectivity
 - **Tests**: 352 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI

--- a/test/DifferentialCounter.t.sol
+++ b/test/DifferentialCounter.t.sol
@@ -281,8 +281,8 @@ contract DifferentialCounter is YulTestBase, DiffTestConfig, DifferentialTestBas
             // Simple PRNG
             prng = _lcg(prng);
 
-            // Generate address
-            address sender = _indexToAddress(prng);
+            // Generate address from bounded pool (5 actors)
+            address sender = _indexToAddress(prng % 5);
 
             // Determine function (3 options: increment, decrement, getCount)
             prng = _lcg(prng);

--- a/test/DifferentialLedger.t.sol
+++ b/test/DifferentialLedger.t.sol
@@ -514,10 +514,12 @@ contract DifferentialLedger is YulTestBase, DiffTestConfig {
     }
 
     function testDifferential_Random100() public {
-        address[] memory actors = new address[](3);
+        address[] memory actors = new address[](5);
         actors[0] = address(0xA11CE);
         actors[1] = address(0xB0B);
         actors[2] = address(0xCA501);
+        actors[3] = address(0xDABE);
+        actors[4] = address(0xEBE);
 
         (uint256 startIndex, uint256 count) = _diffRandomSmallRange();
         uint256 seed = _diffRandomSeed("Ledger");
@@ -537,10 +539,12 @@ contract DifferentialLedger is YulTestBase, DiffTestConfig {
     }
 
     function testDifferential_Random10000() public {
-        address[] memory actors = new address[](3);
+        address[] memory actors = new address[](5);
         actors[0] = address(0xA11CE);
         actors[1] = address(0xB0B);
         actors[2] = address(0xCA501);
+        actors[3] = address(0xDABE);
+        actors[4] = address(0xEBE);
 
         (uint256 startIndex, uint256 count) = _diffRandomLargeRange();
         uint256 seed = _diffRandomSeed("Ledger");

--- a/test/DifferentialOwned.t.sol
+++ b/test/DifferentialOwned.t.sol
@@ -426,10 +426,12 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig {
         (uint256 startIndex, uint256 numTransactions) = _diffRandomSmallRange();
         uint256 seed = _diffRandomSeed("Owned");
 
-        address[] memory testAddresses = new address[](3);
+        address[] memory testAddresses = new address[](5);
         testAddresses[0] = address(this);
         testAddresses[1] = address(0xa11ce);
         testAddresses[2] = address(0xb0b);
+        testAddresses[3] = address(0xCA401);
+        testAddresses[4] = address(0xDABE);
 
         console2.log("Generated", numTransactions, "random transactions");
 
@@ -474,10 +476,12 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig {
         (uint256 startIndex, uint256 numTransactions) = _diffRandomLargeRange();
         uint256 seed = _diffRandomSeed("Owned");
 
-        address[] memory testAddresses = new address[](3);
+        address[] memory testAddresses = new address[](5);
         testAddresses[0] = address(this);
         testAddresses[1] = address(0xa11ce);
         testAddresses[2] = address(0xb0b);
+        testAddresses[3] = address(0xCA401);
+        testAddresses[4] = address(0xDABE);
 
         console2.log("Generated", numTransactions, "random transactions");
 

--- a/test/DifferentialOwnedCounter.t.sol
+++ b/test/DifferentialOwnedCounter.t.sol
@@ -591,10 +591,12 @@ contract DifferentialOwnedCounter is YulTestBase, DiffTestConfig {
     }
 
     function testDifferential_Random100() public {
-        address[] memory actors = new address[](3);
+        address[] memory actors = new address[](5);
         actors[0] = address(this);  // Owner
         actors[1] = address(0xA11CE);
         actors[2] = address(0xB0B);
+        actors[3] = address(0xCA401);
+        actors[4] = address(0xDABE);
 
         (uint256 startIndex, uint256 count) = _diffRandomSmallRange();
         uint256 seed = _diffRandomSeed("OwnedCounter");
@@ -613,10 +615,12 @@ contract DifferentialOwnedCounter is YulTestBase, DiffTestConfig {
     }
 
     function testDifferential_Random10000() public {
-        address[] memory actors = new address[](3);
+        address[] memory actors = new address[](5);
         actors[0] = address(this);  // Owner
         actors[1] = address(0xA11CE);
         actors[2] = address(0xB0B);
+        actors[3] = address(0xCA401);
+        actors[4] = address(0xDABE);
 
         (uint256 startIndex, uint256 count) = _diffRandomLargeRange();
         uint256 seed = _diffRandomSeed("OwnedCounter");

--- a/test/DifferentialSimpleToken.t.sol
+++ b/test/DifferentialSimpleToken.t.sol
@@ -764,10 +764,12 @@ contract DifferentialSimpleToken is YulTestBase, DiffTestConfig {
     }
 
     function testDifferential_Random100() public {
-        address[] memory actors = new address[](3);
+        address[] memory actors = new address[](5);
         actors[0] = address(this);  // Owner
         actors[1] = address(0xA11CE);
         actors[2] = address(0xB0B);
+        actors[3] = address(0xCA401);
+        actors[4] = address(0xDABE);
 
         (uint256 startIndex, uint256 count) = _diffRandomSmallRange();
         uint256 seed = _diffRandomSeed("SimpleToken");
@@ -787,10 +789,12 @@ contract DifferentialSimpleToken is YulTestBase, DiffTestConfig {
     }
 
     function testDifferential_Random10000() public {
-        address[] memory actors = new address[](3);
+        address[] memory actors = new address[](5);
         actors[0] = address(this);  // Owner
         actors[1] = address(0xA11CE);
         actors[2] = address(0xB0B);
+        actors[3] = address(0xCA401);
+        actors[4] = address(0xDABE);
 
         (uint256 startIndex, uint256 count) = _diffRandomLargeRange();
         uint256 seed = _diffRandomSeed("SimpleToken");

--- a/test/yul/YulTestBase.sol
+++ b/test/yul/YulTestBase.sol
@@ -4,14 +4,19 @@ pragma solidity ^0.8.0;
 import "forge-std/Test.sol";
 
 abstract contract YulTestBase is Test {
+    // Edge-case values matching Lean's edgeUint256Values and DiffTestConfig._edgeUintValues():
+    //   [0, 1, 2, 2^128, 2^255, 2^256-2, 2^256-1]
+    // Selectors 0-6 return these edge values (~7/16 probability);
+    // selectors 7-15 return prng % smallMod (~9/16 probability).
     function _coerceRandomUint256(uint256 prng, uint256 smallMod) internal pure returns (uint256) {
         uint256 selector = prng % 16;
         if (selector == 0) return 0;
         if (selector == 1) return 1;
-        if (selector == 2) return type(uint256).max;
-        if (selector == 3) return type(uint256).max - 1;
-        if (selector == 4) return 2 ** 128;
-        if (selector == 5) return 2 ** 255;
+        if (selector == 2) return 2;
+        if (selector == 3) return 2 ** 128;
+        if (selector == 4) return 2 ** 255;
+        if (selector == 5) return type(uint256).max - 1;
+        if (selector == 6) return type(uint256).max;
         if (smallMod == 0) return prng;
         return prng % smallMod;
     }


### PR DESCRIPTION
## Summary

- **Fix `_coerceRandomUint256` edge-value ordering** in `YulTestBase.sol` to match Lean's `edgeUint256Values` and `DiffTestConfig._edgeUintValues()`. The previous mapping was `[0, 1, MAX, MAX-1, 2^128, 2^255]` but should be `[0, 1, 2, 2^128, 2^255, MAX-1, MAX]` — the value `2` was missing entirely, and `MAX`/`MAX-1` were in positions 2-3 instead of 5-6.
- **Expand address pools** from 3 to 5 actors in Ledger, OwnedCounter, SimpleToken, and Owned random differential tests, improving address diversity and reducing the chance that bugs related to distinct-address assumptions go untested.
- **Bound Counter's address derivation** from unbounded `_indexToAddress(prng)` to bounded `_indexToAddress(prng % 5)`, preventing every iteration from using a unique keccak-derived address.
- **Fix docs-site CryptoHash misrepresentation**: `index.mdx` said "Nine contracts are implemented and verified" but CryptoHash has 0 specs and 0 proofs. Changed to "Eight" with CryptoHash correctly labeled as an unverified linker demo. Updated `llms.txt` similarly.

## Why this matters

The `_coerceRandomUint256` function determines which edge-case values the random differential tests exercise. With the old mapping, selectors 0-5 gave `[0, 1, MAX, MAX-1, 2^128, 2^255]` and selector 6+ fell through to `prng % smallMod`. The value `2` (important for off-by-one boundary testing) was never generated in the random path. This PR aligns the Solidity random path with the Lean generator so both sides use identical edge-value distributions.

Addresses issue #168 (weak PRNG test coverage) and issue #145 (CryptoHash docs accuracy).

## Test plan

- [ ] CI doc count check passes (`check_doc_counts.py`)
- [ ] CI axiom location check passes (`check_axiom_locations.py`)
- [ ] Foundry differential tests pass with updated edge values and address pools
- [ ] Verify no test regressions in any shard


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test harness randomness/address selection and documentation wording; no production contract/compiler logic is modified.
> 
> **Overview**
> Improves differential-test coverage and determinism by aligning `YulTestBase._coerceRandomUint256` edge-case selection with `DiffTestConfig._edgeUintValues()` (adds missing `2` and reorders max values) and by expanding random actor pools from 3 to 5 addresses across multiple differential suites.
> 
> Also bounds Counter’s random sender generation to a fixed 5-actor pool (avoiding a new address per iteration) and updates docs (`index.mdx`, `llms.txt`) to clarify that `CryptoHash` is an *unverified* linker demo and adjust the “verified contracts” count accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b82cb55fef8bfb38f51fd8beff4bb3bfeece2fba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->