### PR TITLE
fix: scaffold getter proof stubs, debugging-proofs type error, docs

### DIFF
--- a/docs-site/content/guides/debugging-proofs.mdx
+++ b/docs-site/content/guides/debugging-proofs.mdx
@@ -361,8 +361,9 @@ theorem two_updates (s : ContractState) :
 
 ```lean
 -- Pattern: Operation succeeds when authorized
-theorem authorized_succeeds (h : state.owner = sender) :
-    (operation sender).isSuccess = true := by
+theorem authorized_succeeds (state : ContractState) (sender : Address)
+    (h : state.storageAddr owner.slot = sender) :
+    ((operation sender).run state).isSuccess = true := by
   unfold operation onlyOwner require
   simp [h]  -- Simplifies sender = owner check
   -- Prove rest of operation

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -622,7 +622,7 @@ contract PropertyTipJarTest is YulTestBase {
 ```
 
 **Key patterns to understand**:
-- `deployYul("TipJar")` compiles and deploys your `compiler/yul/TipJar.yul` contract
+- `deployYul("TipJar")` deploys your pre-generated `compiler/yul/TipJar.yul` contract (via `solc` assembly through `vm.ffi`)
 - `vm.prank(sender)` sets `msg.sender` for the next call (Foundry cheatcode)
 - `vm.load`/`vm.store` read/write raw storage slots (for assertions and test setup)
 - Mapping slot formula: `keccak256(abi.encode(key, baseSlot))` — this is the standard Solidity storage layout


### PR DESCRIPTION
## Summary
- **generate_contract.py**: Fix getter proof stubs to use `.fst` (return value extraction, matching `retrieve_meets_spec`) instead of `.snd` (output state). Mutator stubs keep `.snd` but gain a TODO hint about adding function parameters. Also fix Uint256 import: now imports `Verity.EVM.Uint256` for all contracts with `uint256` fields, not just mapping contracts — otherwise specs using `add`/`sub` fail with "unknown identifier".
- **debugging-proofs.mdx**: Fix `authorized_succeeds` proof pattern which had `(operation sender).isSuccess = true` — a type error since `.isSuccess` is defined on `ContractResult`, not `Contract`. Fixed to `((operation sender).run state).isSuccess = true`.
- **first-contract.mdx**: Fix `deployYul` description from "compiles and deploys" to "deploys pre-generated Yul via solc" — the Lean compiler generates the Yul file; `deployYul` only assembles it via `solc`.

## Test plan
- [ ] `python3 scripts/check_doc_counts.py` passes
- [ ] Verify `ContractResult.isSuccess` is on `ContractResult`, not `Contract` (`Verity/Core.lean:128`)
- [ ] Verify `retrieve_meets_spec` uses `.fst` pattern (`Verity/Proofs/SimpleStorage/Basic.lean:81`)
- [ ] Test scaffold: `python3 scripts/generate_contract.py TestContract --fields "value:uint256" --functions "getValue,setValue"` should show correct getter/mutator proof stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to scaffolding output and documentation; no runtime contract logic or verification primitives are modified.
> 
> **Overview**
> Fixes scaffolded Lean proof generation and docs for contract execution results. `generate_contract.py` now emits getter `_meets_spec` stubs that bind the return value via `((op).run s).fst` (instead of incorrectly using `.snd`), and ensures `Verity.EVM.Uint256` is imported/opened whenever a contract has `uint256` fields (not only mappings).
> 
> Docs are corrected to match the runtime model: the proof debugging guide’s authorization pattern now checks `((operation sender).run state).isSuccess`, and the first-contract guide clarifies `deployYul` deploys pre-generated Yul via `solc`/`vm.ffi` rather than compiling it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 193e308175d2b081a81024287358bb8619455b07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->