### PR TITLE
fix: VERIFICATION_STATUS.md differential test count (10,000 → 70,000)

### DIFF
--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -187,7 +187,7 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ## Differential Testing ✅ **PRODUCTION READY**
 
-**Status**: Scaled to 10,000+ tests with 8-shard parallelization
+**Status**: Scaled to 70,000+ tests (10,000 per contract × 7 contracts) with 8-shard parallelization
 
 ### Features
 

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -89,6 +89,13 @@ def get_contract_count() -> int:
     return len(list(examples_dir.glob("*.lean")))
 
 
+def get_diff_test_total() -> int:
+    """Compute total differential tests (10,000 per contract × number of contracts)."""
+    test_dir = ROOT / "test"
+    diff_count = len(list(test_dir.glob("Differential*.t.sol")))
+    return diff_count * 10_000
+
+
 def get_exclusion_count() -> int:
     """Count total property exclusions from property_exclusions.json."""
     exclusions = ROOT / "test" / "property_exclusions.json"
@@ -229,6 +236,7 @@ def main() -> None:
     non_stdlib_total = total_theorems - stdlib_count
     contract_count = get_contract_count()
     property_fn_count = get_property_test_function_count()
+    diff_test_total = get_diff_test_total()
 
     errors: list[str] = []
 
@@ -535,6 +543,11 @@ def main() -> None:
                     "sorry count",
                     re.compile(r"(\d+) `sorry` remaining"),
                     str(sorry_count),
+                ),
+                (
+                    "differential test total",
+                    re.compile(r"Scaled to (\d+,\d+)\+"),
+                    f"{diff_test_total:,}",
                 ),
             ],
         )


### PR DESCRIPTION
## Summary
- Fix stale differential test count in VERIFICATION_STATUS.md: "10,000+" → "70,000+" (7 contracts × 10,000 each)
- All other docs (README, TRUST_ASSUMPTIONS, ROADMAP, AXIOMS.md, llms.txt) already say "70,000+" or "70k+"
- Add `get_diff_test_total()` to `check_doc_counts.py` that computes the total dynamically from the number of `Differential*.t.sol` files × 10,000 and validates the VERIFICATION_STATUS claim

## Test plan
- [ ] `python3 scripts/check_doc_counts.py` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change plus a small CI/documentation validation tweak; no runtime or verification logic is affected.
> 
> **Overview**
> Updates `docs/VERIFICATION_STATUS.md` to reflect the current differential testing scale (**70,000+** tests = 10,000 per contract × 7 contracts) instead of the stale 10,000+ claim.
> 
> Extends `scripts/check_doc_counts.py` with `get_diff_test_total()` and a new doc check to compute the expected differential test total from `test/Differential*.t.sol` and assert the doc’s “Scaled to X+” number stays in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8670e66014a671ce1bb97af0c3e859dd0dc46d01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->