### PR TITLE
fix: correct stale docs, wrong test commands, and inaccurate API surface

### DIFF
--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -572,14 +572,14 @@ def myContractSpec : ContractSpec := {
   functions := [/* ... */]
 }
 
-def myContractSelectors : List Nat := [0x..., 0x...]
-
 -- Add to allSpecs
-def allSpecs := [
-  /* ... */,
-  (myContractSpec, myContractSelectors)
+def allSpecs : List ContractSpec := [
+  /* ... existing contracts ... */,
+  myContractSpec
 ]
 ```
+
+Function selectors are computed automatically by `computeSelectors` during compilation — you do not need to list them manually.
 
 2. **Recompile**:
 ```bash

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -27,16 +27,20 @@ structure StorageSlot (α : Type) where
 
 ```lean
 structure ContractState where
-  storage : Nat → Uint256                -- Uint256 storage
-  storageAddr : Nat → Address            -- Address storage
-  storageMap : Nat → Address → Uint256  -- Mapping storage
+  storage : Nat → Uint256                          -- Uint256 storage
+  storageAddr : Nat → Address                      -- Address storage
+  storageMap : Nat → Address → Uint256             -- Mapping storage (Address → Uint256)
+  storageMapUint : Nat → Uint256 → Uint256         -- Uint256-keyed mapping storage
+  storageMap2 : Nat → Address → Address → Uint256  -- Double mapping storage
   sender : Address
   thisAddress : Address
   msgValue : Uint256
   blockTimestamp : Uint256
+  knownAddresses : Nat → FiniteAddressSet          -- Tracked addresses per slot (for sum proofs)
+  events : List Event := []                         -- Emitted events log
 ```
 
-Three independent storage spaces: Uint256 slots, Address slots, and Mapping slots. Each is indexed by a natural number (the slot). The state also carries the sender address, the contract's own address, and the EVM context fields `msg.value` and `block.timestamp`.
+Five independent storage spaces: Uint256 slots, Address slots, Address-keyed mappings, Uint256-keyed mappings, and double mappings (Address → Address → Uint256). Each is indexed by a natural number (the slot). The state also carries the sender address, the contract's own address, EVM context fields (`msg.value`, `block.timestamp`), a per-slot address tracker for sum property proofs, and an append-only event log.
 
 ## ContractResult
 
@@ -77,7 +81,17 @@ def setStorage (s : StorageSlot Uint256) (value : Uint256) : Contract Unit :=
         if slot == s.slot then value else state.storage slot }
 ```
 
-Address storage (`getStorageAddr`/`setStorageAddr`) and mapping storage (`getMapping`/`setMapping`) follow the same pattern with their respective state fields.
+All storage types follow the same pattern:
+
+| Operation | Type | State field |
+|-----------|------|-------------|
+| `getStorageAddr`/`setStorageAddr` | Address slots | `storageAddr` |
+| `getMapping`/`setMapping` | Address-keyed mappings | `storageMap` |
+| `getMappingUint`/`setMappingUint` | Uint256-keyed mappings | `storageMapUint` |
+| `getMapping2`/`setMapping2` | Double mappings | `storageMap2` |
+| `emitEvent` | Event emission | `events` |
+
+Context accessors (`msgSender`, `msgValue`, `contractAddress`, `blockTimestamp`) read from the state without modifying it.
 
 ## Require guard
 

--- a/docs-site/content/examples.mdx
+++ b/docs-site/content/examples.mdx
@@ -10,14 +10,18 @@ A small set of contracts, each introducing a new pattern. They build on each oth
 ## How to organize a contract
 
 - **Spec**: `Verity/Specs/<Name>/Spec.lean`
+- **Invariants**: `Verity/Specs/<Name>/Invariants.lean`
 - **Implementation**: `Verity/Examples/<Name>.lean`
-- **Proof**: `Verity/Specs/<Name>/Proofs.lean`
+- **Basic proofs**: `Verity/Proofs/<Name>/Basic.lean`
+- **Advanced proofs**: `Verity/Proofs/<Name>/Correctness.lean`
+- **Proof re-export**: `Verity/Specs/<Name>/Proofs.lean` (imports from `Compiler/Proofs/`)
 - **Reusable proof infra**: `Verity/Proofs/Stdlib/`
 
 Example (SimpleStorage):
 - Spec: `Verity/Specs/SimpleStorage/Spec.lean`
 - Implementation: `Verity/Examples/SimpleStorage.lean`
-- Proof: `Verity/Specs/SimpleStorage/Proofs.lean`
+- Basic proofs: `Verity/Proofs/SimpleStorage/Basic.lean`
+- Correctness proofs: `Verity/Proofs/SimpleStorage/Correctness.lean`
 
 ## Authoring checklist
 
@@ -168,7 +172,7 @@ Two parallel bank contracts — one vulnerable, one safe — demonstrating that 
 theorem vulnerable_attack_exists :
   ∃ (s : ContractState),
     supplyInvariant s ["attacker"] ∧
-    ¬ supplyInvariant (withdraw MAX_UINT256).runState s) ["attacker"]
+    ¬ supplyInvariant ((withdraw MAX_UINT256).runState s) ["attacker"]
 
 -- Safe: state update before external call
 -- The supply invariant is universally provable

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -51,14 +51,13 @@ The first build downloads Mathlib and compiles everything — expect **5–15 mi
 ## 4. Run the test suite
 
 ```bash
