### PR TITLE
ci: add concurrency controls, fix path filter gaps

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,12 +10,13 @@ on:
       - 'Verity.lean'
       - 'Compiler/**'
       - 'Compiler.lean'
-      - 'examples/solidity/**'
+      - 'examples/**'
       - 'test/**'
       - 'scripts/**'
       - 'docs/**'
       - 'docs-site/**'
       - 'lakefile.lean'
+      - 'lake-manifest.json'
       - 'lean-toolchain'
       - 'foundry.toml'
       - 'AXIOMS.md'
@@ -29,18 +30,23 @@ on:
       - 'Verity.lean'
       - 'Compiler/**'
       - 'Compiler.lean'
-      - 'examples/solidity/**'
+      - 'examples/**'
       - 'test/**'
       - 'scripts/**'
       - 'docs/**'
       - 'docs-site/**'
       - 'lakefile.lean'
+      - 'lake-manifest.json'
       - 'lean-toolchain'
       - 'foundry.toml'
       - 'AXIOMS.md'
       - 'README.md'
       - 'TRUST_ASSUMPTIONS.md'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   SOLC_VERSION: "0.8.33"
@@ -66,17 +72,17 @@ jobs:
               - 'Verity.lean'
               - 'Compiler/**'
               - 'Compiler.lean'
-              - 'examples/solidity/**'
+              - 'examples/**'
               - 'test/**'
               - 'scripts/**'
               - 'lakefile.lean'
+              - 'lake-manifest.json'
               - 'lean-toolchain'
               - 'foundry.toml'
 
   # Python-only checks (fast, ~5s, always run)
   checks:
     runs-on: ubuntu-latest
-    needs: changes
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/check_storage_layout.py
+++ b/scripts/check_storage_layout.py
@@ -167,7 +167,7 @@ def check_cross_layer(
 
     for contract, compiler_fields in compiler.items():
         if contract not in edsl:
-            # Not all compiler specs have EDSL counterparts (e.g., CryptoHash only in EDSL)
+            # Not all compiler specs have matching EDSL implementations
             continue
 
         edsl_fields = edsl[contract]


### PR DESCRIPTION
## Summary
- Add `concurrency` group to cancel superseded CI runs on the same branch, saving CI minutes
- Widen `examples/solidity/**` to `examples/**` so changes to `examples/external-libs/` (Poseidon Yul files used by the build job) correctly trigger CI
- Add `lake-manifest.json` to both workflow path triggers and the `code` path filter — Lake dependency changes should trigger a build
- Remove unnecessary `needs: changes` from `checks` job — it always runs regardless of the `code` output, so the dependency just adds ~6s of wait time
- Fix stale comment in `check_storage_layout.py` ("CryptoHash only in EDSL" was wrong)

## Test plan
- [ ] CI runs on this PR (validates YAML syntax)
- [ ] `checks` job starts immediately without waiting for `changes` job
- [ ] Verify concurrency cancellation works by pushing a follow-up commit while CI is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes (workflow triggers/concurrency and a comment tweak) with minimal impact beyond when jobs run and whether redundant runs are canceled.
> 
> **Overview**
> **CI workflow behavior is tightened and made more responsive.** The `verify` workflow now uses `concurrency` to cancel in-progress runs for the same ref, and the always-on `checks` job no longer waits on the `changes` job.
> 
> **Path filtering is broadened so CI triggers correctly.** Workflow triggers and the `dorny/paths-filter` rules now include all `examples/**` (not just `examples/solidity/**`) and also include `lake-manifest.json` so dependency changes run the pipeline. A minor comment in `scripts/check_storage_layout.py` is updated for accuracy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9a2b06009d85a18432818546ec3301cef1f0884. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->