### PR TITLE
docs: add guide links to landing page, fix onboarding gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,10 @@ Closes #X, addresses #Y
 
 **Before submitting**:
 ```bash
-lake build  # Must pass
+lake build  # Must pass — verifies all proofs
+FOUNDRY_PROFILE=difftest forge test  # Must pass — runs all Foundry tests
+# FOUNDRY_PROFILE=difftest is required because property and differential
+# tests use vm.ffi() to invoke the Lean-based interpreter
 # No new `sorry` without documentation
 # No new `axiom` without documenting in AXIOMS.md
 # Update docs/ROADMAP.md if architectural changes

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -79,7 +79,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: 220 properties tested across 9 contracts (72% coverage, 305 total theorems)
+**Coverage**: All 305 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (72% runtime test coverage).
 
 **What this guarantees**:
 - Contract behavior matches specification

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -136,6 +136,13 @@ theorem store_retrieve : store 42 >> retrieve = pure 42 := by
 
 ## Documentation
 
+**Guides**:
+- **[Getting Started](/getting-started)** — Install prerequisites, build, and run tests
+- **[First Contract](/guides/first-contract)** — Step-by-step walkthrough: spec, implement, prove, test
+- **[Debugging Proofs](/guides/debugging-proofs)** — Common proof strategies and error messages
+- **[Linking Libraries](/guides/linking-libraries)** — Use external Yul libraries (Poseidon, etc.) with verified contracts
+
+**Reference**:
 - **[Verification](/verification)** — Full theorem list by contract
 - **[Examples](/examples)** — All 9 example contracts and what they demonstrate
 - **[Core](/core)** — How the 428-line EDSL works


### PR DESCRIPTION
## Summary

- **Landing page** (`index.mdx`): Added links to all 4 guide/tutorial pages (Getting Started, First Contract, Debugging Proofs, Linking Libraries). Previously, the Documentation section only linked to reference pages — new developers had no obvious path from the homepage to a hands-on tutorial.
- **CONTRIBUTING.md**: Added `FOUNDRY_PROFILE=difftest forge test` to the "before submitting" checklist with an explanation of why it's needed. Contributors running `forge test` without this profile get confusing FFI failures.
- **TRUST_ASSUMPTIONS.md**: Clarified that "72% coverage" refers to Foundry runtime test coverage, not proof coverage. The previous wording ("220 properties tested, 72% coverage, 305 total theorems") could mislead auditors into thinking only 72% of contract behavior is formally verified, when all 305 theorems are 100% proven.

## Test plan

- [ ] Verify docs-site builds and guide links resolve correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust contributor commands and clarify coverage wording; minimal risk beyond potential for broken links or inaccurate instructions.
> 
> **Overview**
> Improves developer onboarding by adding a **Guides** section with prominent links (Getting Started, First Contract, Debugging Proofs, Linking Libraries) to the docs landing page (`docs-site/content/index.mdx`).
> 
> Updates `CONTRIBUTING.md`’s pre-submit checklist to require `FOUNDRY_PROFILE=difftest forge test` (with rationale for FFI-based tests), and revises `TRUST_ASSUMPTIONS.md` to distinguish **100% formal proof coverage** from **72% Foundry runtime/property-test coverage**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69dfaf8da639dd2210c1b27f3816829076c4eb38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->