### PR TITLE
fix: suppress build warning, complete doc checklists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ FOUNDRY_PROFILE=difftest forge test  # Must pass — runs all Foundry tests
 - Plus any other files that reference theorem/test/contract counts (e.g., `compiler.mdx`, `research.mdx`, `index.mdx`, `layout.tsx`, `ROADMAP.md`, `TRUST_ASSUMPTIONS.md`, `test/README.md`)
 - Run `python3 scripts/check_contract_structure.py` to verify file structure is complete
 - Run `python3 scripts/check_doc_counts.py` to verify all counts are synchronized (validates 14 doc files + property test headers)
+- Run `python3 scripts/check_lean_hygiene.py` to verify no `#eval` in proof files and `allowUnsafeReducibility` count is correct
 
 ## Code Style
 

--- a/Verity/Specs/Common/Sum.lean
+++ b/Verity/Specs/Common/Sum.lean
@@ -77,7 +77,7 @@ theorem sumBalances_insert_existing {slot : Nat} {addr : Address} {addrs : Finit
 theorem sumBalances_insert_new {slot : Nat} {addr : Address} {addrs : FiniteAddressSet}
     {balances : Nat → Address → Uint256} {amount : Uint256}
     (h : addr ∉ addrs.addresses.elements)
-    (h_zero : balances slot addr = 0) :
+    (_h_zero : balances slot addr = 0) :
     sumBalances slot (addrs.insert addr) (fun s a =>
       if s == slot && a == addr then amount else balances s a) =
     add (sumBalances slot addrs balances) amount := by

--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -109,11 +109,13 @@ python3 scripts/check_property_manifest.py
 python3 scripts/check_property_manifest_sync.py
 python3 scripts/check_property_coverage.py
 
-# 5. Storage layout and selectors are correct
+# 5. Storage layout, selectors, and code hygiene
 python3 scripts/check_storage_layout.py
 python3 scripts/check_selectors.py
 python3 scripts/check_contract_structure.py
 python3 scripts/check_doc_counts.py
+python3 scripts/check_axiom_locations.py
+python3 scripts/check_lean_hygiene.py
 ```
 
 **Reference**: See [SimpleStorage](/examples#simplestorage) for a minimal end-to-end example.


### PR DESCRIPTION
## Summary
- Rename unused `h_zero` to `_h_zero` in `Sum.lean` — eliminates the **only** build warning in the entire codebase (0 warnings now)
- Add `check_axiom_locations.py` and `check_lean_hygiene.py` to the developer checklists in `add-contract.mdx` and `CONTRIBUTING.md`

## Test plan
- [x] `lake build` succeeds with **zero warnings** (was 1 warning before)
- [x] `check_doc_counts.py` passes
- [x] `check_lean_hygiene.py` passes
- [ ] CI build + Foundry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only a Lean proof parameter rename to silence a warning and documentation checklist updates; no functional or proof logic changes.
> 
> **Overview**
> Eliminates a Lean build warning by renaming an unused hypothesis parameter in `Verity/Specs/Common/Sum.lean`.
> 
> Updates contributor docs/checklists (`CONTRIBUTING.md`, `docs-site/content/add-contract.mdx`) to include additional validation steps, adding `check_axiom_locations.py` and `check_lean_hygiene.py` to the recommended contract-add workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b978ba0428faffb86ec81e06f919a01d3f178d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->