### PR TITLE
fix: scaffold generator supports mapping(uint256) field type

### DIFF
--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -20,6 +20,9 @@ python3 scripts/generate_contract.py MyToken --fields "balances:mapping,totalSup
 # Contract with typed function signatures
 python3 scripts/generate_contract.py MyToken --fields "balances:mapping" --functions "deposit(uint256),withdraw(uint256),getBalance(address)"
 
+# Contract with uint256-keyed mapping
+python3 scripts/generate_contract.py MyRegistry --fields "data:mapping(uint256)" --functions "store(uint256,uint256),get(uint256)"
+
 # Preview without creating files
 python3 scripts/generate_contract.py MyContract --dry-run
 ```


### PR DESCRIPTION
## Summary
- The scaffold generator now recognizes `mapping(uint256)` as a field type, generating correct `StorageSlot (Uint256 → Uint256)` in EDSL and `FieldType.mappingTyped (.simple .uint256)` in the compiler spec
- Previously, `--fields "data:mapping(uint256)"` was silently downgraded to `uint256` with a warning, producing incorrect scaffolds
- Added `display_type` property for clean user-facing output (`mapping(uint256)` not `mapping_uint`)
- Updated add-contract.mdx with example using the new syntax

## Test plan
- [x] `mapping` still generates `Address → Uint256` (backward compatible)
- [x] `mapping(address)` is equivalent to `mapping` (explicit address key)
- [x] `mapping(uint256)` generates `Uint256 → Uint256` with correct compiler type
- [x] Test helpers use `uint256` key type for `mapping_uint` fields
- [x] Display output shows `mapping(uint256)` not internal `mapping_uint`
- [x] All CI validation scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ef39b36c805e341322f8c5ec07357a3f11445da0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->