### PR TITLE
docs: fix layer counts and complete first-contract checklist

### DIFF
--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -665,6 +665,10 @@ FOUNDRY_PROFILE=difftest forge test --match-contract TipJar
 # 5. All CI checks pass
 python3 scripts/check_selectors.py
 python3 scripts/check_property_manifest.py
+python3 scripts/check_property_manifest_sync.py
+python3 scripts/check_property_coverage.py
+python3 scripts/check_contract_structure.py
+python3 scripts/check_storage_layout.py
 python3 scripts/check_doc_counts.py
 ```
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -19,7 +19,7 @@ The project evolved in two phases:
 
 This is the single source of truth for progress, roadmap, and milestone updates.
 
-- **Layer 1 (Spec Correctness)**: Complete for all 7 contracts.
+- **Layer 1 (Spec Correctness)**: Complete for all 8 verified contracts (7 compiler-spec contracts + ReentrancyExample).
 - **Layer 2 (ContractSpec → IR)**: Complete for all 7 contracts (per‑function preservation theorems compiled in Lean).
 - **Layer 3 (IR → Yul)**: Complete — all 8 statement equivalence proofs + universal dispatcher proven (PR #42).
 

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -25,7 +25,8 @@ The compiler is verified with IR preservation proofs and Yul equivalence proofs 
 ## Compiler Proofs (IR + Yul)
 
 - **Spec semantics**: `Verity/Proofs/Stdlib/SpecInterpreter.lean`
-- **IR generation**: `Compiler/Proofs/IRGeneration/` (complete for all 7 contracts)
+- **Spec correctness**: `Compiler/Proofs/SpecCorrectness/` (complete for all 7 contracts — proves each ContractSpec matches its EDSL)
+- **IR generation**: `Compiler/Proofs/IRGeneration/` (infrastructure + per-contract proofs for Counter, SimpleStorage)
 - **Yul semantics + preservation**: `Compiler/Proofs/YulGeneration/` (complete — PR #42)
 
 ## Structure


### PR DESCRIPTION
## Summary
- **research.mdx**: fix Layer 1 count — "all 7 contracts" → "all 8 verified contracts (7 compiler-spec + ReentrancyExample)". Layer 1 EDSL proofs cover 8 contracts, not 7.
- **verification.mdx**: fix misleading "IR generation complete for all 7 contracts" — `Compiler/Proofs/IRGeneration/` only has per-contract proofs for Counter and SimpleStorage. Split into separate SpecCorrectness (complete for all 7) and IRGeneration lines.
- **first-contract.mdx**: add 4 missing CI checks to the Phase 7 final checklist — `check_contract_structure.py`, `check_property_manifest_sync.py`, `check_property_coverage.py`, `check_storage_layout.py`. These are all run in CI but were missing from the tutorial, causing developers to discover failures only after pushing.

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI `checks` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes; risk is limited to potential confusion if any counts or script names are still inaccurate.
> 
> **Overview**
> Updates documentation to reflect current verification status and CI expectations.
> 
> `research.mdx` corrects the Layer 1 completion statement to cover **8 verified contracts** (including `ReentrancyExample`). `verification.mdx` clarifies compiler proof status by splitting `SpecCorrectness` (complete for 7) from `IRGeneration` (infrastructure + per-contract proofs for Counter/SimpleStorage).
> 
> `first-contract.mdx` expands the final checklist to include additional CI scripts (`check_property_manifest_sync.py`, `check_property_coverage.py`, `check_contract_structure.py`, `check_storage_layout.py`) so developers run the same validations locally before pushing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 257a54cc1a038fa13e33d1c1c6cec29135030ab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->