### PR TITLE
docs: add spec helpers reference and complete sameExcept* composites

### DIFF
--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -122,6 +122,24 @@ def storageMapUnchangedExceptKeysAtSlot (slot : Nat) (addr1 addr2 : Address) (s 
   storageMapUnchangedExceptKeys slot addr1 addr2 s s' ∧
   storageMapUnchangedExceptSlot slot s s'
 
+/-- Everything except uint256-keyed mapping storage is unchanged.
+    Use for operations that only modify `storageMapUint` entries. -/
+def sameExceptStorageMapUint (s s' : ContractState) : Prop :=
+  sameStorage s s' ∧
+  sameStorageAddr s s' ∧
+  sameStorageMap s s' ∧
+  sameStorageMap2 s s' ∧
+  sameContext s s'
+
+/-- Everything except double mapping storage is unchanged.
+    Use for operations that only modify `storageMap2` entries. -/
+def sameExceptStorageMap2 (s s' : ContractState) : Prop :=
+  sameStorage s s' ∧
+  sameStorageAddr s s' ∧
+  sameStorageMap s s' ∧
+  sameStorageMapUint s s' ∧
+  sameContext s s'
+
 /-- All uint256-keyed mapping slots except `slot` are unchanged. -/
 def storageMapUintUnchangedExceptSlot (slot : Nat) (s s' : ContractState) : Prop :=
   ∀ other : Nat, other ≠ slot → ∀ key : Uint256, s'.storageMapUint other key = s.storageMapUint other key

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -208,6 +208,63 @@ let allow ← getMapping2 allowances owner spender -- Uint256
 let wrong ← getStorage owner  -- Type error: owner is Address, not Uint256
 ```
 
+## Spec helpers (`Verity/Specs/Common.lean`)
+
+Specs express what a function **did not change**. `Common.lean` provides named predicates so specs don't repeat field-by-field equality.
+
+Import with `import Verity.Specs.Common` and `open Verity.Specs`.
+
+### Atomic helpers (single field)
+
+| Helper | Asserts |
+|--------|---------|
+| `sameStorage s s'` | `s'.storage = s.storage` |
+| `sameStorageAddr s s'` | `s'.storageAddr = s.storageAddr` |
+| `sameStorageMap s s'` | `s'.storageMap = s.storageMap` |
+| `sameStorageMapUint s s'` | `s'.storageMapUint = s.storageMapUint` |
+| `sameStorageMap2 s s'` | `s'.storageMap2 = s.storageMap2` |
+| `sameContext s s'` | sender, thisAddress, msgValue, blockTimestamp unchanged |
+
+### Composite helpers
+
+Use these instead of conjunctions of atomics:
+
+| Helper | Meaning | Use when operation only writes... |
+|--------|---------|-----------------------------------|
+| `sameAllStorage s s'` | All 5 storage types unchanged | Context fields only |
+| `sameExceptStorage s s'` | Everything except `storage` unchanged | `setStorage` |
+| `sameExceptStorageAddr s s'` | Everything except `storageAddr` unchanged | `setStorageAddr` |
+| `sameExceptStorageMap s s'` | Everything except `storageMap` unchanged | `setMapping` |
+| `sameExceptStorageMapUint s s'` | Everything except `storageMapUint` unchanged | `setMappingUint` |
+| `sameExceptStorageMap2 s s'` | Everything except `storageMap2` unchanged | `setMapping2` |
+
+All composites include `sameContext`.
+
+### Fine-grained helpers (specific slot or key)
+
+For operations that modify a single entry in a mapping:
+
+| Helper | Asserts |
+|--------|---------|
+| `storageUnchangedExcept slot s s'` | All uint256 slots except `slot` unchanged |
+| `storageAddrUnchangedExcept slot s s'` | All address slots except `slot` unchanged |
+| `storageMapUnchangedExceptKeyAtSlot slot addr s s'` | Mapping unchanged except `slot`/`addr` |
+| `storageMapUnchangedExceptKeysAtSlot slot a1 a2 s s'` | Mapping unchanged except `slot`/`a1`/`a2` (transfers) |
+| `storageMapUintUnchangedExceptSlot slot s s'` | Uint256-keyed mapping unchanged except `slot` |
+| `storageMapUintUnchangedExceptKey slot key s s'` | Uint256-keyed mapping at `slot` unchanged except `key` |
+| `storageMap2UnchangedExceptSlot slot s s'` | Double mapping unchanged except `slot` |
+
+### Choosing the right helper
+
+| Operation | Composite | Fine-grained |
+|-----------|-----------|--------------|
+| `setStorage count v` | `sameExceptStorage` | `storageUnchangedExcept count.slot` |
+| `setStorageAddr owner v` | `sameExceptStorageAddr` | `storageAddrUnchangedExcept owner.slot` |
+| `setMapping balances addr v` | `sameExceptStorageMap` | `storageMapUnchangedExceptKeyAtSlot balances.slot addr` |
+| ERC20 transfer (two keys) | `sameExceptStorageMap` | `storageMapUnchangedExceptKeysAtSlot balances.slot from to` |
+| `setMappingUint prices id v` | `sameExceptStorageMapUint` | `storageMapUintUnchangedExceptKey prices.slot id` |
+| Read-only (`getStorage`, etc.) | `sameAllStorage ∧ sameContext` | — |
+
 ## Source
 
-[`Verity/Core.lean`](https://github.com/Th0rgal/verity/blob/main/Verity/Core.lean)
+[`Verity/Core.lean`](https://github.com/Th0rgal/verity/blob/main/Verity/Core.lean) · [`Verity/Specs/Common.lean`](https://github.com/Th0rgal/verity/blob/main/Verity/Specs/Common.lean)


### PR DESCRIPTION
## Summary
- Adds comprehensive **Spec Helpers Reference** section to `core.mdx` documenting all 21 predicates in `Verity/Specs/Common.lean`
- Adds two missing composite helpers to `Common.lean`: `sameExceptStorageMapUint` and `sameExceptStorageMap2`
- Includes a **"Choosing the right helper"** decision table mapping each storage operation to its recommended predicates

## Details
The PR #299 helpers (`sameAllStorage`, `sameExcept*`, fine-grained `*UnchangedExcept*`) had zero documentation — a developer reading `core.mdx` would only see `sameStorage`/`sameStorageAddr`/`sameStorageMap`/`sameContext` mentioned. The new section organizes all 21 helpers into three tiers (atomic, composite, fine-grained) with clear "when to use which" guidance.

The two new composites complete the symmetric set: previously `sameExcept*` existed for `storage`, `storageAddr`, and `storageMap` but NOT for `storageMapUint` or `storageMap2`. Any contract using `setMappingUint` or `setMapping2` had to manually enumerate four `same*` conjuncts.

## Test plan
- [ ] `lake build` passes (new defs are trivially well-typed — conjunctions of existing predicates)
- [ ] `python3 scripts/check_doc_counts.py` passes (no theorem count change — these are `def` not `theorem`)
- [ ] Docs site builds correctly (Vercel preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two small spec helper `def`s and documentation tables; no runtime logic or core semantics change.
> 
> **Overview**
> Adds the missing composite predicates `sameExceptStorageMapUint` and `sameExceptStorageMap2` to `Verity/Specs/Common.lean`, completing the symmetric `sameExcept*` helpers for all storage spaces.
> 
> Expands `docs-site/content/core.mdx` with a **Spec helpers** reference section that catalogs atomic/composite/fine-grained predicates and includes a quick decision table mapping common storage operations to the recommended helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b0bce77090147eaf87870cb3083155cda33991a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->