### PR TITLE
ci: extend check_doc_counts.py with banner and additional count checks

### DIFF
--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -498,6 +498,16 @@ def main() -> None:
                     re.compile(r"forge test\s+#\s*(\d+)/\d+ tests pass"),
                     str(test_count),
                 ),
+                (
+                    "test count in metrics",
+                    re.compile(r"Foundry tests pass \((\d+) as of"),
+                    str(test_count),
+                ),
+                (
+                    "test count in results",
+                    re.compile(r"All Foundry tests passing \((\d+) as of"),
+                    str(test_count),
+                ),
             ],
         )
     )
@@ -517,7 +527,7 @@ def main() -> None:
         )
     )
 
-    # Check theorem count in index.mdx
+    # Check theorem count and test counts in index.mdx
     index_mdx = ROOT / "docs-site" / "content" / "index.mdx"
     errors.extend(
         check_file(
@@ -527,6 +537,16 @@ def main() -> None:
                     "theorem count",
                     re.compile(r"(\d+) machine-checked theorems"),
                     str(total_theorems),
+                ),
+                (
+                    "test count",
+                    re.compile(r"(\d+) Foundry tests across"),
+                    str(test_count),
+                ),
+                (
+                    "test suite count",
+                    re.compile(r"Foundry tests across (\d+) suites"),
+                    str(suite_count),
                 ),
             ],
         )
@@ -573,6 +593,26 @@ def main() -> None:
                     "core line count",
                     re.compile(r"the (\d+)-line EDSL"),
                     str(core_lines),
+                ),
+            ],
+        )
+    )
+
+    # Check layout.tsx banner (theorem count appears twice: N/N)
+    layout_tsx = ROOT / "docs-site" / "app" / "layout.tsx"
+    errors.extend(
+        check_file(
+            layout_tsx,
+            [
+                (
+                    "banner proven count",
+                    re.compile(r"(\d+)/\d+ theorems proven"),
+                    str(total_theorems),
+                ),
+                (
+                    "banner total count",
+                    re.compile(r"\d+/(\d+) theorems proven"),
+                    str(total_theorems),
                 ),
             ],
         )


### PR DESCRIPTION
## Summary
- Add validation for `layout.tsx` banner theorem count (`319/319 theorems proven`)
- Add validation for `index.mdx` Foundry test count and suite count (`361 Foundry tests across 25 suites`)
- Add validation for `research.mdx` test count in two additional locations (metrics line and results line)

These 5 new checks catch stale references that were previously unvalidated. If someone adds a theorem or test, the CI `checks` job will now flag these files too.

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes with all new checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds additional regex-based documentation validations only; it doesn’t change runtime or protocol logic, but may cause CI failures if docs wording changes.
> 
> **Overview**
> Extends the CI `scripts/check_doc_counts.py` doc-consistency validator to catch more stale count references.
> 
> Adds new regex checks for Foundry test counts in `docs-site/content/research.mdx` (metrics + results), test and suite counts in `docs-site/content/index.mdx`, and the `N/N theorems proven` banner text in `docs-site/app/layout.tsx` (validating both numbers).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 519e707942459063db9603697f654ce14e7988bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->