### PR TITLE
fix: scaffold only imports Uint256 when fields need it

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -136,13 +136,14 @@ def _is_getter_name(name: str) -> bool:
 def gen_example(cfg: ContractConfig) -> str:
     """Generate Verity/Examples/{Name}.lean"""
     has_mapping = any(f.is_mapping for f in cfg.fields)
+    has_uint256 = any(f.ty == "uint256" for f in cfg.fields)
 
     imports = ["import Verity.Core"]
-    if has_mapping or len(cfg.fields) > 1:
+    if has_mapping or has_uint256:
         imports.append("import Verity.EVM.Uint256")
 
     opens = ["open Verity"]
-    if has_mapping or len(cfg.fields) > 1:
+    if has_mapping or has_uint256:
         opens.append("open Verity.EVM.Uint256")
 
     # Storage definitions


### PR DESCRIPTION
## Summary
- Fix `generate_contract.py` to only import `Verity.EVM.Uint256` when the contract has uint256 or mapping fields
- Previously, the condition was `has_mapping or len(cfg.fields) > 1`, which incorrectly imported Uint256 for address-only multi-field contracts (e.g. `--fields "owner:address,operator:address"`)
- New condition: `has_mapping or has_uint256` — matches how real contracts use the import

**Before:** `python3 scripts/generate_contract.py MyVault --fields "owner:address,operator:address"` would generate `import Verity.EVM.Uint256` unnecessarily

**After:** Address-only contracts correctly import only `Verity.Core`

## Test plan
- [x] `--fields "owner:address,operator:address"` no longer includes Uint256 import
- [x] `--fields "count:uint256"` still includes Uint256 import
- [x] `--fields "balances:mapping"` still includes Uint256 import
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to scaffold code generation; risk is confined to slightly different imports/opens in newly generated Lean files.
> 
> **Overview**
> Fixes `scripts/generate_contract.py` so `gen_example` conditionally includes `import Verity.EVM.Uint256` / `open Verity.EVM.Uint256` only when the generated contract has a `uint256` field or any `mapping` field, instead of triggering on multi-field storage.
> 
> This avoids unnecessary Uint256 imports for address-only contracts while preserving imports for `uint256`/`mapping`-based contracts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea0c5afb0f41252924bcecbfcc8eb897d132876a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->