### PR TITLE
add @[simp] reflexivity lemmas for all same* predicates

### DIFF
--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -25,13 +25,19 @@ def sameContext (s s' : ContractState) : Prop :=
 def sameStorage (s s' : ContractState) : Prop :=
   s'.storage = s.storage
 
+@[simp] theorem sameStorage_rfl (s : ContractState) : sameStorage s s := rfl
+
 /-- Address storage is unchanged. -/
 def sameStorageAddr (s s' : ContractState) : Prop :=
   s'.storageAddr = s.storageAddr
 
+@[simp] theorem sameStorageAddr_rfl (s : ContractState) : sameStorageAddr s s := rfl
+
 /-- Mapping storage is unchanged. -/
 def sameStorageMap (s s' : ContractState) : Prop :=
   s'.storageMap = s.storageMap
+
+@[simp] theorem sameStorageMap_rfl (s : ContractState) : sameStorageMap s s := rfl
 
 /-- Address storage, mapping storage, and context are unchanged. -/
 def sameAddrMapContext (s s' : ContractState) : Prop :=
@@ -39,17 +45,26 @@ def sameAddrMapContext (s s' : ContractState) : Prop :=
   sameStorageMap s s' ∧
   sameContext s s'
 
+@[simp] theorem sameAddrMapContext_rfl (s : ContractState) : sameAddrMapContext s s :=
+  ⟨rfl, rfl, sameContext_rfl s⟩
+
 /-- Uint256 storage, mapping storage, and context are unchanged. -/
 def sameStorageMapContext (s s' : ContractState) : Prop :=
   sameStorage s s' ∧
   sameStorageMap s s' ∧
   sameContext s s'
 
+@[simp] theorem sameStorageMapContext_rfl (s : ContractState) : sameStorageMapContext s s :=
+  ⟨rfl, rfl, sameContext_rfl s⟩
+
 /-- Uint256 storage, address storage, and context are unchanged. -/
 def sameStorageAddrContext (s s' : ContractState) : Prop :=
   sameStorage s s' ∧
   sameStorageAddr s s' ∧
   sameContext s s'
+
+@[simp] theorem sameStorageAddrContext_rfl (s : ContractState) : sameStorageAddrContext s s :=
+  ⟨rfl, rfl, sameContext_rfl s⟩
 
 /-- All storage slots except `slot` are unchanged. -/
 def storageUnchangedExcept (slot : Nat) (s s' : ContractState) : Prop :=


### PR DESCRIPTION
## Summary
- Add 6 `@[simp]` reflexivity lemmas for composite state-equality predicates in `Verity/Specs/Common.lean`
- Previously only `sameContext_rfl` existed — the new lemmas cover `sameStorage`, `sameStorageAddr`, `sameStorageMap`, `sameAddrMapContext`, `sameStorageMapContext`, and `sameStorageAddrContext`
- These predicates appear 54 times across 18 proof files; the new lemmas let `simp` close trivial unchanged-state goals automatically

## Test plan
- [x] `lake build` passes (all 86 modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes (370 theorems, 2 axioms, 0 sorry)
- [x] `check_selectors.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only new lemmas/attributes with no runtime behavior changes; main risk is minor proof search/simplification behavior changes in dependent proofs.
> 
> **Overview**
> Adds `@[simp]` reflexivity lemmas in `Verity/Specs/Common.lean` for `sameStorage`, `sameStorageAddr`, `sameStorageMap`, and the composite predicates `sameAddrMapContext`, `sameStorageMapContext`, and `sameStorageAddrContext`.
> 
> This is a proof-automation improvement: unchanged-state goals of the form `same* s s` can now be closed by `simp` without expanding the predicates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2beab025ad4cbd9a7a730576deb3b29d99e07288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->