### PR TITLE
docs: update llms.txt with current issue references

### DIFF
--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -81,8 +81,8 @@ The GitHub Actions workflow validates:
 - All manifest theorems have tests (or documented exclusions)
 - Storage layout consistency across EDSL/Spec/Compiler layers
 - Selector hashes match specs
-- Generated Yul compiles with solc
-- Contract file structure validation
+- Generated Yul compiles with solc (including CryptoHash with linked libraries)
+- Contract file structure and All.lean import validation
 - Foundry tests pass (8 shards, 7 seeds)
 
 ## External Library Linking
@@ -136,7 +136,7 @@ The ContractSpec DSL supports: if/else branching (`Stmt.ite`), bounded loops (`S
 
 ## What's Next
 
-1. EVMYulLean UInt256 integration (#67)
+1. EVMYulLean integration: upgrade Lean, replace Yul semantics (#294)
 2. ERC-20 standard token (#69)
 3. Storage layout formalization (#84)
-4. Gas cost modeling (#80)
+4. Address soundness: replace String with ByteArray (#253)


### PR DESCRIPTION
## Summary
- Replace closed issues (#67, #80) in "What's Next" with current open issues (#294 EVMYulLean, #253 Address soundness)
- Update CI validation description to mention CryptoHash linking and All.lean import validation (added in #321, #323)

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; no code or behavior changes, so risk is minimal aside from potentially stale/mistaken references.
> 
> **Overview**
> Updates `docs-site/public/llms.txt` to reflect newer CI checks by explicitly calling out solc compilation with CryptoHash-linked libraries and adding All.lean import/contract structure validation.
> 
> Refreshes the "What's Next" roadmap by replacing closed issue references with current open issues for EVMYulLean integration (`#294`) and address soundness (`#253`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13a78483a58fae7abbde8c6702efa477337fd3fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->