### PR TITLE
fix: correct test counts, linker docs, and validation checklists

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ lake exe verity-compiler --link examples/external-libs/MyLib.yul -o compiler/yul
 
 **Run tests:**
 ```bash
-FOUNDRY_PROFILE=difftest forge test           # 361 tests across 25 suites
+FOUNDRY_PROFILE=difftest forge test           # 375 tests across 32 suites
 ```
 
 ---
@@ -123,7 +123,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-319 theorems across 9 categories, all fully proven. 361 Foundry tests across 25 test suites. 220 covered by property tests (69% coverage, 99 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+319 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (69% coverage, 99 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -306,12 +306,13 @@ ContractSpec → IR → Yul AST → Yul text → [Linker injects library text] �
 ```
 Library functions are provided via `--link <path.yul>` flags to the compiler CLI. The Linker parses function definitions from library files and injects them as raw text into the rendered Yul output.
 
-**Safety Checks** (enabled in `CompileDriver.lean`):
-1. **External reference validation**: All non-builtin function calls in the contract must be resolved by a linked library
-2. **Duplicate name detection**: No two library functions may share the same name
+**Safety Checks** (implemented in `Compiler/Linker.lean`):
+1. **Duplicate name detection** (`validateNoDuplicateNames`): No two library functions may share the same name
+2. **Name collision detection** (`validateNoNameCollisions`): Library functions cannot shadow Yul builtins (`add`, `sstore`, etc.) or internal helpers (`mappingSlot`)
+3. **External reference validation** (`validateExternalReferences`): All non-builtin function calls in the contract must be resolved by a linked library
+4. **Call arity validation** (`validateCallArity`): Call sites must match the declared parameter count of linked functions
 
 **Remaining Gaps**:
-- Injection is text-level, not AST-level — no syntax or arity checking of library code
 - Library code is entirely outside the formal proof boundary
 
 **Risk Assessment**: **Medium to High** (depends on library)

--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -94,10 +94,13 @@ FOUNDRY_PROFILE=difftest forge test --match-contract Property<Name>
 
 # 4. Property manifest is in sync
 python3 scripts/check_property_manifest.py
+python3 scripts/check_property_manifest_sync.py
 python3 scripts/check_property_coverage.py
 
-# 5. Selectors are correct
+# 5. Selectors and structure are correct
 python3 scripts/check_selectors.py
+python3 scripts/check_contract_structure.py
+python3 scripts/check_doc_counts.py
 ```
 
 **Reference**: See [SimpleStorage](/examples#simplestorage) for a minimal end-to-end example.

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -64,7 +64,7 @@ The first build downloads Mathlib and compiles everything — expect **20–45 m
 FOUNDRY_PROFILE=difftest forge test
 
 # Unit tests only (no FFI needed)
-forge test --no-match-path "test/Property*" --no-match-path "test/Differential*" --no-match-path "test/CallValue*" --no-match-path "test/CalldataSize*"
+forge test --no-match-path "test/Property*" --no-match-path "test/Differential*" --no-match-path "test/CallValue*" --no-match-path "test/CalldataSize*" --no-match-path "test/yul/*"
 ```
 
 The `difftest` profile enables `vm.ffi()` calls so that Foundry can invoke the Lean-based interpreter. This requires `lake build` to have completed successfully.

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 319 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 361 Foundry tests across 25 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 319 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -173,7 +173,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (361 as of 2026-02-17), Lean proofs verify (319 theorems as of 2026-02-17)
+- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (319 theorems as of 2026-02-17)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:
@@ -187,7 +187,7 @@ def ownedSpec : ContractSpec := {
 ```bash
 lake build verity-compiler    # Build compiler
 lake exe verity-compiler      # Generate all contracts
-FOUNDRY_PROFILE=difftest forge test  # 361/361 tests pass (as of 2026-02-17)
+FOUNDRY_PROFILE=difftest forge test  # 375/375 tests pass (as of 2026-02-18)
 ```
 
 ### Differential Testing (Completed 2026-02-10)
@@ -224,7 +224,7 @@ FOUNDRY_PROFILE=difftest forge test  # 361/361 tests pass (as of 2026-02-17)
 - 10,000+ random transactions pass per contract in CI (large suite)
 - Large suite is sharded across 8 CI jobs to stay within per-test gas limits
 - Zero mismatches detected
-- All Foundry tests passing (361 as of 2026-02-17)
+- All Foundry tests passing (375 as of 2026-02-18)
 - CI: All checks passing
 
 **Usage**:

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -19,7 +19,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 319 across 9 categories (319 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 2 documented axioms (see AXIOMS.md) — keccak256, address injectivity
-- **Tests**: 361 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
+- **Tests**: 375 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -20,7 +20,7 @@ EVM Bytecode
 
 ## Layer 1: EDSL ≡ ContractSpec ✅ **COMPLETE**
 
-**Status**: All 9 contracts verified (7 with full spec proofs, 2 with inline proofs)
+**Status**: 8 contracts verified (7 with full spec proofs, 1 with inline proofs); CryptoHash is an unverified linker demo (0 specs)
 
 **What This Layer Proves**: User-facing EDSL contracts satisfy their human-readable specifications.
 

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -51,11 +51,11 @@ def get_axiom_count() -> int:
 
 
 def get_test_counts() -> tuple[int, int]:
-    """Count test functions and test suite files."""
+    """Count test functions and test suite files (recursive, includes test/yul/)."""
     test_dir = ROOT / "test"
-    suite_count = len(list(test_dir.glob("*.t.sol")))
+    suite_count = len(list(test_dir.rglob("*.t.sol")))
     test_count = 0
-    for sol in test_dir.glob("*.t.sol"):
+    for sol in test_dir.rglob("*.t.sol"):
         text = sol.read_text(encoding="utf-8")
         test_count += len(re.findall(r"function\s+test", text))
     return test_count, suite_count

--- a/test/README.md
+++ b/test/README.md
@@ -37,7 +37,7 @@ Basic contract behavior validation without formal property mapping.
 FOUNDRY_PROFILE=difftest forge test
 
 # Unit tests only (no FFI needed)
-forge test --no-match-path "test/Property*" --no-match-path "test/Differential*" --no-match-path "test/CallValue*" --no-match-path "test/CalldataSize*"
+forge test --no-match-path "test/Property*" --no-match-path "test/Differential*" --no-match-path "test/CallValue*" --no-match-path "test/CalldataSize*" --no-match-path "test/yul/*"
 
 # Single contract
 FOUNDRY_PROFILE=difftest forge test --match-path test/PropertyCounter.t.sol


### PR DESCRIPTION
## Summary
- **Root cause fix**: `check_doc_counts.py` used non-recursive `glob("*.t.sol")` instead of `rglob`, silently excluding 7 test suites in `test/yul/` (14 tests). Actual counts: **375 tests across 32 suites** (was reporting 361/25).
- **Test count updates**: README.md, llms.txt, index.mdx, research.mdx all updated from 361→375, 25→32
- **Unit test command fix**: `getting-started.mdx` and `test/README.md` — add `--no-match-path "test/yul/*"` to the "unit tests only (no FFI needed)" command, since yul tests use `deployYul()` which requires FFI
- **VERIFICATION_STATUS.md**: fix "All 9 contracts verified" → "8 verified + CryptoHash unverified demo" (CryptoHash has 0 specs)
- **add-contract.mdx**: add 3 missing CI checks to validation checklist — `check_property_manifest_sync.py`, `check_contract_structure.py`, `check_doc_counts.py`
- **TRUST_ASSUMPTIONS.md**: list all 4 linker safety checks from `Compiler/Linker.lean` (was only 2), remove incorrect claim that "no arity checking" exists (`validateCallArity` has been implemented)

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes (375 tests, 32 suites)
- [x] `python3 scripts/check_property_manifest.py` passes
- [x] `python3 scripts/check_property_manifest_sync.py` passes
- [x] `python3 scripts/check_contract_structure.py` passes
- [ ] CI `checks` job passes
- [ ] CI full pipeline passes (scripts/ changed → triggers build + foundry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a small Python counting-script change; no runtime compiler/proof/test logic is modified, but it may affect CI doc-count gating.
> 
> **Overview**
> Updates documentation and checklists to reflect the *actual* Foundry test totals (**375 tests across 32 suites**) and clarifies that `CryptoHash` is an unverified linker demo (so Layer 1 is 8 verified contracts, not 9).
> 
> Fixes `scripts/check_doc_counts.py` to count Solidity test suites recursively (including `test/yul/`), and updates “unit tests only” commands to exclude `test/yul/*` since those tests require FFI. Also corrects linker trust-boundary docs to list the full set of linker validations (duplicate names, name collisions, unresolved externals, and call-arity mismatches).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4db4523b7567406e2dad44f43ed720ff823bf4f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->