### PR TITLE
fix: add verification.mdx validation to CI doc-count checker

### DIFF
--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -3,7 +3,8 @@
 
 Validates counts in README.md, test/README.md, docs/VERIFICATION_STATUS.md,
 docs/ROADMAP.md, TRUST_ASSUMPTIONS.md, docs-site llms.txt, compiler.mdx,
-core.mdx, and index.mdx against the actual property manifest and codebase.
+verification.mdx, core.mdx, and index.mdx against the actual property
+manifest and codebase.
 
 Usage:
     python3 scripts/check_doc_counts.py
@@ -394,6 +395,46 @@ def main() -> None:
             ],
         )
     )
+
+    # Check verification.mdx
+    verification_mdx = ROOT / "docs-site" / "content" / "verification.mdx"
+    verification_checks = [
+        (
+            "theorem count in Status",
+            re.compile(r"\*\*Status\*\*: (\d+) theorems across"),
+            str(total_theorems),
+        ),
+        (
+            "category count in Status",
+            re.compile(r"\*\*Status\*\*: \d+ theorems across (\d+) categor"),
+            str(num_categories),
+        ),
+        (
+            "theorem count in Snapshot",
+            re.compile(r"EDSL theorems: (\d+) across"),
+            str(total_theorems),
+        ),
+        (
+            "category count in Snapshot",
+            re.compile(r"EDSL theorems: \d+ across (\d+) categor"),
+            str(num_categories),
+        ),
+        (
+            "Stdlib count",
+            re.compile(r"Stdlib: (\d+) theorems"),
+            str(stdlib_count),
+        ),
+    ]
+    # Add per-contract total checks
+    for contract, count in per_contract.items():
+        if contract == "Stdlib":
+            continue  # Handled separately above
+        verification_checks.append((
+            f"{contract} total",
+            re.compile(rf"- {contract}: (\d+) total"),
+            str(count),
+        ))
+    errors.extend(check_file(verification_mdx, verification_checks))
 
     # Check core size claims
     core_mdx = ROOT / "docs-site" / "content" / "core.mdx"


### PR DESCRIPTION
## Summary
- Add `verification.mdx` validation to `check_doc_counts.py` — overall theorem count, category count, Stdlib count, and per-contract totals (auto-generated from the property manifest)
- Fix Stdlib count in `verification.mdx`: 64 → 69 (MappingAutomation.lean was added but docs never updated)

## Why this matters

The CI doc-count validator (`check_doc_counts.py`) checks 10+ files for stale counts but **missed `verification.mdx` entirely**. This allowed the Stdlib count to drift from 64 to 69 when `MappingAutomation.lean` (7 theorems) was added without anyone noticing.

With this change, any future theorem additions that aren't reflected in `verification.mdx` will be caught by CI automatically. The per-contract checks are auto-generated from the property manifest, so they'll adapt as contracts are added.

## Details

### New validations added
| Check | Pattern | Source |
|-------|---------|--------|
| Status theorem count | `**Status**: N theorems across` | manifest total |
| Status category count | `N categories` | manifest key count |
| Snapshot theorem count | `EDSL theorems: N across` | manifest total |
| Snapshot category count | `N categories` | manifest key count |
| Stdlib count | `Stdlib: N theorems` | manifest Stdlib count |
| Per-contract totals | `- {Contract}: N total` | manifest per-contract |

### Stdlib fix
`MappingAutomation.lean` adds 7 theorems to Stdlib (5 new + 2 that also exist in `Automation.lean`), bringing the manifest count from 64 to 69. Updated the docs to "69 theorems (Math 25, Automation 39, MappingAutomation 7; 2 shared)".

## Test plan
- [x] `check_doc_counts.py` passes locally with all checks
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/documentation-count validation logic via additional regex checks, with no runtime product behavior or security-sensitive code affected.
> 
> **Overview**
> Extends `scripts/check_doc_counts.py` to also validate `docs-site/content/verification.mdx` against the property manifest.
> 
> The checker now asserts the overall theorem/category counts in the **Status** and **Snapshot** sections, validates the `Stdlib` theorem count, and adds per-contract total validations (auto-derived from manifest keys), so stale numbers in `verification.mdx` will fail CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05c781ef404e5dcb930cbb86b83c6a3408ff54b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->