### PR TITLE
fix: docs accuracy — broken paths, missing fields, wrong counts

### DIFF
--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -24,7 +24,7 @@ python3 scripts/generate_contract.py MyToken --fields "balances:mapping" --funct
 python3 scripts/generate_contract.py MyContract --dry-run
 ```
 
-This creates 6 scaffold files (EDSL, Spec, Invariants, Basic proofs, Correctness proofs, Property tests) and prints the manual steps for `All.lean` and `Compiler/Specs.lean`.
+This creates 7 scaffold files (EDSL, Spec, Invariants, Proofs re-export shim, Basic proofs, Correctness proofs, Property tests) and prints the manual steps for `All.lean` and `Compiler/Specs.lean`.
 
 ## Checklist
 
@@ -38,7 +38,8 @@ This creates 6 scaffold files (EDSL, Spec, Invariants, Basic proofs, Correctness
    - Reuse helper lemmas for storage updates and mapping reads
 
 3. **Layer 1 Proofs**
-   - Prove correctness in `Verity/Specs/<Name>/Proofs.lean`
+   - Prove correctness in `Verity/Proofs/<Name>/Basic.lean` and `Correctness.lean`
+   - `Verity/Specs/<Name>/Proofs.lean` is a re-export shim (imports from `Verity/Proofs/`)
    - Each theorem states observable behavior (return values + storage deltas)
 
 4. **Compiler Spec + Layer 2 Proofs**

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -27,16 +27,22 @@ structure StorageSlot (α : Type) where
 
 ```lean
 structure ContractState where
-  storage : Nat → Uint256                -- Uint256 storage
-  storageAddr : Nat → Address            -- Address storage
-  storageMap : Nat → Address → Uint256  -- Mapping storage
+  storage : Nat → Uint256                         -- Uint256 storage
+  storageAddr : Nat → Address                      -- Address storage
+  storageMap : Nat → Address → Uint256            -- Mapping storage (address-keyed)
+  storageMapUint : Nat → Uint256 → Uint256        -- Mapping storage (uint256-keyed)
+  storageMap2 : Nat → Address → Address → Uint256 -- Double mapping storage
   sender : Address
   thisAddress : Address
   msgValue : Uint256
   blockTimestamp : Uint256
+  knownAddresses : Nat → FiniteAddressSet          -- Tracked addresses per slot
+  events : List Event := []                        -- Emitted events (append-only)
 ```
 
-Three independent storage spaces: Uint256 slots, Address slots, and Mapping slots. Each is indexed by a natural number (the slot). The state also carries the sender address, the contract's own address, and the EVM context fields `msg.value` and `block.timestamp`.
+Five independent storage spaces: `storage` for Uint256 values, `storageAddr` for addresses, `storageMap` for address-keyed mappings (e.g., `balances[owner]`), `storageMapUint` for uint256-keyed mappings, and `storageMap2` for double mappings (e.g., `allowances[owner][spender]`). Each is indexed by a natural number (the slot).
+
+The state also carries: the `sender` address, the contract's own `thisAddress`, EVM context fields (`msgValue`, `blockTimestamp`), `knownAddresses` for tracking which addresses have been seen per slot (used in conservation proofs), and an append-only `events` log.
 
 ## ContractResult
 

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -12,7 +12,8 @@ description: How to use external Yul libraries (Poseidon, Groth16, etc.) with ve
 
 ```bash
 # 1. Write your Yul library (plain functions, no object wrapper)
-echo 'function myHash(a, b) -> result { result := add(xor(a, b), 0x42) }' > libs/MyHash.yul
+mkdir -p examples/external-libs
+echo 'function myHash(a, b) -> result { result := add(xor(a, b), 0x42) }' > examples/external-libs/MyHash.yul
 
 # 2. Use a placeholder in your Lean EDSL (for proofs)
 def myHash (a b : Uint256) : Contract Uint256 := return add a b
@@ -21,7 +22,7 @@ def myHash (a b : Uint256) : Contract Uint256 := return add a b
 Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 # 4. Compile with linking
-lake exe verity-compiler --link libs/MyHash.yul -o compiler/yul
+lake exe verity-compiler --link examples/external-libs/MyHash.yul -o compiler/yul
 ```
 
 Your proofs verify the contract logic (using placeholders). Real implementations are injected at compile time.
@@ -41,7 +42,7 @@ Your proofs verify the contract logic (using placeholders). Real implementations
 Create a file with plain Yul function definitions (no `object` wrapper):
 
 ```yul
