### PR TITLE
Remove dead spec definitions and unused proof scaffolding (-126 lines)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ Tag format: `/// Property: exact_theorem_name`
 
 ## Development
 
-**Layer 3 proofs**: Read [Compiler/Proofs/README.md](Compiler/Proofs/README.md), study completed proofs (`assign_equiv`, `storageLoad_equiv`), use templates
+**Layer 3 proofs**: Read [Compiler/Proofs/README.md](Compiler/Proofs/README.md), study completed proofs (`assign_equiv`, `storageStore_equiv`), use templates
 
 **New contracts**: Use `python3 scripts/generate_contract.py <Name>` to scaffold all boilerplate files, then follow the `SimpleStorage` pattern: Spec → Invariants → Implementation → Proofs → Tests
 

--- a/Compiler/Proofs/YulGeneration/Equivalence.lean
+++ b/Compiler/Proofs/YulGeneration/Equivalence.lean
@@ -178,24 +178,6 @@ theorem resultsMatch_of_execResultsAligned
     simp [irResultOfExecWithRollback, yulResultOfExecWithRollback, resultsMatch,
       yulStateOfIR]
 
-/-- Generic function equivalence goal: holds for any IR function and its compiled Yul body. -/
-def ir_yul_function_equiv_goal
-    (fn : IRFunction) (tx : IRTransaction) (state : IRState) : Prop :=
-    tx.functionSelector < selectorModulus →
-    resultsMatch
-      (execIRFunction fn tx.args { state with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })
-      (interpretYulBody fn tx { state with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })
-
-theorem ir_yul_function_equiv_goal_of_resultsMatch
-    (fn : IRFunction) (tx : IRTransaction) (state : IRState)
-    (hMatch :
-      resultsMatch
-        (execIRFunction fn tx.args { state with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })
-        (interpretYulBody fn tx { state with sender := tx.sender, calldata := tx.args, selector := tx.functionSelector })) :
-    ir_yul_function_equiv_goal fn tx state := by
-  intro _
-  simpa [ir_yul_function_equiv_goal] using hMatch
-
 /-! ## Generic Layer 3 Lemmas (Fuel-Agnostic)
 
 These lemmas lift instruction-level equivalence to sequences and function
@@ -465,12 +447,6 @@ Previously this required:
   axiom execIRStmtsFuel_adequate : ...
 This axiom has been **eliminated** by making the IR interpreter total.
 -/
-
-theorem execIRFunctionFuel_eq_execIRFunction
-    (fn : IRFunction) (args : List Nat) (initialState : IRState) :
-    execIRFunctionFuel (sizeOf fn.body + 1) fn args initialState =
-      execIRFunction fn args initialState := by
-  rfl
 
 def execIRFunctionFuel_adequate_goal
     (fn : IRFunction) (args : List Nat) (initialState : IRState) : Prop :=

--- a/Compiler/Proofs/YulGeneration/Preservation.lean
+++ b/Compiler/Proofs/YulGeneration/Preservation.lean
@@ -93,7 +93,7 @@ theorem yulCodegen_preserves_semantics
 /-! ## Complete Preservation Theorem (No Undischarged Hypotheses)
 
 This version of the preservation theorem discharges the `hbody` hypothesis
-using the proven `all_stmts_equiv` and the `execIRFunctionFuel_eq_execIRFunction` lemma.
+using the proven `all_stmts_equiv` and the `execIRFunctionFuel_adequate` lemma.
 
 The remaining gap between `interpretYulBodyFromState` (fuel-based proof chain) and
 `interpretYulBody` (used by the parameterized theorem above) requires bridging two
@@ -102,7 +102,7 @@ different Yul execution entry points. This bridging lemma documents that gap exp
 **Proof chain** (complete — fuel adequacy is now `rfl`):
 1. `all_stmts_equiv` — every IR statement type is equivalent (StatementEquivalence.lean)
 2. `execIRStmtsFuel_equiv_execYulStmtsFuel_of_stmt_equiv` — lifts to lists (Equivalence.lean)
