### PR TITLE
fix: scaffold compiler spec getter stubs + first-contract Lake note

### DIFF
--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -404,7 +404,7 @@ Function selectors (the first 4 bytes of `keccak256("functionName(paramTypes)")`
 
 ### 5.3 Write Layer 2 Proofs
 
-Layer 2 proofs show that the `ContractSpec` you just wrote faithfully represents the EDSL implementation. Create `Compiler/Proofs/SpecCorrectness/TipJar.lean`:
+Layer 2 proofs show that the `ContractSpec` you just wrote faithfully represents the EDSL implementation. Create `Compiler/Proofs/SpecCorrectness/TipJar.lean` (Lake discovers all `.lean` files under `Compiler/` automatically via `globs := #[.andSubmodules `Compiler]` in `lakefile.lean`, so no registration is needed):
 
 ```lean
 /-


### PR DESCRIPTION
## Summary
- **generate_contract.py**: `gen_compiler_spec()` now distinguishes getter functions from mutators using `_getter_prefix()`. Getters emit `Stmt.return (Expr.storage "field")` with `returnType := some FieldType.uint256`, matching the pattern of `getCount`, `getOwner`, `getBalance` in `Compiler/Specs.lean`. Mutators keep `Stmt.stop` with `returnType := none`. Previously, ALL functions used `Stmt.stop`, which causes getter functions to silently return 0 instead of the stored value.
- **first-contract.mdx**: Add note explaining that Lake auto-discovers all `.lean` files under `Compiler/` via the `.andSubmodules` glob in `lakefile.lean`, so creating `Compiler/Proofs/SpecCorrectness/TipJar.lean` requires no registration step.

## Test plan
- [ ] `python3 scripts/check_doc_counts.py` passes
- [ ] Test scaffold: `python3 scripts/generate_contract.py TestGetSet --fields "value:uint256" --functions "getValue,setValue"` shows `Stmt.return` for `getValue` and `Stmt.stop` for `setValue`
- [ ] Verify `lakefile.lean` uses `.andSubmodules` for `Compiler` library

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small changes to scaffold output and documentation; risk is limited to potentially affecting newly generated contract templates, not existing compiled contracts.
> 
> **Overview**
> Fixes the scaffolded compiler spec emitted by `scripts/generate_contract.py` to **distinguish getters from mutators** using `_getter_prefix()`: getters now generate a `returnType := some ...` and a `Stmt.return (Expr.storage ...)` stub instead of always emitting `Stmt.stop`.
> 
> Updates `docs-site/content/guides/first-contract.mdx` to note that **Lake auto-discovers** new `Compiler/` `.lean` files via the `lakefile.lean` glob, so adding a new `Compiler/Proofs/SpecCorrectness/*.lean` file requires no manual registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4340c629b03c6ef1d0fbe0ffdaccd8ceffd3e2c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->