### PR TITLE
fix: add verbose guards to differential tests, stale refs

### DIFF
--- a/Compiler/Specs.lean
+++ b/Compiler/Specs.lean
@@ -1,10 +1,8 @@
 /-
   Compiler.Specs: Declarative Contract Specifications
 
-  This file demonstrates the new declarative contract specification system.
+  Declarative contract specification system.
   Each contract is specified once, and IR is generated automatically.
-
-  This replaces the manual IR definitions in Translate.lean.
 -/
 
 import Compiler.ContractSpec

--- a/test/DifferentialCounter.t.sol
+++ b/test/DifferentialCounter.t.sol
@@ -70,10 +70,13 @@ contract DifferentialCounter is YulTestBase, DiffTestConfig, DifferentialTestBas
         string memory edslResult = _runInterpreter(functionName, sender, storageState);
 
         // 3. Parse and compare results
-        console2.log("EVM success:", evmSuccess);
-        console2.log("EVM storage[0]:", evmStorageAfter);
-        console2.log("EVM return value:", evmReturnValue);
-        console2.log("EDSL result:", edslResult);
+        bool verbose = _diffVerbose();
+        if (verbose) {
+            console2.log("EVM success:", evmSuccess);
+            console2.log("EVM storage[0]:", evmStorageAfter);
+            console2.log("EVM return value:", evmReturnValue);
+            console2.log("EDSL result:", edslResult);
+        }
 
         // Parse EDSL result
         bool edslSuccess = contains(edslResult, "\"success\":true");
