### PR TITLE
fix: remove dead sub_add_cancel_of_lt from EVM.Uint256

### DIFF
--- a/Verity/EVM/Uint256.lean
+++ b/Verity/EVM/Uint256.lean
@@ -45,11 +45,6 @@ theorem sub_add_cancel (a b : Verity.Core.Uint256) :
   sub (add a b) b = a :=
   Verity.Core.Uint256.sub_add_cancel a b
 
-theorem sub_add_cancel_of_lt {a b : Verity.Core.Uint256}
-  (_ha : (a : Nat) < 2^256) (_hb : (b : Nat) < 2^256) :
-  sub (add a b) b = a :=
-  Verity.Core.Uint256.sub_add_cancel a b
-
 end Uint256
 
 end Verity.EVM


### PR DESCRIPTION
## Summary
- Removes the unused `sub_add_cancel_of_lt` theorem from `Verity/EVM/Uint256.lean`
- This theorem accepts two hypotheses (`_ha`, `_hb`) it immediately discards (both prefixed with `_`) and delegates to the unconditional `sub_add_cancel`
- Zero references anywhere in the codebase (verified with grep)
- The equivalent theorem in `Core/Uint256.lean` IS used — only the EVM re-export wrapper is dead

## Test plan
- [ ] `lake build` succeeds (no references to the removed theorem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes a single unreferenced theorem; risk is limited to downstream users who imported this lemma directly.
> 
> **Overview**
> Removes the unused `sub_add_cancel_of_lt` theorem from `Verity/EVM/Uint256.lean`, leaving only the unconditional `sub_add_cancel` re-export.
> 
> This eliminates a redundant lemma that accepted (and ignored) extra bounds hypotheses, reducing API surface without changing arithmetic behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd529fb238c51913b49668047310f513b18daaaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->