### PR TITLE
fix: stale compiler.mdx test counts, extend CI validation, improve docs

### DIFF
--- a/Compiler/Specs.lean
+++ b/Compiler/Specs.lean
@@ -448,6 +448,11 @@ def safeCounterSpec : ContractSpec := {
 `cryptoHashSpec` is excluded because it requires `--link` flags for external
 Yul libraries (PoseidonT3/T4). Use `lake exe verity-compiler --link ...` to
 compile it separately.
+
+**Adding a new contract**: After adding `myContractSpec` here, also ensure
+each function's selector is pre-computed in `Compiler/Selectors.lean` via
+`computeSelectors`. The compiler will fail at runtime if a function has no
+matching selector.
 -/
 
 def allSpecs : List ContractSpec := [

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -558,7 +558,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 361/361 tests pass
+# Expected: 375/375 tests pass
 ```
 
 ### Add New Contract
@@ -599,10 +599,10 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 361/361 passing (100%)
+**Foundry Tests**: 375/375 passing (100%)
 ```bash
 $ FOUNDRY_PROFILE=difftest forge test
-Ran 25 test suites: 361 tests passed, 0 failed, 0 skipped (361 total tests)
+Ran 32 test suites: 375 tests passed, 0 failed, 0 skipped (375 total tests)
 ```
 
 **Coverage**: Unit, property, and differential tests across EDSL and compiled Yul. See `test/` for suites.

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -67,7 +67,7 @@ FOUNDRY_PROFILE=difftest forge test
 forge test --no-match-path "test/Property*" --no-match-path "test/Differential*" --no-match-path "test/CallValue*" --no-match-path "test/CalldataSize*" --no-match-path "test/yul/*"
 ```
 
-The `difftest` profile enables `vm.ffi()` calls so that Foundry can invoke the Lean-based interpreter. This requires `lake build` to have completed successfully.
+The `difftest` profile enables `vm.ffi()` calls needed by property tests (to invoke `solc` for Yul compilation), differential tests (to invoke the Lean-based interpreter), and Yul end-to-end tests. This requires `lake build` to have completed successfully.
 
 ## 5. Generate your first contract
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,7 +78,7 @@ These CI-critical scripts validate cross-layer consistency:
 
 - **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
 - **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, and Compiler layers; detects intra-contract slot collisions
-- **`check_doc_counts.py`** - Validates theorem, axiom, category, test, suite counts and core size in README.md, llms.txt, core.mdx, index.mdx, and TRUST_ASSUMPTIONS.md against actual codebase data
+- **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage counts across 13 files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx) plus theorem-name completeness in verification.mdx tables
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
 

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -305,6 +305,21 @@ def main() -> None:
                     re.compile(r"Verification.+ — (\d+) proven theorems"),
                     str(total_theorems),
                 ),
+                (
+                    "expected test count",
+                    re.compile(r"Expected: (\d+)/\d+ tests pass"),
+                    str(test_count),
+                ),
+                (
+                    "Foundry test count",
+                    re.compile(r"\*\*Foundry Tests\*\*: (\d+)/"),
+                    str(test_count),
+                ),
+                (
+                    "test suite count",
+                    re.compile(r"Ran (\d+) test suites:"),
+                    str(suite_count),
+                ),
             ],
         )
     )


### PR DESCRIPTION
## Summary
- **compiler.mdx**: fix 3 stale test count references (361→375, 25→32 suites) — these were the last test counts not caught by CI after PR #334 fixed the root `glob→rglob` issue
- **check_doc_counts.py**: add 3 new compiler.mdx validations (expected test count, Foundry test count, test suite count) so these can never drift again
- **scripts/README.md**: update `check_doc_counts.py` description — was listing 5 of 13 validated files, now accurately describes full scope including theorem-name completeness checks
- **getting-started.mdx**: fix difftest profile description — said FFI enables "the Lean-based interpreter" but property tests use FFI for `solc` compilation (confirmed in `YulTestBase.sol` line 29-33)
- **Compiler/Specs.lean**: add `allSpecs` doc comment warning that new entries require pre-computed selectors in `Compiler/Selectors.lean`

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes (375 tests, 32 suites — all 3 new compiler.mdx checks pass)
- [x] `python3 scripts/check_property_manifest.py` passes
- [x] `python3 scripts/check_property_manifest_sync.py` passes
- [x] `python3 scripts/check_contract_structure.py` passes
- [ ] CI full pipeline passes (scripts + Lean source changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI validation tweaks only, plus an additional comment; no production compiler or proof logic changes.
> 
> **Overview**
> Updates documentation to reflect current Foundry metrics (361→375 tests, 25→32 suites) and clarifies that the `difftest` profile’s `vm.ffi()` is used for both `solc`-based Yul compilation (property tests) and the Lean interpreter (differential/Yul e2e tests).
> 
> Extends `scripts/check_doc_counts.py` to *CI-enforce* `compiler.mdx`’s expected test count, Foundry test count, and suite count so these numbers can’t drift again, and updates `scripts/README.md` to reflect the script’s expanded validation scope.
> 
> Adds a `Compiler/Specs.lean` note warning that new entries in `allSpecs` require precomputed function selectors in `Compiler/Selectors.lean` to avoid runtime failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d95071261d6ea0344e9270f32ff0d0e2097b983d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->