### PR TITLE
docs: fix examples.mdx code snippets and stale counts

### DIFF
--- a/docs-site/content/examples.mdx
+++ b/docs-site/content/examples.mdx
@@ -55,11 +55,11 @@ def count : StorageSlot Uint256 := ⟨0⟩
 
 def increment : Contract Unit := do
   let current ← getStorage count
-  setStorage count (current + 1)
+  setStorage count (add current 1)
 
 def decrement : Contract Unit := do
   let current ← getStorage count
-  setStorage count (current - 1)
+  setStorage count (sub current 1)
 ```
 
 Proofs cover arithmetic, composition (two increments add 2), and decrement-at-zero behavior.
@@ -107,7 +107,7 @@ def count : StorageSlot Uint256 := ⟨1⟩
 def increment : Contract Unit := do
   onlyOwner
   let current ← getStorage count
-  setStorage count (current + 1)
+  setStorage count (add current 1)
 ```
 
 Proofs cover cross-pattern composition, ownership transfer locking out old owner, and counter value surviving ownership transfer.
@@ -117,21 +117,21 @@ Proofs cover cross-pattern composition, ownership transfer locking out old owner
 Mapping storage for per-address balances with deposit, withdraw, and transfer.
 
 ```lean
--- Simplified — full code includes self-transfer guard and safeAdd overflow checks
+-- Simplified — full code includes self-transfer guard and safeAdd overflow check on transfer
 def balances : StorageSlot (Address → Uint256) := ⟨0⟩
 
 def deposit (amount : Uint256) : Contract Unit := do
   let sender ← msgSender
   let currentBalance ← getMapping balances sender
-  setMapping balances sender (currentBalance + amount)
+  setMapping balances sender (add currentBalance amount)
 
 def transfer (to : Address) (amount : Uint256) : Contract Unit := do
   let sender ← msgSender
   let senderBalance ← getMapping balances sender
   require (senderBalance >= amount) "Insufficient balance"
   let recipientBalance ← getMapping balances to
-  setMapping balances sender (senderBalance - amount)
-  setMapping balances to (recipientBalance + amount)
+  setMapping balances sender (sub senderBalance amount)
+  setMapping balances to (add recipientBalance amount)
 ```
 
 Proofs cover balance guards, deposit/withdraw/transfer sum equations, and deposit-withdraw cancellation.
@@ -141,7 +141,7 @@ Proofs cover balance guards, deposit/withdraw/transfer sum equations, and deposi
 Composes Owned and Ledger. Adds owner-controlled minting and supply tracking.
 
 ```lean
--- Simplified — full code includes safeAdd overflow checks and self-transfer guard
+-- Simplified — full code uses safeAdd for overflow checks and self-transfer guard
 def owner : StorageSlot Address := ⟨0⟩
 def balances : StorageSlot (Address → Uint256) := ⟨1⟩
 def totalSupply : StorageSlot Uint256 := ⟨2⟩
@@ -149,17 +149,19 @@ def totalSupply : StorageSlot Uint256 := ⟨2⟩
 def mint (to : Address) (amount : Uint256) : Contract Unit := do
   onlyOwner
   let currentBalance ← getMapping balances to
-  setMapping balances to (currentBalance + amount)
+  let newBalance ← requireSomeUint (safeAdd currentBalance amount) "Balance overflow"
   let currentSupply ← getStorage totalSupply
-  setStorage totalSupply (currentSupply + amount)
+  let newSupply ← requireSomeUint (safeAdd currentSupply amount) "Supply overflow"
+  setMapping balances to newBalance
+  setStorage totalSupply newSupply
 
 def transfer (to : Address) (amount : Uint256) : Contract Unit := do
   let sender ← msgSender
   let senderBalance ← getMapping balances sender
   require (senderBalance >= amount) "Insufficient balance"
   let recipientBalance ← getMapping balances to
-  setMapping balances sender (senderBalance - amount)
-  setMapping balances to (recipientBalance + amount)
+  setMapping balances sender (sub senderBalance amount)
+  setMapping balances to (add recipientBalance amount)
 ```
 
 Proofs cover mint/transfer correctness, supply conservation equations, and storage isolation across all three slot types.
