### PR TITLE
Remove redundant imports and unused open from SpecCorrectness

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Counter.lean
+++ b/Compiler/Proofs/SpecCorrectness/Counter.lean
@@ -15,7 +15,6 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Examples.Counter
-import Verity.Core.Uint256
 
 namespace Compiler.Proofs.SpecCorrectness
 
@@ -25,7 +24,7 @@ open Verity.Proofs.Stdlib.SpecInterpreter
 open Verity
 open Verity.Examples.Counter
 open Verity.EVM.Uint256 (add sub)
-open Verity.Core.Uint256 (modulus val_ofNat ofNat)
+open Verity.Core.Uint256 (modulus val_ofNat)
 
 /- State Conversion -/
 

--- a/Compiler/Proofs/SpecCorrectness/Ledger.lean
+++ b/Compiler/Proofs/SpecCorrectness/Ledger.lean
@@ -18,10 +18,7 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
-import Compiler.Hex
 import Verity.Examples.Ledger
-import Verity.Stdlib.Math
-import Verity.Core.Uint256
 import Verity.Proofs.Ledger.Basic
 
 -- Increased heartbeats due to additional struct fields (mappings2, events, etc.)

--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -17,7 +17,6 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
-import Compiler.Hex
 import Verity.Examples.Owned
 import Verity.Proofs.Owned.Basic
 import Verity.Proofs.Owned.Correctness
@@ -31,7 +30,6 @@ open Verity.Proofs.Stdlib.Automation
 open Compiler.Hex
 open Verity
 open Verity.Examples.Owned
-open Verity.Proofs.Owned
 
 /- State Conversion -/
 

--- a/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
@@ -18,10 +18,8 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
-import Compiler.Hex
 import Verity.Examples.OwnedCounter
 import Verity.Proofs.OwnedCounter.Basic
-import Verity.Core.Uint256
 
 namespace Compiler.Proofs.SpecCorrectness
 

--- a/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
@@ -17,8 +17,6 @@ import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
 import Verity.Examples.SafeCounter
-import Verity.Core.Uint256
-import Verity.Stdlib.Math
 import Verity.Proofs.SafeCounter.Basic
 
 namespace Compiler.Proofs.SpecCorrectness

--- a/Compiler/Proofs/SpecCorrectness/SimpleStorage.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleStorage.lean
@@ -15,7 +15,6 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Examples.SimpleStorage
-import Verity.Core.Uint256
 
 namespace Compiler.Proofs.SpecCorrectness
 

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -19,12 +19,9 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
-import Compiler.Hex
 import Verity.Examples.SimpleToken
-import Verity.Stdlib.Math
 import Verity.Proofs.SimpleToken.Basic
 import Verity.Proofs.SimpleToken.Correctness
-import Verity.Core.Uint256
 
 -- Increased heartbeats due to additional struct fields (mappings2, events, etc.)
 set_option maxHeartbeats 400000


### PR DESCRIPTION
## Summary
- Remove 12 transitive imports across 7 SpecCorrectness files (Verity.Core.Uint256, Compiler.Hex, Verity.Stdlib.Math already provided via Automation/Examples)
- Remove unused `open Verity.Proofs.Owned` from Owned.lean (all references use fully-qualified names)
- Remove unused `ofNat` selector from partial open in Counter.lean

## Test plan
- [x] `lake build` passes (all 370 theorems, 0 sorry)
- [x] All 11 Python check scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely removes unused/redundant `import`/`open` statements in proof files; no runtime logic changes, with minimal risk beyond potential build breakage from missing transitive deps.
> 
> **Overview**
> **Proof-only cleanup in `SpecCorrectness`** by removing redundant/transitively-provided imports across the Counter/Ledger/Owned/OwnedCounter/SafeCounter/SimpleStorage/SimpleToken correctness proof files.
> 
> Also trims unused namespace openings: drops `open Verity.Proofs.Owned` in `Owned.lean` and removes unused `ofNat` from the partial `open Verity.Core.Uint256 (...)` in `Counter.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c58f99e27a7ba4bb73072e2c4c2c12472bb83ba8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->