### PR TITLE
fix: remove dead FiniteSet code, stale comments, add CI hygiene checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Check storage layout consistency
         run: python3 scripts/check_storage_layout.py
 
+      - name: Check Lean hygiene
+        run: python3 scripts/check_lean_hygiene.py
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/Compiler/Proofs/IRGeneration/Expr.lean
+++ b/Compiler/Proofs/IRGeneration/Expr.lean
@@ -2,9 +2,8 @@
   Expression Compilation Correctness
 
   The compilation functions (compileExpr, compileStmt, etc.) in ContractSpec are
-  now public, enabling structural induction proofs over Expr/Stmt constructors.
-  See issue #358 for the roadmap toward a universal compile_preserves_semantics
-  theorem.
+  now public (PR #374), enabling structural induction proofs over Expr/Stmt
+  constructors toward a universal compile_preserves_semantics theorem.
 
   This file retains the concrete-IR approach for SimpleStorage as a reference
   and baseline. New generic proofs should go in dedicated files.
@@ -35,9 +34,9 @@ Now that compileExpr/compileStmt are public, two proof approaches are available:
    contract, prove `compile spec selectors = .ok concreteIR` by `rfl`, then
    prove function-level correctness by `simp`-unfolding both sides.
 
-2. **Structural induction** (enabled by #358 Step 1): Prove correctness by
+2. **Structural induction** (enabled by PR #374): Prove correctness by
    induction over `Expr`/`Stmt` constructors. This yields a universal theorem
-   covering all contracts — see issue #358 for the full roadmap.
+   covering all contracts (see issue #358).
 
 This file uses approach (1) for SimpleStorage as a baseline.
 -/

--- a/Compiler/Proofs/IRGeneration/SimpleStorageProof.lean
+++ b/Compiler/Proofs/IRGeneration/SimpleStorageProof.lean
@@ -21,13 +21,6 @@ open Verity
 open DiffTestTypes
 open Verity.Proofs.Stdlib.SpecInterpreter
 
-/-! ## Setup: Compile SimpleStorage
-
-First, let's verify that SimpleStorage compiles successfully.
--/
-
-#eval compile simpleStorageSpec [0x6057361d, 0x2e64cec1]
-
 /-! ## Store Function Correctness
 
 The store function should:

--- a/Compiler/Proofs/YulGeneration/Preservation.lean
+++ b/Compiler/Proofs/YulGeneration/Preservation.lean
@@ -93,16 +93,16 @@ theorem yulCodegen_preserves_semantics
 /-! ## Complete Preservation Theorem (No Undischarged Hypotheses)
 
 This version of the preservation theorem discharges the `hbody` hypothesis
-using the proven `all_stmts_equiv` and the `execIRStmtsFuel_adequate` axiom.
+using the proven `all_stmts_equiv` and the `execIRFunctionFuel_eq_execIRFunction` lemma.
 
 The remaining gap between `interpretYulBodyFromState` (fuel-based proof chain) and
 `interpretYulBody` (used by the parameterized theorem above) requires bridging two
 different Yul execution entry points. This bridging lemma documents that gap explicitly.
 
-**Proof chain** (complete except for fuel adequacy axiom):
+**Proof chain** (complete — fuel adequacy is now `rfl`):
 1. `all_stmts_equiv` — every IR statement type is equivalent (StatementEquivalence.lean)
 2. `execIRStmtsFuel_equiv_execYulStmtsFuel_of_stmt_equiv` — lifts to lists (Equivalence.lean)
-3. `execIRStmtsFuel_adequate` — bridges partial ↔ fuel-based IR (Equivalence.lean, axiom)
+3. `execIRFunctionFuel_eq_execIRFunction` — bridges fuel-based ↔ total IR (Equivalence.lean, `rfl`)
 4. `ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy` — function-level equivalence
 
 The theorem `ir_function_body_equiv` below demonstrates the complete chain for any

--- a/Verity/Core/FiniteSet.lean
+++ b/Verity/Core/FiniteSet.lean
@@ -5,11 +5,9 @@
   lists, together with the operations and theorems needed for proving
   balance-conservation properties (e.g. Ledger sum proofs, issue #65).
 
-  Key operations: empty, insert, remove, contains, union, inter, filter, sum,
-                  subset, member, toList, fromList.
+  Key operations: empty, insert, sum.
   Key types: FiniteSet α, FiniteAddressSet.
-  Key theorems: insert_of_mem, insert_of_not_mem, mem_elements_insert,
-                card_insert_of_not_mem, card_insert_of_mem, sum_empty.
+  Key theorems: insert_of_not_mem, mem_elements_insert, sum_empty.
 -/
 
 namespace Verity.Core
@@ -35,50 +33,9 @@ def insert [DecidableEq α] (a : α) (s : FiniteSet α) : FiniteSet α :=
   else
     ⟨a :: s.elements, List.nodup_cons.mpr ⟨h, s.nodup⟩⟩
 
-/-- Check if an element is in the set -/
-def contains [DecidableEq α] (a : α) (s : FiniteSet α) : Bool :=
-  s.elements.contains a
-
-/-- Remove an element from the set -/
-def remove [DecidableEq α] (a : α) (s : FiniteSet α) : FiniteSet α :=
-  let filtered := s.elements.filter (fun x => !(x == a))
-  ⟨filtered, List.Nodup.sublist (List.filter_sublist _) s.nodup⟩
-
-/-- Get the size of the set -/
-def card (s : FiniteSet α) : Nat :=
-  s.elements.length
-
 /-- Sum a function over all elements in the set -/
 def sum [Add β] [OfNat β 0] (s : FiniteSet α) (f : α → β) : β :=
   s.elements.foldl (fun acc x => acc + f x) 0
-
-/-- Filter elements satisfying a predicate -/
-def filter (p : α → Bool) (s : FiniteSet α) : FiniteSet α :=
-  ⟨s.elements.filter p, List.Nodup.sublist (List.filter_sublist _) s.nodup⟩
-
-/-- Union of two sets -/
-def union [DecidableEq α] (s₁ s₂ : FiniteSet α) : FiniteSet α :=
-  s₂.elements.foldl (fun acc x => acc.insert x) s₁
-
-/-- Intersection of two sets -/
-def inter [DecidableEq α] (s₁ s₂ : FiniteSet α) : FiniteSet α :=
-  s₁.filter (fun x => s₂.contains x)
-
-/-- Convert to a list (the underlying elements) -/
-def toList (s : FiniteSet α) : List α :=
-  s.elements
-
-/-- Create a finite set from a list (removes duplicates) -/
-def fromList [DecidableEq α] (l : List α) : FiniteSet α :=
-  l.foldl (fun acc x => acc.insert x) empty
-
-/-- Check if one set is a subset of another -/
-def subset [DecidableEq α] (s₁ s₂ : FiniteSet α) : Bool :=
-  s₁.elements.all (fun x => s₂.contains x)
-
-/-- Check if an element is a member (alias for contains, returns Prop for proofs) -/
-def member [DecidableEq α] (a : α) (s : FiniteSet α) : Prop :=
-  a ∈ s.elements
 
 /-!
 ### Theorems
@@ -90,25 +47,11 @@ These are directly needed by Ledger sum proofs (#65).
 /-- The empty set has no members in its elements list -/
 @[simp] theorem elements_empty : (empty : FiniteSet α).elements = [] := rfl
 
-/-- Inserting an element already in the set returns the same set -/
-theorem insert_of_mem [DecidableEq α] (a : α) (s : FiniteSet α) (h : a ∈ s.elements) :
-    s.insert a = s := by
-  unfold insert
-  simp [dif_pos h]
-
 /-- Inserting a new element prepends it -/
 theorem insert_of_not_mem [DecidableEq α] (a : α) (s : FiniteSet α) (h : a ∉ s.elements) :
     (s.insert a).elements = a :: s.elements := by
   unfold insert
   simp [dif_neg h]
-
-/-- After inserting, the element is in the elements list -/
-theorem mem_elements_insert_self [DecidableEq α] (a : α) (s : FiniteSet α) :
-    a ∈ (s.insert a).elements := by
-  unfold insert
-  split
-  · assumption
-  · exact List.mem_cons_self a s.elements
 
 /-- Membership in insert: either the new element or an existing one -/
 theorem mem_elements_insert [DecidableEq α] (a b : α) (s : FiniteSet α) :
@@ -122,34 +65,9 @@ theorem mem_elements_insert [DecidableEq α] (a b : α) (s : FiniteSet α) :
       | inr hmem => exact hmem
   · simp [List.mem_cons]
 
-/-- Card of empty is 0 -/
-@[simp] theorem card_empty : (empty : FiniteSet α).card = 0 := rfl
-
-/-- Card increases by 1 on fresh insert -/
-theorem card_insert_of_not_mem [DecidableEq α] (a : α) (s : FiniteSet α) (h : a ∉ s.elements) :
-    (s.insert a).card = s.card + 1 := by
-  unfold insert card
-  simp [dif_neg h]
-
-/-- Card is unchanged for duplicate insert -/
-theorem card_insert_of_mem [DecidableEq α] (a : α) (s : FiniteSet α) (h : a ∈ s.elements) :
-    (s.insert a).card = s.card := by
-  unfold insert card
-  simp [dif_pos h]
-
 /-- Sum of empty set is zero -/
 @[simp] theorem sum_empty [Add β] [OfNat β 0] (f : α → β) :
     (empty : FiniteSet α).sum f = 0 := rfl
-
-/-- Subset is reflexive -/
-theorem subset_refl [DecidableEq α] (s : FiniteSet α) : s.subset s = true := by
-  unfold subset
-  simp [List.all_eq_true, contains]
-
-/-- Empty set is subset of any set -/
-theorem empty_subset [DecidableEq α] (s : FiniteSet α) : (empty : FiniteSet α).subset s = true := by
-  unfold subset
-  simp
 
 end FiniteSet
 
@@ -167,18 +85,6 @@ def empty : FiniteAddressSet :=
 /-- Insert an address into the set -/
 def insert (addr : String) (s : FiniteAddressSet) : FiniteAddressSet :=
   ⟨s.addresses.insert addr⟩
-
-/-- Check if an address is in the set -/
-def contains (addr : String) (s : FiniteAddressSet) : Bool :=
-  s.addresses.contains addr
-
-/-- Remove an address from the set -/
-def remove (addr : String) (s : FiniteAddressSet) : FiniteAddressSet :=
-  ⟨s.addresses.remove addr⟩
-
-/-- Get the number of addresses in the set -/
-def card (s : FiniteAddressSet) : Nat :=
-  s.addresses.card
 
 end FiniteAddressSet
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,7 +62,7 @@ Example output:
    Covered:    52 ( 88.1%)
    Excluded:     7 (proof-only)
 
-Overall: 69% coverage (220/319 properties)
+Overall: 67% coverage (220/326 properties)
 ```
 
 ### Property Exclusions
@@ -81,6 +81,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
+- **`check_lean_hygiene.py`** - Validates no `#eval` in Compiler/Proofs/ and exactly 1 `allowUnsafeReducibility` (documented trust assumption)
 
 ```bash
 # Run locally before submitting documentation changes
@@ -142,6 +143,7 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 5. Documentation count validation (`check_doc_counts.py`)
 6. Property manifest sync (`check_property_manifest_sync.py`)
 7. Storage layout consistency (`check_storage_layout.py`)
+8. Lean hygiene (`check_lean_hygiene.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/check_lean_hygiene.py
+++ b/scripts/check_lean_hygiene.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Check for Lean code hygiene issues.
+
+Validates:
+1. No #eval in Compiler/Proofs/ files (debug commands slow builds)
+2. Exactly 1 allowUnsafeReducibility (documented trust assumption)
+
+Usage:
+    python3 scripts/check_lean_hygiene.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from property_utils import die, report_errors
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    errors: list[str] = []
+
+    # Check 1: No #eval in proof files
+    proof_dirs = [ROOT / "Compiler" / "Proofs"]
+    for proof_dir in proof_dirs:
+        for lean_file in proof_dir.rglob("*.lean"):
+            rel = lean_file.relative_to(ROOT)
+            for i, line in enumerate(lean_file.read_text().splitlines(), 1):
+                stripped = line.lstrip()
+                if stripped.startswith("#eval ") or stripped == "#eval":
+                    errors.append(
+                        f"{rel}:{i}: found #eval in proof file "
+                        f"(debug command that slows builds)"
+                    )
+
+    # Check 2: Exactly 1 allowUnsafeReducibility
+    expected_unsafe = 1
+    unsafe_count = 0
+    unsafe_locations: list[str] = []
+    for lean_file in ROOT.rglob("*.lean"):
+        if ".lake" in str(lean_file):
+            continue
+        rel = lean_file.relative_to(ROOT)
+        for i, line in enumerate(lean_file.read_text().splitlines(), 1):
+            if "allowUnsafeReducibility" in line and not line.lstrip().startswith("--"):
+                unsafe_count += 1
+                unsafe_locations.append(f"{rel}:{i}")
+
+    if unsafe_count != expected_unsafe:
+        errors.append(
+            f"Expected {expected_unsafe} allowUnsafeReducibility, "
+            f"found {unsafe_count}: {unsafe_locations}"
+        )
+
+    report_errors(errors, "Lean hygiene check failed")
+    print(
+        f"Lean hygiene check passed "
+        f"(0 #eval in proofs, {unsafe_count} allowUnsafeReducibility)."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Remove ~100 lines of unused `FiniteSet`/`FiniteAddressSet` code (`remove`, `contains`, `card`, `filter`, `union`, `inter`, `toList`, `fromList`, `subset`, `member`, 6 unused theorems)
- Remove debug `#eval` from `SimpleStorageProof.lean` (runs at compile time, slows builds)
- Fix stale "axiom" label in `Preservation.lean` — `execIRStmtsFuel_adequate` was eliminated (now `rfl`)
- Update `Expr.lean` issue #358 references to credit PR #374 as the enabling work
- Add `check_lean_hygiene.py` CI script: validates no `#eval` in `Compiler/Proofs/` and exactly 1 `allowUnsafeReducibility` (documented trust assumption)

## Test plan
- [x] `lake build` succeeds (87/87 modules, zero errors)
- [x] `check_doc_counts.py` passes (326 theorems, 375 tests)
- [x] `check_contract_structure.py` passes (7/7 contracts)
- [x] `check_lean_hygiene.py` passes (0 #eval, 1 unsafe)
- [x] `check_axiom_locations.py` passes (2 axioms)
- [ ] CI build + Foundry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly removes dead code and updates comments/docs, plus a new CI lint that may fail existing/future PRs if they introduce `#eval` or extra `allowUnsafeReducibility`.
> 
> **Overview**
> Adds a new CI `checks` step (`scripts/check_lean_hygiene.py`) to enforce Lean proof hygiene by rejecting `#eval` under `Compiler/Proofs/` and requiring exactly one `allowUnsafeReducibility` across the repo.
> 
> Cleans up Lean sources by removing a debug `#eval` from `SimpleStorageProof.lean`, updating preservation proof commentary to reflect that fuel adequacy is now handled by `execIRFunctionFuel_eq_execIRFunction` (not an axiom), tightening `FiniteSet`/`FiniteAddressSet` to only the currently-used `empty`/`insert`/`sum` surface, and refreshing a few stale references in `Expr.lean`/`scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b068f3116b5ab3f4a8959e00f654075e931cceb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->