### PR TITLE
docs: fix Layer 1/2 proof labeling, add Layer 2 guidance to tutorial

### DIFF
--- a/Compiler/Proofs/README.md
+++ b/Compiler/Proofs/README.md
@@ -14,7 +14,7 @@ Key entry points:
 - IR generation and proofs: `Compiler/Proofs/IRGeneration/`
 - Yul semantics and preservation: `Compiler/Proofs/YulGeneration/`
 
-Layer 1 proofs live alongside each contract spec in `Verity/Specs/<Name>/Proofs.lean`.
+Layer 1 proofs live in `Verity/Proofs/<Name>/Basic.lean` and `Correctness.lean`. The re-export shim at `Verity/Specs/<Name>/Proofs.lean` imports Layer 2 proofs from `Compiler/Proofs/SpecCorrectness/<Name>.lean`.
 
 ## Build
 

--- a/Verity/Specs/Counter/Proofs.lean
+++ b/Verity/Specs/Counter/Proofs.lean
@@ -1,6 +1,6 @@
 import Compiler.Proofs.SpecCorrectness.Counter
 
 /-
-  Layer 1 proof re-export.
+  Layer 2 proof re-export.
   This keeps the user-facing path stable while reusing the core proof module.
 -/

--- a/Verity/Specs/Ledger/Proofs.lean
+++ b/Verity/Specs/Ledger/Proofs.lean
@@ -1,6 +1,6 @@
 import Compiler.Proofs.SpecCorrectness.Ledger
 
 /-
-  Layer 1 proof re-export.
+  Layer 2 proof re-export.
   This keeps the user-facing path stable while reusing the core proof module.
 -/

--- a/Verity/Specs/Owned/Proofs.lean
+++ b/Verity/Specs/Owned/Proofs.lean
@@ -1,6 +1,6 @@
 import Compiler.Proofs.SpecCorrectness.Owned
 
 /-
-  Layer 1 proof re-export.
+  Layer 2 proof re-export.
   This keeps the user-facing path stable while reusing the core proof module.
 -/

--- a/Verity/Specs/OwnedCounter/Proofs.lean
+++ b/Verity/Specs/OwnedCounter/Proofs.lean
@@ -1,6 +1,6 @@
 import Compiler.Proofs.SpecCorrectness.OwnedCounter
 
 /-
-  Layer 1 proof re-export.
+  Layer 2 proof re-export.
   This keeps the user-facing path stable while reusing the core proof module.
 -/

--- a/Verity/Specs/SafeCounter/Proofs.lean
+++ b/Verity/Specs/SafeCounter/Proofs.lean
@@ -1,6 +1,6 @@
 import Compiler.Proofs.SpecCorrectness.SafeCounter
 
 /-
-  Layer 1 proof re-export.
+  Layer 2 proof re-export.
   This keeps the user-facing path stable while reusing the core proof module.
 -/

--- a/Verity/Specs/SimpleStorage/Proofs.lean
+++ b/Verity/Specs/SimpleStorage/Proofs.lean
@@ -1,6 +1,6 @@
 import Compiler.Proofs.SpecCorrectness.SimpleStorage
 
 /-
-  Layer 1 proof re-export.
+  Layer 2 proof re-export.
   This keeps the user-facing path stable while reusing the core proof module.
 -/

--- a/Verity/Specs/SimpleToken/Proofs.lean
+++ b/Verity/Specs/SimpleToken/Proofs.lean
@@ -1,6 +1,6 @@
 import Compiler.Proofs.SpecCorrectness.SimpleToken
 
 /-
-  Layer 1 proof re-export.
+  Layer 2 proof re-export.
   This keeps the user-facing path stable while reusing the core proof module.
 -/

