### PR TITLE
Extend hygiene check to catch all debug commands in proof files

### DIFF
--- a/scripts/check_lean_hygiene.py
+++ b/scripts/check_lean_hygiene.py
@@ -2,7 +2,7 @@
 """Check for Lean code hygiene issues.
 
 Validates:
-1. No #eval in Compiler/Proofs/ files (debug commands slow builds)
+1. No debug commands (#eval, #check, #print, #reduce) in proof files
 2. Exactly 1 allowUnsafeReducibility (documented trust assumption)
 
 Usage:
@@ -17,18 +17,22 @@ from property_utils import ROOT, die, report_errors
 def main() -> None:
     errors: list[str] = []
 
-    # Check 1: No #eval in proof files
+    # Check 1: No debug commands in proof files
+    debug_commands = ["#eval", "#check", "#print", "#reduce"]
     proof_dirs = [ROOT / "Compiler" / "Proofs", ROOT / "Verity" / "Proofs"]
     for proof_dir in proof_dirs:
         for lean_file in proof_dir.rglob("*.lean"):
             rel = lean_file.relative_to(ROOT)
             for i, line in enumerate(lean_file.read_text().splitlines(), 1):
                 stripped = line.lstrip()
-                if stripped.startswith("#eval ") or stripped == "#eval":
-                    errors.append(
-                        f"{rel}:{i}: found #eval in proof file "
-                        f"(debug command that slows builds)"
-                    )
+                if stripped.startswith("--"):
+                    continue
+                for cmd in debug_commands:
+                    if stripped.startswith(cmd + " ") or stripped == cmd:
+                        errors.append(
+                            f"{rel}:{i}: found {cmd} in proof file "
+                            f"(debug command that slows builds)"
+                        )
 
     # Check 2: Exactly 1 allowUnsafeReducibility
     expected_unsafe = 1
@@ -52,7 +56,7 @@ def main() -> None:
     report_errors(errors, "Lean hygiene check failed")
     print(
         f"Lean hygiene check passed "
-        f"(0 #eval in proofs, {unsafe_count} allowUnsafeReducibility)."
+        f"(0 debug commands in proofs, {unsafe_count} allowUnsafeReducibility)."
     )
 
 


### PR DESCRIPTION
## Summary
- Extend `check_lean_hygiene.py` to catch `#check`, `#print`, `#reduce` in addition to `#eval`
- Skip commented-out lines (`--`) to avoid false positives
- Prevents accidental debug commands from landing in proof files

## Test plan
- [x] `python3 scripts/check_lean_hygiene.py` passes (0 debug commands found)
- [x] All other CI check scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to a developer hygiene script; primary risk is only potential false positives/negatives in CI checks.
> 
> **Overview**
> Extends `scripts/check_lean_hygiene.py` to flag additional Lean debug directives in proof files, expanding the check from just `#eval` to also catch `#check`, `#print`, and `#reduce`.
> 
> To reduce false positives, the scan now skips lines commented out with `--`, and the success output message is updated to reflect the broader “debug commands” check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d02458144f756b90db6dc3b45631ae48c2e73ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->