### PR TITLE
fix: stale line refs and paths in 3 files

### DIFF
--- a/Compiler/Main.lean
+++ b/Compiler/Main.lean
@@ -29,7 +29,7 @@ private def parseArgs (args : List String) : IO (String × List String × Bool) 
         IO.println "  -h                 Short form of --help"
         IO.println ""
         IO.println "Example:"
-        IO.println "  verity-compiler --link libs/Poseidon.yul --link libs/Groth16.yul -o out/"
+        IO.println "  verity-compiler --link examples/external-libs/PoseidonT3.yul -o compiler/yul"
         throw (IO.userError "help")
     | "--link" :: path :: rest =>
         go rest outDir (path :: libs) verbose

--- a/Compiler/Selectors.lean
+++ b/Compiler/Selectors.lean
@@ -18,7 +18,7 @@ on manual selector computation.
 ## References
 
 - Solidity ABI Spec: https://docs.soliditylang.org/en/latest/abi-spec.html#function-selector
-- Trust Assumptions: docs/ROADMAP.md
+- Trust Assumptions: TRUST_ASSUMPTIONS.md
 -/
 
 import Compiler.Hex

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -444,7 +444,7 @@ uint256 x = type(uint256).max + 1;  // reverts with overflow
 
 ### 9. Address Type: String Without Validation
 
-**Role**: Ethereum addresses are represented as plain `String` throughout the codebase (`Verity/Core.lean:19`):
+**Role**: Ethereum addresses are represented as plain `String` throughout the codebase (`Verity/Core.lean:16`):
 
 ```lean
 abbrev Address := String


### PR DESCRIPTION
## Summary
- **Compiler/Selectors.lean**: Fix trust assumptions reference (`docs/ROADMAP.md` → `TRUST_ASSUMPTIONS.md`)
- **TRUST_ASSUMPTIONS.md**: Fix Address type line reference (`Core.lean:19` → `Core.lean:16`)
- **Compiler/Main.lean**: Fix help example path (`libs/Poseidon.yul` → `examples/external-libs/PoseidonT3.yul`)

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] `python3 scripts/check_axiom_locations.py` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/comment-only updates; no runtime or verification logic changes.
> 
> **Overview**
> Updates a few stale references in user-facing docs/comments.
> 
> The CLI `--help` example now points to `examples/external-libs/PoseidonT3.yul`, the selector module comment references `TRUST_ASSUMPTIONS.md` instead of `docs/ROADMAP.md`, and `TRUST_ASSUMPTIONS.md` fixes the `Address` type line reference (`Verity/Core.lean:19` → `:16`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f5363d0d8b7009e9501e638c5022003e2f2b776. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->