### PR TITLE
fix: deduplicate _skipRandom, fix emit comment

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -610,9 +610,9 @@ private def compileStmt (fields : List Field) : Stmt → Except String (List Yul
       pure [YulStmt.for_ initStmts condExpr postStmts bodyStmts]
 
   | Stmt.emit eventName args => do
-      -- Emit event using LOG opcode (#153)
+      -- Emit event using LOG1 opcode (#153)
       -- Topic0 = keccak256(eventSignature), resolved by linker at link time.
-      -- Indexed args become additional topics; unindexed args go into LOG data.
+      -- All args are stored in LOG data (indexed topics not yet implemented).
       -- Use free memory pointer (0x40) to avoid clobbering scratch space.
       -- Wrapped in block { } so __evt_ptr doesn't collide with other emit statements.
       let topic0 := YulExpr.call s!"__event_{eventName}" []

--- a/test/DiffTestConfig.sol
+++ b/test/DiffTestConfig.sol
@@ -72,6 +72,14 @@ abstract contract DiffTestConfig is Test {
         return (1103515245 * prng + 12345) % (2**31);
     }
 
+    function _skipRandom(uint256 prng, uint256 iterations) internal pure virtual returns (uint256) {
+        for (uint256 i = 0; i < iterations; i++) {
+            prng = _lcg(prng);
+            prng = _lcg(prng);
+        }
+        return prng;
+    }
+
     function _edgeUintValues() internal pure returns (uint256[] memory) {
         uint256[] memory values = new uint256[](7);
         values[0] = 0;

--- a/test/DifferentialCounter.t.sol
+++ b/test/DifferentialCounter.t.sol
@@ -311,11 +311,4 @@ contract DifferentialCounter is YulTestBase, DiffTestConfig, DifferentialTestBas
         assertEq(testsFailed, 0, "Some random tests failed");
     }
 
-    function _skipRandom(uint256 prng, uint256 iterations) internal pure returns (uint256) {
-        for (uint256 i = 0; i < iterations; i++) {
-            prng = _lcg(prng);
-            prng = _lcg(prng);
-        }
-        return prng;
-    }
 }

--- a/test/DifferentialOwned.t.sol
+++ b/test/DifferentialOwned.t.sol
@@ -263,13 +263,4 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig, DifferentialTestBase 
         _runRandomOwnershipTests(startIndex, numTransactions, _diffRandomSeed("Owned"));
     }
 
-    // ========== Helper Functions ==========
-
-    function _skipRandom(uint256 seed, uint256 iterations) internal pure returns (uint256) {
-        for (uint256 i = 0; i < iterations; i++) {
-            seed = _lcg(seed);
-            seed = _lcg(seed);
-        }
-        return seed;
-    }
 }

--- a/test/DifferentialSafeCounter.t.sol
+++ b/test/DifferentialSafeCounter.t.sol
@@ -298,14 +298,6 @@ contract DifferentialSafeCounter is YulTestBase, DiffTestConfig, DifferentialTes
         assertEq(testsFailed, 0, "Some random tests failed");
     }
 
-    function _skipRandom(uint256 prng, uint256 iterations) internal pure returns (uint256) {
-        for (uint256 i = 0; i < iterations; i++) {
-            prng = _lcg(prng);
-            prng = _lcg(prng);
-        }
-        return prng;
-    }
-
     function _indexToAddress(uint256 index) internal pure override returns (address) {
         if (index == 0) return address(0xA11CE);
         if (index == 1) return address(0xB0B);

--- a/test/DifferentialSimpleStorage.t.sol
+++ b/test/DifferentialSimpleStorage.t.sol
@@ -258,7 +258,7 @@ contract DifferentialSimpleStorage is YulTestBase, DiffTestConfig, DifferentialT
         assertEq(testsFailed, 0, "Some random tests failed");
     }
 
-    function _skipRandom(uint256 prng, uint256 iterations) internal pure returns (uint256) {
+    function _skipRandom(uint256 prng, uint256 iterations) internal pure override returns (uint256) {
         for (uint256 i = 0; i < iterations; i++) {
             prng = _lcg(prng);
             prng = _lcg(prng);


### PR DESCRIPTION
## Summary
- Move identical `_skipRandom` function to `DiffTestConfig` base class, removing duplicate definitions from `DifferentialCounter`, `DifferentialSafeCounter`, and `DifferentialOwned` (~16 lines removed). `DifferentialSimpleStorage` keeps its `override` version (extra `_lcg` call for store args).
- Fix misleading emit comment in `ContractSpec.lean`: all args go into LOG data — indexed topics are not yet implemented. The old comment falsely claimed indexed args become additional topics.

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [ ] CI passes (Lean build + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test helper refactoring and comment/documentation corrections; no runtime compiler behavior or contract logic is modified.
> 
> **Overview**
> Test utilities are refactored to **deduplicate** the `_skipRandom` helper by adding a `virtual` implementation in `test/DiffTestConfig.sol` and removing identical copies from several differential test contracts; `DifferentialSimpleStorage` keeps a custom `override` to match its different random-generation sequence.
> 
> In `Compiler/ContractSpec.lean`, the `Stmt.emit` documentation is corrected to reflect the current implementation: events are emitted via `log1` with only `topic0`, and **all arguments are placed in LOG data** (indexed topics not implemented yet).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afb9434b156df64a6c9046e378bdf4860f1986b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->