### PR TITLE
simplify: misc cleanups across 3 files (-13 lines)

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -641,15 +641,13 @@ def genConstructorArgLoads (params : List Param) : List YulStmt :=
     let loadArgs := params.enum.flatMap fun (idx, param) =>
       let offset := idx * 32
       match param.ty with
-      | ParamType.uint256 =>
-        [YulStmt.let_ s!"arg{idx}" (YulExpr.call "mload" [YulExpr.lit offset])]
       | ParamType.address =>
         [YulStmt.let_ s!"arg{idx}" (YulExpr.call "and" [
           YulExpr.call "mload" [YulExpr.lit offset],
           YulExpr.hex ((2^160) - 1)
         ])]
       | _ =>
-        -- bytes32 and other types loaded as raw 256-bit values
+        -- uint256, bytes32, and other types loaded as raw 256-bit values
         [YulStmt.let_ s!"arg{idx}" (YulExpr.call "mload" [YulExpr.lit offset])]
     argsOffset ++ loadArgs
 

--- a/Verity/Proofs/Ledger/Conservation.lean
+++ b/Verity/Proofs/Ledger/Conservation.lean
@@ -15,7 +15,6 @@ import Verity.Core
 import Verity.Examples.Ledger
 import Verity.EVM.Uint256
 import Verity.Specs.Ledger.Spec
-import Verity.Specs.Ledger.Invariants
 import Verity.Proofs.Ledger.Basic
 import Verity.Proofs.Stdlib.ListSum
 import Verity.Stdlib.Math


### PR DESCRIPTION
## Summary
- **CompileDriver.lean**: Extract `orThrow` helper for the repeated `match .error/.ok` validation pattern, collapsing 4 three-line blocks into one-liners
- **ContractSpec.lean**: Remove redundant `ParamType.uint256` arm in `genConstructorArgLoads` — it was identical to the `_` catch-all
- **Conservation.lean**: Remove unused `import Verity.Specs.Ledger.Invariants` (no symbols from that module are referenced)
- Net: **-13 lines**

## Test plan
- [x] `lake build` passes (all 370 theorems verified)
- [x] All 11 Python check scripts pass
- [x] Yul compilation check passes (ensures `genConstructorArgLoads` change doesn't affect output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical refactors and dead-code cleanup; the only behavioral risk is accidental change in validation/constructor argument loading control flow, but logic remains equivalent.
> 
> **Overview**
> Refactors `Compiler/CompileDriver.lean` library validation by introducing `orThrow` and collapsing repeated `Except`-to-`IO` error handling into one-liners, without changing validation coverage.
> 
> Simplifies `genConstructorArgLoads` in `Compiler/ContractSpec.lean` by removing a redundant `ParamType.uint256` match arm (now handled by the default raw `mload` path), and removes an unused `import Verity.Specs.Ledger.Invariants` from `Verity/Proofs/Ledger/Conservation.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0677c9fcef016b29e1d97e7a815f7c789633881. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->