### PR TITLE
refactor: extract require_beq_success_implies_eq, dedup owner proofs

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -56,7 +56,6 @@ theorem owned_constructor_correct (state : ContractState) (initialOwner : Addres
     edslResult.isSuccess = true ∧
     specResult.success = true ∧
     specResult.finalStorage.getSlot 0 = addressToNat (edslResult.getState.storageAddr 0) := by
-  -- Constructor sets owner to initialOwner in both EDSL and spec
   unfold Verity.Examples.Owned.constructor Contract.run ownedSpec interpretSpec
   simp [setStorageAddr, Verity.Examples.Owned.owner, Verity.bind, Verity.pure]
   simp [execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
@@ -162,33 +161,21 @@ theorem only_owner_can_transfer (state : ContractState) (newOwner : Address) (se
     ((transferOwnership newOwner).run { state with sender := sender }).isSuccess = true →
     state.storageAddr 0 = sender := by
   intro h_success
-  -- If transferOwnership succeeds, onlyOwner must have succeeded.
   have h_onlyOwner :
       ((onlyOwner).run { state with sender := sender }).isSuccess = true := by
-    -- Use bind success propagation from Automation
     simpa [transferOwnership, Contract.run] using
       (Verity.Proofs.Stdlib.Automation.bind_isSuccess_left
         (m1 := onlyOwner)
         (m2 := fun _ => setStorageAddr owner newOwner)
         (state := { state with sender := sender })
         h_success)
-  -- onlyOwner is just a require on isOwner, so success implies the condition holds.
   have h_require_success :
       ((require (sender == state.storageAddr 0) "Caller is not the owner").run
         { state with sender := sender }).isSuccess = true := by
     simpa [onlyOwner, isOwner, msgSender, getStorageAddr, Contract.run, Verity.bind, Verity.pure]
       using h_onlyOwner
-  have h_eq : (sender == state.storageAddr 0) = true :=
-    Verity.Proofs.Stdlib.Automation.require_success_implies_cond
-      (cond := sender == state.storageAddr 0)
-      (msg := "Caller is not the owner")
-      (state := { state with sender := sender })
-      h_require_success
-  -- Convert boolean equality to propositional equality.
-  exact
-    (Verity.Proofs.Stdlib.Automation.address_beq_eq_true_iff_eq sender (state.storageAddr 0)).1
-        h_eq
-      |>.symm
+  exact (require_beq_success_implies_eq sender (state.storageAddr 0)
+    "Caller is not the owner" _ h_require_success).symm
 
 /-- Constructor sets initial owner correctly -/
 theorem constructor_sets_owner (state : ContractState) (initialOwner : Address) (sender : Address) :

--- a/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
@@ -67,7 +67,6 @@ theorem ownedCounter_constructor_correct (state : ContractState) (initialOwner :
     edslResult.isSuccess = true ∧
     specResult.success = true ∧
     specResult.finalStorage.getSlot 0 = addressToNat (edslResult.getState.storageAddr 0) := by
-  -- Constructor sets owner to initialOwner in both EDSL and spec
   unfold Verity.Examples.OwnedCounter.constructor Contract.run ownedCounterSpec interpretSpec
   simp [setStorageAddr, Verity.Examples.OwnedCounter.owner, Verity.bind, Verity.pure]
   simp [execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
@@ -102,8 +101,7 @@ theorem ownedCounter_increment_correct_as_owner (state : ContractState) (sender 
       execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot, h]
   · -- Spec storage count equals EDSL count
     have h_owner' : ({ state with sender := sender }).sender =
-        ({ state with sender := sender }).storageAddr 0 := by
-      simp [h]
+        ({ state with sender := sender }).storageAddr 0 := by simp [h]
     have h_inc :
         ((increment.run { state with sender := sender }).getState.storage 1) =
           Verity.EVM.Uint256.add (state.storage 1) 1 := by
@@ -175,8 +173,7 @@ theorem ownedCounter_decrement_correct_as_owner (state : ContractState) (sender 
       execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot, h]
   · -- Spec storage count equals EDSL count
     have h_owner' : ({ state with sender := sender }).sender =
-        ({ state with sender := sender }).storageAddr 0 := by
-      simp [h]
+        ({ state with sender := sender }).storageAddr 0 := by simp [h]
     have h_dec :
         ((decrement.run { state with sender := sender }).getState.storage 1) =
           Verity.EVM.Uint256.sub (state.storage 1) 1 := by
@@ -312,16 +309,8 @@ theorem ownedCounter_only_owner_modifies (state : ContractState) (sender : Addre
         { state with sender := sender }).isSuccess = true := by
     simpa [onlyOwner, isOwner, msgSender, getStorageAddr, Contract.run, Verity.bind, Verity.pure]
       using h_onlyOwner
-  have h_eq : (sender == state.storageAddr 0) = true :=
-    Verity.Proofs.Stdlib.Automation.require_success_implies_cond
-      (cond := sender == state.storageAddr 0)
-      (msg := "Caller is not the owner")
-      (state := { state with sender := sender })
-      h_require_success
-  exact
-    (Verity.Proofs.Stdlib.Automation.address_beq_eq_true_iff_eq sender (state.storageAddr 0)).1
-        h_eq
-      |>.symm
+  exact (require_beq_success_implies_eq sender (state.storageAddr 0)
+    "Caller is not the owner" _ h_require_success).symm
 
 /-- Owner and count slots are independent -/
 theorem ownedCounter_slots_independent (state : ContractState) (newOwner : Address) (sender : Address)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/Th0rgal/verity/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/built%20with-Lean%204-blueviolet.svg" alt="Built with Lean 4"></a>
-  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-365-brightgreen.svg" alt="365 Theorems"></a>
+  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-366-brightgreen.svg" alt="366 Theorems"></a>
   <a href="https://github.com/Th0rgal/verity/actions"><img src="https://img.shields.io/github/actions/workflow/status/Th0rgal/verity/verify.yml?label=verify" alt="Verify"></a>
 </p>
 
@@ -28,7 +28,7 @@ source ~/.elan/env
 # 2. Clone and build
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                                    # Verifies all 365 theorems
+lake build                                    # Verifies all 366 theorems
 
 # 3. Generate a new contract
 python3 scripts/generate_contract.py MyContract
@@ -123,7 +123,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-365 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (60% coverage, 145 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+366 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (60% coverage, 146 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -79,7 +79,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: All 365 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (60% runtime test coverage).
+**Coverage**: All 366 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (60% runtime test coverage).
 
 **What this guarantees**:
 - Contract behavior matches specification
@@ -714,7 +714,7 @@ Verity provides **strong formal verification** with a **small trusted computing 
 ✅ Contract implementations match specifications (Layer 1)
 ✅ Specifications preserved through compilation (Layer 2)
 ✅ IR semantics equivalent to Yul semantics (Layer 3)
-✅ 365 theorems across 9 categories (220 covered by property tests)
+✅ 366 theorems across 9 categories (220 covered by property tests)
 
 ### What is Trusted (Validated but Not Proven)
 ⚠️ Solidity compiler (solc) - Validated by 70k+ differential tests

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -781,6 +781,14 @@ theorem uint256_ofNat_le_of_val_ge (bal : Verity.Core.Uint256) (amount : Nat)
   simp [Verity.Core.Uint256.le_def, Verity.Core.Uint256.val_ofNat,
     Nat.mod_eq_of_lt h_lt, h]
 
+/-- If `require (a == b) msg` succeeds, then `a = b`.
+    Composes `require_success_implies_cond` with `address_beq_eq_true_iff_eq`. -/
+theorem require_beq_success_implies_eq (a b : Address) (msg : String)
+    (s : ContractState)
+    (h : ((Verity.require (a == b) msg).run s).isSuccess = true) :
+    a = b :=
+  (address_beq_eq_true_iff_eq a b).1 (require_success_implies_cond (cond := a == b) (msg := msg) (state := s) h)
+
 -- All lemmas in this file are fully proven with zero sorry (1 axiom: addressToNat_injective).
 
 end Verity.Proofs.Stdlib.Automation

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 
 const banner = (
   <Banner storageKey="verification-complete">
-    365/365 theorems proven — 100% formal verification
+    366/366 theorems proven — 100% formal verification
   </Banner>
 )
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -596,7 +596,7 @@ Time: **~5 minutes** (vs ~30 minutes manual IR)
 
 ### All Tests Pass ✅
 
-**Lean Proofs**: All proofs verified (365 EDSL theorems, 100%)
+**Lean Proofs**: All proofs verified (366 EDSL theorems, 100%)
 ```bash
 $ lake build
 Build completed successfully.
@@ -710,5 +710,5 @@ def ownedSpec : ContractSpec := {
 
 - [Research & Development](/research) — Design decisions and proof techniques
 - [Examples](/examples) — 9 example contracts
-- [Verification](/verification) — 365 proven theorems
+- [Verification](/verification) — 366 proven theorems
 - [GitHub Repository](https://github.com/Th0rgal/verity) — Source code

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -52,7 +52,7 @@ forge --version
 ```bash
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                # Downloads dependencies and verifies all 365 theorems
+lake build                # Downloads dependencies and verifies all 366 theorems
 ```
 
 The first build downloads Mathlib and compiles everything — expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 365 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 366 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 365 theorems, all fully proven. 2 documented axioms, 0 sorry.**
+**Compact core, built across 7 iterations. 366 theorems, all fully proven. 2 documented axioms, 0 sorry.**
 
 ## Evolution
 
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (365 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (366 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,11 +7,11 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 365 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 366 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-17)
 
-- EDSL theorems: 365 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
+- EDSL theorems: 366 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
 - SimpleStorage: 20 total (Basic 13, Correctness 7).
 - Counter: 28 total (Basic 19, Correctness 10; 1 shared between Basic and Correctness).
 - Owned: 22 total (Basic 18, Correctness 4).
@@ -20,7 +20,7 @@ The compiler is verified with IR preservation proofs and Yul equivalence proofs 
 - Ledger: 33 total (Basic 20, Correctness 6, Conservation 7 — all proven).
 - SafeCounter: 25 total (Basic 17, Correctness 8).
 - ReentrancyExample: 4 total (inline proofs: vulnerability existence, supply invariant).
-- Stdlib: 129 theorems (Math 25, Automation 55, MappingAutomation 37, ListSum 7; 2 shared between Automation and MappingAutomation).
+- Stdlib: 130 theorems (Math 25, Automation 55, MappingAutomation 37, ListSum 7; 2 shared between Automation and MappingAutomation).
 
 ## Unified AST Bridge (Issue #364)
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -17,7 +17,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Language**: Lean 4.15.0
 - **Core Size**: 350 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
-- **Theorems**: 365 across 9 categories (365 fully proven, 0 `sorry` placeholders)
+- **Theorems**: 366 across 9 categories (366 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 2 documented axioms (see AXIOMS.md) — keccak256, address injectivity
 - **Tests**: 375 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,10 +6,10 @@
 
 ## Current Status
 
-- ✅ **Layer 1 Complete**: 365 theorems across 9 categories (8 contracts + Stdlib math library)
+- ✅ **Layer 1 Complete**: 366 theorems across 9 categories (8 contracts + Stdlib math library)
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
-- ✅ **Property Testing**: 60% coverage (220/365), all testable properties covered
+- ✅ **Property Testing**: 60% coverage (220/366), all testable properties covered
 - ✅ **Differential Testing**: Production-ready with 70k+ tests
 - ✅ **Trust Reduction Phase 1**: keccak256 axiom + CI validation (PR #43, #46)
 - ✅ **External Linking**: Cryptographic library support (PR #49)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -63,7 +63,7 @@ EVM Bytecode
 | ReentrancyExample | 4 | ✅ Complete | `Verity/Examples/ReentrancyExample.lean` |
 | **Total** | **236** | **✅ 100%** | — |
 
-> **Note**: Stdlib (129 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (365 total properties).
+> **Note**: Stdlib (130 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (366 total properties).
 
 ### Example Property
 
@@ -177,13 +177,13 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ## Property Test Coverage 🎯 **NEAR COMPLETE**
 
-**Status**: 60% coverage (220/365), 145 remaining exclusions all proof-only
+**Status**: 60% coverage (220/366), 146 remaining exclusions all proof-only
 
 ### Current Coverage
 
-- **Total Properties**: 365
+- **Total Properties**: 366
 - **Covered**: 220 (60%)
-- **Excluded**: 145 (all proof-only)
+- **Excluded**: 146 (all proof-only)
 - **Missing**: 0
 
 ### Coverage by Contract
@@ -198,11 +198,11 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 | SimpleToken | 88% (52/59) | 7 proof-only | ✅ High coverage |
 | Counter | 82% (23/28) | 5 proof-only | ✅ High coverage |
 | Ledger | 100% (33/33) | 0 | ✅ Complete |
-| Stdlib | 0% (0/129) | 129 proof-only | — Internal |
+| Stdlib | 0% (0/130) | 130 proof-only | — Internal |
 
 ### Exclusion Categories
 
-**Proof-Only Properties (145 exclusions)**: Internal proof machinery that cannot be tested in Foundry
+**Proof-Only Properties (146 exclusions)**: Internal proof machinery that cannot be tested in Foundry
 - Storage helpers: `setStorage_*`, `getStorage_*`, `setMapping_*`, `getMapping_*`
 - Internal helpers: `isOwner_*` functions tested implicitly
 - Low-level operations used only in proofs

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ function testProperty_StoreRetrieve() public {
 }
 ```
 
-**Coverage**: 220/365 theorems tested (60%), 145 proof-only exclusions documented in `property_exclusions.json`.
+**Coverage**: 220/366 theorems tested (60%), 146 proof-only exclusions documented in `property_exclusions.json`.
 
 ### Differential Tests
 **Pattern**: `Differential<Contract>.t.sol`
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (195 functions, covering 220/365 theorems)
+├── Property*.t.sol           # Property tests (195 functions, covering 220/366 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -68,6 +68,7 @@
     "msgSender_runState",
     "msgSender_runValue",
     "require_false_isSuccess",
+    "require_beq_success_implies_eq",
     "require_success_implies_cond",
     "require_true_isSuccess",
     "safeAdd_comm",

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -293,6 +293,7 @@
     "modulus_eq_max_uint256_succ",
     "msgSender_runState",
     "msgSender_runValue",
+    "require_beq_success_implies_eq",
     "require_false_isSuccess",
     "require_success_implies_cond",
     "require_true_isSuccess",


### PR DESCRIPTION
## Summary
- Extract `require_beq_success_implies_eq` helper in Automation.lean composing `require_success_implies_cond` + `address_beq_eq_true_iff_eq`
- Replace duplicated 12-line tails in `only_owner_can_transfer` (Owned.lean) and `ownedCounter_only_owner_modifies` (OwnedCounter.lean)
- Collapse `h_owner'` blocks and remove redundant comments (-14 lines net)

## Test plan
- [x] `lake build` passes (all 366 theorems verified, 0 sorry)
- [x] All 11 CI check scripts pass
- [x] Doc counts updated (365→366)
- [x] `require_beq_success_implies_eq` added to property exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof automation refactor plus documentation/manifest count bumps; no changes to contract semantics, compiler behavior, or runtime code generation.
> 
> **Overview**
> Extracts a new proof automation lemma `require_beq_success_implies_eq` in `Verity/Proofs/Stdlib/Automation.lean` that turns successful `require (a == b)` guards into an `a = b` equality.
> 
> Refactors the `only_owner_can_transfer` and `ownedCounter_only_owner_modifies` theorems (SpecCorrectness for `Owned`/`OwnedCounter`) to use the helper, removing duplicated boolean→Prop conversion proof tails and minor simp cleanup.
> 
> Updates theorem/coverage counts across README, docs site, trust docs, and test manifests/exclusions to reflect **365→366** total theorems and to mark the new automation lemma as proof-only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ccb27236718f8a95e36ef09b77abf1771b3e693. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->