### PR TITLE
perf: skip heavy CI for doc-only changes (path filter)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -46,10 +46,53 @@ env:
   SOLC_SHA256: "1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '.github/workflows/verify.yml'
+              - 'Verity/**'
+              - 'Verity.lean'
+              - 'Compiler/**'
+              - 'Compiler.lean'
+              - 'examples/solidity/**'
+              - 'test/**'
+              - 'scripts/**'
+              - 'lakefile.lean'
+              - 'lean-toolchain'
+              - 'foundry.toml'
+
+  # Python-only checks (fast, ~5s, always run)
+  checks:
+    runs-on: ubuntu-latest
+    needs: changes
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check property manifest references
+        run: python3 scripts/check_property_manifest.py
+
+      - name: Check property coverage
+        run: python3 scripts/check_property_coverage.py
+
+      - name: Check contract file structure
+        run: python3 scripts/check_contract_structure.py
+
+      - name: Check documentation counts
+        run: python3 scripts/check_doc_counts.py
+
   build:
     runs-on: ubuntu-latest
-    # Skip verification for draft PRs
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -240,7 +283,8 @@ jobs:
 
   foundry:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -305,7 +349,8 @@ jobs:
   # Multi-seed testing to detect flakiness and seed-dependent failures
   foundry-multi-seed:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false  # Test all seeds even if one fails
       matrix:


### PR DESCRIPTION
## Summary
Add `dorny/paths-filter` to detect code vs doc-only changes in CI:

- **New `changes` job**: Detects whether code files changed (Lean, Compiler, test, scripts, foundry.toml, etc.)
- **New `checks` job**: Always runs fast Python validation (~5s total) — `check_doc_counts.py`, `check_property_manifest.py`, `check_property_coverage.py`, `check_contract_structure.py`
- **`build`/`foundry`/`foundry-multi-seed`**: Only run when code files actually changed

When only docs/README/markdown change, the full Lean build (50s), 8 Foundry shards (2m each), and 7 multi-seed tests (1.5m each) are all skipped. Python checks still catch documentation count drift.

For code changes, behavior is identical to before.

Closes #305 (item 3)

## Test plan
- [ ] CI runs full pipeline for this PR (since it changes `.github/workflows/verify.yml`)
- [ ] `dorny/paths-filter` correctly detects code changes
- [ ] Python-only checks pass in the new `checks` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that primarily gates existing CI jobs; main risk is accidentally skipping required builds/tests due to an incomplete path filter.
> 
> **Overview**
> Adds a new `changes` job (via `dorny/paths-filter`) to classify PRs as *code* vs doc-only changes and wires the result into downstream jobs.
> 
> Introduces an always-on fast `checks` job that runs several Python validation scripts, while gating the expensive `build`, `foundry`, and `foundry-multi-seed` jobs behind `needs.changes.outputs.code == 'true'` to avoid running heavy CI when only docs/markdown change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5da8eac2b64b61f455da07945639d4ddfc077c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->