### PR TITLE
Prove Contract monad laws, eliminating trust assumption

### DIFF
--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -254,4 +254,34 @@ instance : Monad Contract where
   pure := pure
   bind := bind
 
+/-!
+## Contract Monad Laws
+
+The Contract monad satisfies all three monad laws, ensuring that do-notation
+rewrites performed by Lean during elaboration preserve program semantics.
+This eliminates a trust assumption noted in issue #146.
+-/
+
+-- Left identity: bind (pure a) f = f a
+@[simp] theorem Contract.bind_pure_left (a : α) (f : α → Contract β) :
+    bind (pure a) f = f a := by rfl
+
+-- Right identity: bind m pure = m
+@[simp] theorem Contract.bind_pure_right (m : Contract α) :
+    bind m pure = m := by
+  funext s
+  simp only [bind, pure]
+  cases m s with
+  | success a s' => rfl
+  | revert msg s' => rfl
+
+-- Associativity: bind (bind m f) g = bind m (fun x => bind (f x) g)
+@[simp] theorem Contract.bind_assoc (m : Contract α) (f : α → Contract β) (g : β → Contract γ) :
+    bind (bind m f) g = bind m (fun x => bind (f x) g) := by
+  funext s
+  simp only [bind]
+  cases m s with
+  | success a s' => rfl
+  | revert msg s' => rfl
+
 end Verity

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -1,6 +1,6 @@
 ---
 title: Core Architecture
-description: How the 257-line core works
+description: How the 287-line core works
 ---
 
 # Core Architecture

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -138,7 +138,7 @@ theorem store_retrieve : store 42 >> retrieve = pure 42 := by
 
 - **[Verification](/verification)** — Full theorem list by contract
 - **[Examples](/examples)** — The 9 contracts and what they demonstrate
-- **[Core](/core)** — How the 257-line EDSL works
+- **[Core](/core)** — How the 287-line EDSL works
 - **[Research](/research)** — Design decisions and proof techniques
 
 ## Learning Resources

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -15,7 +15,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 ## Quick Facts
 
 - **Language**: Lean 4.15.0
-- **Core Size**: 257 lines
+- **Core Size**: 287 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 300 across 9 categories (288 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
 - **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, fuel adequacy, address injectivity


### PR DESCRIPTION
## Summary

- Prove all three monad laws for the `Contract` type, eliminating the trust assumption identified in issue #146
- Mark theorems `@[simp]` so they participate in proof automation
- Sync core line count (257→287) in docs

## Monad Law Proofs

| Law | Theorem | Statement |
|-----|---------|-----------|
| Left identity | `Contract.bind_pure_left` | `bind (pure a) f = f a` |
| Right identity | `Contract.bind_pure_right` | `bind m pure = m` |
| Associativity | `Contract.bind_assoc` | `bind (bind m f) g = bind m (λ x => bind (f x) g)` |

All three proofs are by `funext s` followed by `cases m s`, which is the standard approach for state-monad-like types wrapping an inductive result.

## Why this matters

Without these proofs, do-notation rewrites performed by Lean during elaboration could theoretically change program semantics. In a formal verification framework, this was an unchecked trust assumption. Now it's machine-verified.

Closes #146

## Test plan

- [ ] `lake build` succeeds (proofs type-check)
- [ ] `check_doc_counts.py` passes with updated core line count
- [ ] No existing proofs broken


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely adds Lean theorems/`@[simp]` lemmas and documentation tweaks, without changing contract execution semantics.
> 
> **Overview**
> Adds machine-checked proofs (marked `@[simp]`) of the three monad laws for the `Contract` monad—`bind_pure_left`, `bind_pure_right`, and `bind_assoc`—to ensure Lean’s do-notation rewrites preserve semantics.
> 
> Updates docs text/metadata to reflect the core size change from 257 to 287 lines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd5f9d90bf5831f165fc5e15f886c773760b9cf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->