### PR TITLE
refactor: replace per-contract storage predicates with Specs.* abbrevs

### DIFF
--- a/Verity/Proofs/Counter/Correctness.lean
+++ b/Verity/Proofs/Counter/Correctness.lean
@@ -54,8 +54,8 @@ theorem getCount_state_preserved (s : ContractState) :
   let s' := ((getCount).run s).snd
   state_preserved_except_count s s' := by
   have h := getCount_preserves_state s
-  simp [h, state_preserved_except_count, storage_isolated, addr_storage_unchanged,
-    map_storage_unchanged, Specs.sameContext]
+  simp [h, state_preserved_except_count, storage_isolated,
+    Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameContext]
 
 /-! ## Combined Spec Proofs
 

--- a/Verity/Proofs/Ledger/Basic.lean
+++ b/Verity/Proofs/Ledger/Basic.lean
@@ -287,14 +287,14 @@ theorem deposit_preserves_non_mapping (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd
   non_mapping_storage_unchanged s s' := by
   rw [deposit_unfold]
-  simp [ContractResult.snd, non_mapping_storage_unchanged]
+  simp [ContractResult.snd, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr]
 
 theorem withdraw_preserves_non_mapping (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
   let s' := ((withdraw amount).run s).snd
   non_mapping_storage_unchanged s s' := by
   rw [withdraw_unfold s amount h_balance]
-  simp [ContractResult.snd, non_mapping_storage_unchanged]
+  simp [ContractResult.snd, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr]
 
 theorem deposit_preserves_wellformedness (s : ContractState) (amount : Uint256)
   (h : WellFormedState s) :

--- a/Verity/Specs/Counter/Invariants.lean
+++ b/Verity/Specs/Counter/Invariants.lean
@@ -29,12 +29,10 @@ def storage_isolated (s s' : ContractState) (slot : Nat) : Prop :=
   slot ≠ 0 → s'.storage slot = s.storage slot
 
 /-- Address storage unchanged: Uint256 operations don't touch Address storage -/
-def addr_storage_unchanged (s s' : ContractState) : Prop :=
-  s'.storageAddr = s.storageAddr
+abbrev addr_storage_unchanged := Specs.sameStorageAddr
 
 /-- Mapping storage unchanged: Counter operations don't touch mapping storage -/
-def map_storage_unchanged (s s' : ContractState) : Prop :=
-  s'.storageMap = s.storageMap
+abbrev map_storage_unchanged := Specs.sameStorageMap
 
 /-- Contract context preserved: Operations don't change sender or contract address -/
 abbrev context_preserved := Specs.sameContext

--- a/Verity/Specs/Ledger/Invariants.lean
+++ b/Verity/Specs/Ledger/Invariants.lean
@@ -20,7 +20,7 @@ structure WellFormedState (s : ContractState) : Prop where
 abbrev context_preserved := Specs.sameContext
 
 /-- Non-mapping storage unchanged by all Ledger operations -/
-def non_mapping_storage_unchanged (s s' : ContractState) : Prop :=
-  s'.storage = s.storage ∧ s'.storageAddr = s.storageAddr
+abbrev non_mapping_storage_unchanged (s s' : ContractState) :=
+  Specs.sameStorage s s' ∧ Specs.sameStorageAddr s s'
 
 end Verity.Specs.Ledger

--- a/Verity/Specs/Owned/Invariants.lean
+++ b/Verity/Specs/Owned/Invariants.lean
@@ -27,8 +27,7 @@ structure WellFormedState (s : ContractState) : Prop where
   owner_nonempty : s.storageAddr 0 ≠ ""
 
 /-- Mapping storage unchanged: Owner operations don't touch mapping storage -/
-def map_storage_unchanged (s s' : ContractState) : Prop :=
-  s'.storageMap = s.storageMap
+abbrev map_storage_unchanged := Specs.sameStorageMap
 
 /-- Contract context preserved: Operations don't change sender or contract address -/
 abbrev context_preserved := Specs.sameContext

--- a/Verity/Specs/SimpleStorage/Invariants.lean
+++ b/Verity/Specs/SimpleStorage/Invariants.lean
@@ -19,12 +19,10 @@ def storage_isolated (s s' : ContractState) (slot : Nat) : Prop :=
   slot ≠ 0 → s'.storage slot = s.storage slot
 
 /-- Address storage unchanged by Uint256 storage operations -/
-def addr_storage_unchanged (s s' : ContractState) : Prop :=
-  s'.storageAddr = s.storageAddr
+abbrev addr_storage_unchanged := Specs.sameStorageAddr
 
 /-- Mapping storage unchanged by Uint256 storage operations -/
-def map_storage_unchanged (s s' : ContractState) : Prop :=
-  s'.storageMap = s.storageMap
+abbrev map_storage_unchanged := Specs.sameStorageMap
 
 /-- Context preservation -/
 abbrev context_preserved := Specs.sameContext


### PR DESCRIPTION
## Summary
- Replace duplicate `def addr_storage_unchanged`, `def map_storage_unchanged`, and `def non_mapping_storage_unchanged` in Counter, SimpleStorage, Owned, and Ledger Invariants files with `abbrev`s pointing to shared `Specs.sameStorageAddr`, `Specs.sameStorageMap`, and `Specs.sameStorage` from Common.lean
- Update 2 proof files (Counter/Correctness, Ledger/Basic) where `simp` needed the sub-definitions explicitly listed after the `def → abbrev` change
- Net: -5 lines across 6 files, removing logical duplication between per-contract and shared predicates

## Test plan
- [x] `lake build` passes (all 365 theorems verified, 0 sorry)
- [x] All 11 CI check scripts pass
- [x] No doc count or manifest changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change that reuses existing shared predicates; the main risk is proof breakage from `simp`/unfolding differences rather than semantic behavior changes.
> 
> **Overview**
> Refactors multiple contract invariant modules (Counter, SimpleStorage, Owned, Ledger) to replace locally-defined “storage unchanged” predicates with `abbrev`s to shared `Specs.sameStorage`, `Specs.sameStorageAddr`, and `Specs.sameStorageMap`.
> 
> Updates a couple of proof files to keep automation working after the `def`→`abbrev` switch by listing the shared `Specs.sameStorage*` lemmas explicitly in `simp` for state-preservation theorems.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00bf3c42ac73061283fa0b0e6eeb5f674dae3485. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->