### PR TITLE
fix: scaffold default setter/getter include typed parameters

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -250,8 +250,20 @@ def parse_functions(spec: str, fields: List[Field]) -> List[Function]:
         f = fields[0]
         setter = f"set{f.name[0].upper()}{f.name[1:]}"
         getter = f"get{f.name[0].upper()}{f.name[1:]}"
-        return [Function(setter), Function(getter)]
-    return [Function("setValue"), Function("getValue")]
+        if f.is_mapping:
+            # Mappings need key + value params
+            key_ty = "address" if f.ty == "mapping" else "uint256"
+            return [
+                Function(setter, [Param("key", key_ty), Param("value", "uint256")]),
+                Function(getter, [Param("key", key_ty)]),
+            ]
+        else:
+            # Scalar fields: setter takes the field's type as param
+            return [
+                Function(setter, [Param("value", f.ty)]),
+                Function(getter),
+            ]
+    return [Function("setValue", [Param("value", "uint256")]), Function("getValue")]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- When no `--functions` flag is provided, the scaffold generator auto-creates setter/getter for the first field
- Previously these had **no parameters**, producing useless stubs like `def setStoredData : Contract Unit`
- Now defaults include properly typed parameters matching the field type

## Examples

| Field type | Setter signature | Getter signature |
|---|---|---|
| `uint256` | `setStoredData(value : Uint256)` | `getStoredData` |
| `address` | `setOwner(value : Address)` | `getOwner` |
| `mapping` | `setBalances(key : Address, value : Uint256)` | `getBalances(key : Address)` |
| `mapping(uint256)` | `setData(key : Uint256, value : Uint256)` | `getData(key : Uint256)` |

## Test plan

- [ ] Default scaffold (`python3 scripts/generate_contract.py Test --dry-run`) includes typed setter param
- [ ] Address field default includes `(value : Address)` param
- [ ] Mapping field default includes key + value params
- [ ] Explicit `--functions` flag still works (no regression)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 9560334763017f2492c80b462c659a6738b51c6d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->