### PR TITLE
Add defaultState helper, fix stale tutorial

### DIFF
--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -47,6 +47,20 @@ structure ContractState where
   knownAddresses : Nat → FiniteAddressSet  -- Tracked addresses per storage slot (for sum properties)
   events : List Event := []  -- Emitted events, append-only log (#153)
 
+-- Default zero state — all storage zero, empty addresses, no events.
+-- Use `{ defaultState with sender := "0xAlice" }` to customize individual fields.
+def defaultState : ContractState where
+  storage := fun _ => 0
+  storageAddr := fun _ => ""
+  storageMap := fun _ _ => 0
+  storageMapUint := fun _ _ => 0
+  storageMap2 := fun _ _ _ => 0
+  sender := ""
+  thisAddress := ""
+  msgValue := 0
+  blockTimestamp := 0
+  knownAddresses := fun _ => Core.FiniteAddressSet.empty
+
 -- Repr instance for ContractState (simplified for readability)
 instance : Repr ContractState where
   reprPrec s _ := s!"ContractState(sender={s.sender}, thisAddress={s.thisAddress})"

--- a/Verity/Examples/Counter.lean
+++ b/Verity/Examples/Counter.lean
@@ -42,17 +42,9 @@ def exampleUsage : Contract Uint256 := do
   decrement
   getCount
 
-#eval (exampleUsage.run {
-  storage := fun _ => 0,
-  storageAddr := fun _ => "",
-  storageMap := fun _ _ => 0,
-  storageMapUint := fun _ _ => 0,
-  storageMap2 := fun _ _ _ => 0,
+#eval (exampleUsage.run { defaultState with
   sender := "0xAlice",
-  thisAddress := "0xCounter",
-  msgValue := 0,
-  blockTimestamp := 0,
-  knownAddresses := fun _ => Core.FiniteAddressSet.empty
+  thisAddress := "0xCounter"
 }).getValue?
 -- Expected output: some 1
 

--- a/Verity/Examples/CryptoHash.lean
+++ b/Verity/Examples/CryptoHash.lean
@@ -61,17 +61,9 @@ def exampleUsage : Contract Uint256 := do
   getLastHash
 
 -- Evaluate the example
-#eval (exampleUsage.run {
-  storage := fun _ => 0,
-  storageAddr := fun _ => "",
-  storageMap := fun _ _ => 0,
-  storageMapUint := fun _ _ => 0,
-  storageMap2 := fun _ _ _ => 0,
+#eval (exampleUsage.run { defaultState with
   sender := "0xAlice",
-  thisAddress := "0xCryptoHash",
-  msgValue := 0,
-  blockTimestamp := 0,
-  knownAddresses := fun _ => Verity.Core.FiniteAddressSet.empty
+  thisAddress := "0xCryptoHash"
 }).getValue?
 -- Expected output: some 300 (with placeholder hash: 100 + 200)
 

--- a/Verity/Examples/Ledger.lean
+++ b/Verity/Examples/Ledger.lean
@@ -67,17 +67,9 @@ def exampleUsage : Contract (Uint256 × Uint256) := do
   return (aliceBalance, bobBalance)
 
 -- Evaluate the example
-#eval! (exampleUsage.run {
-  storage := fun _ => 0,
-  storageAddr := fun _ => "",
-  storageMap := fun _ _ => 0,
-  storageMapUint := fun _ _ => 0,
-  storageMap2 := fun _ _ _ => 0,
+#eval! (exampleUsage.run { defaultState with
   sender := "0xAlice",
-  thisAddress := "0xLedger",
-  msgValue := 0,
-  blockTimestamp := 0,
-  knownAddresses := fun _ => Core.FiniteAddressSet.empty
+  thisAddress := "0xLedger"
 }).getValue?
 -- Expected output: some (20, 50) - Alice has 20, Bob has 50
 

--- a/Verity/Examples/Owned.lean
+++ b/Verity/Examples/Owned.lean
@@ -51,17 +51,9 @@ def exampleUsage : Contract Address := do
   getOwner
 
 -- Note: This will evaluate in a context where msgSender is set
-#eval (exampleUsage.run {
-  storage := fun _ => 0,
-  storageAddr := fun _ => "",
-  storageMap := fun _ _ => 0,
-  storageMapUint := fun _ _ => 0,
-  storageMap2 := fun _ _ _ => 0,
+#eval (exampleUsage.run { defaultState with
   sender := "0xAlice",  -- Alice is the caller
-  thisAddress := "0xContract",
-  msgValue := 0,
-  blockTimestamp := 0,
-  knownAddresses := fun _ => Core.FiniteAddressSet.empty
+  thisAddress := "0xContract"
 }).getValue?
 -- Expected output: some "0xBob" (after transfer)
 

