### PR TITLE
fix: add missing FOUNDRY_PROFILE=difftest to forge test commands

### DIFF
--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -84,10 +84,10 @@ test/Property<Name>.t.sol              # Property tests
 lake build
 
 # 2. Differential tests pass
-forge test --match-contract Differential<Name>
+FOUNDRY_PROFILE=difftest forge test --match-contract Differential<Name>
 
 # 3. Property tests pass
-forge test --match-contract Property<Name>
+FOUNDRY_PROFILE=difftest forge test --match-contract Property<Name>
 
 # 4. Property manifest is in sync
 python3 scripts/check_property_manifest.py

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -583,7 +583,7 @@ contract PropertyTipJarTest is YulTestBase {
 ### 6.2 Run Tests
 
 ```bash
-forge test --match-contract TipJar -vv
+FOUNDRY_PROFILE=difftest forge test --match-contract TipJar -vv
 ```
 
 ### 6.3 Verify Property Coverage
@@ -612,7 +612,7 @@ lake exe verity-compiler
 python3 scripts/check_yul_compiles.py
 
 # 4. Tests pass
-forge test --match-contract TipJar
+FOUNDRY_PROFILE=difftest forge test --match-contract TipJar
 
 # 5. All CI checks pass
 python3 scripts/check_selectors.py

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -231,11 +231,11 @@ FOUNDRY_PROFILE=difftest forge test  # 361/361 tests pass (as of 2026-02-17)
 ```bash
 lake build Compiler.Interpreter           # Build interpreter
 lake exe difftest-interpreter simpleStorage store 0 100  # Run single tx
-forge test --match-contract Differential  # Run default (100) random tests
+FOUNDRY_PROFILE=difftest forge test --match-contract Differential  # Run default (100) random tests
 # Scale the large suite (used in CI):
-DIFFTEST_RANDOM_LARGE=10000 forge test --match-contract Differential
+FOUNDRY_PROFILE=difftest DIFFTEST_RANDOM_LARGE=10000 forge test --match-contract Differential
 # Shard the large suite (CI uses 8 shards):
-DIFFTEST_SHARD_COUNT=8 DIFFTEST_SHARD_INDEX=0 DIFFTEST_RANDOM_LARGE=10000 \
+FOUNDRY_PROFILE=difftest DIFFTEST_SHARD_COUNT=8 DIFFTEST_SHARD_INDEX=0 DIFFTEST_RANDOM_LARGE=10000 \
   forge test --match-contract Differential
 ```
 

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -651,7 +651,7 @@ Examples:
 
     print("4. Run validation:")
     print("   lake build")
-    print(f"   forge test --match-contract Property{name}")
+    print(f"   FOUNDRY_PROFILE=difftest forge test --match-contract Property{name}")
     print("   python3 scripts/check_property_coverage.py")
     print()
 


### PR DESCRIPTION
## Summary

- Add `FOUNDRY_PROFILE=difftest` prefix to 8 `forge test` commands across docs and the scaffold generator that were missing it
- Property and differential tests use `deployYul()` → `vm.ffi()` → `solc`, which requires the `difftest` profile to enable FFI
- Without the profile, users following these instructions get cryptic revert errors with no indication of the fix

## Files changed

| File | Commands fixed |
|------|---------------|
| `docs-site/content/guides/first-contract.mdx` | 2 (Phase 6.2 run tests, Phase 7.1 checklist) |
| `docs-site/content/add-contract.mdx` | 2 (validation checklist) |
| `docs-site/content/research.mdx` | 3 (differential testing usage examples) |
| `scripts/generate_contract.py` | 1 (printed validation instructions) |

## Context

The `getting-started.mdx` page already correctly includes `FOUNDRY_PROFILE=difftest` (fixed in #284), but these other user-facing locations were missed. The `compiler.mdx` command on line 559 also already had the profile.

## Test plan

- [x] `python3 scripts/check_doc_counts.py` passes (no count regressions)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CLI output-only changes; no runtime or contract logic is modified.
> 
> **Overview**
> Adds the `FOUNDRY_PROFILE=difftest` prefix to user-facing `forge test` commands in docs and to the scaffold generator’s printed validation instructions, ensuring property/differential test runs have the expected Foundry profile enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 741c5638b22bf82069fbe14d3546bc42623efeae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->