### PR TITLE
fix: stale libs/ paths and misleading FFI comment

### DIFF
--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -60,11 +60,11 @@ The first build downloads Mathlib and compiles everything — expect **20–45 m
 ## 4. Run the test suite
 
 ```bash
-# Property tests (no FFI needed)
-forge test
-
-# Differential tests (compares EDSL interpreter output against compiled Yul on EVM)
+# All tests (property tests deploy Yul via vm.ffi, so FFI is required)
 FOUNDRY_PROFILE=difftest forge test
+
+# Unit tests only (no FFI needed)
+forge test --no-match-path "test/Property*" --no-match-path "test/Differential*"
 ```
 
 The `difftest` profile enables `vm.ffi()` calls so that Foundry can invoke the Lean-based interpreter. This requires `lake build` to have completed successfully.

--- a/examples/external-libs/README.md
+++ b/examples/external-libs/README.md
@@ -11,7 +11,7 @@ This directory contains example Yul library files that can be linked with Verity
 
 Want to add a cryptographic hash function to your contract? Here's the minimum you need:
 
-### Step 1: Create your Yul library (`libs/MyHash.yul`)
+### Step 1: Create your Yul library (`examples/external-libs/MyHash.yul`)
 
 ```yul
 function myHash(a, b) -> result {
@@ -29,7 +29,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 ### Step 3: Compile with linking
 
 ```bash
-lake exe verity-compiler --link libs/MyHash.yul -o compiler/yul
+lake exe verity-compiler --link examples/external-libs/MyHash.yul -o compiler/yul
 ```
 
 That's it! The compiler validates your library and injects it into the generated Yul.
@@ -58,14 +58,14 @@ The key benefit: **prove with simple placeholders, deploy with real code**.
 
 | Error | Solution |
 |-------|----------|
-| `Unresolved external references: myFunc` | Add `--link libs/MyFunc.yul` to your command |
+| `Unresolved external references: myFunc` | Add `--link examples/external-libs/MyFunc.yul` to your command |
 | `Arity mismatch` | Check parameter count in `Expr.externalCall` matches Yul function |
 | `Function shadows Yul builtin` | Rename your function (e.g., `myAdd` instead of `add`) |
 | `Duplicate function names` | Each library must have unique function names |
 
 ## Step-by-Step Example
 
-### 1. Create Your Library (e.g., `libs/MyHash.yul`)
+### 1. Create Your Library (e.g., `examples/external-libs/MyHash.yul`)
 
 ```yul
 // Simple hash function for demonstration
@@ -95,7 +95,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 ### 4. Compile with Linking
 
 ```bash
-lake exe verity-compiler --link libs/MyHash.yul -o compiler/yul
+lake exe verity-compiler --link examples/external-libs/MyHash.yul -o compiler/yul
 ```
 
 ## Complete Guide


### PR DESCRIPTION
## Summary
- **examples/external-libs/README.md**: Fix 5 broken `libs/` paths → `examples/external-libs/` (the actual directory where library files live)
- **getting-started.mdx**: Fix misleading "Property tests (no FFI needed)" comment — all `Property*.t.sol` files inherit `YulTestBase` which uses `vm.ffi()` to invoke `solc`, so they all require `FOUNDRY_PROFILE=difftest`

## Context
The `libs/` directory doesn't exist in the repo. External libraries live in `examples/external-libs/`. Previous PRs (#280, #283) fixed `libs/` paths in `README.md`, `linking-libraries.mdx`, and other docs, but the `examples/external-libs/README.md` quickstart guide was missed — this is the first file a developer opens when trying to use the linker feature.

## Test plan
- [x] `check_doc_counts.py` passes
- [x] All `libs/` paths in `examples/external-libs/README.md` updated to match actual directory
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates: adjusts test commands/comments around `vm.ffi()` requirements and fixes broken example `--link` paths. Low risk since no runtime or compiler behavior changes.
> 
> **Overview**
> Updates the docs to remove misleading guidance about running tests without FFI: the getting started guide now treats `FOUNDRY_PROFILE=difftest forge test` as the **default for all tests**, and provides a separate command to run **unit tests only** without FFI.
> 
> Fixes stale `libs/` references in `examples/external-libs/README.md`, updating the quickstart and troubleshooting snippets to use the correct `examples/external-libs/*.yul` paths for `--link`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dfa7d7950bc3a7520e69935cd7fcc525abebe5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->