### PR TITLE
fix: stale proof status, examples clarity, Solidity reference accuracy

### DIFF
--- a/Verity/Proofs/SimpleStorage/Basic.lean
+++ b/Verity/Proofs/SimpleStorage/Basic.lean
@@ -3,8 +3,7 @@
 
   This file contains proofs of basic correctness properties for SimpleStorage.
 
-  Status: Initial proofs with some axioms. These establish the foundation
-  for more rigorous proofs as we develop proof tactics.
+  Status: Complete — all 13 proofs proven with zero axioms and zero sorry.
 -/
 
 import Verity.Core

--- a/docs-site/content/examples.mdx
+++ b/docs-site/content/examples.mdx
@@ -117,6 +117,7 @@ Proofs cover cross-pattern composition, ownership transfer locking out old owner
 Mapping storage for per-address balances with deposit, withdraw, and transfer.
 
 ```lean
+-- Simplified — full code includes self-transfer guard and safeAdd overflow checks
 def balances : StorageSlot (Address → Uint256) := ⟨0⟩
 
 def deposit (amount : Uint256) : Contract Unit := do
@@ -140,6 +141,7 @@ Proofs cover balance guards, deposit/withdraw/transfer sum equations, and deposi
 Composes Owned and Ledger. Adds owner-controlled minting and supply tracking.
 
 ```lean
+-- Simplified — full code includes safeAdd overflow checks and self-transfer guard
 def owner : StorageSlot Address := ⟨0⟩
 def balances : StorageSlot (Address → Uint256) := ⟨1⟩
 def totalSupply : StorageSlot Uint256 := ⟨2⟩

--- a/examples/solidity/Counter.sol
+++ b/examples/solidity/Counter.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.0;
 
 /**
  * @title Counter
- * @notice Reference implementation matching the Lean EDSL example
- * @dev Demonstrates basic arithmetic operations (increment/decrement)
+ * @notice Readable reference implementation for the Lean EDSL example
+ * @dev Solidity 0.8 uses checked arithmetic (reverts on overflow/underflow),
+ *      while the Lean EDSL and compiled Yul use wrapping EVM arithmetic.
  */
 contract Counter {
     uint256 private count;

--- a/examples/solidity/SafeCounter.sol
+++ b/examples/solidity/SafeCounter.sol
@@ -11,9 +11,6 @@ pragma solidity ^0.8.0;
 contract SafeCounter {
     uint256 private count;
 
-    error Overflow();
-    error Underflow();
-
     function increment() public {
         // Solidity 0.8+ reverts on overflow automatically
         count = count + 1;


### PR DESCRIPTION
## Summary

- `SimpleStorage/Basic.lean`: update stale header — was "Initial proofs with some axioms", now "Complete — all 13 proofs proven with zero axioms and zero sorry"
- `examples.mdx`: add "Simplified" comment to Ledger and SimpleToken snippets that omit self-transfer guards and safeAdd overflow checks from the actual EDSL code
- `Counter.sol`: clarify NatSpec to say "Readable reference" instead of "matching" — Solidity 0.8 checked arithmetic differs from EDSL/Yul wrapping arithmetic
- `SafeCounter.sol`: remove unused `error Overflow()` / `error Underflow()` custom errors (dead code — Solidity 0.8 built-in checks handle this)

## Test plan

- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/comment-only changes plus removal of unused Solidity custom errors; no runtime logic or proof terms are altered in a way that affects execution. Risk is limited to potential confusion if the updated descriptions are inaccurate.
> 
> **Overview**
> Marks `SimpleStorage/Basic.lean` as **complete** (13 proofs, no axioms/`sorry`) by updating the header status comment.
> 
> Clarifies that the `Ledger` and `SimpleToken` docs snippets are *simplified* and omit safety checks present in full code, and updates Solidity reference NatSpec to distinguish Solidity 0.8 checked arithmetic from the EDSL/Yul wrapping semantics. Removes unused `Overflow`/`Underflow` custom errors from `SafeCounter.sol`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e488a29c41429a17acb909fd8accac8ffb4a29fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->