### PR TITLE
refactor: extract balance-conversion helpers into Automation

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Ledger.lean
+++ b/Compiler/Proofs/SpecCorrectness/Ledger.lean
@@ -148,14 +148,8 @@ theorem ledger_withdraw_correct_sufficient (state : ContractState) (amount : Nat
     specResult.success = true ∧
     specResult.finalStorage.getMapping 0 (addressToNat sender) =
       (edslResult.getState.storageMap 0 sender).val := by
-  have h_amount_lt : amount < Verity.Core.Uint256.modulus := by
-    have hlt : (state.storageMap 0 sender).val < Verity.Core.Uint256.modulus := by
-      exact (state.storageMap 0 sender).isLt
-    exact Nat.lt_of_le_of_lt h hlt
-  have h_balance_u :
-      (state.storageMap 0 sender) ≥ Verity.Core.Uint256.ofNat amount := by
-    simp [Verity.Core.Uint256.le_def, Verity.Core.Uint256.val_ofNat,
-      Nat.mod_eq_of_lt h_amount_lt, h]
+  have h_amount_lt := amount_lt_modulus_of_val_ge (state.storageMap 0 sender) amount h
+  have h_balance_u := uint256_ofNat_le_of_val_ge (state.storageMap 0 sender) amount h
   constructor
   · -- EDSL success
     simp [withdraw, msgSender, getMapping, setMapping, balances,
@@ -288,14 +282,8 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
       (edslResult.getState.storageMap 0 sender).val ∧
     specResult.finalStorage.getMapping 0 (addressToNat to) =
       (edslResult.getState.storageMap 0 to).val := by
-  have h_amount_lt : amount < Verity.Core.Uint256.modulus := by
-    have hlt : (state.storageMap 0 sender).val < Verity.Core.Uint256.modulus := by
-      exact (state.storageMap 0 sender).isLt
-    exact Nat.lt_of_le_of_lt h hlt
-  have h_balance_u :
-      (state.storageMap 0 sender) ≥ Verity.Core.Uint256.ofNat amount := by
-    simp [Verity.Core.Uint256.le_def, Verity.Core.Uint256.val_ofNat,
-      Nat.mod_eq_of_lt h_amount_lt, h]
+  have h_amount_lt := amount_lt_modulus_of_val_ge (state.storageMap 0 sender) amount h
+  have h_balance_u := uint256_ofNat_le_of_val_ge (state.storageMap 0 sender) amount h
   -- Helper: overflow ge-check for the spec's new require on newRecipientBal
   have h_overflow_mod_eq : ((state.storageMap 0 to).val + amount) % Verity.Core.Uint256.modulus = (state.storageMap 0 to).val + amount := by
     exact Nat.mod_eq_of_lt (lt_modulus_of_le_max_uint256 _ h_no_overflow)
@@ -665,14 +653,8 @@ theorem ledger_transfer_preserves_total (state : ContractState) (to : Address) (
     let finalState := (transfer to (Verity.Core.Uint256.ofNat amount)).runState { state with sender := sender }
     (finalState.storageMap 0 sender).val + (finalState.storageMap 0 to).val =
     (state.storageMap 0 sender).val + (state.storageMap 0 to).val := by
-  have h_amount_lt : amount < Verity.Core.Uint256.modulus := by
-    have hlt : (state.storageMap 0 sender).val < Verity.Core.Uint256.modulus := by
-      exact (state.storageMap 0 sender).isLt
-    exact Nat.lt_of_le_of_lt h2 hlt
-  have h_balance_u :
-      (state.storageMap 0 sender) ≥ Verity.Core.Uint256.ofNat amount := by
-    simp [Verity.Core.Uint256.le_def, Verity.Core.Uint256.val_ofNat,
-      Nat.mod_eq_of_lt h_amount_lt, h2]
+  have h_amount_lt := amount_lt_modulus_of_val_ge (state.storageMap 0 sender) amount h2
+  have h_balance_u := uint256_ofNat_le_of_val_ge (state.storageMap 0 sender) amount h2
   have h_no_overflow_u2 : (state.storageMap 0 to : Nat) + ((Verity.Core.Uint256.ofNat amount) : Nat) ≤ MAX_UINT256 := by
     simp only [Verity.Core.Uint256.val_ofNat, Nat.mod_eq_of_lt h_amount_lt, MAX_UINT256, Verity.Stdlib.Math.MAX_UINT256]
     have h_max : Verity.Core.Uint256.modulus = 2 ^ 256 := rfl

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -334,14 +334,8 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
     specResult.success = true ∧
     specResult.finalStorage.getMapping 1 (addressToNat sender) = (edslResult.getState.storageMap 1 sender).val ∧
     specResult.finalStorage.getMapping 1 (addressToNat to) = (edslResult.getState.storageMap 1 to).val := by
-  have h_amount_lt : amount < Verity.Core.Uint256.modulus := by
-    have hlt : (state.storageMap 1 sender).val < Verity.Core.Uint256.modulus := by
-      exact (state.storageMap 1 sender).isLt
-    exact Nat.lt_of_le_of_lt h hlt
-  have h_balance_u :
-      (state.storageMap 1 sender) ≥ Verity.Core.Uint256.ofNat amount := by
-    simp [Verity.Core.Uint256.le_def, Verity.Core.Uint256.val_ofNat,
-      Nat.mod_eq_of_lt h_amount_lt, h]
+  have h_amount_lt := amount_lt_modulus_of_val_ge (state.storageMap 1 sender) amount h
+  have h_balance_u := uint256_ofNat_le_of_val_ge (state.storageMap 1 sender) amount h
   by_cases h_eq : sender = to
   · subst h_eq
     constructor
@@ -759,14 +753,8 @@ theorem token_transfer_preserves_supply (state : ContractState) (to : Address) (
     (h : (state.storageMap 1 sender).val ≥ amount) :
     let finalState := (transfer to (Verity.Core.Uint256.ofNat amount)).runState { state with sender := sender }
     finalState.storage 2 = state.storage 2 := by
-  have h_amount_lt : amount < Verity.Core.Uint256.modulus := by
-    have hlt : (state.storageMap 1 sender).val < Verity.Core.Uint256.modulus := by
-      exact (state.storageMap 1 sender).isLt
-    exact Nat.lt_of_le_of_lt h hlt
-  have h_balance_u :
-      (state.storageMap 1 sender) ≥ Verity.Core.Uint256.ofNat amount := by
-    simp [Verity.Core.Uint256.le_def, Verity.Core.Uint256.val_ofNat,
-      Nat.mod_eq_of_lt h_amount_lt, h]
+  have h_amount_lt := amount_lt_modulus_of_val_ge (state.storageMap 1 sender) amount h
+  have h_balance_u := uint256_ofNat_le_of_val_ge (state.storageMap 1 sender) amount h
   by_cases h_eq : sender = to
   · subst h_eq
     simp [transfer, msgSender, getMapping, setMapping, balances,
@@ -812,14 +800,8 @@ theorem token_transfer_preserves_total_balance (state : ContractState) (to : Add
     let finalState := (transfer to (Verity.Core.Uint256.ofNat amount)).runState { state with sender := sender }
     (finalState.storageMap 1 sender).val + (finalState.storageMap 1 to).val =
     (state.storageMap 1 sender).val + (state.storageMap 1 to).val := by
-  have h_amount_lt : amount < Verity.Core.Uint256.modulus := by
-    have hlt : (state.storageMap 1 sender).val < Verity.Core.Uint256.modulus := by
-      exact (state.storageMap 1 sender).isLt
-    exact Nat.lt_of_le_of_lt h2 hlt
-  have h_balance_u :
-      (state.storageMap 1 sender) ≥ Verity.Core.Uint256.ofNat amount := by
-    simp [Verity.Core.Uint256.le_def, Verity.Core.Uint256.val_ofNat,
-      Nat.mod_eq_of_lt h_amount_lt, h2]
+  have h_amount_lt := amount_lt_modulus_of_val_ge (state.storageMap 1 sender) amount h2
+  have h_balance_u := uint256_ofNat_le_of_val_ge (state.storageMap 1 sender) amount h2
   have h_no_overflow_nat : (state.storageMap 1 to).val + amount ≤ MAX_UINT256 := by
     have := modulus_eq_max_uint256_succ; omega
   have h_safe : safeAdd (state.storageMap 1 to) (Verity.Core.Uint256.ofNat amount) = some (state.storageMap 1 to + Verity.Core.Uint256.ofNat amount) := by

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/Th0rgal/verity/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/built%20with-Lean%204-blueviolet.svg" alt="Built with Lean 4"></a>
-  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-363-brightgreen.svg" alt="363 Theorems"></a>
+  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-365-brightgreen.svg" alt="365 Theorems"></a>
   <a href="https://github.com/Th0rgal/verity/actions"><img src="https://img.shields.io/github/actions/workflow/status/Th0rgal/verity/verify.yml?label=verify" alt="Verify"></a>
 </p>
 
@@ -28,7 +28,7 @@ source ~/.elan/env
 # 2. Clone and build
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                                    # Verifies all 363 theorems
+lake build                                    # Verifies all 365 theorems
 
 # 3. Generate a new contract
 python3 scripts/generate_contract.py MyContract
@@ -123,7 +123,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-363 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (61% coverage, 143 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+365 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (60% coverage, 145 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -79,7 +79,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: All 363 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (61% runtime test coverage).
+**Coverage**: All 365 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (60% runtime test coverage).
 
 **What this guarantees**:
 - Contract behavior matches specification
@@ -714,7 +714,7 @@ Verity provides **strong formal verification** with a **small trusted computing 
 ✅ Contract implementations match specifications (Layer 1)
 ✅ Specifications preserved through compilation (Layer 2)
 ✅ IR semantics equivalent to Yul semantics (Layer 3)
-✅ 363 theorems across 9 categories (220 covered by property tests)
+✅ 365 theorems across 9 categories (220 covered by property tests)
 
 ### What is Trusted (Validated but Not Proven)
 ⚠️ Solidity compiler (solc) - Validated by 70k+ differential tests

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -766,6 +766,21 @@ theorem lt_modulus_of_le_max_uint256 (n : Nat)
 theorem uint256_ge_val_le {a b : Verity.Core.Uint256} (h : a ≥ b) : b.val ≤ a.val := by
   simpa [Verity.Core.Uint256.le_def] using h
 
+/-- `amount < modulus` when `bal.val ≥ amount` (amount fits in a Uint256 because balance does).
+    Eliminates the repeated 3-line pattern:
+    `have hlt := bal.isLt; exact Nat.lt_of_le_of_lt h hlt` -/
+theorem amount_lt_modulus_of_val_ge (bal : Verity.Core.Uint256) (amount : Nat)
+    (h : bal.val ≥ amount) : amount < Verity.Core.Uint256.modulus :=
+  Nat.lt_of_le_of_lt h bal.isLt
+
+/-- `bal ≥ ofNat amount` when `bal.val ≥ amount` (lift Nat comparison to Uint256).
+    Eliminates the repeated 3-line `simp [le_def, val_ofNat, mod_eq_of_lt ...]` block. -/
+theorem uint256_ofNat_le_of_val_ge (bal : Verity.Core.Uint256) (amount : Nat)
+    (h : bal.val ≥ amount) : bal ≥ Verity.Core.Uint256.ofNat amount := by
+  have h_lt := amount_lt_modulus_of_val_ge bal amount h
+  simp [Verity.Core.Uint256.le_def, Verity.Core.Uint256.val_ofNat,
+    Nat.mod_eq_of_lt h_lt, h]
+
 -- All lemmas in this file are fully proven with zero sorry (1 axiom: addressToNat_injective).
 
 end Verity.Proofs.Stdlib.Automation

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 
 const banner = (
   <Banner storageKey="verification-complete">
-    363/363 theorems proven — 100% formal verification
+    365/365 theorems proven — 100% formal verification
   </Banner>
 )
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -596,7 +596,7 @@ Time: **~5 minutes** (vs ~30 minutes manual IR)
 
 ### All Tests Pass ✅
 
-**Lean Proofs**: All proofs verified (363 EDSL theorems, 100%)
+**Lean Proofs**: All proofs verified (365 EDSL theorems, 100%)
 ```bash
 $ lake build
 Build completed successfully.
@@ -710,5 +710,5 @@ def ownedSpec : ContractSpec := {
 
 - [Research & Development](/research) — Design decisions and proof techniques
 - [Examples](/examples) — 9 example contracts
-- [Verification](/verification) — 363 proven theorems
+- [Verification](/verification) — 365 proven theorems
 - [GitHub Repository](https://github.com/Th0rgal/verity) — Source code

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -52,7 +52,7 @@ forge --version
 ```bash
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                # Downloads dependencies and verifies all 363 theorems
+lake build                # Downloads dependencies and verifies all 365 theorems
 ```
 
 The first build downloads Mathlib and compiles everything — expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 363 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 365 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 363 theorems, all fully proven. 2 documented axioms, 0 sorry.**
+**Compact core, built across 7 iterations. 365 theorems, all fully proven. 2 documented axioms, 0 sorry.**
 
 ## Evolution
 
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (363 theorems as of 2026-02-18)
+- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (365 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,11 +7,11 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 363 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 365 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-17)
 
-- EDSL theorems: 363 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
+- EDSL theorems: 365 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
 - SimpleStorage: 20 total (Basic 13, Correctness 7).
 - Counter: 28 total (Basic 19, Correctness 10; 1 shared between Basic and Correctness).
 - Owned: 22 total (Basic 18, Correctness 4).
@@ -20,7 +20,7 @@ The compiler is verified with IR preservation proofs and Yul equivalence proofs 
 - Ledger: 33 total (Basic 20, Correctness 6, Conservation 7 — all proven).
 - SafeCounter: 25 total (Basic 17, Correctness 8).
 - ReentrancyExample: 4 total (inline proofs: vulnerability existence, supply invariant).
-- Stdlib: 127 theorems (Math 25, Automation 53, MappingAutomation 37, ListSum 7; 2 shared between Automation and MappingAutomation).
+- Stdlib: 129 theorems (Math 25, Automation 55, MappingAutomation 37, ListSum 7; 2 shared between Automation and MappingAutomation).
 
 ## Unified AST Bridge (Issue #364)
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -17,7 +17,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Language**: Lean 4.15.0
 - **Core Size**: 350 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
-- **Theorems**: 363 across 9 categories (363 fully proven, 0 `sorry` placeholders)
+- **Theorems**: 365 across 9 categories (365 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 2 documented axioms (see AXIOMS.md) — keccak256, address injectivity
 - **Tests**: 375 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,10 +6,10 @@
 
 ## Current Status
 
-- ✅ **Layer 1 Complete**: 363 theorems across 9 categories (8 contracts + Stdlib math library)
+- ✅ **Layer 1 Complete**: 365 theorems across 9 categories (8 contracts + Stdlib math library)
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
-- ✅ **Property Testing**: 61% coverage (220/363), all testable properties covered
+- ✅ **Property Testing**: 60% coverage (220/365), all testable properties covered
 - ✅ **Differential Testing**: Production-ready with 70k+ tests
 - ✅ **Trust Reduction Phase 1**: keccak256 axiom + CI validation (PR #43, #46)
 - ✅ **External Linking**: Cryptographic library support (PR #49)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -63,7 +63,7 @@ EVM Bytecode
 | ReentrancyExample | 4 | ✅ Complete | `Verity/Examples/ReentrancyExample.lean` |
 | **Total** | **236** | **✅ 100%** | — |
 
-> **Note**: Stdlib (127 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (363 total properties).
+> **Note**: Stdlib (129 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (365 total properties).
 
 ### Example Property
 
@@ -177,13 +177,13 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ## Property Test Coverage 🎯 **NEAR COMPLETE**
 
-**Status**: 61% coverage (220/363), 143 remaining exclusions all proof-only
+**Status**: 60% coverage (220/365), 145 remaining exclusions all proof-only
 
 ### Current Coverage
 
-- **Total Properties**: 363
-- **Covered**: 220 (61%)
-- **Excluded**: 143 (all proof-only)
+- **Total Properties**: 365
+- **Covered**: 220 (60%)
+- **Excluded**: 145 (all proof-only)
 - **Missing**: 0
 
 ### Coverage by Contract
@@ -198,11 +198,11 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 | SimpleToken | 88% (52/59) | 7 proof-only | ✅ High coverage |
 | Counter | 82% (23/28) | 5 proof-only | ✅ High coverage |
 | Ledger | 100% (33/33) | 0 | ✅ Complete |
-| Stdlib | 0% (0/127) | 127 proof-only | — Internal |
+| Stdlib | 0% (0/129) | 129 proof-only | — Internal |
 
 ### Exclusion Categories
 
-**Proof-Only Properties (143 exclusions)**: Internal proof machinery that cannot be tested in Foundry
+**Proof-Only Properties (145 exclusions)**: Internal proof machinery that cannot be tested in Foundry
 - Storage helpers: `setStorage_*`, `getStorage_*`, `setMapping_*`, `getMapping_*`
 - Internal helpers: `isOwner_*` functions tested implicitly
 - Low-level operations used only in proofs

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ function testProperty_StoreRetrieve() public {
 }
 ```
 
-**Coverage**: 220/363 theorems tested (61%), 143 proof-only exclusions documented in `property_exclusions.json`.
+**Coverage**: 220/365 theorems tested (60%), 145 proof-only exclusions documented in `property_exclusions.json`.
 
 ### Differential Tests
 **Pattern**: `Differential<Contract>.t.sol`
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (195 functions, covering 220/363 theorems)
+├── Property*.t.sol           # Property tests (195 functions, covering 220/365 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -36,6 +36,7 @@
     "addressToNat_ne_of_ne",
     "address_beq_eq_true_iff_eq",
     "address_beq_false_of_ne",
+    "amount_lt_modulus_of_val_ge",
     "bind_getStorage_setStorage_runState",
     "bind_isSuccess_left",
     "countOccU_cons_eq",
@@ -150,6 +151,7 @@
     "setStorage_runState",
     "uint256_add_val",
     "uint256_ge_val_le",
+    "uint256_ofNat_le_of_val_ge",
     "uint256_sub_val",
     "uint256_sub_val_of_le",
     "wf_of_state_eq"

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -262,6 +262,7 @@
     "addressToNat_ne_of_ne",
     "address_beq_eq_true_iff_eq",
     "address_beq_false_of_ne",
+    "amount_lt_modulus_of_val_ge",
     "bind_getStorage_setStorage_runState",
     "bind_isSuccess_left",
     "countOccU_cons_eq",
@@ -376,6 +377,7 @@
     "setStorage_runState",
     "uint256_add_val",
     "uint256_ge_val_le",
+    "uint256_ofNat_le_of_val_ge",
     "uint256_sub_val",
     "uint256_sub_val_of_le",
     "wf_of_state_eq"


### PR DESCRIPTION
## Summary
- Adds `amount_lt_modulus_of_val_ge` and `uint256_ofNat_le_of_val_ge` to `Automation.lean` — two helpers that prove `amount < modulus` and `bal ≥ ofNat amount` from `bal.val ≥ amount`
- Replaces 6 instances of 8-line boilerplate blocks in `Ledger.lean` and `SimpleToken.lean` SpecCorrectness proofs with 2-line helper calls (-17 lines net)
- Updates manifest (365 theorems), exclusions (145), and all doc counts across 14 files

## Test plan
- [x] `lake build` passes (86/86 modules)
- [x] `python3 scripts/check_doc_counts.py` passes (365 theorems)
- [x] `python3 scripts/check_lean_hygiene.py` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical proof refactor plus documentation/manifest count updates; no runtime/compiler semantics change, with risk limited to potential proof automation lemma misuse or stale count synchronization.
> 
> **Overview**
> Refactors spec-correctness proofs by introducing `amount_lt_modulus_of_val_ge` and `uint256_ofNat_le_of_val_ge` in `Verity/Proofs/Stdlib/Automation.lean`, then replacing repeated local boilerplate in Ledger/SimpleToken correctness and invariant proofs with these helpers.
> 
> Updates the theorem/coverage bookkeeping to account for the two new Automation theorems (now **365** total), including property manifests/exclusions and various README/docs-site counters/badges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc47b1482ba84f7e02bfd4d74013b1aeeabf2fd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->