### PR TITLE
fix: correct docs that cause compile errors + stale counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ def myHash (a b : Uint256) : Contract Uint256 := do
   return (a + b)  -- simple placeholder
 
 -- 2. ContractSpec calls the real library
-Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param 0, Expr.param 1])
+Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 -- 3. Compile with: lake exe verity-compiler --link libs/MyHash.yul
 ```
@@ -209,7 +209,7 @@ def hash (a b : Uint256) : Contract Uint256 := do
 
 2. **Add external call** in `Compiler/Specs.lean`:
 ```lean
-Stmt.letVar "h" (Expr.externalCall "poseidonHash" [Expr.param 0, Expr.param 1])
+Stmt.letVar "h" (Expr.externalCall "poseidonHash" [Expr.param "a", Expr.param "b"])
 ```
 
 3. **Compile with linking**:

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -79,7 +79,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: 220 properties tested across 9 contracts (73% coverage, 300 total theorems)
+**Coverage**: 220 properties tested across 9 contracts (73% coverage, 305 total theorems)
 
 **What this guarantees**:
 - Contract behavior matches specification

--- a/Verity/Examples/CryptoHash.lean
+++ b/Verity/Examples/CryptoHash.lean
@@ -25,19 +25,21 @@ In the EDSL, we use a simple placeholder (addition) for the hash function.
 This allows us to prove properties about the contract logic without dealing
 with complex cryptographic primitives.
 
-At compile time, this will be replaced with a call to an external Poseidon
-hash implementation via the @[extern] attribute (to be added in future).
+At compile time, the real Poseidon hash is linked via `Expr.externalCall` in
+the ContractSpec and the `--link` CLI flag. See `Compiler/Specs.lean` for the
+ContractSpec that references `PoseidonT3_hash`/`PoseidonT4_hash`, and
+`examples/external-libs/` for the Yul library files.
 
 For now, we demonstrate the pattern with a simple addition-based placeholder.
 -/
 
 -- Placeholder hash: just add the inputs (for proving)
--- In production: @[extern "PoseidonT3_hash"] would replace this
+-- In production: linked via `lake exe verity-compiler --link examples/external-libs/PoseidonT3.yul`
 def hashTwo (a b : Uint256) : Contract Uint256 := do
   return add a b
 
 -- Placeholder hash for three inputs
--- In production: @[extern "PoseidonT4_hash"]
+-- In production: linked via `lake exe verity-compiler --link examples/external-libs/PoseidonT4.yul`
 def hashThree (a b c : Uint256) : Contract Uint256 := do
   return add (add a b) c
 

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -389,20 +389,19 @@ python3 scripts/keccak256.py "tip(uint256)" "getBalance(address)"
 # Output: two hex values like 0xd3e5769a 0xf8b2cb4f
 ```
 
-Add the selectors and register in `allSpecs`:
+Register your contract in the `allSpecs` list:
 
 ```lean
--- Selectors must match the order of functions in tipJarSpec.functions
-def tipJarSelectors : List Nat := [0xd3e5769a, 0xf8b2cb4f]
-
--- Add to allSpecs list
-def allSpecs := [
+-- Add to allSpecs list in Compiler/Specs.lean
+def allSpecs : List ContractSpec := [
   -- ... existing contracts ...,
-  (tipJarSpec, tipJarSelectors)
+  tipJarSpec
 ]
 ```
 
-> **Important**: The selector list must be in the same order as the functions list. `#guard` statements in `Specs.lean` enforce that the counts match, but order correctness is the developer's responsibility. Run `python3 scripts/check_selectors.py` to validate.
+Function selectors are computed automatically by `computeSelectors` during compilation — you do not need to list them manually. The compiler derives selectors from your function signatures using keccak256.
+
+> **Tip**: Run `python3 scripts/check_selectors.py` to verify that the auto-computed selectors match `solc --hashes` output.
 
 ### 5.3 Generate Yul Code
 

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -18,7 +18,7 @@ echo 'function myHash(a, b) -> result { result := add(xor(a, b), 0x42) }' > libs
 def myHash (a b : Uint256) : Contract Uint256 := return add a b
 
 # 3. Reference it in your ContractSpec
-Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param 0, Expr.param 1])
+Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 # 4. Compile with linking
 lake exe verity-compiler --link libs/MyHash.yul -o compiler/yul
@@ -65,10 +65,12 @@ In `Compiler/Specs.lean`, use `Expr.externalCall` to reference the library funct
 
 ```lean
 -- Inside your contract spec's function body:
-Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param 0, Expr.param 1])
+Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 ```
 
-The compiler generates a Yul `myHash(arg0, arg1)` call that will be resolved by the linked library.
+> **Important**: `Expr.param` takes the parameter **name** as a string — it must match the `name` field in your function's `params` list. For example, if your function declares `{ name := "a", ty := ParamType.uint256 }`, use `Expr.param "a"`.
+
+The compiler generates a Yul `myHash(a, b)` call that will be resolved by the linked library.
 
 ### 4. Compile with `--link`
 

