### PR TITLE
fix: update check_doc_counts.py description, remove unused import

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ FOUNDRY_PROFILE=difftest forge test  # Must pass — runs all Foundry tests
 - `docs-site/content/examples.mdx` — Contract descriptions and count
 - Plus any other files that reference theorem/test/contract counts (e.g., `compiler.mdx`, `research.mdx`, `index.mdx`, `layout.tsx`, `ROADMAP.md`, `TRUST_ASSUMPTIONS.md`, `test/README.md`)
 - Run `python3 scripts/check_contract_structure.py` to verify file structure is complete
-- Run `python3 scripts/check_doc_counts.py` to verify all counts are synchronized (validates 14 files)
+- Run `python3 scripts/check_doc_counts.py` to verify all counts are synchronized (validates 14 doc files + property test headers)
 
 ## Code Style
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,7 +78,7 @@ These CI-critical scripts validate cross-layer consistency:
 
 - **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
 - **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, and Compiler layers; detects intra-contract slot collisions
-- **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx) plus theorem-name completeness in verification.mdx tables
+- **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
 

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -3,8 +3,9 @@
 
 Validates counts in README.md, test/README.md, docs/VERIFICATION_STATUS.md,
 docs/ROADMAP.md, TRUST_ASSUMPTIONS.md, docs-site llms.txt, compiler.mdx,
-verification.mdx, research.mdx, core.mdx, examples.mdx, and index.mdx
-against the actual property manifest and codebase.
+verification.mdx, research.mdx, core.mdx, examples.mdx, index.mdx,
+getting-started.mdx, and layout.tsx against the actual property manifest
+and codebase. Also validates theorem counts in Property*.t.sol file headers.
 
 Usage:
     python3 scripts/check_doc_counts.py

--- a/test/DifferentialTestBase.sol
+++ b/test/DifferentialTestBase.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.33;
 
-import {console2} from "forge-std/Test.sol";
-
 /**
  * @title DifferentialTestBase
  * @notice Shared utilities for differential testing contracts


### PR DESCRIPTION
## Summary
- Update `check_doc_counts.py` docstring to list all validated files including `getting-started.mdx`, `layout.tsx`, and property test headers (added in PRs #326, #327, #357)
- Update `scripts/README.md` and `CONTRIBUTING.md` to mention property test header validation alongside the 14 doc files
- Remove unused `console2` import from `DifferentialTestBase.sol` (all derived Differential* classes import it themselves)

## Test plan
- [ ] `python3 scripts/check_doc_counts.py` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only documentation/string updates plus removal of an unused Solidity import; no runtime logic changes beyond compile-time cleanup.
> 
> **Overview**
> Updates contributor and scripts documentation to reflect that `check_doc_counts.py` now also verifies `getting-started.mdx`, `layout.tsx`, and proven-theorem counts in `Property*.t.sol` headers (in addition to the 14 doc files).
> 
> Clarifies `check_doc_counts.py`’s module docstring accordingly, and removes an unused `console2` import from `test/DifferentialTestBase.sol`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a88b24246b6c87e104cad744009a2f360727d5f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->