### PR TITLE
Remove redundant imports from proof files (-54 lines)

### DIFF
--- a/Verity/Proofs/Counter/Correctness.lean
+++ b/Verity/Proofs/Counter/Correctness.lean
@@ -7,11 +7,6 @@
   - State preservation composition
 -/
 
-import Verity.Core
-import Verity.Examples.Counter
-import Verity.EVM.Uint256
-import Verity.Specs.Counter.Spec
-import Verity.Specs.Counter.Invariants
 import Verity.Proofs.Counter.Basic
 import Verity.Proofs.Stdlib.Automation
 

--- a/Verity/Proofs/Ledger/Conservation.lean
+++ b/Verity/Proofs/Ledger/Conservation.lean
@@ -11,13 +11,8 @@
   factor accounts for addresses appearing multiple times in the list.
 -/
 
-import Verity.Core
-import Verity.Examples.Ledger
-import Verity.EVM.Uint256
-import Verity.Specs.Ledger.Spec
 import Verity.Proofs.Ledger.Basic
 import Verity.Proofs.Stdlib.ListSum
-import Verity.Stdlib.Math
 
 namespace Verity.Proofs.Ledger.Conservation
 

--- a/Verity/Proofs/Ledger/Correctness.lean
+++ b/Verity/Proofs/Ledger/Correctness.lean
@@ -7,13 +7,7 @@
   - Deposit-withdraw cancellation: deposit then withdraw returns to original balance
 -/
 
-import Verity.Core
-import Verity.Examples.Ledger
-import Verity.EVM.Uint256
-import Verity.Specs.Ledger.Spec
-import Verity.Specs.Ledger.Invariants
 import Verity.Proofs.Ledger.Basic
-import Verity.Stdlib.Math
 
 namespace Verity.Proofs.Ledger.Correctness
 

--- a/Verity/Proofs/Owned/Correctness.lean
+++ b/Verity/Proofs/Owned/Correctness.lean
@@ -7,10 +7,6 @@
   - End-to-end composition: constructor → transferOwnership → getOwner
 -/
 
-import Verity.Core
-import Verity.Examples.Owned
-import Verity.Specs.Owned.Spec
-import Verity.Specs.Owned.Invariants
 import Verity.Proofs.Owned.Basic
 
 namespace Verity.Proofs.Owned.Correctness

--- a/Verity/Proofs/OwnedCounter/Correctness.lean
+++ b/Verity/Proofs/OwnedCounter/Correctness.lean
@@ -7,11 +7,6 @@
   - End-to-end: constructor → increment → getCount → transferOwnership → verify lockout
 -/
 
-import Verity.Core
-import Verity.Examples.OwnedCounter
-import Verity.EVM.Uint256
-import Verity.Specs.OwnedCounter.Spec
-import Verity.Specs.OwnedCounter.Invariants
 import Verity.Proofs.OwnedCounter.Basic
 
 namespace Verity.Proofs.OwnedCounter.Correctness

--- a/Verity/Proofs/OwnedCounter/Isolation.lean
+++ b/Verity/Proofs/OwnedCounter/Isolation.lean
@@ -11,9 +11,6 @@
   actual contract behavior.
 -/
 
-import Verity.Core
-import Verity.Examples.OwnedCounter
-import Verity.Specs.OwnedCounter.Invariants
 import Verity.Proofs.OwnedCounter.Basic
 
 namespace Verity.Proofs.OwnedCounter.Isolation

--- a/Verity/Proofs/SafeCounter/Correctness.lean
+++ b/Verity/Proofs/SafeCounter/Correctness.lean
@@ -7,12 +7,6 @@
   - Composition: decrement → getCount
 -/
 
-import Verity.Core
-import Verity.Stdlib.Math
-import Verity.EVM.Uint256
-import Verity.Examples.SafeCounter
-import Verity.Specs.SafeCounter.Spec
-import Verity.Specs.SafeCounter.Invariants
 import Verity.Proofs.SafeCounter.Basic
 import Verity.Proofs.Stdlib.Automation
 

--- a/Verity/Proofs/SimpleStorage/Correctness.lean
+++ b/Verity/Proofs/SimpleStorage/Correctness.lean
@@ -7,10 +7,6 @@
   - Retrieve preserves well-formedness
 -/
 
