### PR TITLE
Add linker safety checks: arity validation and injection-site error

### DIFF
--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -40,11 +40,19 @@ private def writeContract (outDir : String) (contract : IRContract) (libraryPath
   | .error err => throw (IO.userError err)
   | .ok () => pure ()
 
-  let text :=
+  -- Validate: call-site argument counts match library parameter counts
+  if !allLibFunctions.isEmpty then
+    match validateCallArity yulObj allLibFunctions with
+    | .error err => throw (IO.userError err)
+    | .ok () => pure ()
+
+  let text ←
     if allLibFunctions.isEmpty then
-      Yul.render yulObj
+      pure (Yul.render yulObj)
     else
-      renderWithLibraries yulObj allLibFunctions
+      match renderWithLibraries yulObj allLibFunctions with
+      | .error err => throw (IO.userError err)
+      | .ok rendered => pure rendered
 
   let path := s!"{outDir}/{contract.name}.yul"
   IO.FS.writeFile path text


### PR DESCRIPTION
## Summary

- **Silent library drop** (critical): If `renderWithLibraries` can't find the runtime `code {` injection site, libraries were silently omitted — the contract would deploy without linked functionality. Now returns an explicit error.
- **Arity mismatch** (safety): No validation that call-site argument counts match library parameter counts. A library with wrong arity would produce malformed Yul caught only by `solc`. Now `validateCallArity` compares AST arg counts against parsed library parameter counts at link time.
- Adds `arity : Nat` field to `LibraryFunction` and `extractFunctionArity` parser helper.

Partially addresses #173.

## Test plan

- [x] `lake build` passes (76/76 modules, all proofs verify)
- [x] `lake exe verity-compiler --link ... -o /tmp/yul-test` produces correct output
- [ ] CI: Lean build passes
- [ ] CI: All Foundry test shards pass
- [ ] CI: Selector and storage layout checks pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Yul linking/compilation pipeline and changes failure modes (now errors instead of silently producing output), which could break existing builds or uncover previously-hidden issues. Logic is straightforward and additive, but it affects all library-linked compilation runs.
> 
> **Overview**
> Adds *link-time safety checks* for external Yul libraries.
> 
> `renderWithLibraries` now returns `Except` and **fails explicitly** if it cannot find the runtime `code {` injection site, preventing silent omission of library code.
> 
> Library parsing now records each function’s parameter count, and the compile driver runs a new `validateCallArity` check to **error when call-site argument counts don’t match** the linked library function signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 524cea9b6561ae7f92b3f25ba8434e39d324e358. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->