-# Property tests (no FFI needed)
-forge test
-
-# Differential tests (compares EDSL interpreter output against compiled Yul on EVM)
+# All tests (property tests + differential tests)
 FOUNDRY_PROFILE=difftest forge test
 ```
 
-The `difftest` profile enables `vm.ffi()` calls so that Foundry can invoke the Lean-based interpreter. This requires `lake build` to have completed successfully.
+The `difftest` profile enables `vm.ffi()` calls, which is required for **all** test suites — property tests use `deployYul()` to compile Yul via `solc`, and differential tests invoke the Lean interpreter. This requires `lake build` to have completed successfully.
+
+> **Note**: Running `forge test` without `FOUNDRY_PROFILE=difftest` will fail because FFI is disabled in the default profile. See [foundry.toml](https://github.com/Th0rgal/verity/blob/main/foundry.toml).
 
 ## 5. Generate your first contract
 

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -592,8 +592,10 @@ contract PropertyTipJarTest is YulTestBase {
 ### 6.2 Run Tests
 
 ```bash
-forge test --match-contract TipJar -vv
+FOUNDRY_PROFILE=difftest forge test --match-contract TipJar -vv
 ```
+
+> **Note**: The `difftest` profile is required because `deployYul()` uses `vm.ffi()` to compile Yul via `solc`. The default Foundry profile has FFI disabled for security. See [foundry.toml](https://github.com/Th0rgal/verity/blob/main/foundry.toml).
 
 ### 6.3 Verify Property Coverage
 
@@ -620,8 +622,8 @@ lake build verity-compiler
 lake exe verity-compiler
 python3 scripts/check_yul_compiles.py
 
-# 4. Tests pass
-forge test --match-contract TipJar
+# 4. Tests pass (difftest profile required for Yul compilation via vm.ffi)
+FOUNDRY_PROFILE=difftest forge test --match-contract TipJar
 
 # 5. All CI checks pass
 python3 scripts/check_selectors.py

--- a/test/README.md
+++ b/test/README.md
@@ -33,26 +33,26 @@ Basic contract behavior validation without formal property mapping.
 ## Running Tests
 
 ```bash
-# All tests (unit + property tests only)
-forge test
-
-# All tests INCLUDING differential and Yul tests (requires FFI)
+# All tests (requires FFI for property tests and differential tests)
 FOUNDRY_PROFILE=difftest forge test
 
+# Unit tests only (no FFI needed)
+forge test --no-match-path "test/Property*" --no-match-path "test/Differential*" --no-match-path "test/CallValue*" --no-match-path "test/CalldataSize*"
+
 # Single contract
