### PR TITLE
fix: correct stale per-contract theorem counts + add CI validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ One spec can have many competing implementations - naive, gas-optimized, packed 
 | SimpleStorage | 20 | Store/retrieve with roundtrip proof |
 | Counter | 28 | Increment/decrement with wrapping, composition proofs |
 | SafeCounter | 25 | Overflow/underflow revert proofs |
-| Owned | 22 | Access control and ownership transfer |
+| Owned | 23 | Access control and ownership transfer |
 | OwnedCounter | 48 | Cross-pattern composition, lockout proofs |
 | Ledger | 33 | Deposit/withdraw/transfer with balance conservation |
 | SimpleToken | 59 | Mint/transfer, supply conservation, storage isolation |

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -36,7 +36,7 @@ Simple contracts (SimpleStorage, Counter, SafeCounter, Ledger) hold by `rfl`. Co
 
 - **Spec semantics**: `Verity/Proofs/Stdlib/SpecInterpreter.lean`
 - **Spec correctness**: `Compiler/Proofs/SpecCorrectness/` (complete for all 7 contracts — proves each ContractSpec matches its EDSL)
-- **IR generation**: `Compiler/Proofs/IRGeneration/` (infrastructure + per-contract proofs for Counter, SimpleStorage)
+- **IR generation**: `Compiler/Proofs/IRGeneration/` (infrastructure + concrete IR proofs in `Expr.lean`)
 - **Yul semantics + preservation**: `Compiler/Proofs/YulGeneration/` (complete — PR #42)
 
 ## Structure

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -60,7 +60,7 @@ def bind (x : Contract α) (f : α → Contract β) : Contract β :=
 | Ledger | 33 | Deposit/withdraw/transfer, balance conservation |
 | SafeCounter | 25 | Overflow/underflow revert proofs |
 | ReentrancyExample | 4 | Reentrancy vulnerability proof, supply invariant |
-| Stdlib | 126 | safeMul/safeDiv correctness, automation lemmas |
+| Stdlib | 130 | safeMul/safeDiv correctness, automation lemmas |
 
 ## Proof Techniques
 

--- a/examples/solidity/README.md
+++ b/examples/solidity/README.md
@@ -9,7 +9,7 @@ These Solidity contracts serve as **reference implementations** for Verity's dif
 | `SimpleStorage.sol` | `Verity/Examples/SimpleStorage.lean` | 20 theorems | Single storage slot (store/retrieve) |
 | `Counter.sol` | `Verity/Examples/Counter.lean` | 28 theorems | Increment/decrement with wrapping arithmetic |
 | `SafeCounter.sol` | `Verity/Examples/SafeCounter.lean` | 25 theorems | Overflow-safe arithmetic (reverts on overflow) |
-| `Owned.sol` | `Verity/Examples/Owned.lean` | 22 theorems | Access control (owner-only functions) |
+| `Owned.sol` | `Verity/Examples/Owned.lean` | 23 theorems | Access control (owner-only functions) |
 | `OwnedCounter.sol` | `Verity/Examples/OwnedCounter.lean` | 48 theorems | Combined access control + counter |
 | `Ledger.sol` | `Verity/Examples/Ledger.lean` | 33 theorems | Balance mapping (deposit/withdraw/transfer) |
 | `SimpleToken.sol` | `Verity/Examples/SimpleToken.lean` | 59 theorems | Token with mint/transfer + supply invariants |

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -318,6 +318,30 @@ def main() -> None:
             ],
         )
     )
+    # Check per-contract theorem counts in README table (| Contract | N | ...)
+    readme_contract_checks = []
+    for contract, count in per_contract.items():
+        if contract == "Stdlib":
+            continue  # Stdlib not in README table
+        readme_contract_checks.append((
+            f"README {contract} count",
+            re.compile(rf"\|\s*{contract}\s*\|\s*(\d+)\s*\|"),
+            str(count),
+        ))
+    errors.extend(check_file(readme, readme_contract_checks))
+
+    # Check per-contract theorem counts in examples/solidity/README.md (| ... | N theorems | ...)
+    solidity_readme = ROOT / "examples" / "solidity" / "README.md"
+    solidity_contract_checks = []
+    for contract, count in per_contract.items():
+        if contract == "Stdlib":
+            continue
+        solidity_contract_checks.append((
+            f"solidity README {contract} count",
+            re.compile(rf"{contract}\.lean.*?(\d+) theorems"),
+            str(count),
+        ))
+    errors.extend(check_file(solidity_readme, solidity_contract_checks))
 
     # Check llms.txt
     llms = ROOT / "docs-site" / "public" / "llms.txt"
@@ -358,6 +382,15 @@ def main() -> None:
             ],
         )
     )
+    # Check per-contract theorem counts in llms.txt table (| Contract | N | ...)
+    llms_contract_checks = []
+    for contract, count in per_contract.items():
+        llms_contract_checks.append((
+            f"llms.txt {contract} count",
+            re.compile(rf"\|\s*{contract}\s*\|\s*(\d+)\s*\|"),
+            str(count),
+        ))
+    errors.extend(check_file(llms, llms_contract_checks))
 
     # Check compiler.mdx
     compiler_mdx = ROOT / "docs-site" / "content" / "compiler.mdx"


### PR DESCRIPTION
## Summary
- Fix Owned theorem count: 22→23 in README.md and examples/solidity/README.md
- Fix Stdlib theorem count: 126→130 in docs-site/public/llms.txt
- Fix stale reference to deleted per-contract IR proof files in verification.mdx
- Add per-contract count validation to `check_doc_counts.py` for README.md, examples/solidity/README.md, and llms.txt

The per-contract counts in these doc tables had drifted from the property manifest. The CI script (`check_doc_counts.py`) validated aggregate counts (370 total) but not individual contract rows, so drift went undetected. The new checks will catch future mismatches.

## Test plan
- [x] `python3 scripts/check_doc_counts.py` passes
- [x] All other Python check scripts pass
- [x] Verified new checks catch wrong counts (tested with Owned=99, correctly reported error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits plus tighter CI validation logic; low blast radius and no runtime or proof semantics changes.
> 
> **Overview**
> Updates documentation theorem tables to match the property manifest (e.g., `Owned` 22→23 in `README.md` and `examples/solidity/README.md`, `Stdlib` 126→130 in `docs-site/public/llms.txt`) and fixes a stale `verification.mdx` reference to deleted IR proof files.
> 
> Enhances `scripts/check_doc_counts.py` to **validate per-contract theorem counts** in the README, Solidity examples README, and `llms.txt`, so future drift is caught in CI rather than only checking aggregate totals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b06e3482ef2d4139aec5d96cb611bbb5adc11c1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->