### PR TITLE
fix: scaffold generator accuracy and dead code cleanup

### DIFF
--- a/scripts/check_property_coverage.py
+++ b/scripts/check_property_coverage.py
@@ -14,7 +14,6 @@ def main() -> None:
     covered = collect_covered()
 
     errors: list[str] = []
-    warnings: list[str] = []
 
     for contract, names in exclusions.items():
         if contract not in manifest:
@@ -41,11 +40,6 @@ def main() -> None:
             )
 
     report_errors(errors, "Property coverage check failed")
-
-    if warnings:
-        for item in warnings:
-            print(f"Warning: {item}")
-
     print("Property coverage check passed.")
 
 

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -191,8 +191,10 @@ def gen_spec(cfg: ContractConfig) -> str:
     spec_defs = []
     for fn in cfg.functions:
         spec_defs.append(f"-- What {fn.name} should do")
+        spec_defs.append(f"-- For mutating ops:   def {fn.name}_spec (params...) (s s' : ContractState) : Prop")
+        spec_defs.append(f"-- For read-only ops:  def {fn.name}_spec (result : Uint256) (s : ContractState) : Prop")
         spec_defs.append(f"def {fn.name}_spec (s s' : ContractState) : Prop :=")
-        spec_defs.append(f"  -- TODO: Define specification")
+        spec_defs.append(f"  -- TODO: Add function parameters before (s s'), define postconditions")
         spec_defs.append(f"  True")
         spec_defs.append("")
 
@@ -443,25 +445,18 @@ def _gen_single_test(
 
     /// Property: {fn.name}_meets_spec
     function testProperty_{camel}_MeetsSpec() public {{
-        // Read storage before the operation
         uint256 slot0Before = readStorage(0);
 
-        // Execute the function
         vm.prank(alice);
         (bool success,) = target.call(
             abi.encodeWithSignature("{fn.name}()")
         );
         require(success, "{fn.name} call failed");
 
-        // Verify the operation's effect on storage.
-        // TODO: Replace this with assertions matching {fn.name}'s specification.
-        // For example, if {fn.name} increments slot 0:
+        // TODO: Add assertions matching {fn.name}'s formal spec.
+        // Examples:
         //   assertEq(readStorage(0), slot0Before + 1, "should increment");
-        uint256 slot0After = readStorage(0);
-        assertTrue(
-            slot0After != slot0Before,
-            "{fn.name}_meets_spec: storage should change"
-        );
+        //   assertEq(readStorage(1), expectedValue, "should update slot 1");
     }}
 """
 
@@ -513,8 +508,8 @@ def gen_compiler_spec(cfg: ContractConfig) -> str:
     func_strs = []
     for fn in cfg.functions:
         func_strs.append(f"""    {{ name := "{fn.name}"
-      params := []  -- TODO: Add parameters
-      returnType := none  -- TODO: Set return type
+      params := []  -- TODO: e.g. [{{ name := "value", ty := ParamType.uint256 }}]
+      returnType := none  -- TODO: e.g. some FieldType.uint256
       body := [
         Stmt.stop  -- TODO: Implement body
       ]


### PR DESCRIPTION
## Summary
- Fix scaffold generator to produce correct spec signatures, realistic compiler spec examples, and non-breaking test assertions
- Remove dead code from property coverage checker

## Details

### Scaffold spec signatures (most impactful)
The generated `Spec.lean` produced:
```lean
def store_spec (s s' : ContractState) : Prop :=
  -- TODO: Define specification
  True
```

But actual specs take function parameters as leading arguments:
```lean
def store_spec (value : Uint256) (s s' : ContractState) : Prop :=
```

And read-only specs use a different signature:
```lean
def retrieve_spec (result : Uint256) (s : ContractState) : Prop :=
```

The scaffold now shows both patterns as comments above each spec, guiding the developer to pick the right one.

### Compiler spec TODO comments
Changed from:
```lean
params := []  -- TODO: Add parameters
returnType := none  -- TODO: Set return type
```
To:
```lean
params := []  -- TODO: e.g. [{ name := "value", ty := ParamType.uint256 }]
returnType := none  -- TODO: e.g. some FieldType.uint256
```

### Test assertion fix
The generated property test for mutating functions used:
```solidity
assertTrue(slot0After != slot0Before, "storage should change");
```

This produces **false test failures** for:
- Functions that modify a slot other than 0
- Access-controlled functions called by non-owner
- Functions that modify address storage, not uint256 storage

Replaced with a `// TODO` comment showing correct assertion patterns, keeping only the `require(success, ...)` check.

### Dead code removal
Removed unused `warnings` list from `check_property_coverage.py` that was declared and checked but never populated.

## Test plan
- [x] `check_property_coverage.py` passes
- [x] `generate_contract.py --dry-run` produces correct output
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to developer scripts and generated scaffold output, not runtime contract/proof logic. Main impact is on newly generated specs/tests, which may change default expectations for downstream users.
> 
> **Overview**
> **Scaffold generation is adjusted to better match real spec/test patterns.** `generate_contract.py` now emits clearer guidance for Lean spec signatures (mutating vs read-only), improves TODO examples in the printed compiler spec entry, and updates generated mutating property tests to avoid a default `storage changed` assertion (leaving only a success check plus example assertions).
> 
> **Dead code cleanup.** `check_property_coverage.py` drops an unused `warnings` path, simplifying the coverage check output to errors-only plus the final pass message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea5731362ac4c503deed9cfc34bdaf07fb549450. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->