### PR TITLE
fix: broken paths, stale axiom refs, CI triggers

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,6 +18,8 @@ on:
       - 'lean-toolchain'
       - 'foundry.toml'
       - 'AXIOMS.md'
+      - 'README.md'
+      - 'TRUST_ASSUMPTIONS.md'
   pull_request:
     paths:
       - '.github/workflows/verify.yml'
@@ -34,6 +36,8 @@ on:
       - 'lean-toolchain'
       - 'foundry.toml'
       - 'AXIOMS.md'
+      - 'README.md'
+      - 'TRUST_ASSUMPTIONS.md'
   workflow_dispatch:
 
 env:

--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -85,7 +85,7 @@ axiom addressToNat_injective :
 
 ### `evalIRExpr_eq_evalYulExpr` (formerly axiom #1)
 
-**Eliminated in**: This PR (Issue #148)
+**Eliminated in**: Issue #148
 
 **Previous statement**:
 ```lean
@@ -99,7 +99,7 @@ axiom evalIRExpr_eq_evalYulExpr (selector : Nat) (irState : IRState) (expr : Yul
 
 ### `evalIRExprs_eq_evalYulExprs` (formerly axiom #2)
 
-**Eliminated in**: This PR (Issue #148)
+**Eliminated in**: Issue #148
 
 **Previous statement**:
 ```lean
@@ -111,7 +111,7 @@ axiom evalIRExprs_eq_evalYulExprs (selector : Nat) (irState : IRState) (exprs : 
 
 ### `execIRStmtsFuel_adequate` (formerly axiom #3)
 
-**Eliminated in**: This PR (Issue #148)
+**Eliminated in**: Issue #148
 
 **Previous statement**:
 ```lean
@@ -123,7 +123,7 @@ axiom execIRStmtsFuel_adequate (state : IRState) (stmts : List YulStmt) :
 
 **Impact**: Eliminated the fuel adequacy axiom entirely. `execIRFunction` and `interpretIR` now use the total, fuel-based definitions directly.
 
-### `addressToNat_injective_valid` (formerly axiom #3, eliminated earlier)
+### `addressToNat_injective_valid` (formerly axiom #4)
 
 **Eliminated in**: PR #202 (2026-02-16)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ lake exe verity-compiler                      # Output in compiler/yul/
 **With external libraries (e.g., Poseidon hash):**
 ```bash
 # Link your Yul library at compile time
-lake exe verity-compiler --link libs/MyLib.yul -o compiler/yul
+lake exe verity-compiler --link examples/external-libs/MyLib.yul -o compiler/yul
 ```
 
 **Run tests:**
@@ -118,7 +118,7 @@ def myHash (a b : Uint256) : Contract Uint256 := do
 -- 2. ContractSpec calls the real library
 Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
--- 3. Compile with: lake exe verity-compiler --link libs/MyHash.yul
+-- 3. Compile with: lake exe verity-compiler --link examples/external-libs/MyHash.yul
 ```
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
@@ -215,7 +215,7 @@ Stmt.letVar "h" (Expr.externalCall "poseidonHash" [Expr.param "a", Expr.param "b
 
 3. **Compile with linking**:
 ```bash
-lake exe verity-compiler --link libs/MyHash.yul -o compiler/yul
+lake exe verity-compiler --link examples/external-libs/MyHash.yul -o compiler/yul
 ```
 
 The compiler validates function names, arities, and prevents name collisions. See [`examples/external-libs/README.md`](examples/external-libs/README.md) for detailed guidance.

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -79,7 +79,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: 220 properties tested across 9 contracts (73% coverage, 305 total theorems)
+**Coverage**: 220 properties tested across 9 contracts (72% coverage, 305 total theorems)
 
 **What this guarantees**:
 - Contract behavior matches specification
@@ -677,7 +677,7 @@ Use this checklist when performing security audits of Verity-verified contracts.
    - Effort: 3-4 months
 
 2. **Further Axiom Elimination**
-   - 3 of 5 axioms already eliminated (PR #241: evalIRExpr, evalIRExprs, execIRStmtsFuel adequacy)
+   - 4 of 6 axioms already eliminated (3 via Issue #148, 1 via PR #202)
    - Remaining: formalize hex string parsing for `addressToNat_injective`
    - Remaining: prove `keccak256_first_4_bytes` via a Lean keccak256 implementation
 


### PR DESCRIPTION
## Summary
- **README.md**: Fix 3 broken `libs/MyHash.yul` paths → `examples/external-libs/` (the actual location)
- **AXIOMS.md**: Replace stale "This PR (Issue #148)" with "Issue #148" (3 occurrences); fix duplicate "formerly axiom #3" numbering → `#4` for `addressToNat_injective_valid`
- **TRUST_ASSUMPTIONS.md**: Fix coverage percentage 73% → 72% (220/305 = 72%); fix axiom elimination count "3 of 5" → "4 of 6" (3 from Issue #148 + 1 from PR #202)
- **verify.yml**: Add `README.md` and `TRUST_ASSUMPTIONS.md` to CI path triggers so `check_doc_counts.py` runs when these files change

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes with all fixes applied
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation corrections and CI path filters, with no effect on proof/compile/runtime logic. Main risk is slightly increased CI runs or missed triggers if paths are misconfigured.
> 
> **Overview**
> Updates CI (`verify.yml`) path filters so the verify workflow also runs when `README.md` or `TRUST_ASSUMPTIONS.md` change (ensuring doc-count checks execute on doc-only edits).
> 
> Refreshes documentation consistency: fixes external library linking examples in `README.md` to point to `examples/external-libs/`, cleans up stale references/numbering in `AXIOMS.md`, and corrects coverage/axiom-elimination stats in `TRUST_ASSUMPTIONS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be1d97c803e77d277476966ecdcc2af1a1a3aad0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->