### PR TITLE
docs: fix module paths, elan source, and scaffold file list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ```bash
 # 1. Install Lean 4
 curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh
-source ~/.profile
+source ~/.elan/env
 
 # 2. Clone and build
 git clone https://github.com/Th0rgal/verity.git
@@ -142,7 +142,7 @@ See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for trust boundaries, [`AXIOM
 ```bash
 # Install Lean 4 via elan
 curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh
-source ~/.profile
+source ~/.elan/env
 
 # Build the project
 lake build
@@ -184,12 +184,13 @@ python3 scripts/generate_contract.py MyToken --fields "balances:mapping,totalSup
 
 This scaffolds the full file layout:
 
-1. **Spec** - `Verity/Specs/<Name>/Spec.lean`
-2. **Invariants** - `Verity/Specs/<Name>/Invariants.lean`
-3. **Implementation** - `Verity/Examples/<Name>.lean`
-4. **Proofs** - `Verity/Specs/<Name>/Proofs.lean`
-5. **Compiler Spec** - `Compiler/Specs.lean`
-6. **Tests** - `test/Property<Name>.t.sol`
+1. **Implementation** - `Verity/Examples/<Name>.lean`
+2. **Spec** - `Verity/Specs/<Name>/Spec.lean`
+3. **Invariants** - `Verity/Specs/<Name>/Invariants.lean`
+4. **Spec Proofs** - `Verity/Specs/<Name>/Proofs.lean`
+5. **Basic Proofs** - `Verity/Proofs/<Name>/Basic.lean`
+6. **Correctness Proofs** - `Verity/Proofs/<Name>/Correctness.lean`
+7. **Tests** - `test/Property<Name>.t.sol`
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for conventions and workflow.
 

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -8,6 +8,11 @@ description: Step-by-step tutorial for creating a verified smart contract in Ver
 **Time Required**: 2-3 hours for first contract
 **Prerequisites**: Basic familiarity with Lean 4 syntax and smart contract concepts
 
+> **New to Lean 4?** You'll need to understand `do` notation, `def`/`theorem`, and basic tactic proofs (`simp`, `intro`, `constructor`). Start with:
+> - [Lean 4 Manual — Basics](https://lean-lang.org/lean4/doc/) — language overview
+> - [Theorem Proving in Lean 4](https://leanprover.github.io/theorem_proving_in_lean4/) — chapters 1–5 cover everything needed here
+> - [Functional Programming in Lean](https://lean-lang.org/functional_programming_in_lean/) — `do` notation and monads (chapter 4)
+
 This tutorial walks you through creating a complete verified smart contract from scratch. We'll build a **TipJar** contract — a simple balance ledger where users can deposit tips and check balances.
 
 > **Why TipJar?** It uses the core EDSL features (mappings, `msgSender`, `require`, arithmetic) while staying simple enough to prove fully on your first attempt.
@@ -46,8 +51,10 @@ python3 scripts/generate_contract.py TipJar \
 This creates all required files:
 - `Verity/Specs/TipJar/Spec.lean` — formal specification
 - `Verity/Specs/TipJar/Invariants.lean` — state invariants
+- `Verity/Specs/TipJar/Proofs.lean` — Layer 2 proof re-export
 - `Verity/Examples/TipJar.lean` — EDSL implementation
-- `Verity/Proofs/TipJar/Basic.lean` — correctness proofs (EDSL matches spec)
+- `Verity/Proofs/TipJar/Basic.lean` — basic correctness proofs (EDSL matches spec)
+- `Verity/Proofs/TipJar/Correctness.lean` — advanced correctness proofs
 - `test/PropertyTipJar.t.sol` — Foundry tests
 
 ### 1.2 Or Create Files Manually
@@ -624,12 +631,12 @@ python3 scripts/check_doc_counts.py
 
 ### 7.2 Add to Module Exports
 
-Update `Verity.lean`:
+Update `Verity/All.lean` to include your new contract:
 ```lean
 import Verity.Examples.TipJar
 ```
 
-Update `Verity.lean` to also export the proofs:
+Also add the proof imports to `Verity/All.lean`:
 ```lean
 import Verity.Proofs.TipJar.Basic
 ```


### PR DESCRIPTION
## Summary

- **first-contract.mdx Phase 7.2**: Change `Verity.lean` → `Verity/All.lean` — `Verity.lean` is just `import Verity.All`, so new contract imports must go in `Verity/All.lean`
- **first-contract.mdx Prerequisites**: Add Lean 4 learning resources (Manual, Theorem Proving, FP in Lean) for developers new to Lean
- **first-contract.mdx scaffold list**: Add missing `Verity/Specs/TipJar/Proofs.lean` and `Verity/Proofs/TipJar/Correctness.lean` that `generate_contract.py` actually creates
- **README.md**: Fix `source ~/.profile` → `source ~/.elan/env` (matches elan's actual output and getting-started.mdx)
- **README.md scaffold list**: Add missing `Verity/Proofs/<Name>/Basic.lean` and `Verity/Proofs/<Name>/Correctness.lean`, remove `Compiler/Specs.lean` which is not generated (only printed to stdout for manual insertion)

## Test plan
- [ ] Verify `generate_contract.py` output matches the updated file lists
- [ ] Confirm `source ~/.elan/env` works after fresh elan install
- [ ] Check docs site renders correctly with updated MDX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 851ec295c5d038e04338e27f10b12db8a12fa9ad. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->