-3. `execIRFunctionFuel_eq_execIRFunction` — bridges fuel-based ↔ total IR (Equivalence.lean, `rfl`)
+3. `execIRFunctionFuel_adequate` — bridges fuel-based ↔ total IR (Equivalence.lean, `rfl`)
 4. `ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy` — function-level equivalence
 
 The theorem `ir_function_body_equiv` below demonstrates the complete chain for any

--- a/Compiler/Proofs/YulGeneration/SmokeTests.lean
+++ b/Compiler/Proofs/YulGeneration/SmokeTests.lean
@@ -24,9 +24,6 @@ private def storageWith (slot value : Nat) : Nat → Nat :=
 private def mappingsWith (base key value : Nat) : Nat → Nat → Nat :=
   fun b k => if b = base ∧ k = key then value else 0
 
-private def mkState (selector : Nat) (args : List Nat) : YulState :=
-  YulState.initial { sender := 0, functionSelector := selector, args := args } emptyStorage emptyMappings
-
 /-! ## Yul Runtime Semantics Smoke Tests -/
 
 private def runYul (runtimeCode : List YulStmt) (tx : YulTransaction)

--- a/Compiler/Proofs/YulGeneration/StatementEquivalence.lean
+++ b/Compiler/Proofs/YulGeneration/StatementEquivalence.lean
@@ -114,31 +114,6 @@ theorem assign_equiv (selector : Nat) (fuel : Nat) (varName : String) (valueExpr
           unfold execResultsAligned statesAligned yulStateOfIR
           simp [IRState.setVar, YulState.setVar]
 
-/-! ### Storage Load Equivalence -/
-
-theorem storageLoad_equiv (selector : Nat) (fuel : Nat)
-    (varName : String) (slotExpr : YulExpr)
-    (irState : IRState) (yulState : YulState)
-    (halign : statesAligned selector irState yulState)
-    (hfuel : fuel > 0) :
-    execResultsAligned selector
-      (execIRStmtFuel fuel irState (YulStmt.let_ varName (.call "sload" [slotExpr])))
-      (execYulStmtFuel fuel yulState (YulStmt.let_ varName (.call "sload" [slotExpr]))) := by
-  unfold statesAligned at halign
-  subst halign
-  cases fuel with
-  | zero => contradiction
-  | succ fuel' =>
-      unfold execIRStmtFuel execIRStmt execYulStmtFuel execYulFuel
-      rw [evalIRExpr_eq_evalYulExpr]
-      cases evalYulExpr (yulStateOfIR selector irState) (.call "sload" [slotExpr]) with
-      | none =>
-          unfold execResultsAligned
-          rfl
-      | some v =>
-          unfold execResultsAligned statesAligned yulStateOfIR
-          simp [IRState.setVar, YulState.setVar]
-
 /-! ### Storage Store Equivalence -/
 
 theorem storageStore_equiv (selector : Nat) (fuel : Nat)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -137,7 +137,6 @@ theorem assign_equiv :
     execYulStmt (assign var expr) yulState
 
 -- Storage operations equivalence
-theorem storageLoad_equiv : ...
 theorem storageStore_equiv : ...
 
 -- Control flow equivalence

--- a/Verity/Specs/Ledger/Spec.lean
+++ b/Verity/Specs/Ledger/Spec.lean
@@ -64,25 +64,4 @@ def Spec_withdraw_sum_equation (amount : Uint256) (s s' : ContractState) : Prop 
 def Spec_transfer_sum_preservation (_to : Address) (_amount : Uint256) (s s' : ContractState) : Prop :=
   totalBalance s' = totalBalance s
 
-/-- Spec: Sum of balances for singleton set containing only sender after deposit -/
-def Spec_deposit_sum_singleton_sender (amount : Uint256) (s s' : ContractState) : Prop :=
-  (∀ addr, addr ≠ s.sender → s.storageMap 0 addr = 0) →
-    totalBalance s' = add (s.storageMap 0 s.sender) amount
-
-/-- Spec: deposit followed by withdraw preserves sum -/
-def Spec_deposit_withdraw_sum_cancel (amount : Uint256) (s s' s'' : ContractState) : Prop :=
-  Spec_deposit_sum_equation amount s s' →
-  Spec_withdraw_sum_equation amount s' s'' →
-  totalBalance s'' = totalBalance s
-
-/-- Spec: Sum of balances for singleton set after withdraw -/
-def Spec_withdraw_sum_singleton_sender (amount : Uint256) (s s' : ContractState) : Prop :=
-  (∀ addr, addr ≠ s.sender → s.storageMap 0 addr = 0) →
-    totalBalance s' = sub (s.storageMap 0 s.sender) amount
-
-/-- Spec: Transfer preserves sum for unique addresses -/
-def Spec_transfer_sum_preserved_unique (to : Address) (_amount : Uint256) (s s' : ContractState) : Prop :=
-  s.sender ≠ to →
-  totalBalance s' = totalBalance s
-
 end Verity.Specs.Ledger

--- a/Verity/Specs/Owned/Invariants.lean
+++ b/Verity/Specs/Owned/Invariants.lean
@@ -26,10 +26,4 @@ structure WellFormedState (s : ContractState) : Prop where
   contract_nonempty : s.thisAddress ≠ ""
   owner_nonempty : s.storageAddr 0 ≠ ""
 
-/-- Mapping storage unchanged: Owner operations don't touch mapping storage -/
-abbrev map_storage_unchanged := Specs.sameStorageMap
-
-/-- Contract context preserved: Operations don't change sender or contract address -/
-abbrev context_preserved := Specs.sameContext
-
 end Verity.Specs.Owned

--- a/Verity/Specs/Owned/Spec.lean
+++ b/Verity/Specs/Owned/Spec.lean
@@ -33,14 +33,4 @@ def transferOwnership_spec (newOwner : Address) (s s' : ContractState) : Prop :=
 def isOwner_spec (result : Bool) (s : ContractState) : Prop :=
   result = (s.sender == s.storageAddr 0)
 
-/-! ## Combined Specifications -/
-
-/-- Constructor followed by getOwner returns the initial owner -/
-def constructor_getOwner_spec (initialOwner : Address) (_s : ContractState) (result : Address) : Prop :=
-  result = initialOwner
-
-/-- TransferOwnership followed by getOwner returns the new owner -/
-def transfer_getOwner_spec (newOwner : Address) (_s : ContractState) (result : Address) : Prop :=
-  result = newOwner
-
 end Verity.Specs.Owned

--- a/Verity/Specs/SimpleToken/Invariants.lean
+++ b/Verity/Specs/SimpleToken/Invariants.lean
@@ -19,14 +19,6 @@ structure WellFormedState (s : ContractState) : Prop where
   contract_nonempty : s.thisAddress ≠ ""
   owner_nonempty : s.storageAddr 0 ≠ ""
 
-/-- All balances are non-negative (implicit in Uint256 model) -/
-def balances_non_negative (s : ContractState) : Prop :=
-  ∀ addr : Address, s.storageMap 1 addr ≥ 0
-
-/-- Total supply is non-negative -/
-def supply_non_negative (s : ContractState) : Prop :=
-  s.storage 2 ≥ 0
-
 /-- Sum balances over a list of addresses -/
 def sum_balances (s : ContractState) (addrs : List Address) : Uint256 :=
   (addrs.map (fun addr => s.storageMap 1 addr)).sum
@@ -34,10 +26,6 @@ def sum_balances (s : ContractState) (addrs : List Address) : Uint256 :=
 /-- Total supply bounds all finite subsets of balances -/
 def supply_bounds_balances (s : ContractState) : Prop :=
   ∀ addrs : List Address, sum_balances s addrs ≤ s.storage 2
-
-/-- Owner cannot change except through transferOwnership (which doesn't exist yet) -/
-def owner_stable (s s' : ContractState) : Prop :=
-  s'.storageAddr 0 = s.storageAddr 0
 
 /-- Total supply storage isolation -/
 def supply_storage_isolated (s s' : ContractState) (slot : Nat) : Prop :=
@@ -53,16 +41,6 @@ def owner_addr_isolated (s s' : ContractState) (slot : Nat) : Prop :=
 
 /-- Context preservation (sender, contract address unchanged) -/
 abbrev context_preserved := Specs.sameContext
-
-/-- State preserved except for specific modifications -/
-def state_preserved_except (s s' : ContractState)
-  (modified_addr_slots : List Nat)
-  (modified_uint_slots : List Nat)
-  (modified_map_slots : List Nat) : Prop :=
-  (∀ slot : Nat, slot ∉ modified_addr_slots → s'.storageAddr slot = s.storageAddr slot) ∧
-  (∀ slot : Nat, slot ∉ modified_uint_slots → s'.storage slot = s.storage slot) ∧
-  (∀ slot : Nat, slot ∉ modified_map_slots → ∀ addr : Address, s'.storageMap slot addr = s.storageMap slot addr) ∧
-  context_preserved s s'
 
 /-- Transfer preserves total supply -/
 def transfer_preserves_supply (s s' : ContractState) : Prop :=

--- a/Verity/Specs/SimpleToken/Spec.lean
+++ b/Verity/Specs/SimpleToken/Spec.lean
@@ -64,18 +64,4 @@ def getOwner_spec (result : Address) (s : ContractState) : Prop :=
 def constructor_getTotalSupply_spec (_initialOwner : Address) (_s : ContractState) (result : Uint256) : Prop :=
   result = 0
 
-/-- Mint followed by balanceOf returns increased balance -/
-def mint_balanceOf_spec (to : Address) (amount : Uint256) (s : ContractState) (result : Uint256) : Prop :=
-  result = add (s.storageMap 1 to) amount
-
-/-- Transfer followed by balanceOf (sender) returns decreased balance -/
-def transfer_balanceOf_sender_spec (sender _to : Address) (amount : Uint256) (s : ContractState) (result : Uint256) : Prop :=
-  s.storageMap 1 sender ≥ amount →
-  result = sub (s.storageMap 1 sender) amount
-
-/-- Transfer followed by balanceOf (recipient) returns increased balance -/
-def transfer_balanceOf_recipient_spec (sender to : Address) (amount : Uint256) (s : ContractState) (result : Uint256) : Prop :=
-  s.storageMap 1 sender ≥ amount →
-  result = add (s.storageMap 1 to) amount
-
 end Verity.Specs.SimpleToken


### PR DESCRIPTION
## Summary
- Remove 9 unused combined spec definitions from Ledger, Owned, and SimpleToken Spec files
- Remove 6 unused invariant/abbrev definitions from Owned and SimpleToken Invariants files
- Remove 3 dead proof artifacts from YulGeneration (storageLoad_equiv, ir_yul_function_equiv_goal cluster, execIRFunctionFuel_eq_execIRFunction, mkState)
- Update doc references in TRUST_ASSUMPTIONS.md, CONTRIBUTING.md, Preservation.lean

All removed items verified unused — no theorem, proof, or manifest references.

## Test plan
- [x] `lake build` passes (all 370 theorems, 0 sorry)
- [x] All 11 Python check scripts pass
- [x] Property manifest unchanged (none of the removed items were tracked)
- [x] Doc count check passes (370 theorems unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily deletes unused definitions and updates documentation/proof references; no functional compiler or semantics changes are introduced.
> 
> **Overview**
> Removes unused/speculative Lean definitions across specs and Layer 3 proofs to reduce dead code and documentation drift, without changing any proved theorems.
> 
> This deletes several unreferenced *combined spec* helpers in `Verity/Specs/*` (Ledger/Owned/SimpleToken) and trims unused invariant abbreviations in `Owned` and `SimpleToken` invariants. In `Compiler/Proofs/YulGeneration`, it drops obsolete proof scaffolding (`ir_yul_function_equiv_goal`, `storageLoad_equiv`, `mkState`, and a redundant fuel-bridging lemma) and updates references to the remaining adequacy lemma (`execIRFunctionFuel_adequate`) plus docs (`CONTRIBUTING.md`, `TRUST_ASSUMPTIONS.md`, `Preservation.lean`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06e61376a5957e885c20b1a94efa52b96d7ecc5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->