### PR TITLE
ci: add least-privilege permissions to workflow files

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ on:
       - 'docs-site/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -44,6 +44,9 @@ on:
       - 'TRUST_ASSUMPTIONS.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/scripts/check_storage_layout.py
+++ b/scripts/check_storage_layout.py
@@ -310,7 +310,6 @@ def generate_report(
 
 def main():
     errors: list[str] = []
-    warnings: list[str] = []
 
     # 1. Extract EDSL slots from Examples (use filename as contract name)
     edsl_all: dict[str, list[tuple[str, str, int]]] = {}


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` to both `verify.yml` and `docs.yml` to enforce least-privilege access (GitHub Actions defaults to `read-write` when no permissions block is present)
- Removes unused `warnings` list variable in `check_storage_layout.py` (declared but never populated or reported)

## Test plan
- [ ] CI passes (permissions block is additive, doesn't restrict any required capability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow permission scoping is additive/read-only and the Python change removes dead code without altering logic.
> 
> **Overview**
> **Security hardening:** Adds `permissions: contents: read` to the `docs.yml` and `verify.yml` GitHub Actions workflows to enforce least-privilege instead of default token access.
> 
> **Cleanup:** Removes an unused `warnings` list variable from `scripts/check_storage_layout.py` with no functional behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62eb239e0cfbd5065ffd37001704001d80ffacca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->