-import Verity.Core
-import Verity.Examples.SimpleStorage
-import Verity.Specs.SimpleStorage.Spec
-import Verity.Specs.SimpleStorage.Invariants
 import Verity.Proofs.SimpleStorage.Basic
 import Verity.Proofs.Stdlib.Automation
 

--- a/Verity/Proofs/SimpleToken/Correctness.lean
+++ b/Verity/Proofs/SimpleToken/Correctness.lean
@@ -10,11 +10,6 @@
   These are Tier 2-3 properties: functional correctness and invariant preservation.
 -/
 
-import Verity.Examples.SimpleToken
-import Verity.EVM.Uint256
-import Verity.Stdlib.Math
-import Verity.Specs.SimpleToken.Spec
-import Verity.Specs.SimpleToken.Invariants
 import Verity.Proofs.SimpleToken.Basic
 
 namespace Verity.Proofs.SimpleToken.Correctness

--- a/Verity/Proofs/SimpleToken/Isolation.lean
+++ b/Verity/Proofs/SimpleToken/Isolation.lean
@@ -10,11 +10,6 @@
   fully independent. No operation corrupts unrelated storage.
 -/
 
-import Verity.Core
-import Verity.Examples.SimpleToken
-import Verity.Stdlib.Math
-import Verity.Specs.SimpleToken.Spec
-import Verity.Specs.SimpleToken.Invariants
 import Verity.Proofs.SimpleToken.Basic
 
 namespace Verity.Proofs.SimpleToken.Isolation

--- a/Verity/Proofs/SimpleToken/Supply.lean
+++ b/Verity/Proofs/SimpleToken/Supply.lean
@@ -14,12 +14,6 @@
   provable statement about how sums change under state-modifying operations.
 -/
 
-import Verity.Core
-import Verity.Examples.SimpleToken
-import Verity.EVM.Uint256
-import Verity.Stdlib.Math
-import Verity.Specs.SimpleToken.Spec
-import Verity.Specs.SimpleToken.Invariants
 import Verity.Proofs.SimpleToken.Basic
 import Verity.Proofs.Stdlib.ListSum
 


### PR DESCRIPTION
## Summary
- Remove 54 transitive import lines across 11 proof files (7 Correctness + Conservation + 2 Isolation + Supply)
- Each file imported modules (Core, Examples, EVM.Uint256, Specs, Stdlib.Math) already provided transitively by Basic.lean
- Minimal imports kept: Basic.lean + any non-transitive modules (Automation, ListSum)

### Files changed
- `Verity/Proofs/Counter/Correctness.lean` (-5 imports)
- `Verity/Proofs/Ledger/Correctness.lean` (-6 imports)
- `Verity/Proofs/Ledger/Conservation.lean` (-5 imports)
- `Verity/Proofs/Owned/Correctness.lean` (-4 imports)
- `Verity/Proofs/OwnedCounter/Correctness.lean` (-5 imports)
- `Verity/Proofs/OwnedCounter/Isolation.lean` (-3 imports)
- `Verity/Proofs/SafeCounter/Correctness.lean` (-6 imports)
- `Verity/Proofs/SimpleStorage/Correctness.lean` (-4 imports)
- `Verity/Proofs/SimpleToken/Correctness.lean` (-5 imports)
- `Verity/Proofs/SimpleToken/Isolation.lean` (-5 imports)
- `Verity/Proofs/SimpleToken/Supply.lean` (-6 imports)

## Test plan
- [x] `lake build` passes (all 370 theorems, 0 sorry)
- [x] All 11 Python check scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: import-only refactor with no semantic changes, though it could surface hidden dependency assumptions if `Basic.lean` imports change or if any file relied on an unintentional transitive import.
> 
> **Overview**
> Removes redundant/transitively-provided `import` lines from 11 Lean proof files (multiple `Correctness`, `Isolation`, plus `Ledger/Conservation` and `SimpleToken/Supply`) so they depend primarily on the corresponding `Verity.Proofs.*.Basic` module, keeping only direct extras like `Verity.Proofs.Stdlib.Automation` and `Verity.Proofs.Stdlib.ListSum`.
> 
> This is a build/maintenance cleanup only; theorem statements and proofs are unchanged, but module dependency graphs and compilation order can be affected if any `Basic` import set changes later.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42b7d29d4e6e4423deda460090d260b0f6f5258b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->