### PR TITLE
docs: fix index.mdx mint snippets and research.mdx stale claims

### DIFF
--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -44,19 +44,23 @@ Each contract has three files:
 ```lean
 -- What should mint do?
 def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  s'.storageMap 1 to = s.storageMap 1 to + amount ∧  -- balance increases
-  s'.storage 2 = s.storage 2 + amount                 -- supply increases
+  s'.storageMap 1 to = add (s.storageMap 1 to) amount ∧  -- balance increases
+  s'.storage 2 = add (s.storage 2) amount ∧               -- supply increases
+  storageMapUnchangedExceptKeyAtSlot 1 to s s' ∧          -- other balances unchanged
+  sameContext s s'                                         -- context preserved
 ```
 
 **2. Implementation** (`Verity/Examples/SimpleToken.lean`)
 ```lean
--- How to implement mint
+-- How to implement mint (with overflow protection)
 def mint (to : Address) (amount : Uint256) : Contract Unit := do
   onlyOwner
   let currentBalance ← getMapping balances to
-  setMapping balances to (currentBalance + amount)
+  let newBalance ← requireSomeUint (safeAdd currentBalance amount) "Balance overflow"
   let currentSupply ← getStorage totalSupply
-  setStorage totalSupply (currentSupply + amount)
+  let newSupply ← requireSomeUint (safeAdd currentSupply amount) "Supply overflow"
+  setMapping balances to newBalance
+  setStorage totalSupply newSupply
 ```
 
 **3. Proof** (`Verity/Proofs/SimpleToken/Basic.lean`)

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -48,7 +48,7 @@ Recent updates:
 - Storage as functions (`Nat -> Uint256`), not finite maps. Uninitialized slots return 0.
 - `require` returns `ContractResult.revert msg s`, preserving original state.
 - Manual storage slot allocation (slot 0, 1, 2...). No automatic allocation needed.
-- Selector maps remain explicit per contract (no ContractSpec-derived builder yet).
+- Selectors are auto-computed from function signatures via `computeSelectors` — no manual selector maps needed.
 - `onlyOwner` is a regular function, not special syntax.
 
 **What didn't work:**
@@ -62,8 +62,8 @@ Recent updates:
 All core arithmetic is EVM‑compatible. `Uint256` wraps at `2^256`, so `+`, `-`, `*`, `/`, and `%` match EVM behavior by default.
 
 Two approaches coexist for overflow safety:
-- **Counter / Ledger / SimpleToken**: Bare `+`/`-` (modular arithmetic, EVM‑accurate)
-- **SafeCounter**: `safeAdd`/`safeSub` from `Stdlib/Math.lean` return `Option`, reverting on overflow/underflow
+- **Counter**: Bare `add`/`sub` (modular arithmetic, EVM‑accurate)
+- **SafeCounter / Ledger / SimpleToken**: `safeAdd`/`safeSub` from `Stdlib/Math.lean` return `Option`, reverting on overflow/underflow
 
 `MAX_UINT256 := 2^256 - 1`. Safe arithmetic checks this bound before returning `some`.
 


### PR DESCRIPTION
## Summary
- **index.mdx**: Update mint_spec to use `add` (not `+`) and include `storageMapUnchangedExceptKeyAtSlot`/`sameContext` conjuncts, matching actual `Spec.lean`
- **index.mdx**: Update mint implementation to show `safeAdd`/`requireSomeUint` overflow protection, matching actual `SimpleToken.lean`
- **research.mdx**: Fix stale "selector maps remain explicit" — selectors are now auto-computed via `computeSelectors`
- **research.mdx**: Fix arithmetic semantics list — Ledger and SimpleToken use `safeAdd`, only Counter uses bare modular arithmetic

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that correct examples and claims; no runtime or proof code is modified.
> 
> **Overview**
> Updates the docs to match the current Lean sources: the `mint_spec` snippet now uses `add` and includes storage/context preservation conjuncts, and the `mint` implementation snippet now shows checked arithmetic via `safeAdd` + `requireSomeUint`.
> 
> Fixes stale claims in `research.mdx` by noting selectors are auto-derived via `computeSelectors` and updating the overflow-safety breakdown so `Ledger`/`SimpleToken` are described as using safe arithmetic (with only `Counter` using bare modular ops).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fba4821b261135a67d88df18ad47bbbd797e7b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->