### PR TITLE
ci: deduplicate solc setup with composite action

### DIFF
--- a/.github/actions/setup-solc/action.yml
+++ b/.github/actions/setup-solc/action.yml
@@ -1,0 +1,25 @@
+name: Setup solc
+description: Cache and install the Solidity compiler
+
+runs:
+  using: composite
+  steps:
+    - name: Cache solc binary
+      id: cache-solc
+      uses: actions/cache@v4
+      with:
+        path: /usr/local/bin/solc
+        key: solc-${{ env.SOLC_VERSION }}
+
+    - name: Install solc
+      if: steps.cache-solc.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl -sSfL "$SOLC_URL" -o solc
+        echo "${SOLC_SHA256}  solc" | sha256sum -c -
+        sudo mv solc /usr/local/bin/solc
+        sudo chmod +x /usr/local/bin/solc
+
+    - name: Verify solc
+      shell: bash
+      run: solc --version

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -221,23 +221,8 @@ jobs:
       - name: Validate Selectors.lean axiom definitions
         run: python3 scripts/validate_selectors.py
 
-      - name: Cache solc binary
-        id: cache-solc
-        uses: actions/cache@v4
-        with:
-          path: /usr/local/bin/solc
-          key: solc-${{ env.SOLC_VERSION }}
-
-      - name: Install solc
-        if: steps.cache-solc.outputs.cache-hit != 'true'
-        run: |
-          curl -sSfL "$SOLC_URL" -o solc
-          echo "${SOLC_SHA256}  solc" | sha256sum -c -
-          sudo mv solc /usr/local/bin/solc
-          sudo chmod +x /usr/local/bin/solc
-
-      - name: Verify solc
-        run: solc --version
+      - name: Setup solc
+        uses: ./.github/actions/setup-solc
 
       - name: Compile generated Yul with solc
         run: python3 scripts/check_yul_compiles.py
@@ -304,23 +289,8 @@ jobs:
         with:
           version: v1.5.0
 
-      - name: Cache solc binary
-        id: cache-solc
-        uses: actions/cache@v4
-        with:
-          path: /usr/local/bin/solc
-          key: solc-${{ env.SOLC_VERSION }}
-
-      - name: Install solc
-        if: steps.cache-solc.outputs.cache-hit != 'true'
-        run: |
-          curl -sSfL "$SOLC_URL" -o solc
-          echo "${SOLC_SHA256}  solc" | sha256sum -c -
-          sudo mv solc /usr/local/bin/solc
-          sudo chmod +x /usr/local/bin/solc
-
-      - name: Verify solc
-        run: solc --version
+      - name: Setup solc
+        uses: ./.github/actions/setup-solc
 
       - name: Run Foundry tests with seed 42
         env:
@@ -370,23 +340,8 @@ jobs:
         with:
           version: v1.5.0
 
-      - name: Cache solc binary
-        id: cache-solc
-        uses: actions/cache@v4
-        with:
-          path: /usr/local/bin/solc
-          key: solc-${{ env.SOLC_VERSION }}
-
-      - name: Install solc
-        if: steps.cache-solc.outputs.cache-hit != 'true'
-        run: |
-          curl -sSfL "$SOLC_URL" -o solc
-          echo "${SOLC_SHA256}  solc" | sha256sum -c -
-          sudo mv solc /usr/local/bin/solc
-          sudo chmod +x /usr/local/bin/solc
-
-      - name: Verify solc
-        run: solc --version
+      - name: Setup solc
+        uses: ./.github/actions/setup-solc
 
       - name: Run tests with seed ${{ matrix.seed }}
         env:


### PR DESCRIPTION
## Summary
- Extract the solc cache/install/verify steps into a reusable composite action at `.github/actions/setup-solc/action.yml`
- Replace 3 identical 17-line blocks (in `build`, `foundry`, and `foundry-multi-seed` jobs) with 2-line references
- Net reduction: 45 lines removed, solc version/URL/SHA defined once (env vars at top of workflow)

## Why
The solc install block was copy-pasted across 3 jobs. If the solc version needs bumping, all 3 had to be updated in sync. Now there's a single source of truth.

## Test plan
- [x] YAML validated: 3 composite action references, 0 inline solc installs
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] `python3 scripts/check_contract_structure.py` passes
- [ ] CI: all 3 jobs (build, foundry, foundry-multi-seed) successfully install solc via composite action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only refactor that consolidates repeated steps into a composite action; main risk is workflow breakage if the action path/env variables are misconfigured.
> 
> **Overview**
> Creates a reusable composite GitHub Action (`.github/actions/setup-solc`) that **caches, installs (with SHA256 verification), and verifies** the `solc` binary.
> 
> Updates the `verify.yml` workflow to replace three duplicated inline `solc` setup blocks with `uses: ./.github/actions/setup-solc`, centralizing the setup logic while keeping the version/URL/SHA driven by workflow `env` variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71dfb8d5abc6bbba82b5a4d1f447c87f2b366eb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->