### PR TITLE
fix: stale comments and test README file tree

### DIFF
--- a/Verity/All.lean
+++ b/Verity/All.lean
@@ -75,7 +75,7 @@ import Verity.Proofs.OwnedCounter.Basic
 import Verity.Proofs.OwnedCounter.Correctness
 import Verity.Proofs.OwnedCounter.Isolation
 
--- Ledger: Spec, Invariants, Proofs (sum proofs incomplete, see issue #65)
+-- Ledger: Spec, Invariants, Proofs
 import Verity.Specs.Ledger.Spec
 import Verity.Specs.Ledger.Invariants
 import Verity.Specs.Ledger.Proofs

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -58,9 +58,9 @@ The coverage report shows:
 Example output:
 ```
 ✅ SimpleToken
-   Total:      56 properties
-   Covered:    47 ( 84.0%)
-   Excluded:     9 (proof-only)
+   Total:      59 properties
+   Covered:    52 ( 88.1%)
+   Excluded:     7 (proof-only)
 
 Overall: 72.1% coverage (220/305 properties)
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -26,7 +26,7 @@ Compare EDSL interpreter output against Yul-compiled EVM execution to catch comp
 **Files**: `DifferentialTestBase.sol` (shared utilities), `DiffTestConfig.sol` (configuration)
 
 ### Unit Tests
-**Pattern**: `Unit<Contract>.t.sol`
+**Pattern**: `<Contract>.t.sol` (e.g., `Counter.t.sol`, `Ledger.t.sol`)
 
 Basic contract behavior validation without formal property mapping.
 
@@ -58,13 +58,17 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol          # Property tests (220 tests)
-├── Differential*.t.sol      # Differential tests
-├── Unit*.t.sol              # Unit tests
-├── DifferentialTestBase.sol # Shared differential test utilities
-├── DiffTestConfig.sol       # Test configuration
-├── property_manifest.json   # All Lean theorems (auto-generated)
-└── property_exclusions.json # Proof-only theorems (manual)
+├── Property*.t.sol           # Property tests (220 tests)
+├── Differential*.t.sol       # Differential tests
+├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
+├── CallValueGuard.t.sol      # Call value rejection tests
+├── CalldataSizeGuard.t.sol   # Calldata size validation tests
+├── SelectorSanity.t.sol      # Selector verification tests
+├── DifferentialTestBase.sol  # Shared differential test utilities
+├── DiffTestConfig.sol        # Test configuration
+├── yul/                      # Yul test utilities (YulTestBase.sol)
+├── property_manifest.json    # All Lean theorems (auto-generated)
+└── property_exclusions.json  # Proof-only theorems (manual)
 ```
 
 ## Coverage Validation


### PR DESCRIPTION
## Summary

- `Verity/All.lean`: remove stale "(sum proofs incomplete, see issue #65)" — all 7 are complete
- `scripts/README.md`: update example SimpleToken output (56→59 properties, 47→52 covered, 9→7 excluded)
- `test/README.md`: fix unit test naming pattern from `Unit<Contract>.t.sol` (no such files exist) to `<Contract>.t.sol`, add CallValueGuard, CalldataSizeGuard, SelectorSanity, and yul/ to file tree

## Test plan

- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no runtime code, proofs, or tests are modified, but incorrect docs could confuse contributors if not kept in sync.
> 
> **Overview**
> Removes the stale note in `Verity/All.lean` claiming Ledger sum proofs are incomplete.
> 
> Updates documentation examples and test organization guidance: refreshes the `scripts/README.md` SimpleToken coverage sample numbers, and corrects `test/README.md` to use the actual unit test naming pattern (`<Contract>.t.sol`) while expanding the illustrated test tree to include guard/selector sanity tests and `yul/` utilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a43925cd5879d7590afa5fa8ff43d0367b7c782. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->