### PR TITLE
fix: first-contract.mdx proof prefixes, add manifest regeneration step

### DIFF
--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -95,7 +95,8 @@ FOUNDRY_PROFILE=difftest forge test --match-contract Differential<Name>
 # 3. Property tests pass
 FOUNDRY_PROFILE=difftest forge test --match-contract Property<Name>
 
-# 4. Property manifest is in sync
+# 4. Regenerate property manifest and validate
+python3 scripts/extract_property_manifest.py
 python3 scripts/check_property_manifest.py
 python3 scripts/check_property_manifest_sync.py
 python3 scripts/check_property_coverage.py

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -277,8 +277,8 @@ open Verity.Specs.TipJar
 theorem tip_meets_spec (s : ContractState) (amount : Uint256) :
     tip_spec amount s (((tip amount).run s).snd) := by
   simp [tip, tip_spec, tips, msgSender, getMapping, setMapping, bind,
-        storageMapUnchangedExceptKeyAtSlot,
-        storageMapUnchangedExceptKey, storageMapUnchangedExceptSlot,
+        Specs.storageMapUnchangedExceptKeyAtSlot,
+        Specs.storageMapUnchangedExceptKey, Specs.storageMapUnchangedExceptSlot,
         Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr,
         Specs.sameContext]
   constructor
@@ -637,6 +637,7 @@ FOUNDRY_PROFILE=difftest forge test --match-contract TipJar -vv
 ### 6.3 Verify Property Coverage
 
 ```bash
+python3 scripts/extract_property_manifest.py  # regenerate manifest with new theorems
 python3 scripts/check_property_manifest.py
 python3 scripts/report_property_coverage.py --format=markdown
 ```
@@ -664,6 +665,7 @@ FOUNDRY_PROFILE=difftest forge test --match-contract TipJar
 
 # 5. All CI checks pass
 python3 scripts/check_selectors.py
+python3 scripts/extract_property_manifest.py
 python3 scripts/check_property_manifest.py
 python3 scripts/check_property_manifest_sync.py
 python3 scripts/check_property_coverage.py

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -973,6 +973,7 @@ Examples:
     print("5. Run validation (see add-contract.mdx for the full checklist):")
     print("   lake build")
     print(f"   FOUNDRY_PROFILE=difftest forge test --match-contract {name}")
+    print("   python3 scripts/extract_property_manifest.py  # regenerate manifest with new theorems")
     print("   python3 scripts/check_property_manifest.py")
     print("   python3 scripts/check_property_manifest_sync.py")
     print("   python3 scripts/check_contract_structure.py")


### PR DESCRIPTION
## Summary
- **first-contract.mdx**: Add missing `Specs.` prefix on `storageMapUnchangedExceptKeyAtSlot`, `storageMapUnchangedExceptKey`, and `storageMapUnchangedExceptSlot` in the proof example — copying the tutorial verbatim would cause "unknown identifier" errors since these live in `Verity.Specs` namespace
- **first-contract.mdx, add-contract.mdx, generate_contract.py**: Add missing `extract_property_manifest.py` step before manifest validation scripts — without regenerating the manifest first, new theorems won't be found by the check scripts

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/scaffold output-only changes; no runtime or verification logic is modified, so impact is limited to developer workflow correctness.
> 
> **Overview**
> Fixes a copy/paste-breaking proof snippet in `first-contract.mdx` by qualifying storage-lemma references with `Specs.` so the tutorial compiles without “unknown identifier” errors.
> 
> Updates the contract-validation checklists in `add-contract.mdx`, `first-contract.mdx`, and `scripts/generate_contract.py` to **regenerate the property manifest** via `scripts/extract_property_manifest.py` before running manifest/coverage validation scripts, ensuring new theorems are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dcc4a71da5ea82445427831cb1ee85a902c8bdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->