### PR TITLE
fix: scaffold generator missing selector step and stub hints

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -162,16 +162,16 @@ def gen_example(cfg: ContractConfig) -> str:
             suffix = fn.name[len(matched_prefix):]
             if matched_prefix in ("is", "has"):
                 ret_type = "Contract Bool"
-                ret_val = "pure false"
+                ret_val = "pure false  -- TODO: implement predicate (see OwnedCounter.lean)"
             elif suffix.lower() in addr_field_names:
                 ret_type = "Contract Address"
-                ret_val = 'pure ""'
+                ret_val = 'pure ""  -- TODO: use getStorageAddr <slot> (see Owned.lean)'
             else:
                 ret_type = "Contract Uint256"
-                ret_val = "pure 0"
+                ret_val = "pure 0  -- TODO: use getStorage <slot> (see SimpleStorage.lean)"
         else:
             ret_type = "Contract Unit"
-            ret_val = "pure ()"
+            ret_val = "pure ()  -- TODO: implement (see Counter.lean for mutating ops)"
         func_lines.append(f"-- TODO: Implement {fn.name}")
         func_lines.append(f"def {fn.name} : {ret_type} := do")
         func_lines.append(f"  {ret_val}")
@@ -683,20 +683,23 @@ Examples:
 
     print(f"3. Register in allSpecs (Compiler/Specs.lean):")
     print(f"   Find 'def allSpecs' and add '{name_lower}Spec' to the list.")
+    print(f"   Also add selectors for each function in Compiler/Selectors.lean")
+    print(f"   (see existing selectors for the pattern using keccak256_first_4_bytes).")
     print()
 
     print(f"4. Create differential tests (not scaffolded):")
     print(f"   Copy test/DifferentialCounter.t.sol to test/Differential{name}.t.sol")
-    print(f"   Inherit YulTestBase, DiffTestConfig, and DifferentialTestBase")
+    print(f"   Inherit YulTestBase, DiffTestConfig, and DifferentialTestBase (all three required)")
     print()
 
-    print("5. Run validation:")
+    print("5. Run validation (see add-contract.mdx for the full checklist):")
     print("   lake build")
-    print(f"   FOUNDRY_PROFILE=difftest forge test --match-contract Property{name}")
-    print("   python3 scripts/check_property_coverage.py")
-    print()
-
-    print("See docs-site/content/add-contract.mdx for the full checklist.")
+    print(f"   FOUNDRY_PROFILE=difftest forge test --match-contract {name}")
+    print("   python3 scripts/check_property_manifest.py")
+    print("   python3 scripts/check_property_manifest_sync.py")
+    print("   python3 scripts/check_contract_structure.py")
+    print("   python3 scripts/check_selectors.py")
+    print("   python3 scripts/check_doc_counts.py")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Step 3 (selector requirement)**: The scaffold tells developers to add their spec to `allSpecs` but didn't mention that function selectors must also be pre-computed in `Compiler/Selectors.lean`. Without this, `lake exe verity-compiler` crashes at runtime with no helpful error message.
- **Step 5 (validation commands)**: Was only listing `lake build`, one forge test, and `check_property_coverage.py`. Now lists the full CI validation checklist (5 scripts) with a reference to add-contract.mdx.
- **Getter stubs**: All 4 stub types now include TODO hints pointing to reference contract files:
  - `pure 0` → "TODO: use getStorage \<slot\> (see SimpleStorage.lean)"
  - `pure ""` → "TODO: use getStorageAddr \<slot\> (see Owned.lean)"
  - `pure false` → "TODO: implement predicate (see OwnedCounter.lean)"
  - `pure ()` → "TODO: implement (see Counter.lean for mutating ops)"

## Test plan
- [x] `python3 scripts/generate_contract.py TestVault --fields "balance:uint256,owner:address" --functions "getBalance,getOwner,isOwner,deposit,withdraw" --dry-run` — output shows selector step, full validation, and reference hints
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI full pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring/output-only guidance changes and comment-level stub hints; no runtime behavior changes beyond what the generator prints/emits in scaffolds.
> 
> **Overview**
> Updates `scripts/generate_contract.py` to make generated Lean stubs more actionable by appending targeted TODO guidance for each stub return (uint/address/bool/unit) pointing to reference contracts.
> 
> Improves the scaffold’s printed “Manual steps” by explicitly calling out the need to add function selectors in `Compiler/Selectors.lean`, tightening the differential test inheritance instruction, and expanding the validation checklist to match the full set of CI scripts (and updating the forge match-contract target).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6606d9f2f3df54767d1803d52f2906b79fa5dbc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->