### PR TITLE
refactor: use Automation helpers across SafeCounter, Ledger, SimpleToken

### DIFF
--- a/Verity/Proofs/Ledger/Basic.lean
+++ b/Verity/Proofs/Ledger/Basic.lean
@@ -16,6 +16,7 @@ import Verity.Specs.Ledger.Spec
 import Verity.Specs.Ledger.Invariants
 import Verity.Stdlib.Math
 import Verity.Proofs.Stdlib.Math
+import Verity.Proofs.Stdlib.Automation
 
 namespace Verity.Proofs.Ledger
 
@@ -24,6 +25,7 @@ open Verity.Examples.Ledger
 open Verity.Specs.Ledger
 open Verity.Stdlib.Math (safeAdd requireSomeUint MAX_UINT256)
 open Verity.Proofs.Stdlib.Math (safeAdd_some safeAdd_none)
+open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne)
 
 /-! ## getBalance Correctness -/
 
@@ -220,14 +222,11 @@ theorem transfer_meets_spec (s : ContractState) (to : Address) (amount : Uint256
   · rw [transfer_unfold_other s to amount h_balance h_eq (h_no_overflow h_eq)]
     simp only [ContractResult.snd, transfer_spec]
     refine ⟨?_, ?_, ?_, ?_⟩
-    · have h_ne' : (s.sender == to) = false := by
-        simp [beq_iff_eq]; exact h_eq
+    · have h_ne' := address_beq_false_of_ne s.sender to h_eq
       simp [beq_iff_eq, h_ne', h_balance]
-    · have h_ne' : (s.sender == to) = false := by
-        simp [beq_iff_eq]; exact h_eq
+    · have h_ne' := address_beq_false_of_ne s.sender to h_eq
       simp [beq_iff_eq, h_ne']
-    · have h_ne' : (s.sender == to) = false := by
-        simp [beq_iff_eq]; exact h_eq
+    · have h_ne' := address_beq_false_of_ne s.sender to h_eq
       simp [h_ne']
       refine ⟨?_, ?_⟩
       · intro addr h_ne_sender h_ne_to

--- a/Verity/Proofs/SafeCounter/Correctness.lean
+++ b/Verity/Proofs/SafeCounter/Correctness.lean
@@ -14,6 +14,7 @@ import Verity.Examples.SafeCounter
 import Verity.Specs.SafeCounter.Spec
 import Verity.Specs.SafeCounter.Invariants
 import Verity.Proofs.SafeCounter.Basic
+import Verity.Proofs.Stdlib.Automation
 
 namespace Verity.Proofs.SafeCounter.Correctness
 
@@ -23,6 +24,7 @@ open Verity.EVM.Uint256
 open Verity.Examples.SafeCounter
 open Verity.Specs.SafeCounter
 open Verity.Proofs.SafeCounter
+open Verity.Proofs.Stdlib.Automation
 
 /-! ## Standalone Invariant Proofs
 
@@ -96,14 +98,9 @@ theorem increment_decrement_cancel (s : ContractState)
   -- After increment, s'.storage 0 = s.storage 0 + 1 ≥ 1
   have h_ge : ((increment).run s).snd.storage 0 ≥ 1 := by
     rw [h_inc, h_add]
-    have h_max_lt : MAX_UINT256 < Verity.Core.Uint256.modulus := by
-      have h_succ : MAX_UINT256 < MAX_UINT256 + 1 := Nat.lt_succ_self _
-      have h_eq : MAX_UINT256 + 1 = Verity.Core.Uint256.modulus :=
-        Verity.Core.Uint256.max_uint256_succ_eq_modulus
-      simpa [h_eq] using h_succ
     have h_sum_lt :
-        (s.storage 0 : Nat) + 1 < Verity.Core.Uint256.modulus := by
-      exact Nat.lt_of_le_of_lt h_no_overflow h_max_lt
+        (s.storage 0 : Nat) + 1 < Verity.Core.Uint256.modulus :=
+      lt_modulus_of_le_max_uint256 _ h_no_overflow
     have h_val :
         ((s.storage 0 + 1 : Uint256) : Nat) = (s.storage 0 : Nat) + 1 := by
       exact Verity.Core.Uint256.add_eq_of_lt h_sum_lt

--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -13,6 +13,7 @@ import Verity.Examples.SimpleToken
 import Verity.EVM.Uint256
 import Verity.Stdlib.Math
 import Verity.Proofs.Stdlib.Math
+import Verity.Proofs.Stdlib.Automation
 import Verity.Specs.SimpleToken.Spec
 import Verity.Specs.SimpleToken.Invariants
 
@@ -21,6 +22,7 @@ namespace Verity.Proofs.SimpleToken
 open Verity
 open Verity.Stdlib.Math
 open Verity.Proofs.Stdlib.Math (safeAdd_some safeAdd_none)
+open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne)
 open Verity.Examples.SimpleToken (constructor mint transfer balanceOf getTotalSupply getOwner isOwner)
 open Verity.Specs.SimpleToken hiding owner balances totalSupply
 
@@ -346,16 +348,13 @@ theorem transfer_meets_spec_when_sufficient (s : ContractState) (to : Address) (
     simp only [ContractResult.snd]
     refine ⟨h_balance, ?_, ?_, ?_, ?_, ?_⟩
     · -- sender balance decreased: the 'to' branch doesn't match sender
-      have h_ne' : (s.sender == to) = false := by
-        simp [beq_iff_eq]; exact h_eq
+      have h_ne' := address_beq_false_of_ne s.sender to h_eq
       simp [h_ne']
     · -- recipient balance increased
-      have h_ne' : (s.sender == to) = false := by
-        simp [beq_iff_eq]; exact h_eq
+      have h_ne' := address_beq_false_of_ne s.sender to h_eq
       simp [h_ne']
     · -- other balances/slots preserved
-      have h_ne' : (s.sender == to) = false := by
-        simp [beq_iff_eq]; exact h_eq
+      have h_ne' := address_beq_false_of_ne s.sender to h_eq
       simp [h_ne']
       refine ⟨?_, ?_⟩
       · intro addr h_ne_sender h_ne_to; simp [h_ne_sender, h_ne_to]

--- a/scripts/check_lean_hygiene.py
+++ b/scripts/check_lean_hygiene.py
@@ -22,7 +22,7 @@ def main() -> None:
     errors: list[str] = []
 
     # Check 1: No #eval in proof files
-    proof_dirs = [ROOT / "Compiler" / "Proofs"]
+    proof_dirs = [ROOT / "Compiler" / "Proofs", ROOT / "Verity" / "Proofs"]
     for proof_dir in proof_dirs:
         for lean_file in proof_dir.rglob("*.lean"):
             rel = lean_file.relative_to(ROOT)


### PR DESCRIPTION
## Summary

- **SafeCounter.lean**: Remove dead `add_one_val_eq_mod` theorem and private `one_modulus` duplicate, replace with `one_mod_modulus` from Automation.lean, open Automation namespace for shorter qualified references
- **SafeCounter/Correctness.lean**: Replace 8-line manual `max_uint256_lt_modulus` derivation with `lt_modulus_of_le_max_uint256` one-liner
- **Ledger/Basic.lean & SimpleToken/Basic.lean**: Replace 6 `h_ne'` beq derivation blocks (`simp [beq_iff_eq]; exact h_eq`) with `address_beq_false_of_ne` calls
- **check_lean_hygiene.py**: Add `Verity/Proofs/` to proof directory scanning (was only checking `Compiler/Proofs/`)

Net: -15 lines, 0 new theorems, all 86 modules build, all CI checks pass.

Continues the proof deduplication work from #387 and #389.

## Test plan
- [x] `lake build` passes (86/86 modules)
- [x] All CI check scripts pass (manifest, doc counts, hygiene, axioms, coverage, structure, storage)
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactors of proof code plus a small CI hygiene-scan expansion; no runtime/contract semantics changes, but failures would surface as Lean proof or CI breakage.
> 
> **Overview**
> Refactors multiple Lean proof modules to **reuse shared lemmas from** `Verity.Proofs.Stdlib.Automation`, removing local duplicates and simplifying proof steps.
> 
> In `Compiler/Proofs/SpecCorrectness/SafeCounter.lean` and `Verity/Proofs/SafeCounter/Correctness.lean`, proofs now rely on `one_mod_modulus`, `add_one_preserves_order_iff_no_overflow`, and `lt_modulus_of_le_max_uint256` instead of bespoke intermediate lemmas/derivations. `Verity/Proofs/Ledger/Basic.lean` and `Verity/Proofs/SimpleToken/Basic.lean` similarly replace repeated address `beq`-simplification blocks with `address_beq_false_of_ne`.
> 
> Updates `scripts/check_lean_hygiene.py` to include `Verity/Proofs` in the “no `#eval` in proofs” scan, tightening CI hygiene coverage beyond `Compiler/Proofs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6370872f374b9dfc9797b67893f7b6fc4f7cb99b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->