### PR TITLE
Eliminate partial functions from trusted compiler code

### DIFF
--- a/Compiler/Selector.lean
+++ b/Compiler/Selector.lean
@@ -26,10 +26,10 @@ private def runKeccak (sigs : List String) : IO (List Nat) := do
   let lines := result.stdout.trim.splitOn "\n"
   if lines.length != sigs.length then
     throw (IO.userError s!"keccak256.py returned {lines.length} lines for {sigs.length} signatures: {result.stdout}")
-  let selectors := lines.map parseSelectorLine
-  if selectors.any (·.isNone) then
+  let selectors := lines.filterMap parseSelectorLine
+  if selectors.length != sigs.length then
     throw (IO.userError s!"Failed to parse selector output: {result.stdout}")
-  return selectors.map Option.get!
+  return selectors
 
 /-- Compute Solidity-compatible selectors for external functions in a spec.
     Internal functions are not dispatched via selector, so they are excluded. -/


### PR DESCRIPTION
## Summary

- Replace `Option.get!` in `Selector.lean` with `filterMap` + length check — removes the panic path from the **trusted selector computation pipeline**
- Replace `List.get!` calls in `RandomGen.lean` with `List.get?` pattern matching — eliminates runtime panic risk even though the prior guards were correct
- Replace `toNat!` in `RandomGen.lean` CLI with `toNat?` + error message — gives readable errors instead of panics on bad input

Zero `get!`, `Option.get!`, or `toNat!` calls remain in the `Compiler/` directory after this change.

Partially addresses #170 (the remaining 5 `partial def` in `IRInterpreter.lean` are in the proof layer and model inherently unbounded EVM loops).

## Test plan

- [x] `lake build` passes (76/76 modules, all proofs verify)
- [ ] CI: Lean build passes
- [ ] CI: All Foundry test shards pass
- [ ] CI: Selector checks pass
- [ ] CI: Multi-seed tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily replaces partial/unsafe operations (`get!`, `Option.get!`, `toNat!`) with total alternatives and explicit error handling, with minimal impact to normal execution paths. Main risk is subtle behavior change in selector parsing or random edge-case selection if assumptions about list lengths/output formatting were relied on.
> 
> **Overview**
> Removes remaining partial functions from `Compiler/` by replacing unsafe indexing and option extraction with total APIs and explicit failure paths.
> 
> `RandomGen.lean` now uses `List.get?` pattern matching for edge-case uint256 selection and address pool lookup, and the CLI parses `count`/`seed` via `toNat?` with clear `IO.userError` messages instead of panicking.
> 
> `Selector.lean` replaces `Option.get!` selector parsing with `filterMap` plus a length check, so malformed `keccak256.py` output fails with a structured error rather than a runtime exception.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a47e781be3016321800b5e1e44e2a4f9a0b31ea8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->