### PR TITLE
ci: extract Foundry test setup into composite action

### DIFF
--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -1,0 +1,29 @@
+name: Setup Foundry test environment
+description: Download build artifacts, install Foundry and solc
+
+runs:
+  using: composite
+  steps:
+    - name: Download generated Yul
+      uses: actions/download-artifact@v4
+      with:
+        name: generated-yul
+        path: compiler/yul
+
+    - name: Download difftest interpreter
+      uses: actions/download-artifact@v4
+      with:
+        name: difftest-interpreter
+        path: .lake/build/bin
+
+    - name: Make difftest interpreter executable
+      shell: bash
+      run: chmod +x .lake/build/bin/difftest-interpreter
+
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: v1.5.0
+
+    - name: Setup solc
+      uses: ./.github/actions/setup-solc

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -273,30 +273,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Download generated Yul
-        uses: actions/download-artifact@v4
-        with:
-          name: generated-yul
-          path: compiler/yul
-
-      - name: Download difftest interpreter
-        uses: actions/download-artifact@v4
-        with:
-          name: difftest-interpreter
-          path: .lake/build/bin
-
-      - name: Make difftest interpreter executable
-        run: |
-          chmod +x .lake/build/bin/difftest-interpreter
-          ls -l .lake/build/bin/difftest-interpreter
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: v1.5.0
-
-      - name: Setup solc
-        uses: ./.github/actions/setup-solc
+      - name: Setup Foundry environment
+        uses: ./.github/actions/setup-foundry
 
       - name: Run Foundry tests with seed 42
         env:
@@ -324,30 +302,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Download generated Yul
-        uses: actions/download-artifact@v4
-        with:
-          name: generated-yul
-          path: compiler/yul
-
-      - name: Download difftest interpreter
-        uses: actions/download-artifact@v4
-        with:
-          name: difftest-interpreter
-          path: .lake/build/bin
-
-      - name: Make difftest interpreter executable
-        run: |
-          chmod +x .lake/build/bin/difftest-interpreter
-          ls -l .lake/build/bin/difftest-interpreter
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: v1.5.0
-
-      - name: Setup solc
-        uses: ./.github/actions/setup-solc
+      - name: Setup Foundry environment
+        uses: ./.github/actions/setup-foundry
 
       - name: Run tests with seed ${{ matrix.seed }}
         env:


### PR DESCRIPTION
## Summary
- Extract the duplicated artifact-download + Foundry-install + solc-setup steps into `.github/actions/setup-foundry/action.yml`
- Both `foundry` and `foundry-multi-seed` jobs now use a single `setup-foundry` composite action instead of 5 duplicated steps each
- Combined with #322, the workflow is now 328 lines (down from 412), with all tool setup centralized

## Changes
- New: `.github/actions/setup-foundry/action.yml` — downloads Yul artifacts, difftest interpreter, installs Foundry v1.5.0, and sets up solc (via the existing `setup-solc` action)
- Modified: `.github/workflows/verify.yml` — replaced 2x identical 24-line setup blocks with 2-line composite action references

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] `python3 scripts/check_contract_structure.py` passes
- [ ] CI: both `foundry` and `foundry-multi-seed` jobs set up correctly via composite action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CI refactor that centralizes existing steps; risk is limited to workflow breakage if the composite action path, artifact names/paths, or permissions differ from the prior inline steps.
> 
> **Overview**
> **CI refactor:** Introduces a new composite GitHub Action, `.github/actions/setup-foundry`, that encapsulates the Foundry test environment setup (download `generated-yul` and `difftest-interpreter` artifacts, chmod the interpreter, install Foundry `v1.5.0`, and run the existing `setup-solc`).
> 
> Updates `verify.yml` so both `foundry` and `foundry-multi-seed` jobs replace the duplicated setup blocks with a single `uses: ./.github/actions/setup-foundry` step, reducing workflow duplication without changing the actual test commands or matrices.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e3206c1d61c34ec92e3fa71f57485d3cd18e0e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->