### PR TITLE
fix: stale theorem counts in property test headers, add CI validation

### DIFF
--- a/test/PropertyCounter.t.sol
+++ b/test/PropertyCounter.t.sol
@@ -6,19 +6,13 @@ import "./yul/YulTestBase.sol";
 /**
  * @title PropertyCounterTest
  * @notice Property-based tests extracted from formally verified Lean theorems
- * @dev Maps theorems from Verity/Proofs/Counter/Correctness.lean to executable tests
+ * @dev Maps theorems from Verity/Proofs/Counter/*.lean to executable tests
  *
- * This file contains 10 property tests corresponding to 10 proven theorems:
- * 1. increment_state_preserved_except_count
- * 2. decrement_state_preserved_except_count
- * 3. getCount_state_preserved
- * 4. increment_getCount_meets_spec
- * 5. decrement_getCount_meets_spec
- * 6. two_increments_meets_spec
- * 7. increment_decrement_meets_cancel
- * 8. getCount_preserves_wellformedness
- * 9. decrement_getCount_correct
- * 10. decrement_at_zero_wraps_max
+ * This file contains property tests corresponding to 28 proven theorems:
+ * - Basic properties (correctness, state preservation, spec conformance)
+ * - Wellformedness preservation
+ * - Composition properties (increment-decrement cancellation, double increment)
+ * - Storage isolation (slot independence)
  */
 contract PropertyCounterTest is YulTestBase {
     address counter;

--- a/test/PropertyOwnedCounter.t.sol
+++ b/test/PropertyOwnedCounter.t.sol
@@ -8,7 +8,7 @@ import "./yul/YulTestBase.sol";
  * @notice Property-based tests extracted from formally verified Lean theorems
  * @dev Maps theorems from Verity/Proofs/OwnedCounter/*.lean to executable tests
  *
- * This file extracts 48 proven theorems into Foundry property tests:
+ * This file extracts 45 proven theorems into Foundry property tests:
  * - Basic properties (correctness, state preservation)
  * - Isolation properties (field independence, context preservation)
  * - Access control properties (owner-only operations)

--- a/test/PropertySimpleStorage.t.sol
+++ b/test/PropertySimpleStorage.t.sol
@@ -8,30 +8,10 @@ import "./yul/YulTestBase.sol";
  * @notice Property-based tests extracted from formally verified Lean theorems
  * @dev Maps theorems from Verity/Proofs/SimpleStorage/ to executable tests
  *
- * This file contains property tests corresponding to 19 proven theorems:
- *
- * From Basic.lean (12 theorems):
- * 1. setStorage_updates_slot
- * 2. getStorage_reads_slot
- * 3. setStorage_preserves_other_slots
- * 4. setStorage_preserves_sender
- * 5. setStorage_preserves_address
- * 6. setStorage_preserves_addr_storage
- * 7. setStorage_preserves_map_storage
- * 8. store_meets_spec
- * 9. retrieve_meets_spec
- * 10. retrieve_preserves_state
- * 11. store_retrieve_roundtrip
- * 12. retrieve_twice_idempotent
- *
- * From Correctness.lean (7 theorems):
- * 13. store_retrieve_roundtrip_holds
- * 14. store_preserves_storage_isolated
- * 15. store_preserves_addr_storage
- * 16. store_preserves_map_storage
- * 17. store_preserves_context
- * 18. retrieve_preserves_context
- * 19. retrieve_preserves_wellformedness
+ * This file contains property tests for SimpleStorage's 20 proven theorems:
+ * - Basic properties (storage ops, spec conformance, roundtrip)
+ * - State isolation (slot independence, context preservation)
+ * - Wellformedness preservation
  */
 contract PropertySimpleStorageTest is YulTestBase {
     address simpleStorage;

--- a/test/PropertySimpleToken.t.sol
+++ b/test/PropertySimpleToken.t.sol
@@ -8,7 +8,7 @@ import "./yul/YulTestBase.sol";
  * @notice Property-based tests extracted from formally verified Lean theorems
  * @dev Maps theorems from Verity/Proofs/SimpleToken/*.lean to executable tests
  *
- * This file extracts 57 proven theorems into Foundry property tests:
+ * This file extracts 59 proven theorems into Foundry property tests:
  * - Basic properties (constructor, mint, transfer, getters)
  * - Supply conservation (total supply invariant)
  * - Isolation properties (storage independence)


### PR DESCRIPTION
## Summary
- Fix stale "proven theorems" counts in Property*.t.sol file headers:
  - Counter: 10 → 28 (originally listed 10, never updated as theorems were added)
  - OwnedCounter: 48 → 45 (overcounted)
  - SimpleStorage: 19 → 20 (was using "covered" count instead of manifest total)
  - SimpleToken: 57 → 59
- Simplify verbose numbered theorem lists to category-based style (consistent with other files)
- Add `check_property_test_headers()` to `check_doc_counts.py` that validates these header counts against `property_manifest.json` in CI, preventing future drift

## Test plan
- [ ] `python3 scripts/check_doc_counts.py` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits plus a new lightweight validation in the docs count checker; minimal runtime impact beyond potentially failing CI on mismatched headers.
> 
> **Overview**
> Updates the `Property*.t.sol` doc headers to correct stale “proven theorems” counts and replaces verbose enumerations with a shorter category-based summary.
> 
> Adds `check_property_test_headers()` to `scripts/check_doc_counts.py` and runs it in `main()` to validate each property test file’s header theorem count against `test/property_manifest.json`, failing CI when they diverge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c58ec3d6002af7e71d5fbe99a8b102e079fe869. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->