@@ -173,8 +175,11 @@ Two parallel bank contracts — one vulnerable, one safe — demonstrating that 
 -- Modeled by subtracting totalSupply twice, balance once
 theorem vulnerable_attack_exists :
   ∃ (s : ContractState),
+    s.storageMap balances.slot "attacker" = (Verity.EVM.MAX_UINT256 : Uint256) ∧
+    s.storage totalSupply.slot = (Verity.EVM.MAX_UINT256 : Uint256) ∧
     supplyInvariant s ["attacker"] ∧
-    ¬ supplyInvariant ((withdraw MAX_UINT256).runState s) ["attacker"]
+    let s' := (withdraw (Verity.EVM.MAX_UINT256 : Uint256)).runState s;
+    ¬ supplyInvariant s' ["attacker"]
 
 -- Safe: state update before external call
 -- The supply invariant is universally provable

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 
 ## Current Status
 
-- ✅ **Layer 1 Complete**: 319 theorems across 9 contracts (EDSL ≡ ContractSpec)
+- ✅ **Layer 1 Complete**: 319 theorems across 9 categories (8 contracts + Stdlib math library)
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
 - ✅ **Property Testing**: 69% coverage (220/319), all testable properties covered

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -366,8 +366,8 @@ def main() -> None:
                     str(exclusion_count),
                 ),
                 (
-                    "property test count in tree",
-                    re.compile(r"Property tests \((\d+) tests\)"),
+                    "property test coverage in tree",
+                    re.compile(r"covering (\d+)/\d+ theorems"),
                     str(covered_count),
                 ),
             ],

--- a/test/README.md
+++ b/test/README.md
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (220 tests)
+├── Property*.t.sol           # Property tests (184 functions, covering 220/319 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests


### PR DESCRIPTION
## Summary
- **examples.mdx**: Fix all code snippets to use actual EDSL functions (`add`/`sub`) instead of Lean's native `+`/`-` operators. A developer copying these snippets would get compile errors. Also: fix Ledger deposit comment (claimed `safeAdd` but uses raw `add`), update SimpleToken mint to show actual `safeAdd` pattern, fix ReentrancyExample `vulnerable_attack_exists` theorem (was missing 2 of 4 preconditions).
- **test/README.md**: File tree said "Property tests (220 tests)" — 220 is theorem coverage count, not test function count. Actual: 184 `testProperty_` functions covering 220/319 theorems.
- **ROADMAP.md**: "319 theorems across 9 contracts" — 1 of the 9 manifest categories is `Stdlib` (a math library), not a contract. Changed to "9 categories (8 contracts + Stdlib math library)".
- **check_doc_counts.py**: Update regex to match new test/README.md format.

## Test plan
- [ ] `python3 scripts/check_doc_counts.py` passes
- [ ] Verify Counter/OwnedCounter use `add`/`sub` (not `+`/`-`) in actual EDSL code
- [ ] Verify ReentrancyExample theorem has 4 conjuncts in actual source
- [ ] Verify 184 `testProperty_` functions across Property*.t.sol files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates plus a small doc-count validation regex tweak; no production code or verification logic changes.
> 
> **Overview**
> Fixes `docs-site/content/examples.mdx` so copied snippets compile against the EDSL (replacing Lean `+`/`-` with `add`/`sub`), updates the `SimpleToken.mint` snippet to demonstrate `safeAdd`-based overflow checks, and corrects the reentrancy “attack exists” theorem snippet to include the missing preconditions.
> 
> Refreshes documentation metrics to match current reality: clarifies the roadmap’s “9” as *categories* (8 contracts + Stdlib), updates `test/README.md` to distinguish property test function count vs theorem coverage, and adjusts `scripts/check_doc_counts.py` regexes accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b58068a8085131408b1797e0340027fb5c79c45f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->