### PR TITLE
refactor: simplify wellformedness proofs in SimpleStorage and Counter

### DIFF
--- a/Verity/Proofs/Counter/Basic.lean
+++ b/Verity/Proofs/Counter/Basic.lean
@@ -171,18 +171,14 @@ theorem increment_decrement_cancel (s : ContractState) :
 theorem increment_preserves_wellformedness (s : ContractState) (h : WellFormedState s) :
   let s' := ((increment).run s).snd
   WellFormedState s' := by
-  have h_spec := increment_meets_spec s
-  rcases h_spec with ⟨_, _, h_same⟩
-  rcases h_same with ⟨_, _, h_ctx⟩
-  exact ⟨h_ctx.1 ▸ h.sender_nonempty, h_ctx.2.1 ▸ h.contract_nonempty⟩
+  simp only [increment, count, getStorage, setStorage, bind, Contract.run, Bind.bind, ContractResult.snd]
+  exact ⟨h.sender_nonempty, h.contract_nonempty⟩
 
 theorem decrement_preserves_wellformedness (s : ContractState) (h : WellFormedState s) :
   let s' := ((decrement).run s).snd
   WellFormedState s' := by
-  have h_spec := decrement_meets_spec s
-  rcases h_spec with ⟨_, _, h_same⟩
-  rcases h_same with ⟨_, _, h_ctx⟩
-  exact ⟨h_ctx.1 ▸ h.sender_nonempty, h_ctx.2.1 ▸ h.contract_nonempty⟩
+  simp only [decrement, count, getStorage, setStorage, bind, Contract.run, Bind.bind, ContractResult.snd]
+  exact ⟨h.sender_nonempty, h.contract_nonempty⟩
 
 theorem getCount_preserves_state (s : ContractState) :
   let s' := ((getCount).run s).snd

--- a/Verity/Proofs/SimpleStorage/Basic.lean
+++ b/Verity/Proofs/SimpleStorage/Basic.lean
@@ -103,11 +103,8 @@ theorem store_preserves_wellformedness (s : ContractState) (value : Uint256)
   (h : WellFormedState s) :
   let s' := ((store value).run s).snd
   WellFormedState s' := by
-  constructor
-  · simp [store, storedData]
-    exact h.sender_nonempty
-  · simp [store, storedData]
-    exact h.contract_nonempty
+  simp only [store, storedData, setStorage, Contract.run, ContractResult.snd]
+  exact ⟨h.sender_nonempty, h.contract_nonempty⟩
 
 -- Theorem: retrieve preserves state (read-only operation)
 theorem retrieve_preserves_state (s : ContractState) :


### PR DESCRIPTION
## Summary
- **SimpleStorage/Basic.lean**: Replace `constructor` + 2× `simp [store, storedData] / exact` with `simp only [...] + exact ⟨...⟩` (-3 lines)
- **Counter/Basic.lean**: Replace `rcases`-based wellformedness proofs with direct `simp only + exact ⟨...⟩` for both `increment_preserves_wellformedness` and `decrement_preserves_wellformedness` (-4 lines)
- Net reduction: **-7 lines**

## Test plan
- [x] `lake build` passes (all 369 theorems, 0 sorry)
- [x] All 11 CI check scripts pass
- [x] No public API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no changes to contract semantics or specifications; risk is limited to potential proof brittleness due to tighter `simp only` rewrite sets.
> 
> **Overview**
> Simplifies well-formedness preservation proofs in `Verity/Proofs/Counter/Basic.lean` and `Verity/Proofs/SimpleStorage/Basic.lean`.
> 
> The `*_preserves_wellformedness` theorems for `increment`, `decrement`, and `store` now avoid intermediate spec/context destructuring and `constructor` blocks, and instead prove the goal via a single `simp only` unfolding of the contract execution followed by `exact ⟨h.sender_nonempty, h.contract_nonempty⟩`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6afc24e067e529fb2fdfb2fa83ff2e8d5625305e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->