### PR TITLE
docs: fix stale theorem counts (305→319) and axiom reference

### DIFF
--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -453,9 +453,10 @@ abbrev Address := String
 
 **Details**:
 
-Two axioms depend on address injectivity:
+One axiom depends on address injectivity:
 - `addressToNat_injective` (Automation.lean): Claims `addressToNat a = addressToNat b → a = b`
-- `addressToNat_injective_valid` (Conversions.lean): Same but requires `isValidAddress` pre-condition
+
+Note: `addressToNat_injective_valid` (Conversions.lean) was previously an axiom but is now a derived theorem that requires an `isValidAddress` pre-condition.
 
 Since `Address = String`, any string can be used as an address. The axiom `addressToNat_injective` (without validity check) is technically unsound for arbitrary strings — `addressToNat "0xFF"` might equal `addressToNat "0xff"` while the strings are different.
 

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -52,7 +52,7 @@ forge --version
 ```bash
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                # Downloads dependencies and verifies all 305 theorems
+lake build                # Downloads dependencies and verifies all 319 theorems
 ```
 
 The first build downloads Mathlib and compiles everything — expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 305 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 361 Foundry tests across 25 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 319 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 361 Foundry tests across 25 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 305 theorems, all fully proven. 2 documented axioms, 0 sorry.**
+**Compact core, built across 7 iterations. 319 theorems, all fully proven. 2 documented axioms, 0 sorry.**
 
 ## Evolution
 
@@ -173,7 +173,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (361 as of 2026-02-17), Lean proofs verify (305 theorems as of 2026-02-16)
+- Test results: Foundry tests pass (361 as of 2026-02-17), Lean proofs verify (319 theorems as of 2026-02-17)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,7 +62,7 @@ Example output:
    Covered:    52 ( 88.1%)
    Excluded:     7 (proof-only)
 
-Overall: 72.1% coverage (220/305 properties)
+Overall: 69% coverage (220/319 properties)
 ```
 
 ### Property Exclusions
@@ -168,4 +168,4 @@ To add test coverage for a proven theorem:
   - Text/Markdown/JSON output formats
   - Per-contract and overall statistics
   - CI integration with GitHub workflow summaries
-  - Coverage improved from 53.1% (155/292) to 72.1% (220/305) — all testable properties covered
+  - Coverage improved from 53.1% (155/292) to 69% (220/319) — all testable properties covered

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -504,6 +504,55 @@ def main() -> None:
         )
     )
 
+    # Check theorem counts in getting-started.mdx
+    getting_started = ROOT / "docs-site" / "content" / "getting-started.mdx"
+    errors.extend(
+        check_file(
+            getting_started,
+            [
+                (
+                    "theorem count",
+                    re.compile(r"verifies all (\d+) theorems"),
+                    str(total_theorems),
+                ),
+            ],
+        )
+    )
+
+    # Check theorem count in index.mdx
+    index_mdx = ROOT / "docs-site" / "content" / "index.mdx"
+    errors.extend(
+        check_file(
+            index_mdx,
+            [
+                (
+                    "theorem count",
+                    re.compile(r"(\d+) machine-checked theorems"),
+                    str(total_theorems),
+                ),
+            ],
+        )
+    )
+
+    # Check theorem count in research.mdx header
+    errors.extend(
+        check_file(
+            research_mdx,
+            [
+                (
+                    "theorem count in header",
+                    re.compile(r"(\d+) theorems, all fully proven"),
+                    str(total_theorems),
+                ),
+                (
+                    "theorem count in metrics",
+                    re.compile(r"(\d+) theorems as of"),
+                    str(total_theorems),
+                ),
+            ],
+        )
+    )
+
     # Check core size claims
     core_mdx = ROOT / "docs-site" / "content" / "core.mdx"
     errors.extend(
@@ -518,7 +567,6 @@ def main() -> None:
             ],
         )
     )
-    index_mdx = ROOT / "docs-site" / "content" / "index.mdx"
     errors.extend(
         check_file(
             index_mdx,


### PR DESCRIPTION
## Summary

- **Fix stale 305→319**: Five files still referenced the old 305 theorem count instead of the current 319 (added in PRs #298, #303, #308)
- **Fix TRUST_ASSUMPTIONS.md**: Listed `addressToNat_injective_valid` as an axiom, but it was converted to a derived theorem in PR #202. The actual 2 axioms are `addressToNat_injective` and `keccak256_first_4_bytes`
- **Extend check_doc_counts.py**: Added theorem count validation for `getting-started.mdx`, `index.mdx`, and `research.mdx` to prevent future drift

### Files updated

| File | Change |
|------|--------|
| `docs-site/content/getting-started.mdx` | `305` → `319` |
| `docs-site/content/index.mdx` | `305` → `319` |
| `docs-site/content/research.mdx` | `305` → `319` (two occurrences) |
| `scripts/README.md` | `220/305` → `220/319`, `72.1%` → `69%` (two occurrences) |
| `TRUST_ASSUMPTIONS.md` | Corrected axiom list (removed theorem `addressToNat_injective_valid`) |
| `scripts/check_doc_counts.py` | Added 3 new validation checks |

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes (319 theorems, 9 categories, 2 axioms)
- [x] `python3 scripts/check_contract_structure.py` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI validation-script updates only; no changes to contract logic, proofs, or security-sensitive runtime code.
> 
> **Overview**
> Updates multiple docs to replace the stale `305` theorem count with `319`, including adjusting the reported property-test coverage ratio/percentage (`220/319`, `69%`).
> 
> Corrects `TRUST_ASSUMPTIONS.md` to clarify that only `addressToNat_injective` depends on address injectivity and that `addressToNat_injective_valid` is now a derived theorem (not an axiom).
> 
> Extends `scripts/check_doc_counts.py` to validate theorem-count claims in `getting-started.mdx`, `index.mdx`, and `research.mdx` (header + metrics), reducing future documentation drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e24be6c2fded7895a5c5b9c651f2e3c6509f043a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->