### PR TITLE
Remove duplicate beq lemmas and dead adequacy scaffolding

### DIFF
--- a/Compiler/Proofs/YulGeneration/Codegen.lean
+++ b/Compiler/Proofs/YulGeneration/Codegen.lean
@@ -16,18 +16,6 @@ These lemmas capture the core obligations for Yul codegen correctness:
 2. Runtime switch dispatch executes the selected function body.
 -/
 
-theorem beq_eq_true_of_eq {a b : Nat} (h : a = b) : (a == b) = true := by
-  exact (Eq.mpr (Nat.beq_eq_true_eq a b) h)
-
-theorem beq_eq_false_of_ne {a b : Nat} (h : a ≠ b) : (a == b) = false := by
-  cases h' : (a == b) with
-  | true =>
-      have : a = b := by
-        exact (Eq.mp (Nat.beq_eq_true_eq a b) (by simpa [h'] ))
-      exact (h this).elim
-  | false =>
-      rfl
-
 @[simp]
 theorem emitYul_runtimeCode_eq (contract : IRContract) :
     (Compiler.emitYul contract).runtimeCode = Compiler.runtimeCode contract := by
@@ -145,13 +133,13 @@ theorem find_switch_case_of_find_function
   | cons f rest ih =>
       by_cases hsel : f.selector = sel
       · have hselb : (f.selector == sel) = true := by
-          exact beq_eq_true_of_eq hsel
+          simp [beq_iff_eq, hsel]
         have hFind' : some f = some fn := by
           simpa [List.find?, hselb] using hFind
         cases hFind'
         simp [switchCases, List.find?, hsel]
       · have hselb : (f.selector == sel) = false := by
-          exact beq_eq_false_of_ne hsel
+          simp [beq_iff_eq, hsel]
         have hFind' : rest.find? (fun f => f.selector == sel) = some fn := by
           simpa [List.find?, hselb] using hFind
         have ih' := ih hFind'
@@ -168,12 +156,12 @@ theorem find_switch_case_of_find_function_none
   | cons f rest ih =>
       by_cases hsel : f.selector = sel
       · have hselb : (f.selector == sel) = true := by
-          exact beq_eq_true_of_eq hsel
+          simp [beq_iff_eq, hsel]
         have hFind' : (some f : Option IRFunction) = none := by
           simpa [List.find?, hselb] using hFind
         cases hFind'
       · have hselb : (f.selector == sel) = false := by
-          exact beq_eq_false_of_ne hsel
+          simp [beq_iff_eq, hsel]
         have hFind' : rest.find? (fun f => f.selector == sel) = none := by
           simpa [List.find?, hselb] using hFind
         have ih' := ih hFind'

--- a/Compiler/Proofs/YulGeneration/Equivalence.lean
+++ b/Compiler/Proofs/YulGeneration/Equivalence.lean
@@ -472,9 +472,6 @@ theorem execIRFunctionFuel_eq_execIRFunction
       execIRFunction fn args initialState := by
   rfl
 
-def execIRStmtsFuel_adequate_goal (state : IRState) (stmts : List YulStmt) : Prop :=
-  execIRStmtsFuel (sizeOf stmts + 1) state stmts = execIRStmts (sizeOf stmts + 1) state stmts
-
 def execIRFunctionFuel_adequate_goal
     (fn : IRFunction) (args : List Nat) (initialState : IRState) : Prop :=
   execIRFunctionFuel (sizeOf fn.body + 1) fn args initialState =
@@ -483,17 +480,6 @@ def execIRFunctionFuel_adequate_goal
 /-- Fuel adequacy is now trivially true (aliases). -/
 theorem execIRFunctionFuel_adequate
     (fn : IRFunction) (args : List Nat) (initialState : IRState) :
-    execIRFunctionFuel_adequate_goal fn args initialState := by
-  rfl
-
-theorem execIRFunctionFuel_adequate_goal_of_stmts_adequate
-    (fn : IRFunction) (args : List Nat) (initialState : IRState)
-    (hAdequacy :
-      execIRStmtsFuel_adequate_goal
-        (fn.params.zip args |>.foldl
-          (fun s (p, v) => s.setVar p.name v)
-          initialState)
-        fn.body) :
     execIRFunctionFuel_adequate_goal fn args initialState := by
   rfl
 


### PR DESCRIPTION
## Summary
- Replace local `beq_eq_true_of_eq` / `beq_eq_false_of_ne` in Codegen.lean with `beq_iff_eq` from Std (-13 lines)
- Remove unused `execIRStmtsFuel_adequate_goal` def and `execIRFunctionFuel_adequate_goal_of_stmts_adequate` theorem from Equivalence.lean (-13 lines). Dead since IR interpreter became total (fuel-based).

Net: **-26 lines** across 2 files.

## Test plan
- [x] `lake build` passes (all 369 theorems, 0 sorry)
- [x] All 11 Python check scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that replaces duplicated lemmas with standard ones and deletes unused adequacy lemmas; no runtime/compiler behavior changes expected.
> 
> **Overview**
> Simplifies Layer 3 Yul codegen proofs by removing local `Nat` boolean-equality helper lemmas and switching the `switchCases` lookup bridges to use `Std`’s `beq_iff_eq`.
> 
> Cleans up IR↔Yul equivalence scaffolding by deleting unused statement-level fuel adequacy goal/theorem, leaving only the now-trivial function-level adequacy (`rfl`) after the IR interpreter became total.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad481289a971e6c88fa24632f9ea7fa790b72728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->