--- a/Verity/Examples/OwnedCounter.lean
+++ b/Verity/Examples/OwnedCounter.lean
@@ -75,17 +75,9 @@ def exampleUsage : Contract (Uint256 × Address) := do
   let finalOwner ← getOwner
   return (finalCount, finalOwner)
 
-#eval (exampleUsage.run {
-  storage := fun _ => 0,
-  storageAddr := fun _ => "",
-  storageMap := fun _ _ => 0,
-  storageMapUint := fun _ _ => 0,
-  storageMap2 := fun _ _ _ => 0,
+#eval (exampleUsage.run { defaultState with
   sender := "0xAlice",  -- Alice is the caller
-  thisAddress := "0xContract",
-  msgValue := 0,
-  blockTimestamp := 0,
-  knownAddresses := fun _ => Core.FiniteAddressSet.empty
+  thisAddress := "0xContract"
 }).getValue?
 -- Expected output: some (2, "0xBob")
 

--- a/Verity/Examples/SafeCounter.lean
+++ b/Verity/Examples/SafeCounter.lean
@@ -44,17 +44,9 @@ def exampleUsage : Contract Uint256 := do
   decrement
   getCount
 
-#eval (exampleUsage.run {
-  storage := fun _ => 0,
-  storageAddr := fun _ => "",
-  storageMap := fun _ _ => 0,
-  storageMapUint := fun _ _ => 0,
-  storageMap2 := fun _ _ _ => 0,
+#eval (exampleUsage.run { defaultState with
   sender := "0xAlice",
-  thisAddress := "0xSafeCounter",
-  msgValue := 0,
-  blockTimestamp := 0,
-  knownAddresses := fun _ => Core.FiniteAddressSet.empty
+  thisAddress := "0xSafeCounter"
 }).getValue?
 -- Expected output: some 1
 

--- a/Verity/Examples/SimpleStorage.lean
+++ b/Verity/Examples/SimpleStorage.lean
@@ -31,17 +31,9 @@ def exampleUsage : Contract Uint256 := do
   store 42
   retrieve
 
-#eval (exampleUsage.run {
-  storage := fun _ => 0,
-  storageAddr := fun _ => "",
-  storageMap := fun _ _ => 0,
-  storageMapUint := fun _ _ => 0,
-  storageMap2 := fun _ _ _ => 0,
+#eval (exampleUsage.run { defaultState with
   sender := "0xAlice",
-  thisAddress := "0xContract",
-  msgValue := 0,
-  blockTimestamp := 0,
-  knownAddresses := fun _ => Core.FiniteAddressSet.empty
+  thisAddress := "0xContract"
 }).getValue?
 -- Expected output: some 42
 

--- a/Verity/Examples/SimpleToken.lean
+++ b/Verity/Examples/SimpleToken.lean
@@ -95,17 +95,9 @@ def exampleUsage : Contract (Uint256 × Uint256 × Uint256) := do
   return (aliceBalance, bobBalance, supply)
 
 -- Evaluate the example
-#eval! (exampleUsage.run {
-  storage := fun _ => 0,
-  storageAddr := fun _ => "",
-  storageMap := fun _ _ => 0,
-  storageMapUint := fun _ _ => 0,
-  storageMap2 := fun _ _ _ => 0,
+#eval! (exampleUsage.run { defaultState with
   sender := "0xAlice",
-  thisAddress := "0xSimpleToken",
-  msgValue := 0,
-  blockTimestamp := 0,
-  knownAddresses := fun _ => Core.FiniteAddressSet.empty
+  thisAddress := "0xSimpleToken"
 }).getValue?
 -- Expected output: some (700, 300, 1000) - Alice: 700, Bob: 300, supply: 1000
 

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -1,6 +1,6 @@
 ---
 title: Core Architecture
-description: How the 325-line core works
+description: How the 339-line core works
 ---
 
 # Core Architecture

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -198,15 +198,9 @@ def exampleUsage : Contract Uint256 := do
   tip 100
   getBalance "0xAlice"
 
-#eval! (exampleUsage.run {
-  storage := fun _ => 0,
-  storageAddr := fun _ => "",
-  storageMap := fun _ _ => 0,
+#eval! (exampleUsage.run { defaultState with
   sender := "0xAlice",
-  thisAddress := "0xTipJar",
-  msgValue := 0,
-  blockTimestamp := 0,
-  knownAddresses := fun _ => Core.FiniteAddressSet.empty
+  thisAddress := "0xTipJar"
 }).getValue?
 -- Expected output: some 100
 
@@ -218,6 +212,8 @@ end Verity.Examples.TipJar
 | Function | Type | Description |
 |----------|------|-------------|
 | `msgSender` | `Contract Address` | Get transaction sender |
