### PR TITLE
fix: only inject linked libraries into contracts with externals

### DIFF
--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -76,7 +76,9 @@ def compileAll (outDir : String) (verbose : Bool := false) (libraryPaths : List 
     let selectors ← computeSelectors spec
     match compile spec selectors with
     | .ok contract =>
-      writeContract outDir contract libraryPaths verbose
+      -- Only pass libraries to contracts that declare external functions
+      let contractLibs := if spec.externals.isEmpty then [] else libraryPaths
+      writeContract outDir contract contractLibs verbose
       if verbose then
         IO.println s!"✓ Compiled {contract.name}"
     | .error err =>


### PR DESCRIPTION
## Summary
Fix compiler linker bug: when `--link` is used, library functions (e.g. PoseidonT3_hash) were injected into **all** compiled contracts, not just those that declare external calls. This means contracts like Counter, SimpleStorage, Ledger, etc. would get Poseidon functions embedded as dead code in their deployed bytecode.

**Root cause**: `compileAll` passes `libraryPaths` to `writeContract` for every spec in the loop, and `writeContract` calls `renderWithLibraries` whenever the library list is non-empty — regardless of whether the contract actually uses external calls.

**Fix**: Only pass `libraryPaths` to `writeContract` when `spec.externals` is non-empty. Currently only `cryptoHashSpec` declares externals, so only `CryptoHash.yul` gets linked libraries.

## Test plan
- [ ] CI build passes (Lean compilation)
- [ ] Foundry tests pass (generated Yul unchanged for contracts without externals)
- [ ] Manual: `lake exe verity-compiler --link examples/external-libs/PoseidonT3.yul -o /tmp/yul -v` should show libraries loaded but only injected into CryptoHash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to the compile loop that only affects library-linking behavior under `--link`, reducing accidental bytecode bloat; low chance of unintended side effects.
> 
> **Overview**
> When `--link` is used, the compiler now **only links external Yul libraries into contracts that actually declare externals**.
> 
> `compileAll` conditionally passes `libraryPaths` to `writeContract` based on `spec.externals`, preventing unrelated contracts from having linked library functions injected as dead code while still allowing external-call validation/linking where needed (e.g., `cryptoHashSpec`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddc8dd9c8360721d45b9936f22dd8ed8bc0e5268. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->