### PR TITLE
refactor: remove redundant @[simp] lookups from simp lists

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Ledger.lean
+++ b/Compiler/Proofs/SpecCorrectness/Ledger.lean
@@ -344,9 +344,6 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
           SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_sender_lt,
           h_eq_nat, h_self_mod_eq, h_self_ge,
-          lookup_senderBal, lookup_recipientBal, lookup_senderBal_with_delta, lookup_recipientBal_with_delta,
-          lookup_sameAddr_with_delta, lookup_delta_with_delta, lookup_amountDelta_with_delta,
-          lookup_addr_first,
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
       have h_edsl_val :
           ((ContractResult.getState
@@ -379,9 +376,6 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
           SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_sender_lt,
           h_eq_nat, h_self_mod_eq, h_self_ge,
-          lookup_senderBal, lookup_recipientBal, lookup_senderBal_with_delta, lookup_recipientBal_with_delta,
-          lookup_sameAddr_with_delta, lookup_delta_with_delta, lookup_amountDelta_with_delta,
-          lookup_addr_first,
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
       have h_edsl_val :
           ((ContractResult.getState
@@ -420,7 +414,7 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
         ledgerSpec, ledgerEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
         SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
         Nat.mod_eq_of_lt h_amount_lt,
-        h_addr_ne, h_addr_ne', lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
+        h_addr_ne, h_addr_ne',
         h_overflow_mod_eq, h_overflow_ge,
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
     constructor
@@ -441,7 +435,6 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
           ledgerSpec, ledgerEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, h_addr_ne, h_addr_ne',
-          lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
           h_overflow_mod_eq, h_overflow_ge,
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
       have h_edsl_state :
@@ -514,7 +507,6 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
           ledgerSpec, ledgerEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
           SpecStorage.setMapping, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, h_addr_ne, h_addr_ne',
-          lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
           h_overflow_mod_eq, h_overflow_ge,
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
       have h_edsl_state :

--- a/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
@@ -116,7 +116,7 @@ theorem ownedCounter_increment_correct_as_owner (state : ContractState) (sender 
       simp [uint256_add_val] at h_inc_val'
       exact h_inc_val'
     simp [ownedCounterSpec, requireOwner, interpretSpec, ownedCounterEdslToSpecStorage, execFunction, execStmts,
-      execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot, h, h_inc_val, lookup_slot_second]
+      execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot, h, h_inc_val]
 
 /-- The `increment` function correctly reverts when called by non-owner -/
 theorem ownedCounter_increment_reverts_as_nonowner (state : ContractState) (sender : Address)
@@ -191,7 +191,7 @@ theorem ownedCounter_decrement_correct_as_owner (state : ContractState) (sender 
               (1 % Verity.Core.Uint256.modulus - (state.storage 1).val)) := by
       simpa [h_dec] using (uint256_sub_val (state.storage 1) 1)
     simp [ownedCounterSpec, requireOwner, interpretSpec, ownedCounterEdslToSpecStorage, execFunction, execStmts,
-      execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot, h, h_dec_val, lookup_slot_second]
+      execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot, h, h_dec_val]
 
 /-- The `decrement` function correctly reverts when called by non-owner -/
 theorem ownedCounter_decrement_reverts_as_nonowner (state : ContractState) (sender : Address)
@@ -234,7 +234,7 @@ theorem ownedCounter_getCount_correct (state : ContractState) (sender : Address)
     specResult.returnValue = some edslValue := by
   unfold Verity.Examples.OwnedCounter.getCount Contract.runValue ownedCounterSpec interpretSpec ownedCounterEdslToSpecStorage
   simp [getStorage, Verity.Examples.OwnedCounter.count, execFunction, execStmts, execStmt, evalExpr,
-    SpecStorage.getSlot, lookup_slot_second]
+    SpecStorage.getSlot]
 
 /-- The `getOwner` function correctly retrieves the owner address -/
 theorem ownedCounter_getOwner_correct (state : ContractState) (sender : Address) :

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -358,7 +358,6 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
         simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
         SpecStorage.setMapping, SpecStorage.setSlot, h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt,
         Nat.mod_eq_of_lt h_sender_lt,
-        lookup_senderBal, lookup_recipientBal, lookup_addr_first,
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
     constructor
     · -- Sender mapping equals EDSL mapping (self-transfer)
@@ -383,8 +382,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
           SpecStorage.setMapping, SpecStorage.setSlot, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_sender_lt,
           h_eq_nat,
-          List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
-          lookup_addr_first]
+          List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
       have h_edsl_val :
           ((ContractResult.getState
               ((transfer sender (Verity.Core.Uint256.ofNat amount)).run
@@ -418,8 +416,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
           SpecStorage.setMapping, SpecStorage.setSlot, SpecStorage_getMapping_setMapping_same, h, h_not_lt,
           Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_sender_lt,
           h_eq_nat,
-          List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
-          lookup_addr_first]
+          List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
       have h_edsl_val :
           ((ContractResult.getState
               ((transfer sender (Verity.Core.Uint256.ofNat amount)).run
@@ -460,8 +457,8 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
       simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
         simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
         SpecStorage.setMapping, SpecStorage.setSlot, h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt,
-        h_addr_ne, h_addr_ne', lookup_senderBal, lookup_recipientBal, lookup_addr_first,
-        lookup_addr_second, List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
+        h_addr_ne, h_addr_ne',
+        List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
         h_recip_add_mod, h_recip_ge]
     constructor
     · -- Sender mapping equals EDSL mapping
@@ -488,7 +485,6 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
           h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt,
           h_ne, h_addr_ne, h_addr_ne',
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
-          lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
           h_recip_add_mod, h_recip_ge]
       have h_edsl_state :
           (ContractResult.getState
@@ -555,7 +551,6 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
           SpecStorage.setMapping, SpecStorage.setSlot, SpecStorage_getMapping_setMapping_same,
           h, h_not_lt, Nat.mod_eq_of_lt h_amount_lt, h_ne, h_addr_ne, h_addr_ne',
           List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
-          lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second,
           h_recip_add_mod, h_recip_ge]
       have h_edsl_state :
           (ContractResult.getState
@@ -632,16 +627,14 @@ theorem token_transfer_reverts_insufficient (state : ContractState) (to : Addres
         simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
         SpecStorage.setMapping, SpecStorage.setSlot, SpecStorage_getMapping_setMapping_same,
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
-        h, h_insufficient, Nat.mod_eq_of_lt h_amount, lookup_senderBal, lookup_recipientBal,
-        lookup_addr_first]
+        h, h_insufficient, Nat.mod_eq_of_lt h_amount]
     · have h_addr_ne : addressToNat sender ≠ addressToNat to :=
         addressToNat_ne_of_ne sender to h_eq
       simp [interpretSpec, execFunction, execStmts, execStmt, evalExpr,
         simpleTokenSpec, requireOwner, tokenEdslToSpecStorageWithAddrs, SpecStorage.getMapping, SpecStorage.getSlot,
         SpecStorage.setMapping, SpecStorage.setSlot, SpecStorage_getMapping_setMapping_same,
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
-        h, h_insufficient, Nat.mod_eq_of_lt h_amount, h_addr_ne, lookup_senderBal, lookup_recipientBal,
-        lookup_addr_first, lookup_addr_second]
+        h, h_insufficient, Nat.mod_eq_of_lt h_amount, h_addr_ne]
 
 /-- The `balanceOf` function correctly retrieves balance -/
 theorem token_balanceOf_correct (state : ContractState) (addr : Address) (sender : Address) :
@@ -673,7 +666,7 @@ theorem token_getTotalSupply_correct (state : ContractState) (sender : Address) 
   unfold getTotalSupply Contract.runValue simpleTokenSpec interpretSpec tokenEdslToSpecStorageWithAddrs
   have h_slot : (List.lookup 2 [(0, addressToNat (state.storageAddr 0)), (2, (state.storage 2).val)]).getD 0
       = (state.storage 2).val := by
-    simp [lookup_addr_second, (by decide : (0:Nat) ≠ 2)]
+    simp [(by decide : (0:Nat) ≠ 2)]
   simp [getStorage, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot,
     totalSupply, h_slot]
 


### PR DESCRIPTION
## Summary

- Removes redundant `@[simp]`-tagged lemma names from explicit `simp [...]` calls across all 3 SpecCorrectness proof files
- All `lookup_*` lemmas (senderBal, recipientBal, addr_first, addr_second, slot_second, and the `_with_delta` variants) are already `@[simp]` in `Automation.lean` — the `simp` tactic includes them automatically, so listing them explicitly is dead weight
- Net result: **-15 lines** across Ledger.lean, SimpleToken.lean, and OwnedCounter.lean with zero semantic change

## Details

| File | Removals |
|------|----------|
| `Ledger.lean` | 5 simp calls cleaned (removed lookup_senderBal, lookup_recipientBal, lookup_addr_first, lookup_addr_second, and all `_with_delta` variants) |
| `SimpleToken.lean` | 9 simp calls cleaned (same lemmas + lookup_addr_first in self-transfer cases) |
| `OwnedCounter.lean` | 3 simp calls cleaned (removed lookup_slot_second) |

This is a continuation of PR #393 which removed the redundant `h_one_mod` aliases and `addressToNat_mod_eq` from the same files.

## Test plan

- [x] `lake build` passes (86/86 modules)
- [x] `check_lean_hygiene.py` passes
- [x] `check_doc_counts.py` passes (362 theorems, 2 axioms, 0 sorry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts proof scripts’ `simp` argument lists; no runtime code, specs, or theorem statements change, so impact should be limited to proof robustness if simp behavior changes upstream.
> 
> **Overview**
> Refactors the SpecCorrectness proofs for `Ledger`, `SimpleToken`, and `OwnedCounter` by removing explicitly listed `lookup_*` lemmas from `simp [...]` calls where those lemmas are already `@[simp]` in `Verity.Proofs.Stdlib.Automation`.
> 
> This is a proof-maintenance cleanup only: it trims redundant simp hints in multiple transfer/getter correctness proofs without changing theorem statements, proof structure, or semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ca7277c9b1a04debb638725623230489785050a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->