### PR TITLE
fix: stale theorem counts in proof summaries, compiler.mdx module list

### DIFF
--- a/Verity/Proofs/OwnedCounter/Correctness.lean
+++ b/Verity/Proofs/OwnedCounter/Correctness.lean
@@ -108,7 +108,7 @@ theorem increment_survives_transfer (s : ContractState) (initialOwner newOwner :
 
 /-! ## Summary
 
-All 6 theorems fully proven with zero sorry:
+All 5 theorems fully proven with zero sorry:
 
 Cross-operation guard interaction:
 1. transfer_then_increment_reverts — old owner locked out of increment

--- a/Verity/Proofs/SafeCounter/Correctness.lean
+++ b/Verity/Proofs/SafeCounter/Correctness.lean
@@ -137,7 +137,7 @@ theorem decrement_getCount_correct (s : ContractState)
 
 /-! ## Summary
 
-All 9 theorems fully proven with zero sorry:
+All 8 theorems fully proven with zero sorry:
 
 Standalone invariants:
 1. increment_preserves_context

--- a/Verity/Proofs/SimpleToken/Correctness.lean
+++ b/Verity/Proofs/SimpleToken/Correctness.lean
@@ -171,7 +171,7 @@ theorem transfer_then_balanceOf_recipient_correct (s : ContractState) (to : Addr
 
 /-! ## Summary
 
-All 12 theorems in this file are fully proven with zero sorry:
+All 10 theorems in this file are fully proven with zero sorry:
 
 Guard revert behavior:
 1. mint_reverts_when_not_owner — non-owners cannot mint

--- a/Verity/Proofs/SimpleToken/Supply.lean
+++ b/Verity/Proofs/SimpleToken/Supply.lean
@@ -306,7 +306,7 @@ theorem transfer_sum_equation (s : ContractState) (to : Address) (amount : Uint2
 
 /-! ## Summary
 
-All 6 theorems fully proven with zero sorry:
+All 10 theorems fully proven with zero sorry (3 public + 7 private helpers):
 
 Helper lemmas:
 1. map_sum_zero_of_all_zero — helper for zero-sum lists

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -167,9 +167,12 @@ forge create SimpleStorage --from 0x... --private-key ...
 - Concise, type-safe, maintainable
 
 **`Compiler/Selector.lean`**
-- Function selector computation
-- Pre-computed Solidity keccak256 hashes
-- Type-safe signature generation
+- Dynamic function selector computation via IO (calls `scripts/keccak256.py`)
+- Type-safe Solidity signature generation from `FunctionSpec`
+
+**`Compiler/Selectors.lean`**
+- `keccak256_first_4_bytes` axiom (validated by CI against `solc --hashes`)
+- Pre-computed selector constants for common functions
 
 **`Compiler/Codegen.lean`**
 - IR → Yul code generation


### PR DESCRIPTION
## Summary
- **OwnedCounter/Correctness.lean**: Fix stale theorem count in summary comment (6→5)
- **SimpleToken/Correctness.lean**: Fix stale theorem count in summary comment (12→10)
- **SafeCounter/Correctness.lean**: Fix stale theorem count in summary comment (9→8)
- **SimpleToken/Supply.lean**: Fix stale theorem count in summary comment (6→10, reflecting 3 public + 7 private helpers)
- **compiler.mdx**: Fix `Compiler/Selector.lean` description (dynamic IO computation, not pre-computed hashes), add missing `Compiler/Selectors.lean` module entry (contains `keccak256_first_4_bytes` axiom)

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only/documentation updates with no changes to executable code or proofs.
> 
> **Overview**
> Updates proof-file `/-! ## Summary -/` comments to reflect the current theorem counts for `OwnedCounter`, `SafeCounter`, and `SimpleToken` correctness/supply proofs.
> 
> Fixes `compiler.mdx`’s module list to describe `Compiler/Selector.lean` as doing *dynamic* selector computation via IO and adds the missing `Compiler/Selectors.lean` entry (axiom + precomputed selector constants).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29392cb42306d79b915e195ae6a58cafcfad0a2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->