### PR TITLE
fix: resolve Bugbot findings from PRs #322-#326

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/actions/**'
       - '.github/workflows/verify.yml'
       - 'Verity/**'
       - 'Verity.lean'
@@ -22,6 +23,7 @@ on:
       - 'TRUST_ASSUMPTIONS.md'
   pull_request:
     paths:
+      - '.github/actions/**'
       - '.github/workflows/verify.yml'
       - 'Verity/**'
       - 'Verity.lean'
@@ -58,6 +60,7 @@ jobs:
         with:
           filters: |
             code:
+              - '.github/actions/**'
               - '.github/workflows/verify.yml'
               - 'Verity/**'
               - 'Verity.lean'
@@ -209,10 +212,7 @@ jobs:
       - name: Build difftest interpreter
         run: lake build difftest-interpreter
 
-      - name: Generate Yul
-        run: ./.lake/build/bin/verity-compiler
-
-      - name: Generate Yul with linked libraries (CryptoHash)
+      - name: Generate Yul (all contracts + CryptoHash with linked libraries)
         run: |
           ./.lake/build/bin/verity-compiler \
             --link examples/external-libs/PoseidonT3.yul \

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -598,7 +598,7 @@ def main() -> None:
         )
     )
 
-    # Check layout.tsx banner (theorem count appears twice: N/N)
+    # Check layout.tsx banner (proven/total theorems proven)
     layout_tsx = ROOT / "docs-site" / "app" / "layout.tsx"
     errors.extend(
         check_file(
@@ -607,7 +607,7 @@ def main() -> None:
                 (
                     "banner proven count",
                     re.compile(r"(\d+)/\d+ theorems proven"),
-                    str(total_theorems),
+                    str(proven_count),
                 ),
                 (
                     "banner total count",


### PR DESCRIPTION
## Summary
Resolves all 4 Bugbot issues flagged on recently merged PRs:

1. **Path triggers missing `.github/actions/**`** (PRs #322, #324 — Medium): Changes to composite actions (`setup-solc`, `setup-foundry`) wouldn't trigger CI. Added to `push.paths`, `pull_request.paths`, and `dorny/paths-filter` code filter.

2. **Banner proven count uses wrong variable** (PR #326 — Medium): The first number in `319/319 theorems proven` should be `proven_count` (= `total_theorems - sorry_count`), not `total_theorems`. Currently equal since `sorry_count=0`, but would break if a sorry is introduced.

3. **Redundant compiler invocation** (PR #323 — Low): The second `verity-compiler --link` call rewrote all 7 standard Yul files identically to the first. Merged into a single invocation that generates all contracts + CryptoHash in one pass.

## Bugbot threads resolved
- PR #322: `890b5520` — composite action path missing from workflow trigger
- PR #323: `eb0a7e43` — second compiler invocation overwrites first
- PR #324: `9a31e230` — workflow paths filter misses setup-foundry
- PR #326: `679dad3f` — banner proven count compared against wrong variable

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] `python3 scripts/check_contract_structure.py` passes
- [ ] CI: single compiler invocation generates all 8 Yul files (7 standard + CryptoHash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow/filter and documentation-metrics validation tweaks with no production/runtime logic changes; risk is limited to CI triggering and build-step behavior.
> 
> **Overview**
> Ensures the `Verify proofs` GitHub Actions workflow runs when composite actions change by adding `.github/actions/**` to the workflow `push`/`pull_request` path filters and the `dorny/paths-filter` `code` filter.
> 
> Simplifies the build job by removing a redundant `verity-compiler` invocation and replacing it with a single Yul generation step that links the external Poseidon libraries. Also fixes `scripts/check_doc_counts.py` to validate the docs-site banner’s *proven* count against `proven_count` (not `total_theorems`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ecb2b1548b2f8b2c50725080ef0cc1c67652ed9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->