+| `msgValue` | `Contract Uint256` | Get ETH value sent with call |
+| `blockTimestamp` | `Contract Uint256` | Get current block timestamp |
 | `getStorage s` | `Contract Uint256` | Read uint256 slot |
 | `setStorage s val` | `Contract Unit` | Write uint256 slot |
 | `getMapping s key` | `Contract Uint256` | Read mapping entry |
@@ -225,6 +221,12 @@ end Verity.Examples.TipJar
 | `getStorageAddr s` | `Contract Address` | Read address slot |
 | `setStorageAddr s val` | `Contract Unit` | Write address slot |
 | `require cond msg` | `Contract Unit` | Revert if condition is false |
+
+> **Tip**: Use `defaultState` to create a zero-initialized state for testing:
+> ```lean
+> #eval! (myContract.run { defaultState with sender := "0xAlice" }).getValue?
+> ```
+> This avoids spelling out every field and stays valid when new fields are added.
 
 ### 3.2 Test the EDSL Implementation
 

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -138,7 +138,7 @@ theorem store_retrieve : store 42 >> retrieve = pure 42 := by
 
 - **[Verification](/verification)** — Full theorem list by contract
 - **[Examples](/examples)** — The 9 contracts and what they demonstrate
-- **[Core](/core)** — How the 325-line EDSL works
+- **[Core](/core)** — How the 339-line EDSL works
 - **[Research](/research)** — Design decisions and proof techniques
 
 ## Learning Resources

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -15,7 +15,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 ## Quick Facts
 
 - **Language**: Lean 4.15.0
-- **Core Size**: 325 lines
+- **Core Size**: 339 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 300 across 9 categories (288 fully proven, 12 `sorry` placeholders in Ledger sum proofs)
 - **Axioms**: 5 documented axioms (see AXIOMS.md) — keccak256, expression evaluation, fuel adequacy, address injectivity


### PR DESCRIPTION
## Summary

- Adds `defaultState` to Core.lean — a zero-initialized ContractState that prevents boilerplate and tutorial staleness
- Fixes the first-contract tutorial which was broken after PR #216 added new ContractState fields

## Problem

When PR #216 added `storageMapUint`, `storageMap2`, and `events` to `ContractState`, the tutorial's `#eval!` example became invalid — it was missing these fields. Any developer following the tutorial would hit a compile error. Additionally, all 8 example contracts had 11-line boilerplate ContractState literals that would break every time a new field is added.

## Solution

### `defaultState` helper (Core.lean)

```lean
def defaultState : ContractState where
  storage := fun _ => 0
  storageAddr := fun _ => ""
  storageMap := fun _ _ => 0
  storageMapUint := fun _ _ => 0
  storageMap2 := fun _ _ _ => 0
  sender := ""
  thisAddress := ""
  msgValue := 0
  blockTimestamp := 0
  knownAddresses := fun _ => Core.FiniteAddressSet.empty
```

Usage: `{ defaultState with sender := "0xAlice", thisAddress := "0xContract" }`

### Before/after in examples

**Before** (11 lines, breaks when fields change):
```lean
#eval (exampleUsage.run {
  storage := fun _ => 0,
  storageAddr := fun _ => "",
  storageMap := fun _ _ => 0,
  storageMapUint := fun _ _ => 0,
  storageMap2 := fun _ _ _ => 0,
  sender := "0xAlice",
  thisAddress := "0xContract",
  msgValue := 0,
  blockTimestamp := 0,
  knownAddresses := fun _ => Core.FiniteAddressSet.empty
}).getValue?
```

**After** (3 lines, resilient to new fields):
```lean
#eval (exampleUsage.run { defaultState with
  sender := "0xAlice",
  thisAddress := "0xContract"
}).getValue?
```

### Files changed

| File | Change |
|------|--------|
| `Verity/Core.lean` | +14 lines: `defaultState` definition |
| 8 × `Verity/Examples/*.lean` | 11-line literals → 3-line `defaultState with` |
| `docs-site/content/guides/first-contract.mdx` | Fix stale ContractState, add `defaultState` tip, update API table |
| 3 × doc files | Sync core line count (325 → 339) |

Net: **-48 lines** of boilerplate removed.

## Test plan

- [x] `check_doc_counts.py` passes
- [x] `check_axiom_locations.py` passes
- [ ] `lake build` passes (CI)
- [ ] All Foundry tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical change introducing a convenience default and updating documentation/example evaluation snippets; no runtime semantics or proof logic is modified.
> 
> **Overview**
> Adds `defaultState` to `Verity/Core.lean` as a zero-initialized `ContractState` helper to avoid repeating full state literals in tests/examples.
> 
> Updates all example contracts’ `#eval` blocks and the “first contract” tutorial to construct initial state via `{ defaultState with ... }`, and refreshes docs metadata (core line counts) plus the tutorial API table/tip so snippets stay valid as `ContractState` evolves.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ca526ccc8697c754c532f5eb367935f1eb8c798. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->