### PR TITLE
docs: fix stale references and scaffold output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ type: description
 
 [optional body]
 
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
 Types: `feat` `fix` `proof` `docs` `refactor` `test` `chore`

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -558,7 +558,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 361/361 tests pass (as of 2026-02-17)
+# Expected: 361/361 tests pass
 ```
 
 ### Add New Contract
@@ -599,7 +599,7 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 361/361 passing (100%, as of 2026-02-17)
+**Foundry Tests**: 361/361 passing (100%)
 ```bash
 $ FOUNDRY_PROFILE=difftest forge test
 Ran 25 test suites: 361 tests passed, 0 failed, 0 skipped (361 total tests)
@@ -609,7 +609,7 @@ Ran 25 test suites: 361 tests passed, 0 failed, 0 skipped (361 total tests)
 
 ### Validated Contracts
 
-All current example contracts compile and pass tests (as of Feb 16, 2026):
+All current example contracts compile and pass tests:
 - ✅ **SimpleStorage** — Basic storage operations
 - ✅ **Counter** — Arithmetic operations
 - ✅ **Owned** — Access control with constructor args
@@ -618,7 +618,7 @@ All current example contracts compile and pass tests (as of Feb 16, 2026):
 - ✅ **SimpleToken** — ERC20-like token with constructor
 - ✅ **SafeCounter** — Checked arithmetic with underflow protection
 
-**Not compiled**: ReentrancyExample (proofs are embedded inline, no compiler spec) and CryptoHash (unverified linker demo, requires `--link` to compile).
+**Not compiled**: ReentrancyExample (proofs are embedded inline, no compiler spec). CryptoHash compiles via `--link` with external Poseidon libraries and is validated in CI.
 
 ## Comparison: Manual vs Automatic
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ These scripts manage the relationship between proven Lean theorems and their cor
 
 - **`check_property_manifest.py`** - Verifies that `property_manifest.json` contains all property theorems from Lean proofs
 - **`check_property_coverage.py`** - Ensures all properties are either tested or explicitly excluded
-- **`report_property_coverage.py`** - Generates detailed coverage statistics (new!)
+- **`report_property_coverage.py`** - Generates detailed coverage statistics
 
 ### Usage
 
@@ -100,6 +100,7 @@ python3 scripts/check_contract_structure.py
 
 - **`check_selectors.py`** - Verifies function selector hashes match between Lean and generated Yul
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes
+- **`validate_selectors.py`** - Validates that selector definitions in `Compiler/Selectors.lean` match keccak256 hashes
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc
 
 ## Contract Scaffold Generator
@@ -162,10 +163,3 @@ To add test coverage for a proven theorem:
 
 3. If the property cannot be tested in Foundry (e.g., proof-only helper), add it to `test/property_exclusions.json`
 
-## Recent Improvements
-
-- **Property Coverage Reporting** (Feb 2026): Added comprehensive coverage statistics and reporting
-  - Text/Markdown/JSON output formats
-  - Per-contract and overall statistics
-  - CI integration with GitHub workflow summaries
-  - Coverage improved from 53.1% (155/292) to 69% (220/319) — all testable properties covered

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -321,7 +321,7 @@ def gen_basic_proofs(cfg: ContractConfig) -> str:
         proof_stubs.append(f"theorem {fn.name}_meets_spec (s : ContractState) :")
         proof_stubs.append(f"  let s' := (({fn.name}).run s).snd")
         proof_stubs.append(f"  {fn.name}_spec s s' := by")
-        proof_stubs.append(f"  sorry")
+        proof_stubs.append(f"  sorry  -- TODO: replace with proof (see debugging-proofs guide)")
         proof_stubs.append("")
 
     imports = [
@@ -685,7 +685,12 @@ Examples:
     print(f"   Find 'def allSpecs' and add '{name_lower}Spec' to the list.")
     print()
 
-    print("4. Run validation:")
+    print(f"4. Create differential tests (not scaffolded):")
+    print(f"   Copy test/DifferentialCounter.t.sol to test/Differential{name}.t.sol")
+    print(f"   Inherit YulTestBase, DiffTestConfig, and DifferentialTestBase")
+    print()
+
+    print("5. Run validation:")
     print("   lake build")
     print(f"   FOUNDRY_PROFILE=difftest forge test --match-contract Property{name}")
     print("   python3 scripts/check_property_coverage.py")


### PR DESCRIPTION
## Summary
- **CONTRIBUTING.md**: Use generic "Claude" in co-author template (avoids re-updating on model changes)
- **scripts/README.md**: Add missing `validate_selectors.py` to Selector & Yul section, remove stale `(new!)` label and historical "Recent Improvements" section
- **generate_contract.py**: Add proof strategy comment to `sorry` stubs per CONTRIBUTING.md policy, add step 4 reminding users to create `Differential<Name>.t.sol` (not scaffolded)
- **compiler.mdx**: Remove hardcoded `(as of 2026-02-17)` dates from test results, fix CryptoHash note (now compiled with `--link` in CI since PR #323)

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] `python3 scripts/generate_contract.py TestX --dry-run` shows updated sorry comment and differential test step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and scaffold-message-only changes; no production logic or verification semantics are modified.
> 
> **Overview**
> Refreshes contributor/docs guidance to remove stale, date-pinned references and align notes with current CI behavior.
> 
> Updates `scripts/generate_contract.py` scaffold output to add an explicit TODO strategy comment on generated `sorry` proof stubs and to print a new manual step reminding authors to create differential tests (not scaffolded). Also fixes minor docs inconsistencies: standardizes the co-author template in `CONTRIBUTING.md`, cleans up `scripts/README.md` script listings (including `validate_selectors.py`) and removes outdated “new!/recent improvements” text, and clarifies `compiler.mdx` test-result wording and CryptoHash compilation/linking status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abfb5d308eecbc625148d325291ca9d8d73d8cdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->