### PR TITLE
refactor: use anonymous constructors for WellFormedState proofs

### DIFF
--- a/Verity/Proofs/Owned/Basic.lean
+++ b/Verity/Proofs/Owned/Basic.lean
@@ -167,10 +167,7 @@ theorem constructor_preserves_wellformedness (s : ContractState) (initialOwner :
   rcases h_same with ⟨_h_storage, _h_map, h_ctx⟩
   have h_sender := h_ctx.1
   have h_this := h_ctx.2.1
-  constructor
-  · exact h_sender ▸ h.sender_nonempty
-  · exact h_this ▸ h.contract_nonempty
-  · exact h_owner_set ▸ h_owner
+  exact ⟨h_sender ▸ h.sender_nonempty, h_this ▸ h.contract_nonempty, h_owner_set ▸ h_owner⟩
 
 theorem getOwner_preserves_wellformedness (s : ContractState) (h : WellFormedState s) :
   let s' := ((getOwner).run s).snd

--- a/Verity/Proofs/Owned/Correctness.lean
+++ b/Verity/Proofs/Owned/Correctness.lean
@@ -50,10 +50,7 @@ theorem transferOwnership_preserves_wellformedness (s : ContractState) (newOwner
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst]
   simp [h_owner]
-  constructor
-  · exact h_owner ▸ h.sender_nonempty
-  · exact h.contract_nonempty
-  · exact h_new
+  exact ⟨h_owner ▸ h.sender_nonempty, h.contract_nonempty, h_new⟩
 
 /-! ## End-to-End Composition -/
 

--- a/Verity/Proofs/OwnedCounter/Basic.lean
+++ b/Verity/Proofs/OwnedCounter/Basic.lean
@@ -263,32 +263,21 @@ theorem constructor_preserves_wellformedness (s : ContractState) (initialOwner :
   rcases h_same with ⟨_h_storage, _h_map, h_ctx⟩
   have h_sender := h_ctx.1
   have h_this := h_ctx.2.1
-  constructor
-  · exact h_sender ▸ h.sender_nonempty
-  · exact h_this ▸ h.contract_nonempty
-  · exact h_set ▸ h_owner
+  exact ⟨h_sender ▸ h.sender_nonempty, h_this ▸ h.contract_nonempty, h_set ▸ h_owner⟩
 
 theorem increment_preserves_wellformedness (s : ContractState)
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) :
   let s' := (increment.run s).snd
   WellFormedState s' := by
-  rw [increment_unfold s h_owner]
-  simp [ContractResult.snd]
-  constructor
-  · exact h.sender_nonempty
-  · exact h.contract_nonempty
-  · exact h.owner_nonempty
+  rw [increment_unfold s h_owner]; simp [ContractResult.snd]
+  exact ⟨h.sender_nonempty, h.contract_nonempty, h.owner_nonempty⟩
 
 theorem decrement_preserves_wellformedness (s : ContractState)
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) :
   let s' := (decrement.run s).snd
   WellFormedState s' := by
-  rw [decrement_unfold s h_owner]
-  simp [ContractResult.snd]
-  constructor
-  · exact h.sender_nonempty
-  · exact h.contract_nonempty
-  · exact h.owner_nonempty
+  rw [decrement_unfold s h_owner]; simp [ContractResult.snd]
+  exact ⟨h.sender_nonempty, h.contract_nonempty, h.owner_nonempty⟩
 
 /-! ## Composition Sequence: constructor → increment → getCount -/
 

--- a/Verity/Proofs/OwnedCounter/Correctness.lean
+++ b/Verity/Proofs/OwnedCounter/Correctness.lean
@@ -77,10 +77,7 @@ theorem transferOwnership_preserves_wellformedness (s : ContractState) (newOwner
   let s' := ((transferOwnership newOwner).run s).snd
   WellFormedState s' := by
   rw [transferOwnership_unfold s newOwner h_owner]; simp [ContractResult.snd]
-  constructor
-  · exact h_owner ▸ h.sender_nonempty
-  · exact h.contract_nonempty
-  · exact h_new
+  exact ⟨h_owner ▸ h.sender_nonempty, h.contract_nonempty, h_new⟩
 
 /-! ## Ownership Transfer Preserves Counter Value
 

--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -487,10 +487,7 @@ theorem constructor_preserves_wellformedness (s : ContractState) (initialOwner :
   have h_spec := constructor_meets_spec s initialOwner
   simp [constructor_spec] at h_spec
   obtain ⟨h_owner_set, h_supply_set, h_other_addr, h_other_uint, h_map, h_sender, h_this, _h_value, _h_time⟩ := h_spec
-  constructor
-  · exact h_sender ▸ h.sender_nonempty
-  · exact h_this ▸ h.contract_nonempty
-  · exact h_owner_set ▸ h_owner
+  exact ⟨h_sender ▸ h.sender_nonempty, h_this ▸ h.contract_nonempty, h_owner_set ▸ h_owner⟩
 
 theorem balanceOf_preserves_wellformedness (s : ContractState) (addr : Address) (h : WellFormedState s) :
   let s' := ((balanceOf addr).run s).snd


### PR DESCRIPTION
## Summary
- Replace 7 `constructor` + 3× `· exact` blocks with single-line `exact ⟨..., ..., ...⟩` form
- Affected files: Owned/Basic, Owned/Correctness, OwnedCounter/Basic, OwnedCounter/Correctness, SimpleToken/Basic
- Net reduction: **-23 lines** (32 deleted, 9 inserted)

The `WellFormedState` structure has 3 fields. The tactic-mode `constructor` followed by 3 focused `· exact` arms is equivalent to the term-mode anonymous constructor `⟨..., ..., ...⟩`, which is more concise and idiomatic for simple projections.

## Test plan
- [x] `lake build` passes (all 369 theorems, 0 sorry)
- [x] All 11 CI check scripts pass
- [x] No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactor with no changes to specs, contract logic, or exported APIs; risk is limited to potential proof breakage from rewritten terms.
> 
> **Overview**
> Refactors multiple `WellFormedState` preservation theorems across Owned, OwnedCounter, and SimpleToken proofs to replace tactic-mode `constructor`/`· exact` chains with the term-style anonymous constructor `⟨..., ..., ...⟩`.
> 
> In a few places (notably OwnedCounter `increment/decrement_preserves_wellformedness`), proof steps are also compressed by combining rewrites/simplification before the final `WellFormedState` tuple, reducing overall proof verbosity without changing statements or behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37ae1b49b426fe42646b513f0f6d85f81e4217b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->