--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -39,12 +39,12 @@ This creates 7 scaffold files (EDSL, Spec, Invariants, Proofs re-export shim, Ba
 
 3. **Layer 1 Proofs**
    - Prove correctness in `Verity/Proofs/<Name>/Basic.lean` and `Correctness.lean`
-   - `Verity/Specs/<Name>/Proofs.lean` is a re-export shim (imports from `Compiler/Proofs/SpecCorrectness/`)
    - Each theorem states observable behavior (return values + storage deltas)
 
 4. **Compiler Spec + Layer 2 Proofs**
    - Add compiler-level spec in `Compiler/Specs.lean`
    - Prove `ContractSpec → IR` preservation in `Compiler/Proofs/SpecCorrectness/<Name>.lean`
+   - `Verity/Specs/<Name>/Proofs.lean` is a re-export shim (imports from `Compiler/Proofs/SpecCorrectness/`)
 
 5. **Differential Tests**
    - Add harness in `test/Differential<Name>.t.sol`

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -84,7 +84,7 @@ This creates all the scaffold files you need:
 | `Verity/Examples/TipJar.lean` | EDSL implementation |
 | `Verity/Specs/TipJar/Spec.lean` | Formal specification |
 | `Verity/Specs/TipJar/Invariants.lean` | State invariants |
-| `Verity/Specs/TipJar/Proofs.lean` | Layer 1 proof re-export |
+| `Verity/Specs/TipJar/Proofs.lean` | Layer 2 proof re-export |
 | `Verity/Proofs/TipJar/Basic.lean` | Basic correctness proofs |
 | `Verity/Proofs/TipJar/Correctness.lean` | Advanced proofs |
 | `test/PropertyTipJar.t.sol` | Solidity property tests |

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -51,7 +51,7 @@ python3 scripts/generate_contract.py TipJar \
 This creates all required files:
 - `Verity/Specs/TipJar/Spec.lean` — formal specification
 - `Verity/Specs/TipJar/Invariants.lean` — state invariants
-- `Verity/Specs/TipJar/Proofs.lean` — Layer 1 proof re-export
+- `Verity/Specs/TipJar/Proofs.lean` — Layer 2 proof re-export (imports from `Compiler/Proofs/SpecCorrectness/`)
 - `Verity/Examples/TipJar.lean` — EDSL implementation
 - `Verity/Proofs/TipJar/Basic.lean` — basic correctness proofs (EDSL matches spec)
 - `Verity/Proofs/TipJar/Correctness.lean` — advanced correctness proofs
@@ -63,8 +63,10 @@ This creates all required files:
 mkdir -p Verity/Specs/TipJar Verity/Proofs/TipJar
 touch Verity/Specs/TipJar/Spec.lean
 touch Verity/Specs/TipJar/Invariants.lean
+touch Verity/Specs/TipJar/Proofs.lean
 touch Verity/Examples/TipJar.lean
 touch Verity/Proofs/TipJar/Basic.lean
+touch Verity/Proofs/TipJar/Correctness.lean
 touch test/PropertyTipJar.t.sol
 ```
 
@@ -401,7 +403,54 @@ Function selectors (the first 4 bytes of `keccak256("functionName(paramTypes)")`
 
 > **Tip**: Run `python3 scripts/check_selectors.py` to verify that the auto-computed selectors match `solc --hashes` output. You can also compute selectors manually with `python3 scripts/keccak256.py "tip(uint256)" "getBalance(address)"`.
 
-### 5.3 Generate Yul Code
+### 5.3 Write Layer 2 Proofs
+
+Layer 2 proofs show that the `ContractSpec` you just wrote faithfully represents the EDSL implementation. Create `Compiler/Proofs/SpecCorrectness/TipJar.lean`:
+
+```lean
+/-
+  Compiler.Proofs.SpecCorrectness.TipJar
+
+  Prove that tipJarSpec accurately represents the TipJar EDSL.
+
+  Strategy:
+  - Define state conversion between EDSL ContractState and Spec evaluation
+  - Prove each function in the spec produces the same result as the EDSL
+-/
+
+import Compiler.Specs
+import Verity.Proofs.Stdlib.SpecInterpreter
+import Verity.Examples.TipJar
+
+namespace Compiler.Proofs.SpecCorrectness
+
+open Compiler.ContractSpec
+open Compiler.Specs
+open Verity.Proofs.Stdlib.SpecInterpreter
+open Verity
+open Verity.Examples.TipJar
+
+-- Prove that the spec interpretation of `tip` matches the EDSL `tip`
+-- Prove that the spec interpretation of `getBalance` matches the EDSL `getBalance`
+-- See Counter.lean or SimpleStorage.lean for the full pattern
+
+end Compiler.Proofs.SpecCorrectness
+```
+
+> **Tip**: Study `Compiler/Proofs/SpecCorrectness/Counter.lean` (simplest) or `SimpleStorage.lean` — they follow a consistent pattern: define a state conversion, then prove each function matches.
+
+Once this file compiles, activate the re-export shim in `Verity/Specs/TipJar/Proofs.lean`:
+
+```lean
+import Compiler.Proofs.SpecCorrectness.TipJar
+
+/-
+  Layer 2 proof re-export.
+  This keeps the user-facing path stable while reusing the core proof module.
+-/
+```
+
+### 5.4 Generate Yul Code
 
 ```bash
 lake build verity-compiler
@@ -411,7 +460,7 @@ lake exe verity-compiler
 ls compiler/yul/TipJar.yul
 ```
 
-### 5.4 Verify Compilation
+### 5.5 Verify Compilation
 
 ```bash
 python3 scripts/check_yul_compiles.py

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -5,7 +5,7 @@ Creates the complete file structure needed to add a new contract:
   - EDSL implementation (Verity/Examples/{Name}.lean)
   - Formal specification (Verity/Specs/{Name}/Spec.lean)
   - State invariants (Verity/Specs/{Name}/Invariants.lean)
-  - Layer 1 proof re-export (Verity/Specs/{Name}/Proofs.lean)
+  - Layer 2 proof re-export (Verity/Specs/{Name}/Proofs.lean)
   - Basic proofs (Verity/Proofs/{Name}/Basic.lean)
   - Correctness proofs (Verity/Proofs/{Name}/Correctness.lean)
   - Compiler spec entry (printed to stdout for manual insertion)
@@ -275,7 +275,7 @@ end Verity.Specs.{cfg.name}
 
 
 def gen_spec_proofs(cfg: ContractConfig) -> str:
-    """Generate Verity/Specs/{Name}/Proofs.lean — Layer 1 proof re-export.
+    """Generate Verity/Specs/{Name}/Proofs.lean — Layer 2 proof re-export.
 
     Every existing contract (SimpleStorage, Counter, Owned, etc.) has this file.
     It re-exports the SpecCorrectness proof so that downstream users have a
@@ -289,7 +289,7 @@ def gen_spec_proofs(cfg: ContractConfig) -> str:
 -- import Compiler.Proofs.SpecCorrectness.{cfg.name}
 
 /-
-  Layer 1 proof re-export.
+  Layer 2 proof re-export.
   This keeps the user-facing path stable while reusing the core proof module.
 
   Once you have written the SpecCorrectness proof for {cfg.name}, uncomment


### PR DESCRIPTION
## Summary

- **Fix mislabeled Proofs.lean**: All 7 `Verity/Specs/<Name>/Proofs.lean` files said "Layer 1 proof re-export" in their comment, but they actually import from `Compiler/Proofs/SpecCorrectness/` (Layer 2). Fixed to say "Layer 2".
- **Add Layer 2 proof section to first-contract.mdx**: The tutorial previously omitted Layer 2 proofs entirely. Added section 5.3 with a scaffold for `Compiler/Proofs/SpecCorrectness/TipJar.lean` and instructions to activate the `Proofs.lean` re-export shim.
- **Fix scaffold generator**: `generate_contract.py` docstring and generated comment now say "Layer 2" instead of "Layer 1".
- **Fix add-contract.mdx**: Moved `Proofs.lean` re-export shim description from the "Layer 1 Proofs" section to "Layer 2 Proofs" where it belongs.
- **Fix getting-started.mdx**: Updated file table to say "Layer 2 proof re-export".
- **Fix Compiler/Proofs/README.md**: Corrected description of where Layer 1 proofs live and what `Proofs.lean` re-exports.
- **Fix first-contract.mdx section 1.2**: Added missing `Proofs.lean` and `Correctness.lean` to manual file creation.

## Context

Verity has two proof layers:
- **Layer 1**: EDSL correctness (`Verity/Proofs/<Name>/Basic.lean` + `Correctness.lean`)
- **Layer 2**: ContractSpec → IR preservation (`Compiler/Proofs/SpecCorrectness/<Name>.lean`)

The `Proofs.lean` re-export shim imports Layer 2, but was consistently mislabeled as "Layer 1" across the codebase and docs.

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI passes (comment-only changes in Lean files, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/comment-only updates plus a scaffold-generator string change; no compiler/proof logic or runtime behavior is modified.
> 
> **Overview**
> Clarifies the proof-layer structure across the repo by correcting `Proofs.lean` re-export comments and `Compiler/Proofs/README.md` to state that `Verity/Specs/<Name>/Proofs.lean` re-exports **Layer 2** (`Compiler/Proofs/SpecCorrectness/*`) rather than Layer 1.
> 
> Updates the docs workflow (`add-contract.mdx`, `getting-started.mdx`, `guides/first-contract.mdx`) to place the re-export shim under Layer 2 and adds a new tutorial section guiding authors to create `Compiler/Proofs/SpecCorrectness/<Name>.lean` (with a TipJar scaffold) and then enable the shim. The scaffold generator (`scripts/generate_contract.py`) is updated to emit the same Layer 2 labeling in its docstring/template output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79405397efc9d5b6bd260cb9258006a24ba21e91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->