### PR TITLE
docs: fix wrong imports, add missing spec helpers, expand checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,10 @@ FOUNDRY_PROFILE=difftest forge test  # Must pass — runs all Foundry tests
 - `docs/VERIFICATION_STATUS.md` — Contract table and coverage stats
 - `docs-site/public/llms.txt` — Quick Facts and theorem breakdown table
 - `docs-site/content/verification.mdx` — Snapshot section
+- `docs-site/content/examples.mdx` — Contract descriptions and count
+- Plus any other files that reference theorem/test/contract counts (e.g., `compiler.mdx`, `research.mdx`, `index.mdx`, `layout.tsx`, `ROADMAP.md`, `TRUST_ASSUMPTIONS.md`, `test/README.md`)
 - Run `python3 scripts/check_contract_structure.py` to verify file structure is complete
-- Run `python3 scripts/check_doc_counts.py` to verify all counts are synchronized
+- Run `python3 scripts/check_doc_counts.py` to verify all counts are synchronized (validates 13 files)
 
 ## Code Style
 

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -131,7 +131,7 @@ These return values from `ContractState` without modifying state.
 ## Event emission
 
 ```lean
-emitEvent "Transfer" [fromBal, toBal] [addressToNat from, addressToNat to]
+emitEvent "Transfer" [amount] [senderBal, recipientBal]
 ```
 
 `emitEvent name args indexedArgs` appends to the `events` log. The `indexedArgs` parameter is optional (defaults to `[]`).
@@ -240,6 +240,18 @@ Use these instead of conjunctions of atomics:
 
 All composites include `sameContext`.
 
+### Mixed storage+context helpers
+
+These combine two atomic storage checks with `sameContext`. They are the most commonly used helpers in practice — appearing in nearly every spec:
+
+| Helper | Meaning | Use when operation only writes... |
+|--------|---------|-----------------------------------|
+| `sameAddrMapContext s s'` | `sameStorageAddr ∧ sameStorageMap ∧ sameContext` | `setStorage` (uint256 slot only) |
+| `sameStorageMapContext s s'` | `sameStorage ∧ sameStorageMap ∧ sameContext` | `setStorageAddr` (address slot only) |
+| `sameStorageAddrContext s s'` | `sameStorage ∧ sameStorageAddr ∧ sameContext` | `setMapping` (mapping only) |
+
+**Example**: A counter's `increment` spec modifies a uint256 storage slot, so the unchanged-state predicate is `sameAddrMapContext` (address storage, mapping storage, and context are all unchanged).
+
 ### Fine-grained helpers (specific slot or key)
 
 For operations that modify a single entry in a mapping:
@@ -256,14 +268,14 @@ For operations that modify a single entry in a mapping:
 
 ### Choosing the right helper
 
-| Operation | Composite | Fine-grained |
-|-----------|-----------|--------------|
-| `setStorage count v` | `sameExceptStorage` | `storageUnchangedExcept count.slot` |
-| `setStorageAddr owner v` | `sameExceptStorageAddr` | `storageAddrUnchangedExcept owner.slot` |
-| `setMapping balances addr v` | `sameExceptStorageMap` | `storageMapUnchangedExceptKeyAtSlot balances.slot addr` |
-| ERC20 transfer (two keys) | `sameExceptStorageMap` | `storageMapUnchangedExceptKeysAtSlot balances.slot from to` |
-| `setMappingUint prices id v` | `sameExceptStorageMapUint` | `storageMapUintUnchangedExceptKey prices.slot id` |
-| Read-only (`getStorage`, etc.) | `sameAllStorage ∧ sameContext` | — |
+| Operation | Mixed (most common) | Composite (strictest) | Fine-grained |
+|-----------|---------------------|----------------------|--------------|
+| `setStorage count v` | `sameAddrMapContext` | `sameExceptStorage` | `storageUnchangedExcept count.slot` |
+| `setStorageAddr owner v` | `sameStorageMapContext` | `sameExceptStorageAddr` | `storageAddrUnchangedExcept owner.slot` |
+| `setMapping balances addr v` | `sameStorageAddrContext` | `sameExceptStorageMap` | `storageMapUnchangedExceptKeyAtSlot balances.slot addr` |
+| ERC20 transfer (two keys) | `sameStorageAddrContext` | `sameExceptStorageMap` | `storageMapUnchangedExceptKeysAtSlot balances.slot from to` |
+| `setMappingUint prices id v` | — | `sameExceptStorageMapUint` | `storageMapUintUnchangedExceptKey prices.slot id` |
+| Read-only (`getStorage`, etc.) | — | `sameAllStorage ∧ sameContext` | — |
 
 ## Source
 

--- a/docs-site/content/guides/debugging-proofs.mdx
+++ b/docs-site/content/guides/debugging-proofs.mdx
@@ -153,7 +153,7 @@ have h' : a + b < MAX + 1 := by omega
 #check (5 : Uint256)  -- Error: failed to synthesize OfNat
 
 -- ✅ WORKS
-import Verity.Core.Uint256
+import Verity.EVM.Uint256
 #check (5 : Uint256)  -- Now works
 ```
 
@@ -453,9 +453,9 @@ theorem good_order : getValue state = value := by
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| "unknown identifier 'Uint256'" | Missing import | `import Verity.Core.Uint256` |
-| "unknown identifier 'Contract'" | Missing import | `import Verity.Core` |
-| "unknown identifier 'ContractState'" | Missing import | `import Verity.Core` |
+| "unknown identifier 'Uint256'" | Missing import | `import Verity.EVM.Uint256` |
+| "unknown identifier 'Contract'" | Missing import | `import Verity.Core` and `open Verity` |
+| "unknown identifier 'ContractState'" | Missing import | `import Verity.Core` and `open Verity` |
 | "ambiguous identifier" | Multiple imports | Use fully qualified name |
 
 ### Type Class Errors


### PR DESCRIPTION
## Summary
- **debugging-proofs.mdx**: Fix wrong `Uint256` import (`Verity.Core.Uint256` → `Verity.EVM.Uint256`) — all user-facing code uses the EVM module. Add `open Verity` requirement for `Contract`/`ContractState` identifiers.
- **core.mdx**: Add 3 missing mixed storage+context helpers (`sameAddrMapContext`, `sameStorageMapContext`, `sameStorageAddrContext`) that appear in 15+ spec uses but were absent from the reference table. Fix `emitEvent` example that used `addressToNat` (unavailable in EDSL scope). Add "Mixed" column to the helper chooser table.
- **CONTRIBUTING.md**: Expand the new-contract checklist to mention all 13 files validated by `check_doc_counts.py`, not just 5.

## Test plan
- [ ] `python3 scripts/check_doc_counts.py` passes
- [ ] Verify `Verity.EVM.Uint256` is the correct user-facing import (grep confirms all Examples/Specs/Proofs use it)
- [ ] Verify the 3 mixed helpers exist in `Verity/Specs/Common.lean` and are used across spec files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes; risk is limited to potentially misleading guidance if any referenced helpers/imports are still incorrect.
> 
> **Overview**
> Updates documentation to match actual user-facing modules and spec patterns.
> 
> Fixes `debugging-proofs.mdx` examples/error-table to import `Verity.EVM.Uint256` (and note `open Verity` for `Contract`/`ContractState`), corrects the `emitEvent` example in `core.mdx`, and adds missing “mixed storage+context” unchanged-state helpers plus an updated helper-selection table.
> 
> Expands `CONTRIBUTING.md`’s new-contract checklist to call out additional files that must stay in sync and clarifies that `check_doc_counts.py` validates 13 files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40546fec08eaffc75d13509d784dc018b72371cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->