### PR TITLE
fix: CI reproduce command and DifferentialOwned assertion consistency

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -356,4 +356,4 @@ jobs:
         if: failure()
         run: |
           echo "::error::Tests failed with seed ${{ matrix.seed }}"
-          echo "::notice::Reproduce locally: DIFFTEST_RANDOM_SEED=${{ matrix.seed }} forge test"
+          echo "::notice::Reproduce locally: FOUNDRY_PROFILE=difftest DIFFTEST_RANDOM_SEED=${{ matrix.seed }} forge test --no-match-test \"Random10000\" -vv"

--- a/test/DifferentialOwned.t.sol
+++ b/test/DifferentialOwned.t.sol
@@ -459,7 +459,7 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig {
         console2.log("All random tests passed!");
         console2.log("Tests passed:", testsPassed);
         console2.log("Tests failed:", testsFailed);
-        require(testsFailed == 0, "Some tests failed");
+        assertEq(testsFailed, 0, "Some random tests failed");
     }
 
     /**
@@ -509,7 +509,7 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig {
         console2.log("All random tests passed!");
         console2.log("Tests passed:", testsPassed);
         console2.log("Tests failed:", testsFailed);
-        require(testsFailed == 0, "Some tests failed");
+        assertEq(testsFailed, 0, "Some random tests failed");
     }
 
     // ========== Helper Functions ==========


### PR DESCRIPTION
## Summary
- Fix the multi-seed CI failure report to include `FOUNDRY_PROFILE=difftest` and `--no-match-test "Random10000"` in the reproduce command — the same bug as #275 but in the CI workflow itself
- Replace `require(testsFailed == 0, ...)` with `assertEq(testsFailed, 0, ...)` in `DifferentialOwned.t.sol` to match all 7 other differential test files and produce better failure diagnostics

## Details

### CI reproduce command (verify.yml)
The `foundry-multi-seed` job's failure report step was missing `FOUNDRY_PROFILE=difftest`, which means developers copying the reproduce command would get confusing errors (tests that can't find FFI binaries). Also added `--no-match-test "Random10000"` to match what CI actually runs.

**Before:**
```
Reproduce locally: DIFFTEST_RANDOM_SEED=42 forge test --no-match-test "Random10000" -vv
```

**After:**
```
Reproduce locally: FOUNDRY_PROFILE=difftest DIFFTEST_RANDOM_SEED=42 forge test --no-match-test "Random10000" -vv
```

### DifferentialOwned assertion consistency
All other differential test files (`DifferentialCounter`, `DifferentialSimpleToken`, `DifferentialLedger`, etc.) use `assertEq(testsFailed, 0, ...)` for the final random test failure check. `DifferentialOwned` was the only one using `require()`, which reverts without showing the actual `testsFailed` count. Changed to `assertEq()` for consistent, informative failure output.

## Test plan
- [ ] CI passes (no functional changes — only diagnostic improvements)
- [ ] Verify the reproduce command in CI failure reports includes `FOUNDRY_PROFILE=difftest`

Closes part of #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 56fb93c2ce5658ff285eb3d08e21d61a3afb0898. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->