### PR TITLE
Extract transfer_isolation helper to dedup isolation proofs

### DIFF
--- a/Verity/Proofs/SimpleToken/Isolation.lean
+++ b/Verity/Proofs/SimpleToken/Isolation.lean
@@ -104,11 +104,13 @@ theorem mint_owner_addr_isolated (s : ContractState) (to : Address) (amount : Ui
 
 /-! ## Transfer Isolation -/
 
-/-- Transfer doesn't write any Uint256 slot (supply unchanged). -/
-theorem transfer_supply_storage_isolated (s : ContractState) (to : Address) (amount : Uint256)
+-- All three transfer isolation properties share the same proof structure:
+-- case-split on sender = to, then simp in each branch.
+private theorem transfer_isolation (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 1 s.sender ≥ amount) (slot : Nat) :
-  supply_storage_isolated s ((transfer to amount).run s).snd slot := by
-  unfold supply_storage_isolated; intro _h_ne_slot
+  (((transfer to amount).run s).snd.storage slot = s.storage slot) ∧
+  (slot ≠ 1 → ∀ addr, ((transfer to amount).run s).snd.storageMap slot addr = s.storageMap slot addr) ∧
+  (((transfer to amount).run s).snd.storageAddr slot = s.storageAddr slot) := by
   by_cases h_eq : s.sender = to
   · have h_balance' := uint256_ge_val_le (h_eq ▸ h_balance)
     simp [transfer, Examples.SimpleToken.balances,
@@ -116,59 +118,33 @@ theorem transfer_supply_storage_isolated (s : ContractState) (to : Address) (amo
       Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
       Contract.run, ContractResult.snd, ContractResult.fst,
       h_balance', h_eq, beq_iff_eq]
-  · simp [transfer, Examples.SimpleToken.balances,
-      msgSender, getMapping, setMapping,
-      requireSomeUint,
-      Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-      Contract.run, ContractResult.snd, ContractResult.fst,
-      h_balance, h_eq, beq_iff_eq]
-    cases safeAdd (s.storageMap 1 to) amount <;>
-      simp [Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-        Contract.run, ContractResult.snd, ContractResult.fst]
+  · refine ⟨?_, fun h_ne_slot addr => ?_, ?_⟩
+    all_goals simp [transfer, Examples.SimpleToken.balances,
+        msgSender, getMapping, setMapping, requireSomeUint,
+        Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
+        Contract.run, ContractResult.snd, ContractResult.fst,
+        h_balance, h_eq, beq_iff_eq]
+    all_goals cases safeAdd (s.storageMap 1 to) amount <;>
+        simp_all [Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
+          Contract.run, ContractResult.snd, ContractResult.fst, beq_iff_eq]
+
+/-- Transfer doesn't write any Uint256 slot (supply unchanged). -/
+theorem transfer_supply_storage_isolated (s : ContractState) (to : Address) (amount : Uint256)
+  (h_balance : s.storageMap 1 s.sender ≥ amount) (slot : Nat) :
+  supply_storage_isolated s ((transfer to amount).run s).snd slot := by
+  unfold supply_storage_isolated; intro _; exact (transfer_isolation s to amount h_balance slot).1
 
 /-- Transfer only writes Mapping slot 1. -/
 theorem transfer_balance_mapping_isolated (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 1 s.sender ≥ amount) (slot : Nat) :
   balance_mapping_isolated s ((transfer to amount).run s).snd slot := by
-  unfold balance_mapping_isolated; intro h_ne_slot addr
-  by_cases h_eq : s.sender = to
-  · have h_balance' := uint256_ge_val_le (h_eq ▸ h_balance)
-    simp [transfer, Examples.SimpleToken.balances,
-      msgSender, getMapping, setMapping,
-      Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-      Contract.run, ContractResult.snd, ContractResult.fst,
-      h_balance', h_eq, beq_iff_eq, h_ne_slot]
-  · simp [transfer, Examples.SimpleToken.balances,
-      msgSender, getMapping, setMapping,
-      requireSomeUint,
-      Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-      Contract.run, ContractResult.snd, ContractResult.fst,
-      h_balance, h_eq, beq_iff_eq]
-    cases safeAdd (s.storageMap 1 to) amount <;>
-      simp [Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-        Contract.run, ContractResult.snd, ContractResult.fst, beq_iff_eq, h_ne_slot]
+  unfold balance_mapping_isolated; exact (transfer_isolation s to amount h_balance slot).2.1
 
 /-- Transfer doesn't write any Address slot (owner unchanged). -/
 theorem transfer_owner_addr_isolated (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 1 s.sender ≥ amount) (slot : Nat) :
   owner_addr_isolated s ((transfer to amount).run s).snd slot := by
-  unfold owner_addr_isolated; intro _h_ne_slot
-  by_cases h_eq : s.sender = to
-  · have h_balance' := uint256_ge_val_le (h_eq ▸ h_balance)
-    simp [transfer, Examples.SimpleToken.balances,
-      msgSender, getMapping, setMapping,
-      Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-      Contract.run, ContractResult.snd, ContractResult.fst,
-      h_balance', h_eq, beq_iff_eq]
-  · simp [transfer, Examples.SimpleToken.balances,
-      msgSender, getMapping, setMapping,
-      requireSomeUint,
-      Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-      Contract.run, ContractResult.snd, ContractResult.fst,
-      h_balance, h_eq, beq_iff_eq]
-    cases safeAdd (s.storageMap 1 to) amount <;>
-      simp [Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-        Contract.run, ContractResult.snd, ContractResult.fst]
+  unfold owner_addr_isolated; intro _; exact (transfer_isolation s to amount h_balance slot).2.2
 
 /-! ## Summary
 


### PR DESCRIPTION
## Summary
- Extract `transfer_isolation` private helper in `SimpleToken/Isolation.lean`, following the same pattern as the existing `mint_isolation` helper
- Three transfer isolation theorems (`transfer_supply_storage_isolated`, `transfer_balance_mapping_isolated`, `transfer_owner_addr_isolated`) now become one-liner projections via `.1`, `.2.1`, `.2.2`
- Net reduction: **-24 lines** (47 deletions, 23 insertions)

## Test plan
- [x] `lake build` passes (86/86 modules, zero sorry)
- [ ] CI passes (`lake build` + Python check scripts + Foundry tests)
- No manifest/doc updates needed since `transfer_isolation` is `private`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactor with no runtime behavior changes; main risk is accidentally weakening a theorem via the new helper’s statement/projections.
> 
> **Overview**
> Refactors the `transfer` storage-isolation proofs in `SimpleToken/Isolation.lean` by extracting a new private helper theorem `transfer_isolation` that proves (in one place) that `transfer` leaves `storage`, all non-slot-`1` mappings, and `storageAddr` unchanged.
> 
> The three public theorems (`transfer_supply_storage_isolated`, `transfer_balance_mapping_isolated`, `transfer_owner_addr_isolated`) are rewritten as one-line projections from this helper, removing duplicated `by_cases`/`simp`/`safeAdd` proof scripts without changing the stated properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08b3cae2d3e9a29eb0809e28f2112cc06aaca9e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->