### PR TITLE
fix: stale refs, duplicate theorem, dead comment

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Check for sorry
         run: |
           # Count sorry across all Lean files (matching both 'sorry' and '· sorry')
-          EXPECTED_SORRY=0  # All proofs complete (Conservation.lean supersedes SumProofs.lean)
+          EXPECTED_SORRY=0  # All proofs complete
           ACTUAL_SORRY=$(grep -rn "sorry" Verity/ Compiler/ --include="*.lean" \
             | grep -v ":[[:space:]]*--" | grep -v "zero sorry" | grep -v "Summary" \
             | grep -v "SORRY" | grep -v "sorry_count" | grep -v "sorry placeholder" \

--- a/Compiler/Proofs/README.md
+++ b/Compiler/Proofs/README.md
@@ -4,9 +4,9 @@ Formal verification proofs for the Verity compiler, proving correctness across t
 
 ## Verification Layers
 
-- **Layer 1: EDSL ≡ ContractSpec** — User contracts satisfy their specs.
-- **Layer 2: ContractSpec → IR** — IR generation preserves spec semantics.
-- **Layer 3: IR → Yul** — All statement equivalence proofs proven (PR #42).
+- **Layer 1: EDSL ≡ ContractSpec** — User contracts satisfy their specs (`Verity/Proofs/<Name>/` + `Compiler/Proofs/SpecCorrectness/`).
+- **Layer 2: ContractSpec → IR** — IR generation preserves spec semantics (`Compiler/Proofs/IRGeneration/`).
+- **Layer 3: IR → Yul** — All statement equivalence proofs proven (`Compiler/Proofs/YulGeneration/`).
 
 Key entry points:
 
@@ -14,7 +14,7 @@ Key entry points:
 - IR generation and proofs: `Compiler/Proofs/IRGeneration/`
 - Yul semantics and preservation: `Compiler/Proofs/YulGeneration/`
 
-Layer 1 proofs live in `Verity/Proofs/<Name>/Basic.lean` and `Correctness.lean`. The re-export shim at `Verity/Specs/<Name>/Proofs.lean` imports Layer 2 proofs from `Compiler/Proofs/SpecCorrectness/<Name>.lean`.
+Layer 1 proofs live in `Verity/Proofs/<Name>/Basic.lean` and `Correctness.lean`. The re-export shim at `Verity/Specs/<Name>/Proofs.lean` imports Layer 1 spec-correctness proofs from `Compiler/Proofs/SpecCorrectness/<Name>.lean`.
 
 ## Build
 
@@ -31,7 +31,7 @@ All proofs complete — no `sorry` warnings expected.
 
 Execution semantics for the ContractSpec language.
 
-**Key Types**: `EvalContext` (execution environment), `SpecStorage` (abstract storage), `ExecutionResult` (success or revert with final state).
+**Key Types**: `EvalContext` (execution environment), `SpecStorage` (abstract storage), `ExecState` (execution state with storage, return value, and halt flag).
 
 **Key Functions**: `evalExpr` (expression evaluation), `execStmt` (statement execution), `interpretSpec` (top-level interpreter).
 

--- a/Verity/Proofs/Counter/Correctness.lean
+++ b/Verity/Proofs/Counter/Correctness.lean
@@ -102,17 +102,6 @@ theorem getCount_preserves_wellformedness (s : ContractState) (h : WellFormedSta
   rw [h_pres]
   exact h
 
-/-! ## Decrement → getCount Composition -/
-
-/-- decrement followed by getCount returns count - 1. -/
-theorem decrement_getCount_correct (s : ContractState) :
-  let s' := ((decrement).run s).snd
-  ((getCount).run s').fst = EVM.Uint256.sub (s.storage 0) 1 := by
-  have h_dec := decrement_subtracts_one s
-  have h_get := getCount_reads_count_value (((decrement).run s).snd)
-  simp only [h_dec] at h_get
-  exact h_get
-
 /-! ## Edge Cases -/
 
 /-- Decrementing at zero wraps to max (EVM modular subtraction). -/
@@ -127,7 +116,7 @@ theorem decrement_at_zero_wraps_max (s : ContractState) (h : s.storage 0 = 0) :
 
 /-! ## Summary
 
-All 10 theorems fully proven with zero sorry:
+All 9 theorems fully proven with zero sorry:
 
 Standalone invariant proofs:
 1. increment_state_preserved_except_count
@@ -143,11 +132,8 @@ Combined spec proofs:
 Read-only preservation:
 8. getCount_preserves_wellformedness
 
-Composition:
-9. decrement_getCount_correct
-
 EVM edge cases:
-10. decrement_at_zero_wraps_max
+9. decrement_at_zero_wraps_max
 -/
 
 end Verity.Proofs.Counter.Correctness


### PR DESCRIPTION
## Summary
- **Compiler/Proofs/README.md**: Fix `ExecutionResult` → `ExecState` (correct SpecInterpreter type name), fix layer numbering inconsistency (SpecCorrectness is part of Layer 1, not Layer 2)
- **Verity/Proofs/Counter/Correctness.lean**: Remove duplicate `decrement_getCount_correct` theorem (already proven in Basic.lean, Correctness version was dead code in a different namespace)
- **.github/workflows/verify.yml**: Remove stale `SumProofs.lean` reference from sorry check comment

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] `python3 scripts/check_contract_structure.py` passes
- [x] `python3 scripts/check_axiom_locations.py` passes
- [x] `python3 scripts/check_property_coverage.py` passes
- [x] Property manifest unchanged (theorem still exists in Basic.lean)
- [ ] CI passes (Lean build + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only documentation/comment fixes and removal of a redundant theorem; no changes to proof logic or compiler behavior beyond eliminating dead/duplicate code.
> 
> **Overview**
> Cleans up stale references and duplication in the proof/verification tooling.
> 
> Updates the CI `sorry` check comment to remove an outdated file reference, corrects `Compiler/Proofs/README.md` layer descriptions and the `SpecInterpreter` type name (`ExecutionResult` → `ExecState`), and removes the duplicate `decrement_getCount_correct` theorem from `Verity/Proofs/Counter/Correctness.lean` (still provided by `Basic.lean`), updating the summary count accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0106d3be4cc111b989837289c76d6248d9cda765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->