### PR TITLE
fix(scaffold): generate correct StorageSlot type for mapping fields

### DIFF
--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -39,7 +39,7 @@ This creates 7 scaffold files (EDSL, Spec, Invariants, Proofs re-export shim, Ba
 
 3. **Layer 1 Proofs**
    - Prove correctness in `Verity/Proofs/<Name>/Basic.lean` and `Correctness.lean`
-   - `Verity/Specs/<Name>/Proofs.lean` is a re-export shim (imports from `Verity/Proofs/`)
+   - `Verity/Specs/<Name>/Proofs.lean` is a re-export shim (imports from `Compiler/Proofs/SpecCorrectness/`)
    - Each theorem states observable behavior (return values + storage deltas)
 
 4. **Compiler Spec + Layer 2 Proofs**
@@ -62,7 +62,7 @@ This creates 7 scaffold files (EDSL, Spec, Invariants, Proofs re-export shim, Ba
 Verity/Specs/<Name>/
   ├── Spec.lean        # Function specifications
   ├── Invariants.lean  # State invariants (optional)
-  └── Proofs.lean      # Re-export shim (imports from Verity/Proofs/)
+  └── Proofs.lean      # Re-export shim (imports from Compiler/Proofs/SpecCorrectness/)
 
 Verity/Examples/<Name>.lean     # EDSL implementation
 Verity/Proofs/<Name>/

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -72,7 +72,9 @@ The `difftest` profile enables `vm.ffi()` calls so that Foundry can invoke the L
 ## 5. Generate your first contract
 
 ```bash
-python3 scripts/generate_contract.py TipJar --fields "balance:uint256,owner:address" --functions "deposit,withdraw,getBalance"
+python3 scripts/generate_contract.py TipJar \
+  --fields "tips:mapping" \
+  --functions "tip,getBalance"
 ```
 
 This creates all the scaffold files you need:

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -10,18 +10,24 @@ description: How to use external Yul libraries (Poseidon, Groth16, etc.) with ve
 
 ## TL;DR
 
+**Step 1** — Write your Yul library (plain functions, no `object` wrapper):
 ```bash
-# 1. Write your Yul library (plain functions, no object wrapper)
 mkdir -p examples/external-libs
 echo 'function myHash(a, b) -> result { result := add(xor(a, b), 0x42) }' > examples/external-libs/MyHash.yul
+```
 
-# 2. Use a placeholder in your Lean EDSL (for proofs)
+**Step 2** — Use a placeholder in your Lean EDSL (for proofs):
+```lean
 def myHash (a b : Uint256) : Contract Uint256 := return add a b
+```
 
-# 3. Reference it in your ContractSpec
+**Step 3** — Reference it in your ContractSpec:
+```lean
 Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
+```
 
-# 4. Compile with linking
+**Step 4** — Compile with linking:
+```bash
 lake exe verity-compiler --link examples/external-libs/MyHash.yul -o compiler/yul
 ```
 


### PR DESCRIPTION
## Summary

The scaffold generator produced broken Lean code for mapping fields — any developer following the first-contract tutorial after running the scaffold would immediately hit type errors.

**Root cause**: `Field.storage_kind` returned `Nat` for mapping fields, generating `def tipsSlot : Nat := 0`. But the EDSL API (`getMapping`/`setMapping` in `Core.lean`) requires `StorageSlot (Address → Uint256)`.

### Before (broken)
```lean
-- Generated by: python3 scripts/generate_contract.py TipJar --fields "tips:mapping"
def tipsSlot : Nat := 0  -- ❌ Wrong type, incompatible with getMapping/setMapping
```

### After (fixed)
```lean
-- Generated by: python3 scripts/generate_contract.py TipJar --fields "tips:mapping"
def tips : StorageSlot (Address → Uint256) := ⟨0⟩  -- ✅ Matches Ledger.lean / SimpleToken.lean pattern
```

### Changes

**Scaffold generator (`scripts/generate_contract.py`)**:
- Fix `Field.storage_kind`: mapping → `StorageSlot (Address → Uint256)` (was `Nat`)
- Simplify `gen_example` storage definitions to use `storage_kind` for all field types
- Add `import Verity.EVM.Uint256` and `open Verity.EVM.Uint256` to spec and proof files when contract has mapping fields

**Documentation fixes**:
- `getting-started.mdx`: Align TipJar scaffold command with `first-contract.mdx` tutorial (was `--fields "balance:uint256,owner:address"`, now `--fields "tips:mapping"`)
- `add-contract.mdx`: Fix Proofs.lean re-export path from `Verity/Proofs/` → `Compiler/Proofs/SpecCorrectness/` (matches actual files)
- `linking-libraries.mdx`: Split TL;DR from single mixed Bash/Lean code block into separate labeled blocks

## Test plan

- [x] `python3 scripts/generate_contract.py TipJar --fields "tips:mapping" --functions "tip,getBalance" --dry-run` — produces correct `StorageSlot (Address → Uint256)` declaration
- [x] Non-mapping contracts (`--fields "value:uint256,owner:address"`) still generate correct `StorageSlot Uint256` / `StorageSlot Address`
- [x] Mixed contracts (mapping + non-mapping fields) generate correct layout matching `SimpleToken.lean` pattern
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to scaffold/documentation output and import wiring; runtime/compiler behavior is unaffected, with risk mainly of breaking generated templates or docs if assumptions about mapping types/imports are wrong.
> 
> **Overview**
> Fixes the scaffold generator so mapping fields are generated as `StorageSlot (Address → Uint256)` (and corresponding Lean field types), aligning with `getMapping`/`setMapping` and preventing immediate type errors in freshly generated contracts.
> 
> Updates generated scaffolds to be mapping-aware by adding `Verity.EVM.Uint256` imports/`open` statements where needed (spec + basic proofs), and simplifies example storage slot declarations to consistently use `Field.storage_kind`. Documentation is adjusted to reflect the correct proof re-export location (`Compiler/Proofs/SpecCorrectness/`), modernize the “first contract” scaffold command, and clarify the external-library linking TL;DR formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b93431de8995c44c8d08ead4e3294a07c7679d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->