### PR TITLE
fix: repro command missing difftest profile + docs friction points

### DIFF
--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -9,7 +9,16 @@ This guide walks you through setting up a development environment for Verity, bu
 | [elan](https://github.com/leanprover/elan) | Lean toolchain manager | Building everything |
 | [Foundry](https://book.getfoundry.sh/getting-started/installation) | Solidity testing framework | Running property tests |
 | Python 3.8+ | Scripts | Scaffold generator, CI scripts |
-| `solc` 0.8.33+ | Solidity compiler | Differential tests only |
+| [`solc`](https://docs.soliditylang.org/en/latest/installing-solidity.html) 0.8.33+ | Solidity compiler | Differential tests only |
+
+> **Installing `solc`**: Foundry does not ship `solc`. Install it separately via [`solc-select`](https://github.com/crytic/solc-select):
+> ```bash
+> pip3 install solc-select
+> solc-select install 0.8.33
+> solc-select use 0.8.33
+> solc --version
+> ```
+> On macOS you can also use `brew install solidity`. The project requires version 0.8.33+.
 
 ## 1. Install Lean 4
 
@@ -46,7 +55,7 @@ cd verity
 lake build                # Downloads dependencies and verifies all 305 theorems
 ```
 
-The first build downloads Mathlib and compiles everything — expect **5–15 minutes** depending on your machine. Subsequent builds are incremental and much faster.
+The first build downloads Mathlib and compiles everything — expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).
 
 ## 4. Run the test suite
 
@@ -90,7 +99,7 @@ lake exe verity-compiler          # Output in compiler/yul/
 For contracts that use external libraries (e.g., Poseidon hash):
 
 ```bash
-lake exe verity-compiler --link libs/PoseidonT3.yul -o compiler/yul
+lake exe verity-compiler --link examples/external-libs/PoseidonT3.yul -o compiler/yul
 ```
 
 See the [Linking Libraries guide](/guides/linking-libraries) for details.

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -51,7 +51,7 @@ python3 scripts/generate_contract.py TipJar \
 This creates all required files:
 - `Verity/Specs/TipJar/Spec.lean` — formal specification
 - `Verity/Specs/TipJar/Invariants.lean` — state invariants
-- `Verity/Specs/TipJar/Proofs.lean` — Layer 2 proof re-export
+- `Verity/Specs/TipJar/Proofs.lean` — Layer 1 proof re-export
 - `Verity/Examples/TipJar.lean` — EDSL implementation
 - `Verity/Proofs/TipJar/Basic.lean` — basic correctness proofs (EDSL matches spec)
 - `Verity/Proofs/TipJar/Correctness.lean` — advanced correctness proofs
@@ -386,29 +386,20 @@ def tipJarSpec : ContractSpec := {
 }
 ```
 
-### 5.2 Compute Function Selectors
+### 5.2 Register Your Contract
 
-Solidity function selectors are the first 4 bytes of `keccak256("functionName(paramTypes)")`. Verity computes them automatically at compile time using `scripts/keccak256.py`:
-
-```bash
-# Compute selectors for your functions
-python3 scripts/keccak256.py "tip(uint256)" "getBalance(address)"
-# Output: two hex values like 0xd3e5769a 0xf8b2cb4f
-```
-
-Register your contract in the `allSpecs` list:
+Add your contract to the `allSpecs` list in `Compiler/Specs.lean`:
 
 ```lean
--- Add to allSpecs list in Compiler/Specs.lean
 def allSpecs : List ContractSpec := [
   -- ... existing contracts ...,
   tipJarSpec
 ]
 ```
 
-Function selectors are computed automatically by `computeSelectors` during compilation — you do not need to list them manually. The compiler derives selectors from your function signatures using keccak256.
+Function selectors (the first 4 bytes of `keccak256("functionName(paramTypes)")`) are computed automatically by `computeSelectors` during compilation — you do not need to list them manually.
 
-> **Tip**: Run `python3 scripts/check_selectors.py` to verify that the auto-computed selectors match `solc --hashes` output.
+> **Tip**: Run `python3 scripts/check_selectors.py` to verify that the auto-computed selectors match `solc --hashes` output. You can also compute selectors manually with `python3 scripts/keccak256.py "tip(uint256)" "getBalance(address)"`.
 
 ### 5.3 Generate Yul Code
 

--- a/scripts/test_multiple_seeds.sh
+++ b/scripts/test_multiple_seeds.sh
@@ -57,7 +57,7 @@ if [ ${#FAILED_SEEDS[@]} -gt 0 ]; then
     echo ""
     echo "To reproduce a failure:"
     for failed_seed in "${FAILED_SEEDS[@]}"; do
-        echo "  DIFFTEST_RANDOM_SEED=$failed_seed forge test -vv"
+        echo "  FOUNDRY_PROFILE=difftest DIFFTEST_RANDOM_SEED=$failed_seed forge test --no-match-test \"Random10000\" -vv"
     done
     exit 1
 else


### PR DESCRIPTION
## Summary

Fixes developer onboarding friction across 3 files:

### 1. `scripts/test_multiple_seeds.sh` (Closes #275)
The repro command printed on test failure was:
```
DIFFTEST_RANDOM_SEED=42 forge test -vv
```
This always fails because it's missing `FOUNDRY_PROFILE=difftest` and the `--no-match-test "Random10000"` filter. Fixed to:
```
FOUNDRY_PROFILE=difftest DIFFTEST_RANDOM_SEED=42 forge test --no-match-test "Random10000" -vv
```

### 2. `getting-started.mdx`
- **Missing `solc` install instructions**: `solc` was listed as a prerequisite with no installation guide. A developer following the guide linearly would hit FFI errors with no diagnosis. Added `solc-select` install steps.
- **Wrong linker path**: `libs/PoseidonT3.yul` doesn't exist — the actual path is `examples/external-libs/PoseidonT3.yul`
- **Underestimated build time**: "5-15 minutes" → "20-45 minutes" for first Mathlib download

### 3. `first-contract.mdx`
- **Layer inconsistency**: `Proofs.lean` was described as "Layer 2 proof re-export" here but "Layer 1 proof re-export" in `getting-started.mdx` and the scaffold generator. Fixed to match the scaffold (Layer 1).
- **Selector contradiction**: Phase 5.2 ("Compute Function Selectors") told users to run `keccak256.py`, then immediately said selectors are auto-computed. Replaced with a clear "Register Your Contract" section that explains auto-computation first, with `keccak256.py` mentioned only as a verification tool.

## Test plan

- [ ] Docs site builds (Vercel preview)
- [ ] `scripts/test_multiple_seeds.sh` repro command now includes `FOUNDRY_PROFILE=difftest`
- [ ] No Lean code modified — existing proofs and CI unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and a shell script’s printed repro command, with no changes to Lean/Solidity logic. Main risk is minor confusion if command flags or paths are still incorrect on some environments.
> 
> **Overview**
> **Developer onboarding fixes across docs and tooling.** Updates `getting-started.mdx` to include explicit `solc` installation instructions, corrects the Poseidon linker example path, and adjusts the expected first `lake build` time estimate.
> 
> Clarifies `first-contract.mdx` by fixing the `Proofs.lean` layer description and replacing the selector-computation section with a clearer “register your contract” step while noting selectors are auto-computed (with manual/verification commands as optional).
> 
> Improves `scripts/test_multiple_seeds.sh` failure output so the suggested repro command includes `FOUNDRY_PROFILE=difftest` and the `--no-match-test "Random10000"` filter (plus `-vv`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 108d986908697e3a9565f4504e098a886fdfc5fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->