### PR TITLE
docs: fix linking guide Yul syntax, CI section, and stale reference

### DIFF
--- a/docs-site/content/guides/debugging-proofs.mdx
+++ b/docs-site/content/guides/debugging-proofs.mdx
@@ -563,7 +563,7 @@ example : (a + 0) = a := rfl  -- Works if definitionally equal
 
 ## Real Examples from Verity
 
-Verity proofs follow the **`_meets_spec` pattern**: each EDSL operation has a corresponding `_spec` predicate, and the proof shows the operation satisfies it. This is the dominant pattern across all 9 contracts.
+Verity proofs follow the **`_meets_spec` pattern**: each EDSL operation has a corresponding `_spec` predicate, and the proof shows the operation satisfies it. This is the dominant pattern across all verified contracts.
 
 ### Example 1: SimpleStorage retrieve (spec-based proof)
 

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -154,9 +154,12 @@ def storeHashThree (a b c : Uint256) : Contract Unit := do
 **External library** (`examples/external-libs/PoseidonT3.yul`):
 ```yul
 function PoseidonT3_hash(a, b) -> result {
-    result := add(xor(a, b), 0x1234...)
+    // Placeholder — real Poseidon uses field arithmetic and S-boxes
+    result := add(xor(a, b), 0x1234567890abcdef)
 }
 ```
+
+> The EDSL function (`hashTwo`) is a placeholder used only in formal proofs — it never appears in the compiled Yul. The ContractSpec's `Expr.externalCall "PoseidonT3_hash"` is what the compiler actually emits, and the linker resolves it to the library function above.
 
 **Compile with linking**:
 ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -131,16 +131,24 @@ Creates 7 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic 
 
 ## CI Integration
 
-All verification scripts run automatically in GitHub Actions (`verify.yml`):
-1. Property manifest sync check
-2. Property coverage validation
-3. Selector hash verification (against Lean specs and solc output)
-4. Yul compilation check
-5. Storage layout consistency validation
-6. Contract file structure validation
-7. Axiom location validation
-8. Documentation count validation
-9. Coverage reports in workflow summary
+Scripts run automatically in GitHub Actions (`verify.yml`) across two jobs:
+
+**`checks` job** (fast, no Lean build required):
+1. Property manifest validation (`check_property_manifest.py`)
+2. Property coverage validation (`check_property_coverage.py`)
+3. Contract file structure validation (`check_contract_structure.py`)
+4. Axiom location validation (`check_axiom_locations.py`)
+5. Documentation count validation (`check_doc_counts.py`)
+6. Property manifest sync (`check_property_manifest_sync.py`)
+7. Storage layout consistency (`check_storage_layout.py`)
+
+**`build` job** (requires `lake build` artifacts):
+1. Keccak-256 self-test (`keccak256.py --self-test`)
+2. Selector hash verification (`check_selectors.py`)
+3. Selector axiom validation (`validate_selectors.py`)
+4. Yul compilation check (`check_yul_compiles.py`)
+5. Selector fixture check (`check_selector_fixtures.py`)
+6. Coverage and storage layout reports in workflow summary
 
 ## Adding New Property Tests
 


### PR DESCRIPTION
## Summary
- **linking-libraries.mdx**: fix invalid Yul pseudocode `0x1234...` (not valid Yul — would cause solc parse error if copy-pasted). Replaced with valid hex constant `0x1234567890abcdef`. Added note explaining the EDSL/ContractSpec name split — the EDSL placeholder is for proofs only, `Expr.externalCall` is what the compiler emits.
- **scripts/README.md**: rewrote CI integration section — was a flat list of 9 items that didn't match actual `verify.yml` (3 items were in the wrong job or missing). Now accurately shows 7 scripts in `checks` job (fast, no Lean build) and 5+2 scripts in `build` job (requires Lake artifacts).
- **debugging-proofs.mdx**: fix "all 9 contracts" → "all verified contracts" to avoid a hardcoded count that will drift.

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI `checks` job passes (doc-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes; main risk is minor confusion if script/job names drift again, with no runtime or verification logic impacted.
> 
> **Overview**
> Updates docs to avoid stale/misleading references and improve copy-pastability.
> 
> In `linking-libraries.mdx`, replaces invalid Yul pseudo-hex (`0x1234...`) with a valid constant and adds a clarifying note that the Lean EDSL hash function is proof-only while the compiler emits `Expr.externalCall` for linking.
> 
> In `scripts/README.md`, rewrites the CI integration section to match `verify.yml` by splitting steps into `checks` (fast, no Lean build) vs `build` (requires `lake build`) and listing the scripts run in each. In `debugging-proofs.mdx`, removes a hardcoded contract count (“all 9 contracts”) in favor of “all verified contracts.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3c499a97feb7f4c4a6c8fe4c9cc714887ecce18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->