### PR TITLE
feat(specs): add complete storage helpers for all 5 ContractState types

### DIFF
--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -30,6 +30,14 @@ def sameStorageAddr (s s' : ContractState) : Prop :=
 def sameStorageMap (s s' : ContractState) : Prop :=
   s'.storageMap = s.storageMap
 
+/-- Uint256-keyed mapping storage is unchanged. -/
+def sameStorageMapUint (s s' : ContractState) : Prop :=
+  s'.storageMapUint = s.storageMapUint
+
+/-- Double mapping storage is unchanged. -/
+def sameStorageMap2 (s s' : ContractState) : Prop :=
+  s'.storageMap2 = s.storageMap2
+
 /-- Address storage, mapping storage, and context are unchanged. -/
 def sameAddrMapContext (s s' : ContractState) : Prop :=
   sameStorageAddr s s' ∧
@@ -46,6 +54,42 @@ def sameStorageMapContext (s s' : ContractState) : Prop :=
 def sameStorageAddrContext (s s' : ContractState) : Prop :=
   sameStorage s s' ∧
   sameStorageAddr s s' ∧
+  sameContext s s'
+
+/-- All five storage types are unchanged (nothing about context).
+    Use this when an operation only modifies context fields. -/
+def sameAllStorage (s s' : ContractState) : Prop :=
+  sameStorage s s' ∧
+  sameStorageAddr s s' ∧
+  sameStorageMap s s' ∧
+  sameStorageMapUint s s' ∧
+  sameStorageMap2 s s'
+
+/-- Everything except uint256 storage is unchanged.
+    Use for operations that only modify `storage` slots. -/
+def sameExceptStorage (s s' : ContractState) : Prop :=
+  sameStorageAddr s s' ∧
+  sameStorageMap s s' ∧
+  sameStorageMapUint s s' ∧
+  sameStorageMap2 s s' ∧
+  sameContext s s'
+
+/-- Everything except address storage is unchanged.
+    Use for operations that only modify `storageAddr` slots. -/
+def sameExceptStorageAddr (s s' : ContractState) : Prop :=
+  sameStorage s s' ∧
+  sameStorageMap s s' ∧
+  sameStorageMapUint s s' ∧
+  sameStorageMap2 s s' ∧
+  sameContext s s'
+
+/-- Everything except mapping storage is unchanged.
+    Use for operations that only modify `storageMap` entries. -/
+def sameExceptStorageMap (s s' : ContractState) : Prop :=
+  sameStorage s s' ∧
+  sameStorageAddr s s' ∧
+  sameStorageMapUint s s' ∧
+  sameStorageMap2 s s' ∧
   sameContext s s'
 
 /-- All storage slots except `slot` are unchanged. -/
@@ -77,5 +121,17 @@ def storageMapUnchangedExceptKeyAtSlot (slot : Nat) (addr : Address) (s s' : Con
 def storageMapUnchangedExceptKeysAtSlot (slot : Nat) (addr1 addr2 : Address) (s s' : ContractState) : Prop :=
   storageMapUnchangedExceptKeys slot addr1 addr2 s s' ∧
   storageMapUnchangedExceptSlot slot s s'
+
+/-- All uint256-keyed mapping slots except `slot` are unchanged. -/
+def storageMapUintUnchangedExceptSlot (slot : Nat) (s s' : ContractState) : Prop :=
+  ∀ other : Nat, other ≠ slot → ∀ key : Uint256, s'.storageMapUint other key = s.storageMapUint other key
+
+/-- All uint256-keyed mapping entries at `slot` except `key` are unchanged. -/
+def storageMapUintUnchangedExceptKey (slot : Nat) (key : Uint256) (s s' : ContractState) : Prop :=
+  ∀ other : Uint256, other ≠ key → s'.storageMapUint slot other = s.storageMapUint slot other
+
+/-- All double-mapping slots except `slot` are unchanged. -/
+def storageMap2UnchangedExceptSlot (slot : Nat) (s s' : ContractState) : Prop :=
+  ∀ other : Nat, other ≠ slot → ∀ a1 a2 : Address, s'.storageMap2 other a1 a2 = s.storageMap2 other a1 a2
 
 end Verity.Specs


### PR DESCRIPTION
## Summary

`Specs/Common.lean` had helpers for only 3 of 5 `ContractState` storage types (`storage`, `storageAddr`, `storageMap`), missing `storageMapUint` and `storageMap2` (added in #154). This meant:

- New contracts using uint256-keyed mappings or double mappings had no shared vocabulary for specs
- The existing composite helpers (`sameAddrMapContext` etc.) silently ignored these two fields — a spec could say "mapping storage is unchanged" without saying anything about `storageMapUint`

### New atomic helpers
| Helper | Covers |
|--------|--------|
| `sameStorageMapUint` | `s'.storageMapUint = s.storageMapUint` |
| `sameStorageMap2` | `s'.storageMap2 = s.storageMap2` |

### New comprehensive composites (cover all 5 storage types + context)
| Composite | Use case |
|-----------|----------|
| `sameAllStorage` | Operation only modifies context, not storage |
| `sameExceptStorage` | Operation only modifies `storage` slots |
| `sameExceptStorageAddr` | Operation only modifies `storageAddr` slots |
| `sameExceptStorageMap` | Operation only modifies `storageMap` entries |

### New unchanged-except helpers
| Helper | For |
|--------|-----|
| `storageMapUintUnchangedExceptSlot` | Uint256-keyed mapping slot isolation |
| `storageMapUintUnchangedExceptKey` | Uint256-keyed mapping key isolation |
| `storageMap2UnchangedExceptSlot` | Double mapping slot isolation |

### Non-breaking
Existing composites (`sameAddrMapContext`, `sameStorageMapContext`, `sameStorageAddrContext`) are preserved unchanged — no existing proofs are affected. New contracts should prefer the comprehensive `sameExcept*` composites.

Addresses #84

## Test plan

- [ ] `lake build` passes (pure definition additions, no proof changes)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Lean `Prop` definitions only, with no behavioral/runtime changes. Risk is limited to potential misuse/incorrect assumptions in future specs that adopt the new helpers.
> 
> **Overview**
> Extends `Specs/Common.lean` with new atomic “unchanged” predicates for the previously unhandled `ContractState` fields `storageMapUint` and `storageMap2`.
> 
> Adds new composite predicates (`sameAllStorage`, `sameExceptStorage`, `sameExceptStorageAddr`, `sameExceptStorageMap`) to express that all other storage/context parts remain unchanged when only one storage component (or only context) is modified.
> 
> Introduces “unchanged-except” helpers for isolating updates to uint256-keyed mappings and double mappings (`storageMapUintUnchangedExceptSlot`, `storageMapUintUnchangedExceptKey`, `storageMap2UnchangedExceptSlot`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33b92b581824d23ff3861dd8e4b70a92cb28a1b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->