### PR TITLE
fix: update stale docs — Ledger sum proofs are all complete

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ Proves IR statement execution is equivalent to Yul statement execution
 when states are aligned.
 
 **Status**: Complete - All statement types proven
-**Dependencies**: Requires expression evaluation axioms (see AXIOMS.md)
+**Dependencies**: Uses keccak256 axiom (see AXIOMS.md)
 -/
 ```
 
@@ -165,12 +165,13 @@ def execIRStmtFuel (fuel : Nat) : ... := ...
 All axioms **must** be documented inline **and** in AXIOMS.md:
 
 ```lean
-/-- AXIOM: Expression evaluation equivalence
+/-- AXIOM: keccak256 selector computation
 
-This is an axiom because evalIRExpr is partial (evalYulExpr is total).
+This is an axiom because Lean cannot natively compute keccak256.
+Validated by CI fixture checks against solc-computed selectors.
 See AXIOMS.md for full soundness justification.
 -/
-axiom evalIRExpr_eq_evalYulExpr : ...
+axiom keccak256_first_4_bytes (sig : String) : Nat
 ```
 
 ### Property Test Tags

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,5 +1,7 @@
 # Sum Properties Proof Strategy
 
+> **Status**: ✅ Complete — all 7/7 sum properties proven with zero `sorry` in `Verity/Proofs/Ledger/Conservation.lean`.
+
 ## Overview
 
 The 7 sum properties in `Verity/Proofs/Ledger/Conservation.lean` prove invariants like "total supply = sum of all balances" using `List.countOcc` for exact sum equations.
@@ -22,7 +24,7 @@ All sum-preserving properties follow from basic operations:
 4. **Composition**: Properties compose via substitution
    - Example: `deposit_withdraw_sum_cancel` uses `sub_add_cancel`
 
-## Required Helper Lemmas
+## Helper Lemmas (all proven)
 
 ### Straightforward
 - `sumBalances_insert_existing` - Sum preserved when re-inserting existing address
@@ -32,5 +34,3 @@ All sum-preserving properties follow from basic operations:
 ### Medium Complexity
 - `sumBalances_insert_new` - Properties about `List.foldl` with addition
 - `sumBalances_update_existing` - Splitting sum and recombining
-
-Once helper lemmas are proven, main theorems follow directly from `deposit_increases_balance`, `withdraw_decreases_balance`, and arithmetic cancellation.

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -202,7 +202,7 @@ FOUNDRY_PROFILE=difftest forge test  # 361/361 tests pass (as of 2026-02-17)
 - `Compiler/Interpreter.lean` — EDSL interpreter for differential testing
   - Executes EDSL contracts on abstract state
   - Returns JSON results for comparison with EVM
-  - Supports SimpleStorage and Counter (extensible to all contracts)
+  - Supports all 7 compiled contracts (Counter, SafeCounter, SimpleStorage, Ledger, Owned, OwnedCounter, SimpleToken)
 - `Compiler/RandomGen.lean` — Random transaction generator
   - Generates random addresses, values, and function calls
   - Contract-specific transaction generation (store/retrieve for SimpleStorage)
@@ -250,7 +250,7 @@ FOUNDRY_PROFILE=difftest DIFFTEST_SHARD_COUNT=8 DIFFTEST_SHARD_INDEX=0 DIFFTEST_
 - Reduce exclusions. Add property tests contract‑by‑contract. Keep coverage script green.
 
 **C. Address Known Limitations (Core Modeling)**:
-- Full "supply = sum balances" proof over a finite address set (PR #47 foundation, PR #51 infrastructure).
+- ~~Full "supply = sum balances" proof over a finite address set~~ (PR #47 foundation, PR #51 infrastructure — all 7/7 sum properties proven in `Conservation.lean`).
 - Extend storage semantics + proofs for nested mappings to support allowances (`approve`/`transferFrom`).
 
 **D. Reduce Remaining Trust Assumptions**:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -70,20 +70,19 @@ These limitations affect only the basic interpreter path (used for proofs). The 
 
 **EVM Semantics**: Mitigated by differential testing against actual EVM execution (Foundry). Likely remains a documented fundamental assumption.
 
-### 🟢 **Ledger Sum Properties** (6 Remaining)
+### ✅ **Ledger Sum Properties** (Complete)
 **What**: Prove total supply equals sum of all balances
-**Status**: Infrastructure complete (PR #47, #51, Issue #39 closed), 1/7 proven, 6 proofs pending (Issue #65)
-**Remaining**: Complete 6 theorem proofs (~10-14 days Lean expertise)
+**Status**: All 7/7 proven with zero `sorry` (PR #47, #51, Issue #65 resolved)
 
 | # | Property | Description |
 |---|----------|-------------|
-| 1 | `Spec_deposit_sum_equation` | Deposit increases total by amount |
-| 2 | `Spec_withdraw_sum_equation` | Withdraw decreases total by amount |
-| 3 | `Spec_transfer_sum_preservation` | Transfer preserves total |
-| 4 | `Spec_deposit_sum_singleton_sender` | Singleton set deposit property |
-| 5 | `Spec_withdraw_sum_singleton_sender` | Singleton set withdraw property |
-| 6 | `Spec_transfer_sum_preserved_unique` | Transfer with unique addresses preserves sum |
-| 7 | ~~`Spec_deposit_withdraw_sum_cancel`~~ | ✅ Deposit then withdraw cancels out (proven) |
+| 1 | ~~`Spec_deposit_sum_equation`~~ | ✅ Deposit increases total by amount |
+| 2 | ~~`Spec_withdraw_sum_equation`~~ | ✅ Withdraw decreases total by amount |
+| 3 | ~~`Spec_transfer_sum_preservation`~~ | ✅ Transfer preserves total |
+| 4 | ~~`Spec_deposit_sum_singleton_sender`~~ | ✅ Singleton set deposit property |
+| 5 | ~~`Spec_withdraw_sum_singleton_sender`~~ | ✅ Singleton set withdraw property |
+| 6 | ~~`Spec_transfer_sum_preserved_unique`~~ | ✅ Transfer with unique addresses preserves sum |
+| 7 | ~~`Spec_deposit_withdraw_sum_cancel`~~ | ✅ Deposit then withdraw cancels out |
 
 ---
 
@@ -151,7 +150,7 @@ These limitations affect only the basic interpreter path (used for proofs). The 
 - ✅ Complete Layer 3 statement-level proofs (PR #42)
 - ✅ Function selector verification (PR #43, #46)
 - ✅ Ledger sum properties infrastructure (PR #47, #51)
-- 🔄 Complete sum property proofs (Issue #65 - requires Lean expertise)
+- ✅ Complete sum property proofs (Issue #65 - all 7/7 proven)
 - 🔄 Yul → EVM bridge investigation
 
 **Success Metrics**:
@@ -195,7 +194,7 @@ These limitations affect only the basic interpreter path (used for proofs). The 
 
 1. **Should we prioritize Yul → EVM bridge or accept it as trust assumption?**
    - Tradeoff: 1-3 months of effort vs. documented trust
-   - Recommendation: Start with documented trust, revisit after ledger sum properties are complete
+   - Recommendation: Start with documented trust (ledger sum properties now complete — revisit when resources allow)
 
 2. **Should we support multiple smart contract languages (Solidity, Vyper, Fe)?**
    - Current: EDSL only
@@ -210,4 +209,4 @@ See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for contribution guidelines and [`VE
 ---
 
 **Last Updated**: 2026-02-17
