### PR TITLE
fix: validate all All.lean imports per contract

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "dev": "next dev -p 3003",
     "build": "next build && pagefind --site .next/server/app --output-path public/_pagefind",
-    "start": "next start -p 3003",
-    "lint": "eslint app components"
+    "start": "next start -p 3003"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.1",

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -6,7 +6,6 @@
     "setStorage_preserves_map_storage",
     "setStorage_updates_count"
   ],
-  "Ledger": [],
   "Owned": [
     "isOwner_meets_spec",
     "isOwner_returns_correct_value"


### PR DESCRIPTION
## Summary
- **Extend `check_contract_structure.py`**: previously only checked that `import Verity.Examples.{name}` existed in `All.lean`. Now validates all 6 required imports per contract (Examples, Spec, Invariants, Proofs, Basic, Correctness). This catches incomplete contract additions where a developer adds the Examples import but forgets the proof/spec imports.

- **Remove empty `"Ledger": []`** from `property_exclusions.json` — Ledger has 100% property test coverage. SafeCounter and ReentrancyExample correctly omit their entries entirely rather than having empty arrays.

- **Remove broken `"lint"` script** from `docs-site/package.json` — ESLint is not installed (`devDependencies` has no eslint), there is no `.eslintrc` config, and `npm run lint` would fail immediately. The script was dead code.

## Test plan
- [x] `python3 scripts/check_contract_structure.py` passes (7 contracts, all 42 imports verified)
- [x] `python3 scripts/check_doc_counts.py` passes (319 theorems, 99 exclusions unchanged)
- [x] `python3 scripts/check_property_coverage.py` passes
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects repo validation tooling and config cleanup; no runtime logic changes beyond stricter CI/script checks that may fail if `All.lean` is missing imports.
> 
> **Overview**
> Strengthens `scripts/check_contract_structure.py` so it no longer only checks `import Verity.Examples.{name}` in `Verity/All.lean`, but also verifies imports for each expected contract module (`Specs/*/{Spec,Invariants,Proofs}` and `Proofs/*/{Basic,Correctness}`) to catch incomplete contract additions.
> 
> Cleans up config by removing an unused/broken `lint` script from `docs-site/package.json` and deleting the empty `"Ledger": []` entry from `test/property_exclusions.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22d455541d53ec8d546899c528b55b7386ec4132. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->