### PR TITLE
fix: scaffold crash on empty input + linking docs completeness

### DIFF
--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -64,7 +64,7 @@ The first build downloads Mathlib and compiles everything — expect **20–45 m
 FOUNDRY_PROFILE=difftest forge test
 
 # Unit tests only (no FFI needed)
-forge test --no-match-path "test/Property*" --no-match-path "test/Differential*"
+forge test --no-match-path "test/Property*" --no-match-path "test/Differential*" --no-match-path "test/CallValue*" --no-match-path "test/CalldataSize*"
 ```
 
 The `difftest` profile enables `vm.ffi()` calls so that Foundry can invoke the Lean-based interpreter. This requires `lake build` to have completed successfully.

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -150,13 +150,14 @@ function foo() {  ->  LibraryFunction { name: "foo", body: [...] }
 
 ### Stage 2: Validate
 
-Three safety checks run before any code is injected:
+Four safety checks run before any code is injected:
 
 | Check | What it catches |
 |-------|-----------------|
 | `validateNoDuplicateNames` | Two libraries defining the same function |
 | `validateNoNameCollisions` | Library function shadowing `mappingSlot` or Yul builtins like `add`, `sstore` |
 | `validateExternalReferences` | Contract calling a function not provided by any library |
+| `validateCallArity` | Library function called with wrong number of arguments |
 
 ### Stage 3: Inject
 
@@ -231,7 +232,7 @@ If you see `Unresolved external references: myFunc`, check that:
 
 ### Arity mismatch
 
-If you see `Arity mismatch: myFunc called with N args but library defines M params`:
+If you see `Arity mismatch: myFunc: called with N args but library defines M params`:
 - The number of parameters in your `Expr.externalCall` must match the library function
 - Remember: return values don't count as parameters
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -97,7 +97,7 @@ Use the Linker to inject production Yul libraries (Poseidon, Groth16, etc.) into
 - Library: `examples/external-libs/PoseidonT3.yul`
 - Compile: `lake exe verity-compiler --link examples/external-libs/PoseidonT3.yul --link examples/external-libs/PoseidonT4.yul`
 
-**Validation**: The Linker checks for duplicate names, builtin shadowing, and unresolved external references before injecting.
+**Validation**: The Linker checks for duplicate names, builtin shadowing, unresolved external references, and call-site arity mismatches before injecting.
 
 **Trust model**: Linked libraries are outside the proof boundary. Proofs establish: "If the library behaves like the placeholder, the contract is correct."
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,7 @@ optimizer_runs = 200
 fs_permissions = [{ access = "read", path = "./compiler/yul" }]
 
 # Testing profile: enables FFI for vm.ffi() calls (solc compilation, difftest-interpreter).
-# Required by: Differential*, Property*, CallValueGuard, CalldataSizeGuard, SelectorSanity, and Yul tests.
+# Required by: Differential*, Property*, CallValueGuard, CalldataSizeGuard, and Yul tests.
 # Usage: FOUNDRY_PROFILE=difftest forge test
 [profile.difftest]
 ffi = true

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -85,13 +85,19 @@ def parse_fields(spec: str) -> List[Field]:
     fields = []
     for part in spec.split(","):
         part = part.strip()
+        if not part:
+            continue
         if ":" in part:
             name, ty = part.split(":", 1)
+            name = name.strip()
             ty = ty.strip().lower()
+            if not name:
+                print("Error: Field name cannot be empty (got ':<type>')", file=sys.stderr)
+                sys.exit(1)
             if ty not in ("uint256", "address", "mapping"):
                 print(f"Warning: Unknown type '{ty}', defaulting to uint256", file=sys.stderr)
                 ty = "uint256"
-            fields.append(Field(name.strip(), ty))
+            fields.append(Field(name, ty))
         else:
             fields.append(Field(part.strip(), "uint256"))
     return fields
@@ -598,6 +604,9 @@ Examples:
 
     # Validate name
     name = args.name
+    if not name:
+        print("Error: Contract name cannot be empty", file=sys.stderr)
+        sys.exit(1)
     if not name[0].isupper():
         print(f"Error: Contract name must be PascalCase (got '{name}')", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary

### Scaffold generator crash fixes
- `python3 scripts/generate_contract.py ""` crashed with `IndexError: string index out of range` — now prints clear error
- `python3 scripts/generate_contract.py "A" --fields ":uint256"` crashed with `IndexError` — now validates field names
- Empty parts from trailing/double commas in `--fields` are now silently skipped

### Linking docs completeness
- Added missing 4th validation check (`validateCallArity`) to the safety checks table in `linking-libraries.mdx`
- Fixed arity error message format to match actual Lean output (missing colon after function name)
- Updated `llms.txt` to mention arity check in Linker validation description

### Getting-started.mdx
- Added `CallValueGuard` and `CalldataSizeGuard` to the "unit tests only" exclusion flags (both use `deployYul()`/`vm.ffi()` and fail without `FOUNDRY_PROFILE=difftest`)

### foundry.toml
- Removed `SelectorSanity` from the FFI-required comment — it uses `vm.readFile` (covered by `fs_permissions` in the default profile), not `vm.ffi`

## Test plan

- [x] `python3 scripts/generate_contract.py ""` → `Error: Contract name cannot be empty`
- [x] `python3 scripts/generate_contract.py "A" --fields ":uint256"` → `Error: Field name cannot be empty`
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small input-validation hardening in the Python scaffold generator plus documentation/comment tweaks; no core compiler or proof logic changes.
> 
> **Overview**
> Prevents scaffold generation crashes by validating empty contract names and empty/blank `--fields` entries (skipping empty comma parts and erroring on missing field names).
> 
> Updates documentation to reflect an additional linker safety check (`validateCallArity`) and the exact arity-mismatch error format, and adjusts test-running guidance/comments to better separate FFI-required tests (adds `CallValue*`/`CalldataSize*` exclusions; removes `SelectorSanity` from the FFI-required list).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 594c223d28b417a29741e7bcd19738f2132f6cc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->