-// libs/MyHash.yul
+// examples/external-libs/MyHash.yul
 function myHash(a, b) -> result {
     // Your implementation here
     result := add(xor(a, b), 0x42)
@@ -75,7 +76,7 @@ The compiler generates a Yul `myHash(a, b)` call that will be resolved by the li
 ### 4. Compile with `--link`
 
 ```bash
-lake exe verity-compiler --link libs/MyHash.yul -o compiler/yul
+lake exe verity-compiler --link examples/external-libs/MyHash.yul -o compiler/yul
 ```
 
 The compiler validates that:
@@ -89,7 +90,7 @@ If validation fails, you get a clear error message:
 Unresolved external references: myHash
 ```
 
-This means you forgot to pass `--link libs/MyHash.yul`.
+This means you forgot to pass `--link examples/external-libs/MyHash.yul`.
 
 ---
 
@@ -245,7 +246,7 @@ If your verified contract works with placeholders but fails with linked librarie
 
 ```bash
 # Generate Yul output to see how external calls are rendered
-lake exe verity-compiler --link libs/MyLib.yul -o compiler/yul -v
+lake exe verity-compiler --link examples/external-libs/MyLib.yul -o compiler/yul -v
 
 # Check the generated Yul in compiler/yul/
 cat compiler/yul/*.yul
@@ -273,12 +274,12 @@ Options:
 lake exe verity-compiler
 
 # Compile with one library
-lake exe verity-compiler --link libs/Poseidon.yul
+lake exe verity-compiler --link examples/external-libs/PoseidonT3.yul
 
 # Compile with multiple libraries, verbose output
 lake exe verity-compiler \
-    --link libs/PoseidonT3.yul \
-    --link libs/PoseidonT4.yul \
-    --link libs/Groth16.yul \
+    --link examples/external-libs/PoseidonT3.yul \
+    --link examples/external-libs/PoseidonT4.yul \
+    --link examples/external-libs/Groth16.yul \
     -v -o output/
 ```

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -20,7 +20,7 @@ The compiler is verified with IR preservation proofs and Yul equivalence proofs 
 - Ledger: 33 total (Basic 21, Correctness 6, Conservation 13 — all proven).
 - SafeCounter: 25 total (Basic 22, Correctness 9).
 - ReentrancyExample: 4 total (inline proofs: vulnerability existence, supply invariant).
-- Stdlib: 64 theorems (Math 25, Automation 39).
+- Stdlib: 69 theorems (Math 25, Automation 39, MappingAutomation 7; 2 shared between Automation and MappingAutomation).
 
 ## Compiler Proofs (IR + Yul)
 


### PR DESCRIPTION
## Summary
- Fix `linking-libraries.mdx`: all examples used non-existent `libs/` directory — a developer following the Quick Start would fail at step 1
- Fix `core.mdx`: ContractState shown with 7 fields but actual has 11 — missing `storageMapUint`, `storageMap2`, `knownAddresses`, `events`
- Fix `verification.mdx`: Stdlib count was 64 but manifest has 69 — `MappingAutomation.lean` (7 theorems) was added but never reflected in docs
- Fix `add-contract.mdx`: scaffold count said "6 files" but creates 7; proof path pointed to re-export shim instead of actual proof directory

## Details

### linking-libraries.mdx (highest impact)
Every command in the TL;DR, Quick Start, Debugging, and CLI Reference sections used paths like `libs/MyHash.yul` or `libs/Poseidon.yul`. This directory does not exist in the repo. The actual convention is `examples/external-libs/` (where PoseidonT3.yul and PoseidonT4.yul live). Changed all occurrences to use the real path, including adding `mkdir -p examples/external-libs` in the TL;DR.

### core.mdx
The ContractState struct was shown with 7 fields but the actual `Core.lean` (lines 37-48) has 11 fields. The 4 missing fields are critical for understanding the EDSL:
- `storageMapUint` — uint256-keyed mappings
- `storageMap2` — double mappings (e.g., `allowances[owner][spender]`)
- `knownAddresses` — tracked address sets for conservation proofs
- `events` — append-only event log

### verification.mdx
The Stdlib section said "64 theorems (Math 25, Automation 39)" but the manifest has 69 Stdlib entries. The 5 additional theorems come from `MappingAutomation.lean` which was added after the docs were written. Updated to "69 theorems (Math 25, Automation 39, MappingAutomation 7; 2 shared)".

### add-contract.mdx
- "6 scaffold files" → "7 scaffold files" (the `Verity/Specs/<Name>/Proofs.lean` re-export shim was omitted from the count)
- Step 3 said "Prove correctness in `Verity/Specs/<Name>/Proofs.lean`" — that file is a re-export shim, not where you write proofs. Fixed to point to `Verity/Proofs/<Name>/Basic.lean` and `Correctness.lean`

## Test plan
- [x] `check_doc_counts.py` passes locally
- [ ] Docs site builds (Vercel preview)
- [ ] CI passes (no Lean/Solidity changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes correcting file counts, paths, and type/state descriptions; low risk aside from potentially breaking reader workflows if any path was still wrong.
> 
> **Overview**
> Fixes several docs inconsistencies so tutorials match the repo:
> 
> Updates `add-contract.mdx` to reflect **7 generated scaffold files** and clarifies that `Verity/Specs/<Name>/Proofs.lean` is a *re-export shim*, with proofs written under `Verity/Proofs/<Name>/`.
> 
> Corrects `core.mdx`’s `ContractState` definition to include the missing storage mapping variants plus `knownAddresses` and `events`, and updates the surrounding explanation accordingly. The linking guide switches all examples from the non-existent `libs/` directory to `examples/external-libs/` (including adding `mkdir -p`), and `verification.mdx` updates the Stdlib theorem count to include `MappingAutomation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed7dcb6e2ccbebadabc46cea4ae70f3a8adba1ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->