### PR TITLE
docs: fix debugging-proofs examples to match actual codebase

### DIFF
--- a/docs-site/content/guides/debugging-proofs.mdx
+++ b/docs-site/content/guides/debugging-proofs.mdx
@@ -17,7 +17,7 @@ description: Practical guide for debugging common proof failures, errors, and ro
 
 | Symptom | Quick Fix | Section |
 |---------|-----------|---------|
-| "simp made no progress" | Add `unfold` before `simp` | [Tactic Failures](#common-tactic-failures) |
+| "simp made no progress" | Pass definitions to `simp`: `simp [myDef]` | [Tactic Failures](#common-tactic-failures) |
 | "omega failed" | Use `by_cases` to split constraints | [Tactic Failures](#common-tactic-failures) |
 | "unknown identifier" | Check imports, spelling | [Import Errors](#import-errors) |
 | "type mismatch" | Use `#check` to compare types | [Type Errors](#type-errors) |
@@ -263,6 +263,43 @@ theorem bounded_add (h1 : a.val ≤ bound) (h2 : b.val ≤ bound) :
 
 ---
 
+## Contract Execution: `.run`, `.fst`, `.snd`
+
+Verity contracts are functions `ContractState → ContractResult α`. Use these to extract results:
+
+| Expression | Returns | Type | When to use |
+|------------|---------|------|-------------|
+| `(op).run s` | Full result | `ContractResult α` | Matching on success/revert |
+| `((op).run s).fst` | Return value | `α` | Proving what a getter returns |
+| `((op).run s).snd` | Output state | `ContractState` | Proving how state changes |
+
+**Common patterns in actual proofs:**
+
+```lean
+-- Proving a getter returns the right value
+theorem retrieve_meets_spec (s : ContractState) :
+  let result := ((retrieve).run s).fst      -- extract return value
+  retrieve_spec result s := by ...
+
+-- Proving a setter modifies state correctly
+theorem store_meets_spec (s : ContractState) (value : Uint256) :
+  let s' := ((store value).run s).snd       -- extract output state
+  store_spec value s s' := by ...
+
+-- Proving a guarded operation succeeds
+theorem increment_unfold (s : ContractState) (h : ...) :
+  (increment).run s = ContractResult.success ()  -- match full result
+    { storage := ..., ... } := by ...
+```
+
+**Important caveat**: `.fst` returns `default` on revert. If the operation might revert, either:
+- Add a guard hypothesis (e.g., `h_no_overflow : ...`) to ensure success
+- Match on the full `ContractResult` instead
+
+Avoid `Contract.runState` and `Contract.runValue` in new proofs — use `((op).run s).snd` and `((op).run s).fst` directly. The `run` + projection pattern is used by all existing proofs and works better with `simp`.
+
+---
+
 ## Storage State Reasoning
 
 ### Function Extensionality
@@ -295,17 +332,25 @@ theorem only_slot_k_changed :
 
 **Problem**: Multiple storage updates in sequence.
 
-**Pattern**: Unfold bind and simp with `Contract.run`
+**Pattern**: Use `have` to chain `_meets_spec` lemmas (see Counter proofs)
 ```lean
-theorem multi_update_proof :
-    (do setStorage slot1 val1; setStorage slot2 val2).runState state = finalState := by
-  simp [bind, setStorage, Contract.run, ContractResult.snd]
-  ext slot                      -- Prove storage equality
-  by_cases h1 : slot = slot1
-  · simp [h1]
-  · by_cases h2 : slot = slot2
-    · simp [h2, h1]
-    · simp [h1, h2]
+-- Actual pattern from Counter/Basic.lean
+theorem increment_twice_adds_two (s : ContractState) :
+  let s' := ((increment).run s).snd
+  let s'' := ((increment).run s').snd
+  s''.storage 0 = EVM.Uint256.add (EVM.Uint256.add (s.storage 0) 1) 1 := by
+  have h1 := increment_adds_one s                         -- First op
+  have h2 := increment_adds_one (((increment).run s).snd) -- Second op
+  calc ... = ... := h2
+    _ = ... := by rw [h1]
+```
+
+For low-level multi-update proofs, unfold bind directly:
+```lean
+theorem two_updates (s : ContractState) :
+  let s' := ((do setStorage slot1 val1; setStorage slot2 val2).run s).snd
+  s'.storage slot2.slot = val2 := by
+  simp [bind, Bind.bind, setStorage, Contract.run, ContractResult.snd]
 ```
 
 ---
@@ -381,23 +426,24 @@ theorem option_proof (opt : Option α) (h : opt.isSome) :
 
 ## Tactic Ordering
 
-**Wrong order** (doesn't work):
+**Preferred (Verity standard)**:
 ```lean
--- ❌ BAD: simp before unfold
-theorem bad_order : getValue state = value := by
-  simp [getStorage]  -- Too early, doesn't know getValue
-  unfold getValue    -- Too late
+-- ✅ BEST: Pass all definitions to simp in one call
+theorem retrieve_meets_spec (s : ContractState) :
+  let result := ((retrieve).run s).fst
+  retrieve_spec result s := by
+  simp [retrieve, storedData, retrieve_spec]  -- One shot
 ```
 
-**Right order** (works):
+**Alternative when simp can't unfold**:
 ```lean
--- ✅ GOOD: unfold before simp
+-- ✅ OK: unfold first, then simp
 theorem good_order : getValue state = value := by
-  unfold getValue     -- First expose the definition
+  unfold getValue     -- Expose the definition
   simp [getStorage]   -- Now simp can work with it
 ```
 
-**General rule**: `unfold` → `simp` → `omega`
+**General rule**: Pass definitions directly to `simp` (e.g. `simp [myDef, mySlot]`). Use `unfold` only when `simp` can't unfold a definition on its own (e.g., mutually recursive definitions).
 
 ---
 
@@ -517,55 +563,112 @@ example : (a + 0) = a := rfl  -- Works if definitionally equal
 
 ## Real Examples from Verity
 
-### Example 1: SimpleStorage retrieve
+Verity proofs follow the **`_meets_spec` pattern**: each EDSL operation has a corresponding `_spec` predicate, and the proof shows the operation satisfies it. This is the dominant pattern across all 9 contracts.
 
-**Goal**: Prove retrieve returns stored value
+### Example 1: SimpleStorage retrieve (spec-based proof)
+
+**Goal**: Prove `retrieve` returns the stored value.
+
 ```lean
-theorem retrieve_correct (state : ContractState) :
-    (retrieve.run state).fst = state.storage storedData := by
-  unfold retrieve Contract.run        -- Expand definitions
-  simp [getStorage, storedData]        -- Simplify storage access
-  -- Result: rfl (definitionally equal)
+-- The spec predicate (defined in Specs/SimpleStorage/Spec.lean)
+def retrieve_spec (result : Uint256) (s : ContractState) : Prop :=
+  result = s.storage storedData.slot
+
+-- The proof (from Proofs/SimpleStorage/Basic.lean)
+theorem retrieve_meets_spec (s : ContractState) :
+  let result := ((retrieve).run s).fst
+  retrieve_spec result s := by
+  simp [retrieve, storedData, retrieve_spec]
 ```
 
 **Key insights**:
-- Unfold `retrieve` first to expose `getStorage`
-- `simp` handles storage function application
-- Result is definitionally equal (rfl)
+- Theorem states the operation's result satisfies a named `_spec` predicate
+- Single `simp` with the operation, slot name, and spec definition — no `unfold` needed
+- `((op).run s).fst` extracts the return value; `.snd` extracts the output state
 
-### Example 2: Counter increment
+### Example 2: Counter increment (multi-conjunct spec)
 
-**Goal**: Prove increment adds 1
+**Goal**: Prove `increment` updates count and preserves everything else.
+
 ```lean
-theorem increment_correct (state : ContractState) :
-    let finalState := increment.runState state
-    finalState.storage countSlot = add (state.storage countSlot) 1 := by
-  unfold increment Contract.runState   -- Expand
-  simp [getStorage, setStorage, countSlot, add]  -- Simplify
-  -- Uses EVM modular arithmetic
+-- The spec is a conjunction: correct value ∧ other slots preserved ∧ context preserved
+theorem increment_meets_spec (s : ContractState) :
+  let s' := ((increment).run s).snd
+  increment_spec s s' := by
+  refine ⟨?_, ?_, ?_⟩                -- Split the conjunction into 3 goals
+  · rfl                               -- Goal 1: s'.storage 0 = add (s.storage 0) 1
+  · intro slot h_neq                  -- Goal 2: other slots unchanged
+    simp only [increment, count, getStorage, setStorage,
+      bind, Contract.run, Bind.bind, ContractResult.snd]
+    split
+    · next h => exact absurd (by simp [beq_iff_eq] at h; exact h) h_neq
+    · rfl
+  · simp [Specs.sameAddrMapContext, ...]  -- Goal 3: context preserved
 ```
 
 **Key insights**:
-- Must account for modular arithmetic (add, not +)
-- Order: unfold → simp
-- Storage slot access needs simplification
+- `refine ⟨?_, ?_, ?_⟩` splits a conjunction into separate goals
+- Each conjunct is proved independently (value correctness, isolation, context preservation)
+- When `simp` alone doesn't close a goal, use `split` for `if`-expressions and `exact absurd` for contradictions
 
-### Example 3: Ledger sum preservation
+### Example 3: Owned transferOwnership (require-guarded proof)
 
-**Goal**: Total balance unchanged by transfer
+**Goal**: Prove ownership transfer works when the caller is the current owner.
+
 ```lean
-theorem transfer_preserves_sum (h : from ≠ to) :
-    sum balances' = sum balances := by
-  unfold transfer sum
-  rw [sum_update_twice]               -- Use helper lemma
-  simp [h]                            -- Simplify with h
-  omega                               -- Arithmetic
+theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
+  (h_is_owner : s.sender = s.storageAddr 0) :
+  let s' := ((transferOwnership newOwner).run s).snd
+  transferOwnership_spec newOwner s s' := by
+  -- Unfold the full chain: transferOwnership → onlyOwner → isOwner → require → setStorageAddr
+  simp only [transferOwnership, onlyOwner, isOwner, owner,
+    msgSender, getStorageAddr, setStorageAddr,
+    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
+    Contract.run, ContractResult.snd, ContractResult.fst,
+    transferOwnership_spec]
+  -- After unfolding, the guard is (s.sender == s.storageAddr 0)
+  -- h_is_owner resolves it, so execution proceeds to setStorageAddr
+  simp [h_is_owner, Specs.sameStorageMapContext, ...]
+  intro slot h_neq
+  simp [beq_iff_eq, h_neq]
 ```
 
 **Key insights**:
-- Need helper lemma `sum_update_twice`
-- Case distinction (from ≠ to) is critical
-- omega handles final arithmetic
+- `require`/`onlyOwner` guards add a hypothesis like `h_is_owner : s.sender = s.storageAddr 0`
+- Pass the guard hypothesis to `simp` so it can resolve the boolean check
+- After the guard resolves, the proof proceeds like an unguarded operation
+
+### Example 4: Ledger sum preservation (conservation proof)
+
+**Goal**: Total balance unchanged by transfer (accounts for duplicate addresses).
+
+```lean
+-- Uses countOcc to handle addresses appearing multiple times in the list
+theorem Spec_transfer_sum_preservation (s : ContractState) (to : Address) (amount : Uint256)
+  (addrs : List Address) (h_guard : ...) :
+  let s' := ((transfer to amount).run s).snd
+  balanceSum s' addrs + countOccU s.sender addrs * amount
+    = balanceSum s addrs + countOccU to addrs * amount := by
+  -- Strategy: use point_update_sum_eq for sender (subtract) and recipient (add)
+  have h_sender := point_update_sum_eq ...
+  have h_recipient := point_update_sum_eq ...
+  -- Combine with omega for final arithmetic
+  omega
+```
+
+**Key insights**:
+- Conservation proofs use `countOcc` to account for duplicate addresses in the sum
+- Helper lemma `point_update_sum_eq` relates storage point-updates to sum changes
+- `omega` handles the final linear arithmetic after `have` statements set up equations
+
+### Pattern summary
+
+| Pattern | When to use | Example |
+|---------|-------------|---------|
+| `simp [op, slot, spec]` | Simple read-only operations | `retrieve_meets_spec` |
+| `refine ⟨?_, ?_, ?_⟩` | Multi-conjunct specs | `increment_meets_spec` |
+| `simp only [... chain ...]` + `simp [h_guard]` | Guarded operations with `require` | `transferOwnership_meets_spec_when_owner` |
+| `have h := helper ...` + `omega` | Conservation / arithmetic properties | `Spec_transfer_sum_preservation` |
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace invented proof examples in "Real Examples from Verity" section with actual code from SimpleStorage, Counter, Owned, and Ledger proofs
- Add new "Contract Execution: `.run`, `.fst`, `.snd`" section with decision table and usage guidance
- Add `_meets_spec` pattern explanation — the dominant proof pattern across all 9 contracts
- Add pattern summary table (simple spec, multi-conjunct, guarded, conservation)
- Fix tactic ordering guidance to prefer `simp [defs...]` over `unfold` → `simp`
- Fix sequential operations section to use actual `have` chaining pattern from Counter/Basic.lean

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] Visual review of rendered mdx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes; risk is limited to potentially misleading guidance if examples or recommended tactics are incorrect.
> 
> **Overview**
> Updates the Proof Debugging Handbook to align with real Verity proof patterns: adds a new section on contract execution via `run`/`.fst`/`.snd` (with a revert caveat), and replaces the “Real Examples” area with spec-based `_meets_spec` excerpts from existing contracts plus a pattern summary table.
> 
> Revises guidance to prefer `simp [defs...]` over `unfold`-first workflows, and updates sequential-operation advice to use `have`-chaining of spec lemmas (with a fallback low-level `bind`/`run` unfolding example).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 593894b5dde7e0311588cceb03ff504768b79a50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->