### PR TITLE
fix: owner and alice share same address in PropertySimpleToken

### DIFF
--- a/test/PropertySimpleToken.t.sol
+++ b/test/PropertySimpleToken.t.sol
@@ -17,7 +17,7 @@ import "./yul/YulTestBase.sol";
 contract PropertySimpleTokenTest is YulTestBase {
     address token;
     address owner = address(0xA11CE);
-    address alice = address(0xA11CE);
+    address alice = address(0xA1);
     address bob = address(0xB0B);
     address charlie = address(0xC4A12);
 


### PR DESCRIPTION
## Summary
`owner` and `alice` in `PropertySimpleToken.t.sol` were both set to `address(0xA11CE)`, making them the same address. This means tests that intended to exercise non-owner behavior using `alice` were actually using the contract owner's address.

## Impact
- `testProperty_Mint_RevertsWhenNotOwner` — was testing with the owner address, so the "revert when not owner" assertion was never exercised from a truly distinct address
- All `vm.prank(alice)` calls in transfer tests — were equivalent to `vm.prank(owner)`, not testing a distinct user

## Fix
Changed `alice` from `address(0xA11CE)` to `address(0xA1)` — a distinct address. All 46 tests pass with the corrected address, confirming no tests relied on the collision.

## Test plan
- [x] `FOUNDRY_PROFILE=difftest forge test --match-path test/PropertySimpleToken.t.sol -vv` — 46/46 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a test fixture address to avoid role-collision; no production contract logic changes.
> 
> **Overview**
> Fixes `PropertySimpleToken.t.sol` test setup where `alice` and `owner` were the same address by assigning `alice` a distinct value, ensuring non-owner paths (e.g., `vm.prank(alice)`/access-control properties) are actually exercised.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aa9516e132e995c1a31494215b92bfffa9bf4b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->