### PR TITLE
[Documentation] Add quick start sections for faster developer onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,39 @@
 
 ---
 
+## 5-Minute Quick Start
+
+```bash
+# 1. Install Lean 4
+curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh
+source ~/.profile
+
+# 2. Clone and build
+git clone https://github.com/Th0rgal/verity.git
+cd verity
+lake build                                    # Verifies all 300 theorems
+
+# 3. Generate a new contract
+python3 scripts/generate_contract.py MyContract
+
+# 4. Compile to Yul/EVM
+lake build verity-compiler
+lake exe verity-compiler                      # Output in compiler/yul/
+```
+
+**With external libraries (e.g., Poseidon hash):**
+```bash
+# Link your Yul library at compile time
+lake exe verity-compiler --link libs/MyLib.yul -o compiler/yul
+```
+
+**Run tests:**
+```bash
+FOUNDRY_PROFILE=difftest forge test           # 352 tests across 25 suites
+```
+
+---
+
 Verity is a Lean 4 framework that lets you write smart contracts in a domain-specific language, formally verify their correctness, and compile them to EVM bytecode.
 
 **The idea is simple:** humans review 10-line specs that are easy to audit. Agents write 1000-line implementations. Lean proves the implementation matches the spec - no trust required.

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -8,7 +8,23 @@ description: How to use external Yul libraries (Poseidon, Groth16, etc.) with ve
 **Time Required**: 30 minutes
 **Prerequisites**: Verity project builds (`lake build` passes)
 
-Use the Linker to inject production cryptographic libraries (or any Yul functions) into your verified contracts. You prove properties against simple placeholders in Lean, then swap in real implementations at compile time.
+## TL;DR
+
+```bash
+# 1. Write your Yul library (plain functions, no object wrapper)
+echo 'function myHash(a, b) -> result { result := add(xor(a, b), 0x42) }' > libs/MyHash.yul
+
+# 2. Use a placeholder in your Lean EDSL (for proofs)
+def myHash (a b : Uint256) : Contract Uint256 := return add a b
+
+# 3. Reference it in your ContractSpec
+Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param 0, Expr.param 1])
+
+# 4. Compile with linking
+lake exe verity-compiler --link libs/MyHash.yul -o compiler/yul
+```
+
+Your proofs verify the contract logic (using placeholders). Real implementations are injected at compile time.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add 5-Minute Quick Start section to README with essential commands
- Add TL;DR summary to linking-libraries guide showing the complete workflow in 4 lines
- Show external library linking usage prominently for developers using existing Yul libraries

## Motivation
The documentation was comprehensive but lacked a concise "get to hello world in 5 minutes" section. This makes it easier for developers to:
1. Quickly try Verity without reading 500+ lines of tutorials
2. Understand the Linker workflow in 30 seconds
3. Get to a working example faster

## Test Plan
- Verified markdown renders correctly
- Existing documentation links remain valid

## Related Issues
Addresses developer experience improvement mentioned in ROADMAP.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no code or behavior modifications.
> 
> **Overview**
> Adds a new **5-Minute Quick Start** section to `README.md` with copy-pastable commands for installing Lean, building/verifying, generating a contract, compiling to Yul/EVM, linking an external Yul library, and running the Foundry test suite.
> 
> Adds a **TL;DR** block to `docs-site/content/guides/linking-libraries.mdx` that summarizes the end-to-end external library linking workflow (write Yul lib, use Lean placeholder, reference via `Expr.externalCall`, compile with `--link`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d239a12d2abc7b9b6938ff051ed8552ab692b101. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->