### PR TITLE
fix: stale property test function count, add CI validation

### DIFF
--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -61,6 +61,16 @@ def get_test_counts() -> tuple[int, int]:
     return test_count, suite_count
 
 
+def get_property_test_function_count() -> int:
+    """Count test functions in Property*.t.sol files only."""
+    test_dir = ROOT / "test"
+    count = 0
+    for sol in sorted(test_dir.glob("Property*.t.sol")):
+        text = sol.read_text(encoding="utf-8")
+        count += len(re.findall(r"function\s+test", text))
+    return count
+
+
 def get_core_line_count() -> int:
     """Count lines in Verity/Core.lean."""
     core = ROOT / "Verity" / "Core.lean"
@@ -193,6 +203,7 @@ def main() -> None:
     stdlib_count = per_contract.get("Stdlib", 0)
     non_stdlib_total = total_theorems - stdlib_count
     contract_count = get_contract_count()
+    property_fn_count = get_property_test_function_count()
 
     errors: list[str] = []
 
@@ -416,6 +427,11 @@ def main() -> None:
                     "property test coverage in tree",
                     re.compile(r"covering (\d+)/\d+ theorems"),
                     str(covered_count),
+                ),
+                (
+                    "property test function count",
+                    re.compile(r"(\d+) functions, covering"),
+                    str(property_fn_count),
                 ),
             ],
         )

--- a/test/README.md
+++ b/test/README.md
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (184 functions, covering 220/319 theorems)
+├── Property*.t.sol           # Property tests (195 functions, covering 220/319 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests


### PR DESCRIPTION
## Summary
- Fix stale property test function count in `test/README.md` (184→195)
- Add `get_property_test_function_count()` to `check_doc_counts.py` so CI catches this drift automatically

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI validation changes only; no runtime/contract logic is affected.
> 
> **Overview**
> Fixes a stale metric in `test/README.md` by updating the documented number of property-test functions (184 → 195).
> 
> Extends `scripts/check_doc_counts.py` with `get_property_test_function_count()` and a new regex check so CI fails if the `Property*.t.sol` function count in `test/README.md` diverges from the codebase.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de12b6757aa08437f5982b1c3fd23c9eedbc4c26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->