@@ -275,7 +278,7 @@ contract DifferentialCounter is YulTestBase, DiffTestConfig, DifferentialTestBas
     function _runRandomDifferentialTests(uint256 startIndex, uint256 count, uint256 seed) internal {
         console2.log("Generated", count, "random transactions");
 
-        uint256 prng = _skipRandomLcg(seed, startIndex);
+        uint256 prng = _skipRandom(seed, startIndex);
         vm.pauseGasMetering();
         for (uint256 i = 0; i < count; i++) {
             // Simple PRNG
@@ -308,7 +311,7 @@ contract DifferentialCounter is YulTestBase, DiffTestConfig, DifferentialTestBas
         assertEq(testsFailed, 0, "Some random tests failed");
     }
 
-    function _skipRandomLcg(uint256 prng, uint256 iterations) internal pure returns (uint256) {
+    function _skipRandom(uint256 prng, uint256 iterations) internal pure returns (uint256) {
         for (uint256 i = 0; i < iterations; i++) {
             prng = _lcg(prng);
             prng = _lcg(prng);

--- a/test/DifferentialLedger.t.sol
+++ b/test/DifferentialLedger.t.sol
@@ -87,11 +87,14 @@ contract DifferentialLedger is YulTestBase, DiffTestConfig, DifferentialTestBase
         string memory edslResult = _runInterpreter(functionName, sender, arg0Addr, arg1, storageState);
 
         // 3. Parse and compare results
-        console2.log("Function:", functionName);
-        console2.log("EVM success:", evmSuccess);
-        console2.log("EVM sender balance:", evmSenderBalance);
-        console2.log("EVM return value:", evmReturnValue);
-        console2.log("EDSL result:", edslResult);
+        bool verbose = _diffVerbose();
+        if (verbose) {
+            console2.log("Function:", functionName);
+            console2.log("EVM success:", evmSuccess);
+            console2.log("EVM sender balance:", evmSenderBalance);
+            console2.log("EVM return value:", evmReturnValue);
+            console2.log("EDSL result:", edslResult);
+        }
 
         // Parse EDSL result
         bool edslSuccess = contains(edslResult, "\"success\":true");

--- a/test/DifferentialSafeCounter.t.sol
+++ b/test/DifferentialSafeCounter.t.sol
@@ -62,10 +62,13 @@ contract DifferentialSafeCounter is YulTestBase, DiffTestConfig, DifferentialTes
         string memory edslResult = _runInterpreter(functionName, sender, storageState);
 
         // 3. Parse and compare results
-        console2.log("EVM success:", evmSuccess);
-        console2.log("EVM storage[0]:", evmStorageAfter);
-        console2.log("EVM return value:", evmReturnValue);
-        console2.log("EDSL result:", edslResult);
+        bool verbose = _diffVerbose();
+        if (verbose) {
+            console2.log("EVM success:", evmSuccess);
+            console2.log("EVM storage[0]:", evmStorageAfter);
+            console2.log("EVM return value:", evmReturnValue);
+            console2.log("EDSL result:", edslResult);
+        }
 
         // Parse EDSL result
         bool edslSuccess = contains(edslResult, "\"success\":true");

--- a/test/DifferentialSimpleStorage.t.sol
+++ b/test/DifferentialSimpleStorage.t.sol
@@ -61,10 +61,13 @@ contract DifferentialSimpleStorage is YulTestBase, DiffTestConfig, DifferentialT
         // The EDSL interpreter returns JSON like:
         // {"success":true,"returnValue":"42","revertReason":null,"storageChanges":[{"slot":0,"value":42}]}
 
-        console2.log("EVM success:", evmSuccess);
-        console2.log("EVM storage change:", evmStorageAfter);
-        console2.log("EVM return value:", evmReturnValue);
-        console2.log("EDSL result:", edslResult);
+        bool verbose = _diffVerbose();
+        if (verbose) {
+            console2.log("EVM success:", evmSuccess);
+            console2.log("EVM storage change:", evmStorageAfter);
+            console2.log("EVM return value:", evmReturnValue);
+            console2.log("EDSL result:", edslResult);
+        }
 
         // Parse EDSL result
         bool edslSuccess = contains(edslResult, "\"success\":true");

--- a/test/DifferentialSimpleToken.t.sol
+++ b/test/DifferentialSimpleToken.t.sol
@@ -111,10 +111,13 @@ contract DifferentialSimpleToken is YulTestBase, DiffTestConfig, DifferentialTes
         string memory edslResult = _runInterpreter(functionName, sender, arg0Addr, arg1, storageState);
 
         // 3. Parse and compare results
-        console2.log("Function:", functionName);
-        console2.log("EVM success:", evmSuccess);
-        console2.log("EVM totalSupply:", evmTotalSupply);
-        console2.log("EDSL result:", edslResult);
+        bool verbose = _diffVerbose();
+        if (verbose) {
+            console2.log("Function:", functionName);
+            console2.log("EVM success:", evmSuccess);
+            console2.log("EVM totalSupply:", evmTotalSupply);
+            console2.log("EDSL result:", edslResult);
+        }
 
         // Parse EDSL result
         bool edslSuccess = contains(edslResult, "\"success\":true");


### PR DESCRIPTION
## Summary
- Add `_diffVerbose()` guards to 5 Differential test files (Counter, SafeCounter, SimpleStorage, Ledger, SimpleToken) to match the pattern already used in DifferentialOwned and DifferentialOwnedCounter — prevents excessive `console2.log` output during 10,000-test differential runs
- Rename `_skipRandomLcg` → `_skipRandom` in DifferentialCounter for consistency with all other Differential test files
- Remove stale `Translate.lean` reference from `Compiler/Specs.lean` header (file no longer exists)

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI passes (Lean build + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test logging behavior and a minor helper rename, plus a comment cleanup in a Lean header.
> 
> **Overview**
> Reduces noise in Foundry differential test runs by wrapping per-transaction `console2.log` output in `Counter`, `SafeCounter`, `SimpleStorage`, `Ledger`, and `SimpleToken` behind the existing `_diffVerbose()`/`DIFFTEST_VERBOSE` flag.
> 
> Renames `DifferentialCounter`’s PRNG fast-forward helper from `_skipRandomLcg` to `_skipRandom` for consistency, and removes a stale `Translate.lean` reference from the `Compiler/Specs.lean` header comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d813295be52fe9529b764f3f29298d8036b4f2cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->