### PR TITLE
fix: remove wrong manual selector instruction from scaffold

### DIFF
--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -79,7 +79,7 @@ test/Property<Name>.t.sol              # Property tests
 ## Common Pitfalls
 
 - **Storage slot mismatches** between spec, EDSL, and compiler
-- **Missing selector updates** in `Compiler/Specs.lean` when adding functions
+- **Missing function entries** in `Compiler/Specs.lean` (selectors are auto-computed from function signatures)
 - **Mapping conversions** not mirrored between spec and proofs
 - **Property tag drift** — test tags must match lemma names exactly
 

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -962,8 +962,7 @@ Examples:
 
     print(f"3. Register in allSpecs (Compiler/Specs.lean):")
     print(f"   Find 'def allSpecs' and add '{name_lower}Spec' to the list.")
-    print(f"   Also add selectors for each function in Compiler/Selectors.lean")
-    print(f"   (see existing selectors for the pattern using keccak256_first_4_bytes).")
+    print(f"   Selectors are computed automatically by computeSelectors during compilation.")
     print()
 
     print(f"4. Create differential tests (not scaffolded):")


### PR DESCRIPTION
## Summary

- The scaffold generator's step 3 told users to "add selectors for each function in Compiler/Selectors.lean" — this is wrong
- `computeSelectors` in `Compiler/Selector.lean` automatically computes selectors from the ContractSpec's function signatures during compilation
- `Compiler/Selectors.lean` is just a collection of pre-defined common selectors (ERC-20 etc.), not something users modify
- Also fixed misleading "Missing selector updates" wording in `add-contract.mdx`

## Changes

- Update scaffold generator step 3 to say "Selectors are computed automatically by computeSelectors during compilation"
- Update `add-contract.mdx` pitfall to clarify auto-computed selectors

## Test plan

- [ ] `check_doc_counts.py` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc and console-output text changes only; no runtime/compiler logic is modified.
> 
> **Overview**
> Updates the contract-adding documentation and scaffold generator output to remove the incorrect instruction to manually add function selectors.
> 
> `add-contract.mdx` now flags missing `Compiler/Specs.lean` function entries (with selectors derived from signatures), and `scripts/generate_contract.py` step 3 explicitly states selectors are computed automatically during compilation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98a719cc726d4f95c621007a0b5e5ebcb6c461f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->