### PR TITLE
docs: fix verification completeness and add reverse theorem check

### DIFF
--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -15,7 +15,7 @@ The project evolved in two phases:
 
 **Phase 2 (Verification)**: Replaced `StateM` with custom `ContractResult` type (`success | revert`) to model `require` guards explicitly. This enabled proving properties like "mint reverts when caller is not owner." The core expanded to include proof automation lemmas and EVM context fields.
 
-## Progress and Roadmap (as of 2026-02-14)
+## Progress and Roadmap (as of 2026-02-18)
 
 This is the single source of truth for progress, roadmap, and milestone updates.
 
@@ -241,10 +241,10 @@ FOUNDRY_PROFILE=difftest DIFFTEST_SHARD_COUNT=8 DIFFTEST_SHARD_INDEX=0 DIFFTEST_
 
 **Remaining Work**:
 
-**A. Scale Differential Testing**:
-- Centralize the "random run" entrypoint so each harness can opt into the same seed/count knobs.
-- Add adversarial patterns: boundary overflows, more edge cases.
-- **Done when**: random harness setup is shared and parameterized across all 7 contracts.
+**A. ~~Scale Differential Testing~~** (done — PR #307):
+- ~~Centralize the "random run" entrypoint so each harness can opt into the same seed/count knobs.~~
+- ~~Add adversarial patterns: boundary overflows, more edge cases.~~
+- ~~**Done when**: random harness setup is shared and parameterized across all 7 contracts.~~ All 7 differential tests now inherit `DifferentialTestBase` with shared utilities.
 
 **B. Property Extraction (Proofs → Tests)**:
 - Reduce exclusions. Add property tests contract‑by‑contract. Keep coverage script green.

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -300,6 +300,25 @@ Transfer proofs now handle self-transfer by modeling it as a no-op (preloading b
 | 4 | `transferOwnership_preserves_wellformedness` | Well-formedness preservation |
 | 5 | `increment_survives_transfer` | Counter value survives ownership transfer |
 
+**Isolation:**
+
+| # | Theorem | Property |
+|---|---------|----------|
+| 1 | `increment_count_preserves_owner` | Increment preserves owner address storage |
+| 2 | `decrement_count_preserves_owner` | Decrement preserves owner address storage |
+| 3 | `constructor_owner_preserves_count` | Constructor preserves counter storage |
+| 4 | `transferOwnership_owner_preserves_count` | Transfer preserves counter storage |
+| 5 | `constructor_context_preserved` | Constructor preserves sender/thisAddress |
+| 6 | `increment_context_preserved` | Increment preserves sender/thisAddress |
+| 7 | `decrement_context_preserved` | Decrement preserves sender/thisAddress |
+| 8 | `transferOwnership_context_preserved` | Transfer preserves sender/thisAddress |
+| 9 | `getCount_context_preserved` | getCount preserves sender/thisAddress |
+| 10 | `getOwner_context_preserved` | getOwner preserves sender/thisAddress |
+| 11 | `constructor_preserves_map_storage` | Constructor preserves mapping storage |
+| 12 | `increment_preserves_map_storage` | Increment preserves mapping storage |
+| 13 | `decrement_preserves_map_storage` | Decrement preserves mapping storage |
+| 14 | `transferOwnership_preserves_map_storage` | Transfer preserves mapping storage |
+
 ### Ledger
 
 **Basic:**

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -8,7 +8,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 
 **Core**: Models contract state, storage operations, and `require` guards using explicit success/revert result type (`ContractResult`).
 
-**Contracts**: 9 example contracts with formal verification covering correctness, conservation laws, and storage isolation.
+**Contracts**: 8 formally verified contracts (+ CryptoHash as unverified linker demo) covering correctness, conservation laws, and storage isolation.
 
 **Compiler**: Declarative `ContractSpec` DSL compiles to Yul with verified IR generation. Solidity-compatible function selectors via keccak256.
 


### PR DESCRIPTION
## Summary
- **llms.txt**: fix inaccurate "9 example contracts with formal verification" → "8 formally verified contracts (+ CryptoHash as unverified linker demo)"
- **verification.mdx**: add missing OwnedCounter Isolation table (14 theorems — context preservation, storage isolation, mapping isolation)
- **research.mdx**: update stale date (2026-02-14 → 2026-02-18), mark Item A "Scale Differential Testing" as complete (done in PR #307)
- **check_doc_counts.py**: add reverse completeness check — verifies every manifest theorem for tabled contracts appears in verification.mdx (catches missing sections like the OwnedCounter Isolation gap)

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes (validates all counts + theorem names + reverse completeness)
- [x] `python3 scripts/check_property_manifest.py` passes
- [x] `python3 scripts/check_property_manifest_sync.py` passes
- [x] `python3 scripts/check_contract_structure.py` passes
- [ ] CI `checks` job passes (includes all 7 Python validators)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes plus a stricter documentation validator; low risk aside from potential CI failures if docs and the manifest drift.
> 
> **Overview**
> Updates docs to reflect current status: corrects `llms.txt` to say *8 formally verified contracts* (with CryptoHash called out as unverified), refreshes the `research.mdx` roadmap date, and marks differential testing scale work as completed.
> 
> Expands `verification.mdx` by adding the missing OwnedCounter **Isolation** theorem table.
> 
> Strengthens `scripts/check_doc_counts.py` by adding a reverse completeness validation: it now ensures every manifest theorem for tabled contracts appears in the `verification.mdx` tables (while allowing partial coverage for Stdlib), catching missing documentation sections in addition to unknown theorem names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a77aad90e46ac7eae6a34308863008d8d93fbc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->