### PR TITLE
docs: fix scripts/README.md CI job count (2 → 5)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -131,7 +131,9 @@ Creates 7 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic 
 
 ## CI Integration
 
-Scripts run automatically in GitHub Actions (`verify.yml`) across two jobs:
+Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
+
+**`changes`** — Path filter that gates code-dependent jobs (doc-only PRs skip build/test)
 
 **`checks` job** (fast, no Lean build required):
 1. Property manifest validation (`check_property_manifest.py`)
@@ -149,6 +151,9 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across two jobs:
 4. Yul compilation check (`check_yul_compiles.py`)
 5. Selector fixture check (`check_selector_fixtures.py`)
 6. Coverage and storage layout reports in workflow summary
+
+**`foundry`** — 8-shard parallel Foundry tests with seed 42
+**`foundry-multi-seed`** — 7-seed flakiness detection (seeds: 0, 1, 42, 123, 999, 12345, 67890)
 
 ## Adding New Property Tests
 


### PR DESCRIPTION
## Summary
- Fixes stale "two jobs" claim in scripts/README.md CI Integration section — the workflow actually has 5 jobs
- Adds descriptions of the `changes`, `foundry`, and `foundry-multi-seed` jobs

## Test plan
- [ ] CI passes (doc-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates CI job descriptions; no code or workflow logic is modified.
> 
> **Overview**
> Updates `scripts/README.md` to reflect that `verify.yml` runs across **5 CI jobs** (not 2) and documents the additional jobs.
> 
> Adds short descriptions for the new `changes` path-filter gate plus the `foundry` sharded test job and `foundry-multi-seed` flakiness-detection job (including the seed list).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab6593649b566ba02e2b16b261d779e7e2e3aa76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->