### PR TITLE
docs: Add common issues and debugging section to linking guide

### DIFF
--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -195,6 +195,39 @@ To increase confidence in linked libraries:
 
 ---
 
+## Common Issues and Debugging
+
+### Function name mismatch
+
+If you see `Unresolved external references: myFunc`, check that:
+- The function name in your ContractSpec matches the Yul library exactly (case-sensitive)
+- The library file is properly formatted with plain function definitions
+
+### Arity mismatch
+
+If you see `Arity mismatch: myFunc called with N args but library defines M params`:
+- The number of parameters in your `Expr.externalCall` must match the library function
+- Remember: return values don't count as parameters
+
+### Runtime errors with linked contracts
+
+If your verified contract works with placeholders but fails with linked libraries:
+1. **Check gas requirements**: Linked functions may use more gas than placeholders
+2. **Verify return types**: Ensure the library returns the expected type
+3. **Test with Foundry**: Add property tests that run against the linked contract
+
+### Debugging tips
+
+```bash
+# Generate Yul output to see how external calls are rendered
+lake exe verity-compiler --link libs/MyLib.yul -o compiler/yul -v
+
+# Check the generated Yul in compiler/yul/
+cat compiler/yul/*.yul
+```
+
+---
+
 ## CLI Reference
 
 ```bash


### PR DESCRIPTION
## Summary

Add practical debugging tips for developers using external libraries in Verity:

- **Common error messages**: Explains function name mismatch and arity mismatch errors
- **Runtime troubleshooting**: Tips for when verified contracts work with placeholders but fail with real libraries
- **Debugging CLI tips**: How to use verbose output and inspect generated Yul

## Changes

- Added new "Common Issues and Debugging" section to `docs-site/content/guides/linking-libraries.mdx`

## Motivation

Developers new to the Linker feature often encounter issues when switching from placeholder implementations to real Yul libraries. This section provides practical guidance to help them debug common problems.

## Testing

- Documentation builds successfully
- No code changes, only markdown

## Related

- Follows up on PR #231 and #232 which improved other documentation areas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or build logic modifications.
> 
> **Overview**
> Adds a new **“Common Issues and Debugging”** section to the linking-libraries guide, covering common linker errors (function name/arity mismatches), troubleshooting when linked libraries behave differently than placeholders, and CLI steps to inspect generated Yul with verbose output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ec78de0e42de605a506fb8a5ab7f0f19c360f50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->