### PR TITLE
simplify: remove dead private code (-73 lines)

### DIFF
--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -257,11 +257,6 @@ sufficiency and the safeAdd/requireSomeUint overflow check are
 fully modeled, matching Solidity ^0.8 checked arithmetic semantics.
 -/
 
--- Helper: Nat.ble is equivalent to ≤ for the >= check
-private theorem ble_true_of_ge {a b : Nat} (h : a ≥ b) : (b <= a) = true := by
-  simp [Nat.ble_eq]
-  exact h
-
 -- Helper lemma: after unfolding transfer with sufficient balance and self-transfer, state is unchanged
 private theorem transfer_unfold_self (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 1 s.sender ≥ amount)

--- a/Verity/Specs/SimpleToken/Invariants.lean
+++ b/Verity/Specs/SimpleToken/Invariants.lean
@@ -35,9 +35,6 @@ def sum_balances (s : ContractState) (addrs : List Address) : Uint256 :=
 def supply_bounds_balances (s : ContractState) : Prop :=
   ∀ addrs : List Address, sum_balances s addrs ≤ s.storage 2
 
-private def supply_equals_sum (s : ContractState) (addrs : List Address) : Prop :=
-  s.storage 2 = sum_balances s addrs
-
 /-- Owner cannot change except through transferOwnership (which doesn't exist yet) -/
 def owner_stable (s s' : ContractState) : Prop :=
   s'.storageAddr 0 = s.storageAddr 0


### PR DESCRIPTION
## Summary
- Remove 5 unused private definitions/theorems from `Counter.lean` SpecCorrectness (`decrement_runState_eq`, `increment_adds_one`, `applyNIncrements`, `applyNIncrements_val`, `multiple_increments`)
- Remove unused `ble_true_of_ge` from `SimpleToken/Basic.lean`
- Remove unused `supply_equals_sum` from `SimpleToken/Invariants.lean`
- All items had zero references outside their declarations (verified via grep)
- Net: **-73 lines**

## Test plan
- [x] `lake build` passes (all theorems verified)
- [x] All 11 Python check scripts pass
- [x] No references to removed items exist elsewhere in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code deletion in proof/spec files only; main risk is accidental removal of a needed lemma causing downstream proof breakage, which should be caught by the build.
> 
> **Overview**
> Removes unused private proof helpers from `Compiler/Proofs/SpecCorrectness/Counter.lean`, including a redundant decrement helper and a small suite of “apply N increments” lemmas/defs.
> 
> Cleans up SimpleToken by deleting unreferenced helpers in `Verity/Proofs/SimpleToken/Basic.lean` and `Verity/Specs/SimpleToken/Invariants.lean` (e.g., `ble_true_of_ge`, `supply_equals_sum`), with no functional/spec behavior changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a918ab1d796b13d58c077e7abe953fe5ca854902. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->