--- a/examples/external-libs/README.md
+++ b/examples/external-libs/README.md
@@ -21,9 +21,9 @@ function myHash(a, b) -> result {
 
 ### Step 2: Add the external call in `Compiler/Specs.lean`
 
-Find your contract spec and add:
+Find your contract spec and add (`Expr.param` takes the parameter **name** as a string, matching the `name` field in your function's `params` list):
 ```lean
-Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param 0, Expr.param 1])
+Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 ```
 
 ### Step 3: Compile with linking
@@ -89,7 +89,7 @@ def myHash (a b : Uint256) : Contract Uint256 := do
 In `Compiler/Specs.lean`, reference the library function:
 
 ```lean
-Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param 0, Expr.param 1])
+Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 ```
 
 ### 4. Compile with Linking

--- a/test/README.md
+++ b/test/README.md
@@ -33,8 +33,11 @@ Basic contract behavior validation without formal property mapping.
 ## Running Tests
 
 ```bash
-# All tests
+# All tests (unit + property tests only)
 forge test
+
+# All tests INCLUDING differential and Yul tests (requires FFI)
+FOUNDRY_PROFILE=difftest forge test
 
 # Single contract
 forge test --match-path test/PropertyCounter.t.sol
@@ -48,6 +51,8 @@ forge test -vvv
 # Multi-seed testing (detects flakiness)
 bash scripts/test_multiple_seeds.sh
 ```
+
+> **Note**: Plain `forge test` skips differential and Yul tests because FFI is disabled in the default profile. Use `FOUNDRY_PROFILE=difftest` to run the full test suite including tests that shell out to `lake exe difftest-interpreter`.
 
 ## Test Organization
 


### PR DESCRIPTION
## Summary

Fixes documentation bugs that would cause **immediate compile errors** for any developer following the getting-started guides, plus stale/misleading references in example code and test docs.

### Critical: `Expr.param` type error (6 occurrences)

All documentation examples showed `Expr.param 0` and `Expr.param 1`, but `Expr.param` takes a `String` (parameter name), not a `Nat`:

```lean
-- ContractSpec.lean:163
inductive Expr
  | literal (n : Nat)
  | param (name : String)   -- ← String, not Nat
```

A developer following any of the three guides (README, external-libs README, linking-libraries guide) would get a Lean type error on their first attempt. Fixed to `Expr.param "a"`, `Expr.param "b"` — matching the actual usage in `Compiler/Specs.lean`.

### Critical: CryptoHash.lean misleading `@[extern]` comments

The example file suggested `@[extern "PoseidonT3_hash"]` is the production mechanism for linking external libraries. This is wrong — Verity uses `Expr.externalCall` + the `--link` CLI flag, not Lean's FFI `@[extern]` attribute. Fixed to reference the actual Linker workflow.

### Critical: first-contract.mdx tutorial wrong `allSpecs` format

The tutorial showed `allSpecs` as a list of `(spec, selectors)` tuples with manually-specified selectors. In reality:
- `allSpecs` is `List ContractSpec` (flat list, no tuples)
- Selectors are auto-computed by `computeSelectors` during compilation

A developer following the tutorial would break `Compiler/Specs.lean`. Fixed to match the actual data structure and explain auto-computation.

### Stale theorem count

TRUST_ASSUMPTIONS.md said "300 total theorems" — fixed to 305 matching the README badge and all other references.

### Developer experience

- **test/README.md**: Added `FOUNDRY_PROFILE=difftest` command and note explaining that plain `forge test` silently skips differential/Yul tests
- **Linking guide + external-libs README**: Added note explaining that `Expr.param` names must match the `name` field in `FunctionSpec.params` — this was previously undiscoverable without reading source code

## Files changed (7)

| File | Change |
|------|--------|
| `README.md` | Fix 2× `Expr.param` type |
| `TRUST_ASSUMPTIONS.md` | Fix theorem count 300→305 |
| `Verity/Examples/CryptoHash.lean` | Replace `@[extern]` with Linker docs |
| `docs-site/content/guides/first-contract.mdx` | Fix `allSpecs` format + selectors |
| `docs-site/content/guides/linking-libraries.mdx` | Fix `Expr.param` + add convention note |
| `examples/external-libs/README.md` | Fix 2× `Expr.param` + add convention note |
| `test/README.md` | Add `FOUNDRY_PROFILE=difftest` docs |

## Test plan

- [x] No code changes — docs/comments only
- [x] All `Expr.param` examples now match actual `Compiler/Specs.lean` usage
- [x] Theorem count (305) matches README badge
- [x] `allSpecs` example matches actual type `List ContractSpec` in `Compiler/Specs.lean:446`
- [x] CryptoHash comments reference correct Linker mechanism