### PR TITLE
[Improvement] Expand FiniteSet operations for upcoming contracts

### DIFF
--- a/Verity/Core/FiniteSet.lean
+++ b/Verity/Core/FiniteSet.lean
@@ -5,9 +5,11 @@
   lists, together with the operations and theorems needed for proving
   balance-conservation properties (e.g. Ledger sum proofs, issue #65).
 
-  Key operations: empty, insert, remove, contains, union, filter, sum.
-  Key theorems:  insert_of_mem, insert_of_not_mem, mem_elements_insert,
-                 card_insert_of_not_mem, card_insert_of_mem.
+  Key operations: empty, insert, remove, contains, union, inter, filter, sum,
+                  subset, member, toList, fromList.
+  Key types: FiniteSet α, FiniteAddressSet, FiniteNatSet.
+  Key theorems: insert_of_mem, insert_of_not_mem, mem_elements_insert,
+                card_insert_of_not_mem, card_insert_of_mem, sum_empty.
 -/
 
 namespace Verity.Core
@@ -70,6 +72,14 @@ def toList (s : FiniteSet α) : List α :=
 def fromList [DecidableEq α] (l : List α) : FiniteSet α :=
   l.foldl (fun acc x => acc.insert x) empty
 
+/-- Check if one set is a subset of another -/
+def subset [DecidableEq α] (s₁ s₂ : FiniteSet α) : Bool :=
+  s₁.elements.all (fun x => s₂.contains x)
+
+/-- Check if an element is a member (alias for contains, returns Prop for proofs) -/
+def member [DecidableEq α] (a : α) (s : FiniteSet α) : Prop :=
+  a ∈ s.elements
+
 /-!
 ### Theorems
 
@@ -127,6 +137,20 @@ theorem card_insert_of_mem [DecidableEq α] (a : α) (s : FiniteSet α) (h : a �
   unfold insert card
   simp [dif_pos h]
 
+/-- Sum of empty set is zero -/
+@[simp] theorem sum_empty [Add β] [OfNat β 0] (f : α → β) :
+    (empty : FiniteSet α).sum f = 0 := rfl
+
+/-- Subset is reflexive -/
+theorem subset_refl [DecidableEq α] (s : FiniteSet α) : s.subset s = true := by
+  unfold subset
+  simp [List.all_eq_true, contains]
+
+/-- Empty set is subset of any set -/
+theorem empty_subset [DecidableEq α] (s : FiniteSet α) : (empty : FiniteSet α).subset s = true := by
+  unfold subset
+  simp
+
 end FiniteSet
 
 /-- Finite set of addresses -/
@@ -157,5 +181,38 @@ def card (s : FiniteAddressSet) : Nat :=
   s.addresses.card
 
 end FiniteAddressSet
+
+/-- Finite set of natural numbers (for ERC721 token ID tracking, issue #73) -/
+structure FiniteNatSet where
+  nats : FiniteSet Nat
+  deriving Repr
+
+namespace FiniteNatSet
+
+/-- Create an empty nat set -/
+def empty : FiniteNatSet :=
+  ⟨FiniteSet.empty⟩
+
+/-- Insert a nat into the set -/
+def insert (n : Nat) (s : FiniteNatSet) : FiniteNatSet :=
+  ⟨s.nats.insert n⟩
+
+/-- Check if a nat is in the set -/
+def contains (n : Nat) (s : FiniteNatSet) : Bool :=
+  s.nats.contains n
+
+/-- Remove a nat from the set -/
+def remove (n : Nat) (s : FiniteNatSet) : FiniteNatSet :=
+  ⟨s.nats.remove n⟩
+
+/-- Get the number of nats in the set -/
+def card (s : FiniteNatSet) : Nat :=
+  s.nats.card
+
+/-- Check if one set is a subset of another -/
+def subset (s₁ s₂ : FiniteNatSet) : Bool :=
+  s₁.nats.subset s₂.nats
+
+end FiniteNatSet
 
 end Verity.Core


### PR DESCRIPTION
## Summary

Expands the `FiniteSet` module with additional operations and types needed for upcoming contracts (ERC20 #69, ERC721 #73, Multi-sig #78).

## Changes

| Addition | Purpose |
|----------|---------|
| `subset` operation | Check if one set is a subset of another |
| `member` operation | Prop-returning alias for contains (useful for proofs) |
| `FiniteNatSet` type | Track natural numbers (needed for ERC721 token IDs, #73) |
| `sum_empty` theorem | Sum of empty set is zero |
| `subset_refl` theorem | Subset is reflexive |
| `empty_subset` theorem | Empty set is subset of any set |

## Related

- Partially addresses #144 (FiniteSet lacks essential operations)
- Unblocks #73 (ERC721 NFT contract)
- Supports #78 (Multi-signature wallet)

## Test plan

- [x] `lake build` passes (all 76 modules)
- [x] New operations have type signatures matching the existing API
- [x] New theorems compile without sorry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive changes limited to new helper definitions and straightforward theorems; no changes to existing data structures or core logic beyond extending the API surface.
> 
> **Overview**
> Extends `Verity/Core/FiniteSet.lean` with additional set capabilities: adds `subset` (Boolean subset check) and `member` (Prop-level membership alias) alongside list conversion helpers in the documented API.
> 
> Adds new lemmas (`sum_empty`, `subset_refl`, `empty_subset`) to support proof workflows, and introduces `FiniteNatSet` (wrapping `FiniteSet Nat`) with basic operations (`empty`, `insert`, `contains`, `remove`, `card`, `subset`) for ERC721 token ID tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e738adaffc8853cadd32503077b5ca6756a3ff0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->