-forge test --match-path test/PropertyCounter.t.sol
+FOUNDRY_PROFILE=difftest forge test --match-path test/PropertyCounter.t.sol
 
 # Specific test
-forge test --match-test testProperty_StoreRetrieve
+FOUNDRY_PROFILE=difftest forge test --match-test testProperty_StoreRetrieve
 
 # With verbosity
-forge test -vvv
+FOUNDRY_PROFILE=difftest forge test -vvv
 
 # Multi-seed testing (detects flakiness)
 bash scripts/test_multiple_seeds.sh
 ```
 
-> **Note**: Plain `forge test` skips differential and Yul tests because FFI is disabled in the default profile. Use `FOUNDRY_PROFILE=difftest` to run the full test suite including tests that shell out to `lake exe difftest-interpreter`.
+> **Note**: Property tests (`Property*.t.sol`) deploy Yul contracts via `vm.ffi()`, and differential tests shell out to `lake exe difftest-interpreter`. Both require `FOUNDRY_PROFILE=difftest`. Plain `forge test` will fail on these suites because FFI is disabled in the default profile. See [foundry.toml](../foundry.toml).
 
 ## Test Organization
 


### PR DESCRIPTION
## Summary

Fixes multiple documentation inaccuracies that would cause developers to fail when following the guides:

- **`core.mdx`**: `ContractState` struct was missing 4 fields (`storageMapUint`, `storageMap2`, `knownAddresses`, `events`) and the storage operations table was incomplete (missing `getMappingUint`/`setMappingUint`, `getMapping2`/`setMapping2`, `emitEvent`, and context accessors)
- **`compiler.mdx`**: `allSpecs` was shown as `List (ContractSpec × List Nat)` (tuple with manual selectors) but the actual code is `List ContractSpec` — selectors are computed automatically by `computeSelectors`
- **`getting-started.mdx`**: Incorrectly claimed `forge test` works for property tests without `FOUNDRY_PROFILE=difftest`. All property tests use `deployYul()` → `vm.ffi()` → `solc`, which requires FFI enabled
- **`first-contract.mdx`**: Test commands missing `FOUNDRY_PROFILE=difftest`, which would fail on first use
- **`examples.mdx`**: File layout section was stale (missing `Proofs/<Name>/Basic.lean` and `Correctness.lean`); ReentrancyExample code had unbalanced parenthesis
- **`test/README.md`**: Claimed `forge test` runs "unit + property tests" but property tests require FFI; fixed all commands to include `FOUNDRY_PROFILE=difftest`

## Verification

Each fix was verified against the actual codebase:
- `ContractState` fields checked against `Verity/Core.lean:37-48`
- `allSpecs` type checked against `Compiler/Specs.lean:453`
- All `Property*.t.sol` files confirmed to import `YulTestBase` (which uses `vm.ffi`)
- `foundry.toml` confirms `ffi = false` in default profile, `ffi = true` in difftest

## Test plan

- [ ] Docs site builds successfully
- [ ] No Lean code was modified — existing proofs and CI unaffected
- [ ] Verify the docs site renders correctly at verity.thomasm.ar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that correct API descriptions and required Foundry commands; no runtime or proof logic is modified.
> 
> **Overview**
> Updates documentation to match the current codebase and prevent broken setup steps. The compiler docs now show `allSpecs : List ContractSpec` and clarify that function selectors are computed automatically during compilation.
> 
> Core docs are corrected to include the full `ContractState` surface (additional mapping types, address tracking, and event log) and to document the missing storage/event operations. Guides and test docs are updated to consistently run Foundry with `FOUNDRY_PROFILE=difftest` (and explain the `vm.ffi()` requirement), and `examples.mdx` is refreshed for the new proofs layout plus a small syntax fix in the ReentrancyExample snippet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c66405bf7fd1d754b9e2f3c7a86611346f2e2bdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->