-**Status**: Layers 1-3 complete. Trust reduction 1/3 done. Sum properties infrastructure complete, 1/7 proven, 6 proofs pending. ContractSpec now supports real-world contracts (loops, branching, events, multi-mappings, internal calls, verified externs).
+**Status**: Layers 1-3 complete. Trust reduction 1/3 done. Sum properties complete (7/7 proven). ContractSpec now supports real-world contracts (loops, branching, events, multi-mappings, internal calls, verified externs).

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,8 +11,8 @@ optimizer = true
 optimizer_runs = 200
 fs_permissions = [{ access = "read", path = "./compiler/yul" }]
 
-# Differential testing profile: enables FFI for vm.ffi() calls to difftest-interpreter.
-# Only differential tests (test/Differential*.t.sol) and Yul tests (test/yul/) use FFI.
+# Testing profile: enables FFI for vm.ffi() calls (solc compilation, difftest-interpreter).
+# Required by: Differential*, Property*, CallValueGuard, CalldataSizeGuard, SelectorSanity, and Yul tests.
 # Usage: FOUNDRY_PROFILE=difftest forge test
 [profile.difftest]
 ffi = true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,7 +62,7 @@ Example output:
    Covered:    47 ( 84.0%)
    Excluded:     9 (proof-only)
 
-Overall: 69.9% coverage (207/296 properties)
+Overall: 72.1% coverage (220/305 properties)
 ```
 
 ### Property Exclusions
@@ -168,4 +168,4 @@ To add test coverage for a proven theorem:
   - Text/Markdown/JSON output formats
   - Per-contract and overall statistics
   - CI integration with GitHub workflow summaries
-  - Coverage improved from 53.1% (155/292) to 70% (207/296) — all testable properties covered
+  - Coverage improved from 53.1% (155/292) to 72.1% (220/305) — all testable properties covered


### PR DESCRIPTION
## Summary

- Mark all 7 Ledger sum property proofs as complete in ROADMAP.md (were listed as 6/7 pending)
- Fix research.mdx: interpreter supports all 7 contracts, not just "SimpleStorage and Counter"
- Fix CONTRIBUTING.md: replace stale `evalIRExpr_eq_evalYulExpr` axiom example with real `keccak256_first_4_bytes`
- Fix foundry.toml: FFI comment now lists all test suites that need the difftest profile
- Update scripts/README.md coverage numbers from 207/296 to 220/305
- Update IMPLEMENTATION_NOTES.md to reflect proof completion

## Why this matters

The ROADMAP is described as the "single source of truth for progress" (research.mdx). It currently gives the false impression that 6 major proofs are pending, when all 7 are fully proven with zero `sorry` in `Conservation.lean`. A new contributor reading the roadmap would either:
1. Think there's significant remaining verification work
2. Waste effort duplicating completed proofs

## Test plan

- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that change project status/metrics; low risk beyond potential for stale or inconsistent counts if future changes aren’t mirrored everywhere.
> 
> **Overview**
> Updates project documentation to reflect that **Ledger sum properties are fully proven (7/7, zero `sorry`)**, including marking the roadmap section and milestone items as complete.
> 
> Refreshes other stale docs/examples: the `CONTRIBUTING.md` axiom example now matches the real `keccak256` selector axiom, `research.mdx` notes the interpreter supports all 7 compiled contracts, `foundry.toml` clarifies which test suites require the FFI-enabled profile, and `scripts/README.md` updates overall property coverage numbers to `220/305` (72.1%).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d244b7099ddcf0c08966411590962bca337ccfdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->