### PR TITLE
docs: fix examples.mdx transfer snippets to match actual code

### DIFF
--- a/docs-site/content/examples.mdx
+++ b/docs-site/content/examples.mdx
@@ -117,21 +117,24 @@ Proofs cover cross-pattern composition, ownership transfer locking out old owner
 Mapping storage for per-address balances with deposit, withdraw, and transfer.
 
 ```lean
--- Simplified — full code includes self-transfer guard and safeAdd overflow check on transfer
 def balances : StorageSlot (Address → Uint256) := ⟨0⟩
 
 def deposit (amount : Uint256) : Contract Unit := do
   let sender ← msgSender
   let currentBalance ← getMapping balances sender
-  setMapping balances sender (add currentBalance amount)
+  setMapping balances sender (add currentBalance amount)  -- modular arithmetic (EVM)
 
 def transfer (to : Address) (amount : Uint256) : Contract Unit := do
   let sender ← msgSender
   let senderBalance ← getMapping balances sender
   require (senderBalance >= amount) "Insufficient balance"
-  let recipientBalance ← getMapping balances to
-  setMapping balances sender (sub senderBalance amount)
-  setMapping balances to (add recipientBalance amount)
+  if sender == to then
+    pure ()
+  else
+    let recipientBalance ← getMapping balances to
+    let newRecipientBalance ← requireSomeUint (safeAdd recipientBalance amount) "Recipient balance overflow"
+    setMapping balances sender (sub senderBalance amount)
+    setMapping balances to newRecipientBalance
 ```
 
 Proofs cover balance guards, deposit/withdraw/transfer sum equations, and deposit-withdraw cancellation.
@@ -141,7 +144,6 @@ Proofs cover balance guards, deposit/withdraw/transfer sum equations, and deposi
 Composes Owned and Ledger. Adds owner-controlled minting and supply tracking.
 
 ```lean
--- Simplified — full code uses safeAdd for overflow checks and self-transfer guard
 def owner : StorageSlot Address := ⟨0⟩
 def balances : StorageSlot (Address → Uint256) := ⟨1⟩
 def totalSupply : StorageSlot Uint256 := ⟨2⟩
@@ -159,9 +161,13 @@ def transfer (to : Address) (amount : Uint256) : Contract Unit := do
   let sender ← msgSender
   let senderBalance ← getMapping balances sender
   require (senderBalance >= amount) "Insufficient balance"
-  let recipientBalance ← getMapping balances to
-  setMapping balances sender (sub senderBalance amount)
-  setMapping balances to (add recipientBalance amount)
+  if sender == to then
+    pure ()
+  else
+    let recipientBalance ← getMapping balances to
+    let newRecipientBalance ← requireSomeUint (safeAdd recipientBalance amount) "Recipient balance overflow"
+    setMapping balances sender (sub senderBalance amount)
+    setMapping balances to newRecipientBalance
 ```
 
 Proofs cover mint/transfer correctness, supply conservation equations, and storage isolation across all three slot types.


### PR DESCRIPTION
## Summary

- The Ledger and SimpleToken `transfer` function snippets in `examples.mdx` showed `add recipientBalance amount` (no overflow protection), while the actual implementations use `safeAdd` with `requireSomeUint` and a self-transfer guard
- The SimpleToken snippet was internally inconsistent — `mint` showed `safeAdd` but `transfer` showed unsafe `add`
- This could mislead developers into thinking overflow-unsafe patterns are acceptable

## Changes

- Update Ledger `transfer` snippet to match `Verity/Examples/Ledger.lean` (self-transfer guard + `safeAdd`)
- Update SimpleToken `transfer` snippet to match `Verity/Examples/SimpleToken.lean`
- Remove "Simplified" comments since snippets now match the real code
- Add `-- modular arithmetic (EVM)` comment to Ledger `deposit` (which intentionally uses `add`)

## Test plan

- [ ] `check_doc_counts.py` passes
- [ ] Snippets match actual Lean source files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit afd5555f238e5483e3bd5b75c487cc65a162c292. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->