### PR TITLE
Remove redundant import Compiler.Hex from Automation.lean

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -51,7 +51,7 @@ axiom keccak256_first_4_bytes (sig : String) : Nat
 
 ### 2. `addressToNat_injective`
 
-**Location**: `Verity/Proofs/Stdlib/Automation.lean:169`
+**Location**: `Verity/Proofs/Stdlib/Automation.lean:168`
 
 **Statement**:
 ```lean

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -26,7 +26,6 @@
 import Verity.Core
 import Verity.Stdlib.Math
 import Verity.EVM.Uint256
-import Compiler.Hex
 import Verity.Proofs.Stdlib.SpecInterpreter
 
 namespace Verity.Proofs.Stdlib.Automation


### PR DESCRIPTION
## Summary
- `Compiler.Hex` is already imported transitively via `SpecInterpreter → ContractSpec → Hex`
- The `open Compiler.Hex` on line 36 remains since `open` is not transitive in Lean 4
- Net: -1 line, no behavioral change

## Test plan
- [x] `lake build` passes (all 86 modules)
- [x] CI check scripts pass (manifest sync, doc counts, selectors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line import cleanup plus a doc line-number update; no logic, proof, or axiom semantics change.
> 
> **Overview**
> Removes the direct `import Compiler.Hex` from `Verity/Proofs/Stdlib/Automation.lean`, relying on the existing transitive import via `SpecInterpreter` while keeping `open Compiler.Hex` for local namespace access.
> 
> Updates `AXIOMS.md` to reflect the shifted line number for `addressToNat_injective` after the import removal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e17ba59cd5172238d17abed50f390e4d1443392. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->