### PR TITLE
fix: expose compiler internals for structural induction proofs (#358)

### DIFF
--- a/Compiler/Proofs/IRGeneration/Expr.lean
+++ b/Compiler/Proofs/IRGeneration/Expr.lean
@@ -1,11 +1,13 @@
 /-
-  Expression Compilation Correctness (High-Level Approach)
+  Expression Compilation Correctness
 
-  Since compileExpr is private in ContractSpec, we prove properties about the
-  overall compilation and execution pipeline rather than individual expressions.
+  The compilation functions (compileExpr, compileStmt, etc.) in ContractSpec are
+  now public, enabling structural induction proofs over Expr/Stmt constructors.
+  See issue #358 for the roadmap toward a universal compile_preserves_semantics
+  theorem.
 
-  Strategy: Prove that for simple contracts like SimpleStorage, the compiled IR
-  produces the same results as the Spec interpreter.
+  This file retains the concrete-IR approach for SimpleStorage as a reference
+  and baseline. New generic proofs should go in dedicated files.
 -/
 
 import Compiler.Proofs.IRGeneration.IRInterpreter
@@ -27,18 +29,17 @@ open Verity.Proofs.Stdlib.SpecInterpreter
 
 /-! ## Proof Strategy
 
-Instead of proving expression compilation directly (since compileExpr is private),
-we prove end-to-end correctness for complete contracts.
+Now that compileExpr/compileStmt are public, two proof approaches are available:
 
-For SimpleStorage:
-1. Compile spec to IR: `compile simpleStorageSpec selectors`
-2. Show IR execution matches Spec execution for store/retrieve functions
-3. Use this as a template for other contracts
+1. **Concrete-IR approach** (used below): Pin the compiled IR for a specific
+   contract, prove `compile spec selectors = .ok concreteIR` by `rfl`, then
+   prove function-level correctness by `simp`-unfolding both sides.
 
-This approach:
-- Works with the actual API (public `compile` function)
-- Validates the full pipeline (not just expressions)
-- Is more maintainable (doesn't depend on internal implementation)
+2. **Structural induction** (enabled by #358 Step 1): Prove correctness by
+   induction over `Expr`/`Stmt` constructors. This yields a universal theorem
+   covering all contracts — see issue #358 for the full roadmap.
+
+This file uses approach (1) for SimpleStorage as a baseline.
 -/
 
 /-! ## Concrete IR for SimpleStorage


### PR DESCRIPTION
## Summary

- Remove `private` from all 24 compilation functions in `Compiler/ContractSpec.lean`
- This is **Step 1 of issue #358** — the prerequisite for generic Layer 2 proofs
- Update `Compiler/Proofs/IRGeneration/Expr.lean` documentation to reflect that direct structural proofs are now possible
- Add AST equivalence theorem count validation to `check_doc_counts.py`

## Why this matters

The `private` modifier on `compileExpr`/`compileStmt` was the **primary structural blocker** preventing generic Layer 2 proofs (see [#358](https://github.com/Th0rgal/verity/issues/358)). Without access to these functions, proofs could only work by:
1. Pinning concrete IR for each contract (fragile, per-contract)
2. Proving `compile spec selectors = .ok concreteIR` by `rfl` (breaks on any compiler change)

With these functions exposed, it's now possible to prove correctness by **structural induction** over `Expr`/`Stmt` constructors — yielding a universal theorem that covers all contracts automatically.

## What changed

| File | Change |
|------|--------|
| `Compiler/ContractSpec.lean` | Removed `private` from 24 functions (zero behavioral change) |
| `Compiler/Proofs/IRGeneration/Expr.lean` | Updated header + strategy docs to document both proof approaches |
| `scripts/check_doc_counts.py` | Added `get_ast_equiv_count()` validation (27 AST theorems across 3 docs files) |

## Test plan

- [x] All 86 Lean modules build successfully (zero errors, zero sorry)
- [x] `check_doc_counts.py` passes with new AST count validation
- [x] `check_contract_structure.py` passes
- [x] `check_property_manifest_sync.py` passes
- [x] No behavioral change — only visibility modifiers removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily changes Lean function visibility and proof/docs tooling; runtime/compiler behavior should be unchanged, with only minor risk of downstream name collisions or doc-count CI regex mismatches.
> 
> **Overview**
> Enables structural-induction proof work by making previously `private` ContractSpec compilation helpers (e.g. `compileExpr`, `compileStmt`, and related utilities) public, without changing their implementations.
> 
> Updates proof documentation in `Compiler/Proofs/IRGeneration/Expr.lean` to reflect the new proof approach options, and extends `scripts/check_doc_counts.py` to count and validate public AST equivalence theorems in `Verity/AST/*.lean` against documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6330c83738c0afaca5e7444fe49003472fa44602. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->