### PR TITLE
docs: fix incomplete All.lean imports in first-contract tutorial

### DIFF
--- a/docs-site/content/examples.mdx
+++ b/docs-site/content/examples.mdx
@@ -14,7 +14,7 @@ A small set of contracts, each introducing a new pattern. They build on each oth
 - **Implementation**: `Verity/Examples/<Name>.lean`
 - **Basic proofs**: `Verity/Proofs/<Name>/Basic.lean`
 - **Advanced proofs**: `Verity/Proofs/<Name>/Correctness.lean`
-- **Proof re-export**: `Verity/Specs/<Name>/Proofs.lean` (imports from `Compiler/Proofs/`)
+- **Proof re-export**: `Verity/Specs/<Name>/Proofs.lean` (imports from `Compiler/Proofs/SpecCorrectness/`)
 - **Reusable proof infra**: `Verity/Proofs/Stdlib/`
 
 Example (SimpleStorage):

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -622,15 +622,17 @@ python3 scripts/check_doc_counts.py
 
 ### 7.2 Add to Module Exports
 
-Update `Verity/All.lean` to include your new contract:
+Update `Verity/All.lean` to include all your new contract modules:
 ```lean
 import Verity.Examples.TipJar
+import Verity.Specs.TipJar.Spec
+import Verity.Specs.TipJar.Invariants
+import Verity.Specs.TipJar.Proofs
+import Verity.Proofs.TipJar.Basic
+import Verity.Proofs.TipJar.Correctness
 ```
 
-Also add the proof imports to `Verity/All.lean`:
-```lean
-import Verity.Proofs.TipJar.Basic
-```
+> **Tip**: The scaffold generator prints these exact lines when you run it — copy them directly.
 
 ---
 


### PR DESCRIPTION
## Summary

- **first-contract.mdx Phase 7.2**: Fixed incomplete `All.lean` import list — only showed 2 of the 6 required imports. A developer following the tutorial step-by-step would end up with an incomplete module tree that `lake build` wouldn't catch (modules just wouldn't be reachable via `import Verity`).

### Before (incomplete)
```lean
import Verity.Examples.TipJar
import Verity.Proofs.TipJar.Basic
```

### After (complete — matches scaffold generator output)
```lean
import Verity.Examples.TipJar
import Verity.Specs.TipJar.Spec
import Verity.Specs.TipJar.Invariants
import Verity.Specs.TipJar.Proofs
import Verity.Proofs.TipJar.Basic
import Verity.Proofs.TipJar.Correctness
```

- **examples.mdx**: Fixed `Proofs.lean` re-export path from `Compiler/Proofs/` to `Compiler/Proofs/SpecCorrectness/` (matching the actual import in the files)

## Test plan

- [ ] CI passes (docs-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only edits that adjust import instructions and a path reference; no runtime or build logic changes.
> 
> **Overview**
> Updates the docs to prevent readers from generating incomplete module export trees when following the “first contract” tutorial by listing the full required set of `Verity/All.lean` imports (examples, specs, invariants, proofs, and correctness).
> 
> Also corrects the `examples.mdx` guidance for `Verity/Specs/<Name>/Proofs.lean` to reference the current `Compiler/Proofs/SpecCorrectness/` import path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a79e009302c40f944ea9954b96171a227248a23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->