### PR TITLE
refactor: add sameContext_rfl, remove dead unfold_defs

### DIFF
--- a/Verity/Proofs/Ledger/Basic.lean
+++ b/Verity/Proofs/Ledger/Basic.lean
@@ -79,7 +79,7 @@ theorem deposit_meets_spec (s : ContractState) (amount : Uint256) :
       simp [ContractResult.snd, beq_iff_eq, h_ne]
   · rfl
   · rfl
-  · exact ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩
+  · exact Specs.sameContext_rfl _
 
 theorem deposit_increases_balance (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd
@@ -133,7 +133,7 @@ theorem withdraw_meets_spec (s : ContractState) (amount : Uint256)
       simp [ContractResult.snd, beq_iff_eq, h_ne]
   · rfl
   · rfl
-  · exact ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩
+  · exact Specs.sameContext_rfl _
 
 theorem withdraw_decreases_balance (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :

--- a/Verity/Proofs/SafeCounter/Basic.lean
+++ b/Verity/Proofs/SafeCounter/Basic.lean
@@ -81,7 +81,7 @@ theorem increment_meets_spec (s : ContractState)
     intro h_eq; exact absurd h_eq h_ne
   · rfl
   · rfl
-  · exact ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩
+  · exact Specs.sameContext_rfl _
 
 theorem increment_adds_one (s : ContractState)
   (h_no_overflow : (s.storage 0 : Nat) + 1 ≤ MAX_UINT256) :
@@ -144,7 +144,7 @@ theorem decrement_meets_spec (s : ContractState)
     intro h_eq; exact absurd h_eq h_ne
   · rfl
   · rfl
-  · exact ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩
+  · exact Specs.sameContext_rfl _
 
 theorem decrement_subtracts_one (s : ContractState)
   (h_no_underflow : (s.storage 0 : Nat) ≥ 1) :

--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -135,14 +135,6 @@ theorem isOwner_true_when_owner (s : ContractState) (h : s.sender = s.storageAdd
   simp only [isOwner, msgSender, getStorageAddr, Examples.SimpleToken.owner, bind, Bind.bind, Contract.run, pure, Pure.pure, ContractResult.fst]
   simp [h]
 
--- Shared unfolding definitions for mint and transfer proofs
-private abbrev unfold_defs := [``mint, ``transfer,
-  ``Verity.Examples.SimpleToken.onlyOwner, ``isOwner,
-  ``Examples.SimpleToken.owner, ``Examples.SimpleToken.balances, ``Examples.SimpleToken.totalSupply,
-  ``msgSender, ``getStorageAddr, ``setStorageAddr, ``getStorage, ``setStorage, ``getMapping, ``setMapping,
-  ``Verity.require, ``Verity.pure, ``Verity.bind, ``Bind.bind, ``Pure.pure,
-  ``Contract.run, ``ContractResult.snd, ``ContractResult.fst]
-
 -- Helper: unfold mint when owner guard passes and no overflow
 private theorem mint_unfold (s : ContractState) (to : Address) (amount : Uint256)
   (h_owner : s.sender = s.storageAddr 0)
@@ -203,7 +195,7 @@ theorem mint_meets_spec_when_owner (s : ContractState) (to : Address) (amount : 
     · intro slot h_neq; intro addr; simp [h_neq] -- other mapping slots
   · trivial -- owner preserved
   · intro slot h_neq; simp [h_neq] -- other uint storage
-  · exact ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩
+  · exact Specs.sameContext_rfl _
 
 theorem mint_increases_balance (s : ContractState) (to : Address) (amount : Uint256)
   (h_owner : s.sender = s.storageAddr 0)

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -18,6 +18,9 @@ def sameContext (s s' : ContractState) : Prop :=
   s'.msgValue = s.msgValue ∧
   s'.blockTimestamp = s.blockTimestamp
 
+@[simp] theorem sameContext_rfl (s : ContractState) : sameContext s s :=
+  ⟨rfl, rfl, rfl, rfl⟩
+
 /-- Uint256 storage is unchanged. -/
 def sameStorage (s s' : ContractState) : Prop :=
   s'.storage = s.storage


### PR DESCRIPTION
## Summary
- Adds `@[simp] theorem sameContext_rfl` to `Specs/Common.lean` — a named lemma for the reflexive case of `sameContext`, replacing the raw `⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩` tuple construction
- Replaces 5 instances of `exact ⟨rfl, ⟨rfl, ⟨rfl, rfl⟩⟩⟩` with `exact Specs.sameContext_rfl _` in SafeCounter, Ledger, and SimpleToken Basic proofs
- Removes unused `private abbrev unfold_defs` from `SimpleToken/Basic.lean` (dead code: defined but never referenced)
- Net: -5 lines (4 files changed, 8 insertions, 13 deletions)

## Test plan
- [x] `lake build` passes (86/86 modules)
- [x] `python3 scripts/check_doc_counts.py` passes (365 theorems)
- [x] `python3 scripts/check_lean_hygiene.py` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of Lean proof code and a new helper lemma; no executable contract/spec behavior changes, with minimal risk beyond proof compilation/simp behavior.
> 
> **Overview**
> Adds `@[simp]` lemma `Specs.sameContext_rfl` to name and reuse the reflexive case of `sameContext`.
> 
> Refactors several contract proof files (Ledger, SafeCounter, SimpleToken) to use `Specs.sameContext_rfl _` instead of repeating the nested `⟨rfl, ...⟩` construction, and deletes the unused `unfold_defs` abbrev from `SimpleToken/Basic.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79ca5ddb86ebc1ab30f431490664aa422a4747d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->