### PR TITLE
refactor: remove redundant h_one_mod aliases from SpecCorrectness proofs

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Ledger.lean
+++ b/Compiler/Proofs/SpecCorrectness/Ledger.lean
@@ -316,20 +316,17 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
     · -- Spec success (self-transfer: amountDelta=0, overflow check trivially passes)
       have h_not_lt : ¬ (state.storageMap 0 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_eq_nat : (addressToNat sender == addressToNat sender) = true := by simp
       simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
         ledgerSpec, ledgerEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
         SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
         Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_sender_lt,
-        addressToNat_mod_eq, h_one_mod, h_eq_nat,
-        lookup_senderBal, lookup_recipientBal, lookup_addr_first,
+        h_eq_nat,
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
     constructor
     · -- Spec sender mapping equals EDSL sender mapping (self-transfer case)
       have h_not_lt : ¬ (state.storageMap 0 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_eq_nat : (addressToNat sender == addressToNat sender) = true := by
         simp
       have h_spec_val :
@@ -346,7 +343,7 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
           ledgerSpec, ledgerEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_sender_lt,
-          h_one_mod, h_eq_nat, h_self_mod_eq, h_self_ge,
+          h_eq_nat, h_self_mod_eq, h_self_ge,
           lookup_senderBal, lookup_recipientBal, lookup_senderBal_with_delta, lookup_recipientBal_with_delta,
           lookup_sameAddr_with_delta, lookup_delta_with_delta, lookup_amountDelta_with_delta,
           lookup_addr_first,
@@ -365,7 +362,6 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
     · -- Spec recipient mapping equals EDSL recipient mapping (same as sender)
       have h_not_lt : ¬ (state.storageMap 0 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_eq_nat : (addressToNat sender == addressToNat sender) = true := by
         simp
       have h_spec_val :
@@ -382,7 +378,7 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
           ledgerSpec, ledgerEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_sender_lt,
-          h_one_mod, h_eq_nat, h_self_mod_eq, h_self_ge,
+          h_eq_nat, h_self_mod_eq, h_self_ge,
           lookup_senderBal, lookup_recipientBal, lookup_senderBal_with_delta, lookup_recipientBal_with_delta,
           lookup_sameAddr_with_delta, lookup_delta_with_delta, lookup_amountDelta_with_delta,
           lookup_addr_first,
@@ -420,11 +416,10 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
     · -- Spec success (different addresses: overflow check uses h_no_overflow)
       have h_not_lt : ¬ (state.storageMap 0 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
         ledgerSpec, ledgerEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
         SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
-        Nat.mod_eq_of_lt h_amount_lt, addressToNat_mod_eq, h_one_mod,
+        Nat.mod_eq_of_lt h_amount_lt,
         h_addr_ne, h_addr_ne', lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
         h_overflow_mod_eq, h_overflow_ge,
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
@@ -432,7 +427,6 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
     · -- Spec sender mapping equals EDSL sender mapping
       have h_not_lt : ¬ (state.storageMap 0 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_spec_val :
           (let specTx : DiffTestTypes.Transaction := {
             sender := sender
@@ -446,7 +440,7 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
         simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
           ledgerSpec, ledgerEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
-          Nat.mod_eq_of_lt h_amount_lt, addressToNat_mod_eq, h_one_mod, h_addr_ne, h_addr_ne',
+          Nat.mod_eq_of_lt h_amount_lt, h_addr_ne, h_addr_ne',
           lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
           h_overflow_mod_eq, h_overflow_ge,
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
@@ -506,7 +500,6 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
     · -- Spec recipient mapping equals EDSL recipient mapping
       have h_not_lt : ¬ (state.storageMap 0 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_spec_val :
           (let specTx : DiffTestTypes.Transaction := {
             sender := sender
@@ -520,7 +513,7 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
         simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
           ledgerSpec, ledgerEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
-          Nat.mod_eq_of_lt h_amount_lt, addressToNat_mod_eq, h_one_mod, h_addr_ne, h_addr_ne',
+          Nat.mod_eq_of_lt h_amount_lt, h_addr_ne, h_addr_ne',
           lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
           h_overflow_mod_eq, h_overflow_ge,
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -353,13 +353,12 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
     · -- Spec success
       have h_not_lt : ¬ (state.storageMap 1 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_sender_lt : (state.storageMap 1 sender).val < Verity.Core.Uint256.modulus := (state.storageMap 1 sender).isLt
       simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
         simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
         SpecStorage.setMapping, SpecStorage.setSlot, h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt,
-        Nat.mod_eq_of_lt h_sender_lt, h_one_mod,
-        addressToNat_mod_eq, lookup_senderBal, lookup_recipientBal, lookup_addr_first,
+        Nat.mod_eq_of_lt h_sender_lt,
+        lookup_senderBal, lookup_recipientBal, lookup_addr_first,
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
     constructor
     · -- Sender mapping equals EDSL mapping (self-transfer)
@@ -367,7 +366,6 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
         exact Nat.not_lt_of_ge h
       have h_sender_lt : (state.storageMap 1 sender).val < Verity.Core.Uint256.modulus := by
         exact (state.storageMap 1 sender).isLt
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_eq_nat : (addressToNat sender == addressToNat sender) = true := by
         simp
       have h_spec_val :
@@ -384,7 +382,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
           simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage.setSlot, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_sender_lt,
-          addressToNat_mod_eq, h_one_mod, h_eq_nat,
+          h_eq_nat,
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
           lookup_addr_first]
       have h_edsl_val :
@@ -403,7 +401,6 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
         exact Nat.not_lt_of_ge h
       have h_sender_lt : (state.storageMap 1 sender).val < Verity.Core.Uint256.modulus := by
         exact (state.storageMap 1 sender).isLt
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_eq_nat : (addressToNat sender == addressToNat sender) = true := by
         simp
       have h_spec_val :
@@ -420,7 +417,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
           simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage.setSlot, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_sender_lt,
-          addressToNat_mod_eq, h_one_mod, h_eq_nat,
+          h_eq_nat,
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
           lookup_addr_first]
       have h_edsl_val :
@@ -455,7 +452,6 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
     · -- Spec success
       have h_not_lt : ¬ (state.storageMap 1 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_no_overflow_nat : (state.storageMap 1 to).val + amount ≤ MAX_UINT256 :=
         h_no_overflow h_ne
       have h_recip_add_mod : ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus = (state.storageMap 1 to).val + amount :=
@@ -464,14 +460,13 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
       simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
         simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
         SpecStorage.setMapping, SpecStorage.setSlot, h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt,
-        addressToNat_mod_eq, h_addr_ne, h_addr_ne', h_one_mod, lookup_senderBal, lookup_recipientBal, lookup_addr_first,
+        h_addr_ne, h_addr_ne', lookup_senderBal, lookup_recipientBal, lookup_addr_first,
         lookup_addr_second, List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
         h_recip_add_mod, h_recip_ge]
     constructor
     · -- Sender mapping equals EDSL mapping
       have h_not_lt : ¬ (state.storageMap 1 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_no_overflow_nat : (state.storageMap 1 to).val + amount ≤ MAX_UINT256 :=
         h_no_overflow h_ne
       have h_recip_add_mod : ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus = (state.storageMap 1 to).val + amount :=
@@ -490,7 +485,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
         simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
           simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage.setSlot, SpecStorage_getMapping_setMapping_same,
-          h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt, addressToNat_mod_eq, h_one_mod,
+          h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt,
           h_ne, h_addr_ne, h_addr_ne',
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
           lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
@@ -540,7 +535,6 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
     · -- Recipient mapping equals EDSL mapping
       have h_not_lt : ¬ (state.storageMap 1 sender).val < amount := by
         exact Nat.not_lt_of_ge h
-      have h_one_mod : (1 % Verity.Core.Uint256.modulus) = 1 := one_mod_modulus
       have h_no_overflow_nat : (state.storageMap 1 to).val + amount ≤ MAX_UINT256 :=
         h_no_overflow h_ne
       have h_recip_add_mod : ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus = (state.storageMap 1 to).val + amount :=
@@ -559,7 +553,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
         simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
           simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage.setSlot, SpecStorage_getMapping_setMapping_same,
-          h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt, addressToNat_mod_eq, h_one_mod, h_ne, h_addr_ne, h_addr_ne',
+          h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt, h_ne, h_addr_ne, h_addr_ne',
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
           lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
           h_recip_add_mod, h_recip_ge]


### PR DESCRIPTION
## Summary

- Remove all `have h_one_mod : (1 % modulus) = 1 := one_mod_modulus` aliases from Ledger.lean and SimpleToken.lean
- Since `one_mod_modulus` is `@[simp]` in Automation.lean, `simp` fires it automatically — no need for explicit hints
- Also remove `addressToNat_mod_eq` from explicit simp lists where it appeared alongside `h_one_mod` (also `@[simp]`)

**Ledger.lean**: -7 alias lines, -7 simp references
**SimpleToken.lean**: -6 alias lines, -7 simp references

Net: -13 lines, all 86 modules build, all CI checks pass. Continues #387, #389, #390 proof dedup series.

## Test plan
- [x] `lake build` passes (86/86 modules)
- [x] All CI check scripts pass (hygiene, axioms, doc counts, coverage)
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactor relying on existing `@[simp]` lemmas; primary risk is only proof fragility/regressions in automation, not runtime behavior.
> 
> **Overview**
> Refactors `Ledger.lean` and `SimpleToken.lean` spec-correctness proofs by removing local `h_one_mod : (1 % Uint256.modulus) = 1` aliases and dropping now-redundant `addressToNat_mod_eq` entries from `simp` argument lists, relying on the `@[simp]` lemmas from `Automation.lean` instead.
> 
> This is a proof-maintenance change only (no spec/EDSL semantics changed), reducing repeated hints and simplifying `simp` invocations in transfer correctness cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 634d105a6b1e735407f54212a0fa86bc05a84df0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->