### PR TITLE
refactor: use beq_iff_eq.mp term-mode, remove breadcrumb comments

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Counter.lean
+++ b/Compiler/Proofs/SpecCorrectness/Counter.lean
@@ -151,7 +151,6 @@ theorem getCount_correct (state : ContractState) (sender : Address) :
     let specResult := interpretSpec counterSpec (counterEdslToSpecStorage state) specTx
     specResult.success = true ∧
     specResult.returnValue = some edslValue := by
-  -- Same pattern as SimpleStorage.retrieve_correct
   unfold getCount Contract.runValue counterSpec interpretSpec counterEdslToSpecStorage
   simp [getStorage, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot, count]
 

--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -143,7 +143,6 @@ theorem getOwner_correct (state : ContractState) (sender : Address) :
     let specResult := interpretSpec ownedSpec (ownedEdslToSpecStorage state) specTx
     specResult.success = true ∧
     specResult.returnValue = some (addressToNat edslAddr) := by
-  -- Same pattern as Counter.getCount_correct and SafeCounter.getCount_correct
   unfold Verity.Examples.Owned.getOwner Contract.runValue ownedSpec interpretSpec ownedEdslToSpecStorage
   simp [getStorageAddr, Verity.Examples.Owned.owner, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot]
 

--- a/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
@@ -421,7 +421,6 @@ theorem safeGetCount_correct (state : ContractState) (sender : Address) :
     let specResult := interpretSpec safeCounterSpec (safeCounterEdslToSpecStorage state) specTx
     specResult.success = true ∧
     specResult.returnValue = some edslValue := by
-  -- Same pattern as Counter.getCount_correct
   unfold getCount Contract.runValue safeCounterSpec interpretSpec safeCounterEdslToSpecStorage
   simp [getStorage, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot, count]
 

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -641,7 +641,6 @@ theorem token_balanceOf_correct (state : ContractState) (addr : Address) (sender
     let specResult := interpretSpec simpleTokenSpec (tokenEdslToSpecStorageWithAddrs state [addr]) specTx
     specResult.success = true ∧
     specResult.returnValue = some edslValue.val := by
-  -- Same pattern as other getters
   unfold balanceOf Contract.runValue simpleTokenSpec interpretSpec tokenEdslToSpecStorageWithAddrs
   simp [getMapping, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getMapping,
     balances]

--- a/Compiler/Proofs/YulGeneration/StatementEquivalence.lean
+++ b/Compiler/Proofs/YulGeneration/StatementEquivalence.lean
@@ -124,7 +124,6 @@ theorem storageLoad_equiv (selector : Nat) (fuel : Nat)
     execResultsAligned selector
       (execIRStmtFuel fuel irState (YulStmt.let_ varName (.call "sload" [slotExpr])))
       (execYulStmtFuel fuel yulState (YulStmt.let_ varName (.call "sload" [slotExpr]))) := by
-  -- Same pattern as assign_equiv
   unfold statesAligned at halign
   subst halign
   cases fuel with

--- a/Verity/Proofs/Counter/Basic.lean
+++ b/Verity/Proofs/Counter/Basic.lean
@@ -69,7 +69,7 @@ theorem increment_meets_spec (s : ContractState) :
     simp only [increment, count, getStorage, setStorage, bind, Contract.run, Bind.bind, ContractResult.snd]
     split
     · next h =>
-      have : slot = 0 := by simp [beq_iff_eq] at h; exact h
+      have : slot = 0 := beq_iff_eq.mp h
       exact absurd this h_neq
     · rfl
   · simp [Specs.sameAddrMapContext, Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap,
@@ -93,7 +93,7 @@ theorem decrement_meets_spec (s : ContractState) :
     simp only [decrement, count, getStorage, setStorage, bind, Contract.run, Bind.bind, ContractResult.snd]
     split
     · next h =>
-      have : slot = 0 := by simp [beq_iff_eq] at h; exact h
+      have : slot = 0 := beq_iff_eq.mp h
       exact absurd this h_neq
     · rfl
   · simp [Specs.sameAddrMapContext, Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap,

--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -90,7 +90,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
       Examples.SimpleToken.totalSupply, bind, Bind.bind, Contract.run, ContractResult.snd]
     split
     · next h =>
-      have : slot = 0 := by simp [beq_iff_eq] at h; exact h
+      have : slot = 0 := beq_iff_eq.mp h
       exact absurd this h_neq
     · rfl
   · intro slot h_neq
@@ -98,7 +98,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
       Examples.SimpleToken.totalSupply, bind, Bind.bind, Contract.run, ContractResult.snd]
     split
     · next h =>
-      have : slot = 2 := by simp [beq_iff_eq] at h; exact h
+      have : slot = 2 := beq_iff_eq.mp h
       exact absurd this h_neq
     · rfl
   · rfl

--- a/Verity/Proofs/SimpleToken/Isolation.lean
+++ b/Verity/Proofs/SimpleToken/Isolation.lean
@@ -37,7 +37,7 @@ theorem constructor_supply_storage_isolated (s : ContractState) (initialOwner : 
     Examples.SimpleToken.owner, Examples.SimpleToken.totalSupply,
     Verity.bind, Bind.bind, Contract.run, ContractResult.snd]
   split
-  · next h => simp [beq_iff_eq] at h; exact absurd h h_ne
+  · next h => exact absurd (beq_iff_eq.mp h) h_ne
   · rfl
 
 /-- Constructor doesn't write any mapping slot. -/
@@ -58,7 +58,7 @@ theorem constructor_owner_addr_isolated (s : ContractState) (initialOwner : Addr
     Examples.SimpleToken.owner, Examples.SimpleToken.totalSupply,
     Verity.bind, Bind.bind, Contract.run, ContractResult.snd]
   split
-  · next h => simp [beq_iff_eq] at h; exact absurd h h_ne
+  · next h => exact absurd (beq_iff_eq.mp h) h_ne
   · rfl
 
 /-! ## Mint Isolation -/


### PR DESCRIPTION
## Summary
- Replace `by simp [beq_iff_eq] at h; exact h` with direct `beq_iff_eq.mp h` in 6 proof sites (Counter/Basic, SimpleToken/Basic, SimpleToken/Isolation)
- Remove 5 vacuous "Same pattern as ..." breadcrumb comments across SpecCorrectness and YulGeneration files
- Net: -5 lines, 8 files touched

## Test plan
- [x] `lake build` passes (all 86 modules, 0 sorry)
- [x] All 11 CI check scripts pass
- [x] No theorem count changes (still 365)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactors with no runtime impact; risk is limited to potential proof brittleness if the rewritten simp/lemma applications were incorrect.
> 
> **Overview**
> Cleans up Lean proof scripts across spec-correctness and Yul-generation proofs by removing redundant “Same pattern as …” breadcrumb comments.
> 
> Refactors several proof steps to use term-mode `beq_iff_eq.mp h` directly instead of a `simp [beq_iff_eq]` intermediate, affecting Counter and SimpleToken proof files (including isolation lemmas) without changing theorem statements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0374b73963064745b90ef629818bdd15704cc8b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->