### PR TITLE
fix: deduplicate _extractNumber across differential tests

### DIFF
--- a/test/DifferentialLedger.t.sol
+++ b/test/DifferentialLedger.t.sol
@@ -306,24 +306,6 @@ contract DifferentialLedger is YulTestBase, DiffTestConfig, DifferentialTestBase
         return 0;
     }
 
-    function _extractNumber(string memory json, uint256 startIdx) internal pure override returns (uint256) {
-        bytes memory jsonBytes = bytes(json);
-        uint256 result = 0;
-        bool foundDigit = false;
-
-        for (uint i = startIdx; i < jsonBytes.length; i++) {
-            bytes1 c = jsonBytes[i];
-            if (c >= '0' && c <= '9') {
-                unchecked { result = result * 10 + uint8(c) - uint8(bytes1('0')); }
-                foundDigit = true;
-            } else if (foundDigit) {
-                break;
-            }
-        }
-
-        return result;
-    }
-
     // ============ Test Cases ============
 
     function testDifferential_Deposit() public {

--- a/test/DifferentialSimpleToken.t.sol
+++ b/test/DifferentialSimpleToken.t.sol
@@ -400,23 +400,6 @@ contract DifferentialSimpleToken is YulTestBase, DiffTestConfig, DifferentialTes
         return 0;
     }
 
-    function _extractNumber(string memory json, uint256 startIdx) internal pure override returns (uint256) {
-        bytes memory jsonBytes = bytes(json);
-        uint256 result = 0;
-        bool foundDigit = false;
-
-        for (uint i = startIdx; i < jsonBytes.length; i++) {
-            bytes1 c = jsonBytes[i];
-            if (c >= '0' && c <= '9') {
-                unchecked { result = result * 10 + uint8(c) - uint8(bytes1('0')); }
-                foundDigit = true;
-            } else if (foundDigit) {
-                break;
-            }
-        }
-        return result;
-    }
-
     // ============ Test Cases ============
 
     function testDifferential_Mint() public {

--- a/test/DifferentialTestBase.sol
+++ b/test/DifferentialTestBase.sol
@@ -226,19 +226,18 @@ abstract contract DifferentialTestBase {
      * @notice Parse a number from JSON starting at given index
      */
     function _extractNumber(string memory json, uint256 startIdx) internal pure virtual returns (uint256) {
-        bytes memory b = bytes(json);
+        bytes memory jsonBytes = bytes(json);
         uint256 result = 0;
-        uint256 i = startIdx;
+        bool foundDigit = false;
 
-        // Skip whitespace
-        while (i < b.length && (b[i] == " " || b[i] == "\t" || b[i] == "\n")) {
-            i++;
-        }
-
-        // Parse digits
-        while (i < b.length && b[i] >= "0" && b[i] <= "9") {
-            result = result * 10 + uint8(b[i]) - uint8(bytes1("0"));
-            i++;
+        for (uint i = startIdx; i < jsonBytes.length; i++) {
+            bytes1 c = jsonBytes[i];
+            if (c >= '0' && c <= '9') {
+                unchecked { result = result * 10 + uint8(c) - uint8(bytes1('0')); }
+                foundDigit = true;
+            } else if (foundDigit) {
+                break;
+            }
         }
 
         return result;


### PR DESCRIPTION
## Summary
- Moves the improved `_extractNumber` implementation (with `unchecked` arithmetic and `foundDigit` early break) from `DifferentialLedger` and `DifferentialSimpleToken` into `DifferentialTestBase`
- Removes the identical override from both child contracts (~35 lines removed)
- The base class version was never called by any test — only the two overriding versions were used

## Test plan
- [ ] All Foundry tests pass (behavior-preserving refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that centralizes a helper function; behavior should remain the same aside from potential edge-case differences in JSON number parsing.
> 
> **Overview**
> Moves the “scan for digits” `_extractNumber` JSON parser into `DifferentialTestBase` (using `unchecked` math and early break after the first digit run).
> 
> Removes the identical `_extractNumber` overrides from `DifferentialLedger.t.sol` and `DifferentialSimpleToken.t.sol`, ensuring all differential tests share the same parsing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44904f14ec64a0d261375f7ca8a5a3212fd836b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->