### PR TITLE
Fix stale docs and improve navigation across site

### DIFF
--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -96,6 +96,12 @@ python3 scripts/check_property_coverage.py
 python3 scripts/check_selectors.py
 ```
 
-**Reference**: See `SimpleStorage` for a minimal end-to-end example.
+**Reference**: See [SimpleStorage](/examples#simplestorage) for a minimal end-to-end example.
 
 **Need external libraries?** If your contract uses cryptographic primitives or other Yul functions, see [Linking External Libraries](/guides/linking-libraries) for the `--link` workflow. `CryptoHash` is a working end-to-end example.
+
+## See also
+
+- [Adding Your First Contract](/guides/first-contract) — step-by-step tutorial with TipJar
+- [Linking External Libraries](/guides/linking-libraries) — if your contract uses Yul library functions
+- [Proof Debugging Handbook](/guides/debugging-proofs) — when proofs get stuck

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -404,6 +404,8 @@ All current example contracts compile and pass tests (as of Feb 16, 2026):
 - ✅ **SimpleToken** — ERC20-like token with constructor
 - ✅ **SafeCounter** — Checked arithmetic with underflow protection
 
+**Not compiled**: ReentrancyExample (proofs are embedded inline, no compiler spec) and CryptoHash (unverified linker demo, requires `--link` to compile).
+
 ## Comparison: Manual vs Automatic
 
 ### Lines of Code

--- a/docs-site/content/examples.mdx
+++ b/docs-site/content/examples.mdx
@@ -183,7 +183,16 @@ Proofs cover: existential attack witness (vulnerability is provably exploitable)
 
 ## CryptoHash
 
-Unverified example demonstrating external library linking via the [Linker](/compiler#linker). Has no specs or proofs — it exists to show how external Yul helper functions integrate with compiled output.
+Unverified example demonstrating external library linking via the [Linker](/compiler#linker). Has no specs or proofs — it exists to show how external Yul helper functions integrate with compiled output. See the [Linking Libraries](/guides/linking-libraries) guide for a walkthrough.
+
+```lean
+-- Hash two values using an external Poseidon library
+def storeHashTwo (a b : Uint256) : Contract Unit := do
+  let hash ← externalCall "PoseidonT3_hash" [a, b]
+  setStorage lastHash hash
+```
+
+Source: [`Verity/Examples/CryptoHash.lean`](https://github.com/Th0rgal/verity/blob/main/Verity/Examples/CryptoHash.lean)
 
 ## Pattern progression
 

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -96,7 +96,7 @@ See [Add a Contract](/add-contract) for the full guide.
 
 ## Example Contracts
 
-Eight contracts are implemented and verified, plus one unverified linking demo:
+Eight contracts are formally verified (plus one unverified linker demo):
 
 | Contract | Demonstrates |
 |----------|--------------|

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -109,8 +109,10 @@ Use the Linker to inject production Yul libraries (Poseidon, Groth16, etc.) into
 - Examples: https://verity.thomasm.ar/examples
 - Core: https://verity.thomasm.ar/core
 - Compiler: https://verity.thomasm.ar/compiler
-- Guides: https://verity.thomasm.ar/guides/first-contract
-- Linking Libraries: https://verity.thomasm.ar/guides/linking-libraries
+- Guides (First Contract): https://verity.thomasm.ar/guides/first-contract
+- Guides (Linking Libraries): https://verity.thomasm.ar/guides/linking-libraries
+- Guides (Debugging Proofs): https://verity.thomasm.ar/guides/debugging-proofs
+- Add a Contract: https://verity.thomasm.ar/add-contract
 
 Add `.md` to any URL for raw markdown (saves tokens).
 


### PR DESCRIPTION
## Summary

- Fix "Eight contracts" count in `index.mdx` to acknowledge CryptoHash demo
- Add 3 missing guide URLs to `llms.txt` (linking-libraries, debugging-proofs, add-contract) so AI agents can discover all documentation pages
- Add "See also" section to `add-contract.mdx` linking to the three guides — currently a developer on the checklist page has no pointer to the detailed tutorial, linking guide, or proof debugging handbook
- Flesh out CryptoHash entry in `examples.mdx` with a Lean code snippet, source link, and cross-reference to the linking-libraries guide
- Add note in `compiler.mdx` explaining why ReentrancyExample and CryptoHash are absent from the validated contracts list

## Test plan

- [ ] Vercel preview deploys successfully
- [ ] All links resolve correctly on the preview site


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates (links, wording, and example snippets) with no runtime/code changes. Primary risk is broken or misdirected URLs/anchors in the docs site.
> 
> **Overview**
> Updates docs navigation and accuracy around example contracts: fixes the “verified contracts” wording/count on the homepage, adds a new *See also* section to `add-contract.mdx`, and clarifies in `compiler.mdx` why `ReentrancyExample` and `CryptoHash` aren’t in the compiled/validated list.
> 
> Expands the `CryptoHash` example description in `examples.mdx` with a Lean snippet, a source link, and a pointer to the linking guide, and updates `llms.txt` to include missing guide/document URLs for better discoverability by AI agents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3d0e41419de8c5f6898ce2a5aa4f9f614dbff14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->