### PR TITLE
fix: stale test count in research.mdx, add CI validation

### DIFF
--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -187,7 +187,7 @@ def ownedSpec : ContractSpec := {
 ```bash
 lake build verity-compiler    # Build compiler
 lake exe verity-compiler      # Generate all contracts
-FOUNDRY_PROFILE=difftest forge test  # 352/352 tests pass (as of 2026-02-17)
+FOUNDRY_PROFILE=difftest forge test  # 361/361 tests pass (as of 2026-02-17)
 ```
 
 ### Differential Testing (Completed 2026-02-10)

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -3,8 +3,8 @@
 
 Validates counts in README.md, test/README.md, docs/VERIFICATION_STATUS.md,
 docs/ROADMAP.md, TRUST_ASSUMPTIONS.md, docs-site llms.txt, compiler.mdx,
-verification.mdx, core.mdx, and index.mdx against the actual property
-manifest and codebase.
+verification.mdx, research.mdx, core.mdx, and index.mdx against the actual
+property manifest and codebase.
 
 Usage:
     python3 scripts/check_doc_counts.py
@@ -440,6 +440,21 @@ def main() -> None:
             str(count),
         ))
     errors.extend(check_file(verification_mdx, verification_checks))
+
+    # Check research.mdx
+    research_mdx = ROOT / "docs-site" / "content" / "research.mdx"
+    errors.extend(
+        check_file(
+            research_mdx,
+            [
+                (
+                    "test count in forge test comment",
+                    re.compile(r"forge test\s+#\s*(\d+)/\d+ tests pass"),
+                    str(test_count),
+                ),
+            ],
+        )
+    )
 
     # Check core size claims
     core_mdx = ROOT / "docs-site" / "content" / "core.mdx"


### PR DESCRIPTION
## Summary
- **research.mdx**: Fix inline comment from `352/352` → `361/361` tests (contradicted lines 176 and 227 in the same file which correctly say 361)
- **check_doc_counts.py**: Add `research.mdx` to CI validation — this was the only doc file with test counts that wasn't covered, which is how the staleness went undetected

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes with both changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1962161d4daa261f7fd6cf17a7c9a30baa110866. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->