### PR TITLE
fix: test assertions, CI check ordering, script consolidation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -95,6 +95,12 @@ jobs:
       - name: Check documentation counts
         run: python3 scripts/check_doc_counts.py
 
+      - name: Check property manifest sync
+        run: python3 scripts/check_property_manifest_sync.py
+
+      - name: Check storage layout consistency
+        run: python3 scripts/check_storage_layout.py
+
   build:
     runs-on: ubuntu-latest
     needs: changes
@@ -235,12 +241,6 @@ jobs:
 
       - name: Check selector fixtures against solc
         run: python3 scripts/check_selector_fixtures.py
-
-      - name: Check property manifest sync
-        run: python3 scripts/check_property_manifest_sync.py
-
-      - name: Check storage layout consistency
-        run: python3 scripts/check_storage_layout.py
 
       - name: Generate property coverage report
         run: python3 scripts/report_property_coverage.py --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/scripts/check_contract_structure.py
+++ b/scripts/check_contract_structure.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from property_utils import die
+
 ROOT = Path(__file__).resolve().parent.parent
 
 # Contracts that use non-standard structure (inline proofs, proof-only, etc.)
@@ -29,11 +31,6 @@ EXPECTED_STRUCTURE = [
     "Verity/Proofs/{name}/Basic.lean",
     "Verity/Proofs/{name}/Correctness.lean",
 ]
-
-
-def die(msg: str) -> None:
-    print(f"ERROR: {msg}", file=sys.stderr)
-    sys.exit(1)
 
 
 def find_contracts() -> list[str]:

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -17,6 +17,8 @@ import re
 import sys
 from pathlib import Path
 
+from property_utils import collect_covered
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -84,9 +86,6 @@ def get_covered_count(total_theorems: int) -> tuple[int, int]:
 
     Returns (covered_count, coverage_percent).
     """
-    sys.path.insert(0, str(ROOT / "scripts"))
-    from property_utils import collect_covered
-
     covered = collect_covered()
     covered_count = sum(len(v) for v in covered.values())
     pct = round(covered_count * 100 / total_theorems) if total_theorems else 0

--- a/scripts/check_property_manifest_sync.py
+++ b/scripts/check_property_manifest_sync.py
@@ -29,9 +29,9 @@ def main() -> None:
         missing = sorted(exp_set - act_set)
         extra = sorted(act_set - exp_set)
         if missing:
-            problems.append(f"{contract}: missing {len(missing)} theorem(s) in manifest")
+            problems.append(f"{contract}: missing {len(missing)} theorem(s) in manifest: {', '.join(missing)}")
         if extra:
-            problems.append(f"{contract}: {len(extra)} extra theorem(s) in manifest")
+            problems.append(f"{contract}: {len(extra)} extra theorem(s) in manifest: {', '.join(extra)}")
 
     if problems:
         print("Property manifest is out of sync with proofs:", file=sys.stderr)

--- a/test/DifferentialOwned.t.sol
+++ b/test/DifferentialOwned.t.sol
@@ -176,10 +176,10 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig, DifferentialTestBase 
         address newOwner = address(0xa11ce);
 
         bool success = executeDifferentialTest("transferOwnership", address(this), uint256(uint160(newOwner)));
-        require(success, "Test failed");
+        assertTrue(success, "Test failed");
 
         bool success2 = executeDifferentialTest("getOwner", address(this), 0);
-        require(success2, "Test failed");
+        assertTrue(success2, "Test failed");
     }
 
     function testDifferential_AccessControl() public {
@@ -187,15 +187,15 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig, DifferentialTestBase 
         address newOwner = address(0xa11ce);
 
         bool success = executeDifferentialTest("transferOwnership", nonOwner, uint256(uint160(newOwner)));
-        require(success, "Test failed");
+        assertTrue(success, "Test failed");
 
         bool success2 = executeDifferentialTest("getOwner", address(this), 0);
-        require(success2, "Test failed");
+        assertTrue(success2, "Test failed");
     }
 
     function testDifferential_GetOwner() public {
         bool success = executeDifferentialTest("getOwner", address(this), 0);
-        require(success, "Test failed");
+        assertTrue(success, "Test failed");
     }
 
     function testDifferential_MultipleTransfers() public {
@@ -203,13 +203,13 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig, DifferentialTestBase 
         address bob = address(0xb0b);
 
         bool success1 = executeDifferentialTest("transferOwnership", address(this), uint256(uint160(alice)));
-        require(success1, "Test 1 failed");
+        assertTrue(success1, "Test 1 failed");
 
         bool success2 = executeDifferentialTest("transferOwnership", alice, uint256(uint160(bob)));
-        require(success2, "Test 2 failed");
+        assertTrue(success2, "Test 2 failed");
 
         bool success3 = executeDifferentialTest("getOwner", address(this), 0);
-        require(success3, "Test 3 failed");
+        assertTrue(success3, "Test 3 failed");
     }
 
     function _runRandomOwnershipTests(uint256 startIndex, uint256 numTransactions, uint256 seed) internal {


### PR DESCRIPTION
## Summary
- **DifferentialOwned.t.sol**: Replace 8 \`require()\` calls with \`assertTrue()\` — this file was missed during the PR #307 refactor that standardized all other differential tests
- **verify.yml**: Move \`check_property_manifest_sync.py\` and \`check_storage_layout.py\` from the \`build\` job to the \`checks\` job — neither needs compiled artifacts, so they now run on all PRs (including doc-only PRs) with ~5s latency instead of waiting for the full build
- **check_property_manifest_sync.py**: Include specific theorem names in error messages (not just counts)
- **check_contract_structure.py**: Replace local \`die()\` with \`property_utils.die()\`
- **check_doc_counts.py**: Move \`collect_covered\` import to top level, remove inline \`sys.path.insert\`

## Test plan
- [x] \`python3 scripts/check_doc_counts.py\` passes
- [x] \`python3 scripts/check_contract_structure.py\` passes
- [x] \`python3 scripts/check_property_manifest_sync.py\` passes
- [ ] Foundry tests pass (verifies assertTrue change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CI/test and developer tooling changes; low production risk, with the main impact being earlier CI failures and slightly different test assertion behavior.
> 
> **Overview**
> Moves `check_property_manifest_sync.py` and `check_storage_layout.py` from the `build` job to the always-run `checks` job in `verify.yml`, so these validations run on doc-only PRs without waiting for compilation.
> 
> Consolidates Python verification scripts by reusing `property_utils` (`die` in `check_contract_structure.py`, top-level `collect_covered` import in `check_doc_counts.py`) and improves `check_property_manifest_sync.py` failures to list the specific missing/extra theorem names.
> 
> Updates `DifferentialOwned.t.sol` to use `assertTrue` instead of `require` for test result assertions to match the rest of the differential test suite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc363bc67f2023a0019b99e53620c48a062dfd08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->