### PR TITLE
ci: add timeout-minutes to all workflow jobs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -56,6 +56,7 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     outputs:
       code: ${{ steps.filter.outputs.code }}
@@ -83,6 +84,7 @@ jobs:
   # Python-only checks (fast, ~5s, always run)
   checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
@@ -109,6 +111,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:
@@ -268,6 +271,7 @@ jobs:
 
   foundry:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [changes, build]
     if: needs.changes.outputs.code == 'true'
     strategy:
@@ -297,6 +301,7 @@ jobs:
   # Multi-seed testing to detect flakiness and seed-dependent failures
   foundry-multi-seed:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [changes, build]
     if: needs.changes.outputs.code == 'true'
     strategy:


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes` to all 5 CI jobs to prevent hung jobs from consuming CI minutes indefinitely
- `changes`/`checks`: 5 min (normally ~6-7s)
- `build`: 20 min (normally ~16s cached, longer uncached with full Lean rebuild)
- `foundry`/`foundry-multi-seed`: 15 min (Foundry test shards)

## Test plan
- [ ] CI passes (only workflow file changed, no code impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that just enforces upper bounds on job runtime; main risk is prematurely timing out legitimately slow runs (e.g., uncached builds or slower runners).
> 
> **Overview**
> Adds `timeout-minutes` to all jobs in `.github/workflows/verify.yml` to prevent hung CI runs from consuming minutes indefinitely (`changes`/`checks`: 5m, `build`: 20m, `foundry` and `foundry-multi-seed`: 15m).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d0d4b18b18b6ada5718c240c6476666db2d58c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->