### PR TITLE
fix: doc bugs, scaffold getter type, and CI deduplication

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check contract file structure
         run: python3 scripts/check_contract_structure.py
 
+      - name: Check axiom locations in AXIOMS.md
+        run: python3 scripts/check_axiom_locations.py
+
       - name: Check documentation counts
         run: python3 scripts/check_doc_counts.py
 
@@ -242,26 +245,11 @@ jobs:
       - name: Check selector fixtures against solc
         run: python3 scripts/check_selector_fixtures.py
 
-      - name: Check property manifest references
-        run: python3 scripts/check_property_manifest.py
-
       - name: Check property manifest sync
         run: python3 scripts/check_property_manifest_sync.py
 
-      - name: Check property coverage
-        run: python3 scripts/check_property_coverage.py
-
       - name: Check storage layout consistency
         run: python3 scripts/check_storage_layout.py
-
-      - name: Check contract file structure
-        run: python3 scripts/check_contract_structure.py
-
-      - name: Check axiom locations in AXIOMS.md
-        run: python3 scripts/check_axiom_locations.py
-
-      - name: Check documentation counts
-        run: python3 scripts/check_doc_counts.py
 
       - name: Generate property coverage report
         run: python3 scripts/report_property_coverage.py --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/docs-site/content/guides/debugging-proofs.mdx
+++ b/docs-site/content/guides/debugging-proofs.mdx
@@ -291,18 +291,15 @@ theorem only_slot_k_changed :
   simp [setStorage, hneq]
 ```
 
-### runState Composition
+### Sequential Operations
 
 **Problem**: Multiple storage updates in sequence.
 
-**Pattern**: Use runState_bind
+**Pattern**: Unfold bind and simp with `Contract.run`
 ```lean
 theorem multi_update_proof :
     (do setStorage slot1 val1; setStorage slot2 val2).runState state = finalState := by
-  rw [runState_bind]           -- Separate first operation
-  simp [setStorage]             -- Simplify first update
-  rw [runState_bind]            -- Separate second operation
-  simp [setStorage]              -- Simplify second update
+  simp [bind, setStorage, Contract.run, ContractResult.snd]
   ext slot                      -- Prove storage equality
   by_cases h1 : slot = slot1
   · simp [h1]
@@ -520,19 +517,19 @@ example : (a + 0) = a := rfl  -- Works if definitionally equal
 
 ## Real Examples from Verity
 
-### Example 1: SimpleStorage getValue
+### Example 1: SimpleStorage retrieve
 
-**Goal**: Prove getValue returns stored value
+**Goal**: Prove retrieve returns stored value
 ```lean
-theorem getValue_correct (state : ContractState) :
-    (getValue.run state).fst = state.storage valueSlot := by
-  unfold getValue Contract.run        -- Expand definitions
-  simp [getStorage, valueSlot]         -- Simplify storage access
+theorem retrieve_correct (state : ContractState) :
+    (retrieve.run state).fst = state.storage storedData := by
+  unfold retrieve Contract.run        -- Expand definitions
+  simp [getStorage, storedData]        -- Simplify storage access
   -- Result: rfl (definitionally equal)
 ```
 
 **Key insights**:
-- Unfold `getValue` first to expose `getStorage`
+- Unfold `retrieve` first to expose `getStorage`
 - `simp` handles storage function application
 - Result is definitionally equal (rfl)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -119,7 +119,7 @@ python3 scripts/generate_contract.py MyToken \
 python3 scripts/generate_contract.py MyContract --dry-run
 ```
 
-Creates 6 files: EDSL implementation, Spec, Invariants, Basic proofs, Correctness proofs, and Property tests. Prints instructions for manual steps (All.lean imports, Compiler/Specs.lean entry).
+Creates 7 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic proofs, Correctness proofs, and Property tests. Prints instructions for manual steps (All.lean imports, Compiler/Specs.lean entry).
 
 ## Utilities
 


### PR DESCRIPTION
## Summary

Four independent fixes bundled into one PR:

### 1. debugging-proofs.mdx: non-existent lemma (bug)
- Section "runState Composition" referenced `runState_bind` which doesn't exist anywhere in the Lean codebase
- Replaced with the actual pattern used in proofs: `simp [bind, Contract.run, ContractResult.snd]`
- Also fixed "Example 1: SimpleStorage getValue" to use real function names (`retrieve`/`storedData` instead of invented `getValue`/`valueSlot`)

### 2. generate_contract.py: address-field getter return type (bug)
- `getOwner` for a contract with `--fields "owner:address"` was generated as `Contract Uint256` instead of `Contract Address`
- This caused a Lean compilation error since the Uint256 import wasn't added for address-only contracts
- Now detects getter names matching address fields and uses the correct return type

### 3. verify.yml: CI deduplication
- Moved `check_axiom_locations.py` from `build` to `checks` job (was previously skipped for doc-only PRs that modify `AXIOMS.md`)
- Removed 5 Python checks that were duplicated between `checks` and `build` jobs: `check_property_manifest.py`, `check_property_coverage.py`, `check_contract_structure.py`, `check_axiom_locations.py`, `check_doc_counts.py`
- These Python-only scripts don't need the Lean build and already run in the fast `checks` job

### 4. scripts/README.md: file count (minor)
- "Creates 6 files" → "Creates 7 files" (missing Proofs.lean re-export shim)

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] `python3 scripts/check_contract_structure.py` passes
- [x] `python3 scripts/check_property_manifest.py` passes
- [x] `python3 scripts/check_property_coverage.py` passes
- [x] Scaffold dry-run: `python3 scripts/generate_contract.py TestOwned --fields "owner:address" --functions "getOwner,setOwner" --dry-run` — `getOwner` returns `Contract Address`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI workflow reorganization and documentation/script fixes; main functional change is limited to scaffolded return types for generated getter stubs.
> 
> **Overview**
> Fixes proof-debugging documentation examples by replacing a non-existent `runState_bind` pattern with a working `simp [bind, ...]` approach and by updating the “SimpleStorage” example to reference real identifiers.
> 
> Improves `scripts/generate_contract.py` scaffolding so getter-like functions (e.g. `getOwner`) return `Contract Address` when they correspond to `address` fields, avoiding incorrect `Uint256` stubs.
> 
> Deduplicates GitHub Actions verification by moving `check_axiom_locations.py` into the always-run `checks` job and removing several Python-only checks from the `build` job; updates `scripts/README.md` to reflect the additional scaffolded `Proofs.lean` file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92436fdf204c8e26b3a9de35d6b9fceb6d618cad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->