### PR TITLE
Add transferOwnership_unfold to Owned, remove unused import

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -19,7 +19,6 @@ import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
 import Compiler.Hex
 import Verity.Examples.Owned
-import Verity.Core.Uint256
 
 namespace Compiler.Proofs.SpecCorrectness
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/Th0rgal/verity/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/built%20with-Lean%204-blueviolet.svg" alt="Built with Lean 4"></a>
-  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-369-brightgreen.svg" alt="369 Theorems"></a>
+  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-370-brightgreen.svg" alt="370 Theorems"></a>
   <a href="https://github.com/Th0rgal/verity/actions"><img src="https://img.shields.io/github/actions/workflow/status/Th0rgal/verity/verify.yml?label=verify" alt="Verify"></a>
 </p>
 
@@ -28,7 +28,7 @@ source ~/.elan/env
 # 2. Clone and build
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                                    # Verifies all 369 theorems
+lake build                                    # Verifies all 370 theorems
 
 # 3. Generate a new contract
 python3 scripts/generate_contract.py MyContract
@@ -123,7 +123,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-369 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (60% coverage, 149 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+370 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (59% coverage, 150 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -79,7 +79,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: All 369 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (60% runtime test coverage).
+**Coverage**: All 370 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (59% runtime test coverage).
 
 **What this guarantees**:
 - Contract behavior matches specification
@@ -714,7 +714,7 @@ Verity provides **strong formal verification** with a **small trusted computing 
 ✅ Contract implementations match specifications (Layer 1)
 ✅ Specifications preserved through compilation (Layer 2)
 ✅ IR semantics equivalent to Yul semantics (Layer 3)
-✅ 369 theorems across 9 categories (220 covered by property tests)
+✅ 370 theorems across 9 categories (220 covered by property tests)
 
 ### What is Trusted (Validated but Not Proven)
 ⚠️ Solidity compiler (solc) - Validated by 70k+ differential tests

--- a/Verity/Proofs/Owned/Correctness.lean
+++ b/Verity/Proofs/Owned/Correctness.lean
@@ -45,11 +45,7 @@ theorem transferOwnership_preserves_wellformedness (s : ContractState) (newOwner
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) (h_new : newOwner ≠ "") :
   let s' := ((transferOwnership newOwner).run s).snd
   WellFormedState s' := by
-  simp only [transferOwnership, onlyOwner, isOwner, owner,
-    msgSender, getStorageAddr, setStorageAddr,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
-  simp [h_owner]
+  rw [transferOwnership_unfold s newOwner h_owner]; simp [ContractResult.snd]
   exact ⟨h_owner ▸ h.sender_nonempty, h.contract_nonempty, h_new⟩
 
 /-! ## End-to-End Composition -/
@@ -73,12 +69,10 @@ theorem transferred_owner_cannot_act (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) (h_ne : s.sender ≠ newOwner) :
   let s' := ((transferOwnership newOwner).run s).snd
   ∃ msg, (transferOwnership "anyone").run s' = ContractResult.revert msg s' := by
-  simp only [transferOwnership, onlyOwner, isOwner, owner,
-    msgSender, getStorageAddr, setStorageAddr,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
-  have h_ne2 : s.storageAddr 0 ≠ newOwner := h_owner ▸ h_ne
-  simp [h_owner, h_ne2]
+  have h_ne' : ((transferOwnership newOwner).run s).snd.sender ≠
+      ((transferOwnership newOwner).run s).snd.storageAddr 0 := by
+    rw [transferOwnership_unfold s newOwner h_owner]; simp [ContractResult.snd, h_ne]
+  exact transferOwnership_reverts_when_not_owner _ _ h_ne'
 
 /-! ## Summary
 

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 
 const banner = (
   <Banner storageKey="verification-complete">
-    369/369 theorems proven — 100% formal verification
+    370/370 theorems proven — 100% formal verification
   </Banner>
 )
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -596,7 +596,7 @@ Time: **~5 minutes** (vs ~30 minutes manual IR)
 
 ### All Tests Pass ✅
 
-**Lean Proofs**: All proofs verified (369 EDSL theorems, 100%)
+**Lean Proofs**: All proofs verified (370 EDSL theorems, 100%)
 ```bash
 $ lake build
 Build completed successfully.
@@ -710,5 +710,5 @@ def ownedSpec : ContractSpec := {
 
 - [Research & Development](/research) — Design decisions and proof techniques
 - [Examples](/examples) — 9 example contracts
-- [Verification](/verification) — 369 proven theorems
+- [Verification](/verification) — 370 proven theorems
 - [GitHub Repository](https://github.com/Th0rgal/verity) — Source code

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -52,7 +52,7 @@ forge --version
 ```bash
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                # Downloads dependencies and verifies all 369 theorems
+lake build                # Downloads dependencies and verifies all 370 theorems
 ```
 
 The first build downloads Mathlib and compiles everything — expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 369 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 370 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 369 theorems, all fully proven. 2 documented axioms, 0 sorry.**
+**Compact core, built across 7 iterations. 370 theorems, all fully proven. 2 documented axioms, 0 sorry.**
 
 ## Evolution
 
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (369 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (370 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,14 +7,14 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 369 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 370 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-17)
 
-- EDSL theorems: 369 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
+- EDSL theorems: 370 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
 - SimpleStorage: 20 total (Basic 13, Correctness 7).
 - Counter: 28 total (Basic 19, Correctness 10; 1 shared between Basic and Correctness).
-- Owned: 22 total (Basic 18, Correctness 4).
+- Owned: 23 total (Basic 19, Correctness 4).
 - SimpleToken: 59 total (Basic 37, Correctness 10, Supply 3, Isolation 9).
 - OwnedCounter: 48 total (Basic 29, Correctness 5, Isolation 14).
 - Ledger: 33 total (Basic 20, Correctness 6, Conservation 7 — all proven).
@@ -173,9 +173,10 @@ This lets proofs reason about both the success path and the revert path of guard
 | 13 | `isOwner_returns_correct_value` | isOwner returns correct boolean |
 | 14 | `transferOwnership_meets_spec_when_owner` | Owner transfer satisfies spec |
 | 15 | `transferOwnership_changes_owner_when_allowed` | Owner successfully changed |
-| 16 | `constructor_getOwner_correct` | Constructor then getOwner equals sender |
-| 17 | `constructor_preserves_wellformedness` | Well-formedness maintained |
-| 18 | `getOwner_preserves_wellformedness` | getOwner preserves well-formedness |
+| 16 | `transferOwnership_unfold` | Unfold lemma for transferOwnership when owner |
+| 17 | `constructor_getOwner_correct` | Constructor then getOwner equals sender |
+| 18 | `constructor_preserves_wellformedness` | Well-formedness maintained |
+| 19 | `getOwner_preserves_wellformedness` | getOwner preserves well-formedness |
 
 **Correctness:**
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -17,7 +17,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Language**: Lean 4.15.0
 - **Core Size**: 350 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
-- **Theorems**: 369 across 9 categories (369 fully proven, 0 `sorry` placeholders)
+- **Theorems**: 370 across 9 categories (370 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 2 documented axioms (see AXIOMS.md) — keccak256, address injectivity
 - **Tests**: 375 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
@@ -54,7 +54,7 @@ def bind (x : Contract α) (f : α → Contract β) : Contract β :=
 |----------|-------|----------------|
 | SimpleStorage | 20 | Store/retrieve roundtrip, state isolation |
 | Counter | 28 | Arithmetic, composition, decrement-at-zero |
-| Owned | 22 | Access control, ownership transfer |
+| Owned | 23 | Access control, ownership transfer |
 | SimpleToken | 59 | Mint/transfer, supply conservation, storage isolation |
 | OwnedCounter | 48 | Cross-pattern composition, lockout proofs |
 | Ledger | 33 | Deposit/withdraw/transfer, balance conservation |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,10 +6,10 @@
 
 ## Current Status
 
-- ✅ **Layer 1 Complete**: 369 theorems across 9 categories (8 contracts + Stdlib math library)
+- ✅ **Layer 1 Complete**: 370 theorems across 9 categories (8 contracts + Stdlib math library)
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
-- ✅ **Property Testing**: 60% coverage (220/369), all testable properties covered
+- ✅ **Property Testing**: 59% coverage (220/370), all testable properties covered
 - ✅ **Differential Testing**: Production-ready with 70k+ tests
 - ✅ **Trust Reduction Phase 1**: keccak256 axiom + CI validation (PR #43, #46)
 - ✅ **External Linking**: Cryptographic library support (PR #49)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -55,15 +55,15 @@ EVM Bytecode
 | SimpleStorage | 20 | ✅ Complete | `Verity/Proofs/SimpleStorage/` |
 | Counter | 28 | ✅ Complete | `Verity/Proofs/Counter/` |
 | SafeCounter | 25 | ✅ Complete | `Verity/Proofs/SafeCounter/` |
-| Owned | 22 | ✅ Complete | `Verity/Proofs/Owned/` |
+| Owned | 23 | ✅ Complete | `Verity/Proofs/Owned/` |
 | OwnedCounter | 48 | ✅ Complete | `Verity/Proofs/OwnedCounter/` |
 | Ledger | 33 | ✅ Complete | `Verity/Proofs/Ledger/` |
 | SimpleToken | 59 | ✅ Complete | `Verity/Proofs/SimpleToken/` |
 | CryptoHash | 0 | ⬜ No specs | `Verity/Examples/CryptoHash.lean` |
 | ReentrancyExample | 4 | ✅ Complete | `Verity/Examples/ReentrancyExample.lean` |
-| **Total** | **239** | **✅ 100%** | — |
+| **Total** | **240** | **✅ 100%** | — |
 
-> **Note**: Stdlib (130 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (369 total properties).
+> **Note**: Stdlib (130 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (370 total properties).
 
 ### Example Property
 
@@ -177,13 +177,13 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ## Property Test Coverage 🎯 **NEAR COMPLETE**
 
-**Status**: 60% coverage (220/369), 149 remaining exclusions all proof-only
+**Status**: 59% coverage (220/370), 150 remaining exclusions all proof-only
 
 ### Current Coverage
 
-- **Total Properties**: 369
-- **Covered**: 220 (60%)
-- **Excluded**: 149 (all proof-only)
+- **Total Properties**: 370
+- **Covered**: 220 (59%)
+- **Excluded**: 150 (all proof-only)
 - **Missing**: 0
 
 ### Coverage by Contract
@@ -193,7 +193,7 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 | SafeCounter | 100% (25/25) | 0 | ✅ Complete |
 | ReentrancyExample | 100% (4/4) | 0 | ✅ Complete |
 | SimpleStorage | 95% (19/20) | 1 proof-only | ✅ Near-complete |
-| Owned | 91% (20/22) | 2 proof-only | ✅ Near-complete |
+| Owned | 87% (20/23) | 3 proof-only | ✅ Near-complete |
 | OwnedCounter | 92% (44/48) | 4 proof-only | ✅ Near-complete |
 | SimpleToken | 88% (52/59) | 7 proof-only | ✅ High coverage |
 | Counter | 82% (23/28) | 5 proof-only | ✅ High coverage |
@@ -202,7 +202,7 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ### Exclusion Categories
 
-**Proof-Only Properties (149 exclusions)**: Internal proof machinery that cannot be tested in Foundry
+**Proof-Only Properties (150 exclusions)**: Internal proof machinery that cannot be tested in Foundry
 - Storage helpers: `setStorage_*`, `getStorage_*`, `setMapping_*`, `getMapping_*`
 - Internal helpers: `isOwner_*` functions tested implicitly
 - Low-level operations used only in proofs

--- a/test/PropertyOwned.t.sol
+++ b/test/PropertyOwned.t.sol
@@ -8,22 +8,23 @@ import "./yul/YulTestBase.sol";
  * @notice Property-based tests extracted from formally verified Lean theorems
  * @dev Maps theorems from Verity/Proofs/Owned/ to executable tests
  *
- * This file contains property tests corresponding to 22 proven theorems:
+ * This file contains property tests corresponding to 23 proven theorems:
  *
- * From Basic.lean (18 theorems):
+ * From Basic.lean (19 theorems):
  * 1-6. Address storage operations (setStorageAddr/getStorageAddr)
  * 7-8. constructor correctness
  * 9-11. getOwner correctness
  * 12-13. isOwner correctness
  * 14-15. transferOwnership correctness (when owner)
- * 16. constructor->getOwner composition
- * 17-18. Well-formedness preservation
+ * 16. transferOwnership_unfold (unfold lemma for transferOwnership)
+ * 17. constructor->getOwner composition
+ * 18-19. Well-formedness preservation
  *
  * From Correctness.lean (4 theorems):
- * 19. transferOwnership_reverts_when_not_owner (core security)
- * 20. transferOwnership_preserves_wellformedness
- * 21. constructor->transferOwnership->getOwner (full lifecycle)
- * 22. transferred_owner_cannot_act (exclusive transfer)
+ * 20. transferOwnership_reverts_when_not_owner (core security)
+ * 21. transferOwnership_preserves_wellformedness
+ * 22. constructor->transferOwnership->getOwner (full lifecycle)
+ * 23. transferred_owner_cannot_act (exclusive transfer)
  */
 contract PropertyOwnedTest is YulTestBase {
     address owned;

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ function testProperty_StoreRetrieve() public {
 }
 ```
 
-**Coverage**: 220/369 theorems tested (60%), 149 proof-only exclusions documented in `property_exclusions.json`.
+**Coverage**: 220/370 theorems tested (59%), 150 proof-only exclusions documented in `property_exclusions.json`.
 
 ### Differential Tests
 **Pattern**: `Differential<Contract>.t.sol`
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (195 functions, covering 220/369 theorems)
+├── Property*.t.sol           # Property tests (195 functions, covering 220/370 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -8,7 +8,8 @@
   ],
   "Owned": [
     "isOwner_meets_spec",
-    "isOwner_returns_correct_value"
+    "isOwner_returns_correct_value",
+    "transferOwnership_unfold"
   ],
   "OwnedCounter": [
     "decrement_unfold",

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -86,6 +86,7 @@
     "transferOwnership_meets_spec_when_owner",
     "transferOwnership_preserves_wellformedness",
     "transferOwnership_reverts_when_not_owner",
+    "transferOwnership_unfold",
     "transferred_owner_cannot_act"
   ],
   "OwnedCounter": [


### PR DESCRIPTION
## Summary
- Add `transferOwnership_unfold` helper to `Owned/Basic.lean`, matching the existing `OwnedCounter` pattern — refactor `transferOwnership_meets_spec_when_owner`, `transferOwnership_changes_owner_when_allowed` (Basic), `transferOwnership_preserves_wellformedness`, and `transferred_owner_cannot_act` (Correctness) to use it
- Remove unused `import Verity.Core.Uint256` from `Compiler/Proofs/SpecCorrectness/Owned.lean`
- Update theorem counts 369→370, exclusions 149→150 across 16 doc/config files

## Test plan
- [x] `lake build` passes (86/86 modules, zero sorry)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes (370 theorems, 150 exclusions, 220/370 covered)
- [ ] CI passes (build + checks + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor plus documentation/manifest count updates; no changes to contract semantics or compiler/runtime behavior, with minimal risk beyond potential bookkeeping drift if counts/manifests are inconsistent.
> 
> **Overview**
> Adds a new `Verity/Proofs/Owned/Basic.lean` helper theorem `transferOwnership_unfold` that concretely characterizes the success-path state update of `transferOwnership` when the caller is the owner, and refactors multiple Owned proofs in `Basic.lean` and `Correctness.lean` to rewrite via this lemma instead of re-unfolding the full `onlyOwner`/`require` chain.
> 
> Removes an unused Lean import from `Compiler/Proofs/SpecCorrectness/Owned.lean`, and updates documentation/test metadata to reflect the additional theorem (**369→370**, Owned **22→23**) including property coverage/exclusion numbers and manifests (`property_manifest.json`, `property_exclusions.json`, and docs-site/README badges).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7665a20ad0a843adac61374e909c84217f5bd398. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->