### PR TITLE
fix: stale issue refs in TRUST_ASSUMPTIONS, extend CI validation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ FOUNDRY_PROFILE=difftest forge test  # Must pass — runs all Foundry tests
 - `docs-site/content/examples.mdx` — Contract descriptions and count
 - Plus any other files that reference theorem/test/contract counts (e.g., `compiler.mdx`, `research.mdx`, `index.mdx`, `layout.tsx`, `ROADMAP.md`, `TRUST_ASSUMPTIONS.md`, `test/README.md`)
 - Run `python3 scripts/check_contract_structure.py` to verify file structure is complete
-- Run `python3 scripts/check_doc_counts.py` to verify all counts are synchronized (validates 13 files)
+- Run `python3 scripts/check_doc_counts.py` to verify all counts are synchronized (validates 14 files)
 
 ## Code Style
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -321,7 +321,7 @@ Library functions are provided via `--link <path.yul>` flags to the compiler CLI
 - Recommendation: Minimize external dependencies, audit linked libraries independently
 
 **Future Work**:
-- Issue #71: Integrate EVMYulLean precompiled contracts
+- Issue #294: EVMYulLean integration (includes precompiled contracts)
 - Formal interface specifications for external calls
 
 ---
@@ -568,7 +568,7 @@ Since `Address = String`, any string can be used as an address. The axiom `addre
 - Document gas assumptions in contract README
 - For high-value contracts: consider formal gas verification (future work)
 
-**Future Work** (Issue #80, #174):
+**Future Work** (Issue #262):
 - Add gas cost annotations to ContractSpec
 - Model gas in Yul semantics
 - Prove gas bounds for critical functions
@@ -634,7 +634,7 @@ Use this checklist when performing security audits of Verity-verified contracts.
 - [ ] Verify compiled bytecode matches Yul output
 - [ ] Check function selectors against specifications
 - [ ] Validate storage layout (issue #84)
-- [ ] Confirm gas costs are acceptable (issue #80)
+- [ ] Confirm gas costs are acceptable (issue #262)
 - [ ] Run gas estimates: `FOUNDRY_PROFILE=difftest forge test --gas-report`
 - [ ] Add gas bounds to property tests for critical functions
 
@@ -650,12 +650,12 @@ Use this checklist when performing security audits of Verity-verified contracts.
 
 ### Short-term (3-6 months)
 
-1. **EVMYulLean UInt256 Integration** (Issue #67)
+1. **EVMYulLean UInt256 Integration** (Issue #294)
    - Replace current Uint256 with EVMYulLean's verified implementation
    - Reduces trust in arithmetic operations
    - Effort: 3 days
 
-2. **Precompiled Contracts Integration** (Issue #71)
+2. **Precompiled Contracts Integration** (Issue #294)
    - Use EVMYulLean's verified precompiles
    - Reduces trust in cryptographic operations
    - Effort: 2 weeks
@@ -683,7 +683,7 @@ Use this checklist when performing security audits of Verity-verified contracts.
    - Remaining: formalize hex string parsing for `addressToNat_injective`
    - Remaining: prove `keccak256_first_4_bytes` via a Lean keccak256 implementation
 
-3. **Gas Cost Verification** (Issue #80)
+3. **Gas Cost Verification** (Issue #262)
    - Formally verify gas bounds
    - Prevents DoS via gas exhaustion
    - Effort: 6 weeks
@@ -714,7 +714,7 @@ Verity provides **strong formal verification** with a **small trusted computing 
 ✅ Contract implementations match specifications (Layer 1)
 ✅ Specifications preserved through compilation (Layer 2)
 ✅ IR semantics equivalent to Yul semantics (Layer 3)
-✅ 319 theorems across 9 contracts (220 covered by property tests)
+✅ 319 theorems across 9 categories (220 covered by property tests)
 
 ### What is Trusted (Validated but Not Proven)
 ⚠️ Solidity compiler (solc) - Validated by 70k+ differential tests

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -362,6 +362,26 @@ def main() -> None:
                     re.compile(r"FULLY VERIFIED, (\d+) axioms"),
                     str(axiom_count),
                 ),
+                (
+                    "covered count",
+                    re.compile(r"(\d+) theorems have corresponding Foundry property tests"),
+                    str(covered_count),
+                ),
+                (
+                    "coverage percentage",
+                    re.compile(r"(\d+)% runtime test coverage"),
+                    str(coverage_pct),
+                ),
+                (
+                    "theorem count in summary",
+                    re.compile(r"(\d+) theorems across \d+ categor"),
+                    str(total_theorems),
+                ),
+                (
+                    "category count in summary",
+                    re.compile(r"\d+ theorems across (\d+) categor"),
+                    str(num_categories),
+                ),
             ],
         )
     )


### PR DESCRIPTION
## Summary
- **TRUST_ASSUMPTIONS.md**: Update 5 stale closed issue references to their open replacements: `#67`→`#294` (EVMYulLean), `#71`→`#294` (precompiled contracts), `#80`/`#174`→`#262` (gas modeling). Fix "9 contracts"→"9 categories" (Stdlib is a math library, not a contract).
- **check_doc_counts.py**: Add 4 new TRUST_ASSUMPTIONS.md validations (covered count 220, coverage percentage 69%, theorem count 319, category count 9) to prevent silent drift.
- **CONTRIBUTING.md**: Fix `check_doc_counts.py` file count description (`13`→`14`).

## Test plan
- [ ] `python3 scripts/check_doc_counts.py` passes (validates new TRUST_ASSUMPTIONS checks)
- [ ] Verify issues #67, #71, #80, #174 are closed and #294, #262 are open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only edits plus stricter documentation count checks; low risk aside from potential CI failures if future doc wording diverges from expected patterns.
> 
> **Overview**
> Updates `TRUST_ASSUMPTIONS.md` to replace stale issue references (EVMYulLean/precompiles/gas work) and to correct the concluding claim from “9 contracts” to “9 categories.”
> 
> Extends `scripts/check_doc_counts.py` to CI-validate additional `TRUST_ASSUMPTIONS.md` metrics (covered theorem count, coverage %, total theorems, and category count) and updates `CONTRIBUTING.md` to reflect the increased number of files checked by that script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e0aeff8ea79b608a931ccf02b94412dbe725e2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->