### PR TITLE
Simplify subtraction bridges in SimpleToken SpecCorrectness (-16 lines)

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -442,18 +442,8 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
           ((ContractResult.getState
               ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
             ).storageMap 1 sender).val =
-            (state.storageMap 1 sender).val - amount := by
-        have h_val := congrArg (fun v : Verity.Core.Uint256 => v.val) h_edsl_state
-        -- Use sub semantics with no underflow
-        have h_val' :
-            ((ContractResult.getState
-                ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-              ).storageMap 1 sender).val =
-              (Verity.EVM.Uint256.sub (state.storageMap 1 sender)
-                (Verity.Core.Uint256.ofNat amount)).val := by
-          simpa using h_val
-        simpa [h_val'] using
-          (uint256_sub_val_of_le (state.storageMap 1 sender) amount h)
+            (state.storageMap 1 sender).val - amount :=
+        h_edsl_state ▸ uint256_sub_val_of_le _ _ h
       calc
         (let specTx : DiffTestTypes.Transaction := {
           sender := sender
@@ -773,14 +763,8 @@ theorem token_transfer_preserves_total_balance (state : ContractState) (to : Add
       ((ContractResult.getState
         ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
       ).storageMap 1 sender).val =
-      (state.storageMap 1 sender).val - amount := by
-    have h_val := congrArg (fun v : Verity.Core.Uint256 => v.val) h_sender_state
-    have h_val' :
-        (Verity.EVM.Uint256.sub (state.storageMap 1 sender)
-          (Verity.Core.Uint256.ofNat amount)).val =
-        (state.storageMap 1 sender).val - amount := by
-      exact uint256_sub_val_of_le (state.storageMap 1 sender) amount h2
-    simpa [h_val'] using h_val
+      (state.storageMap 1 sender).val - amount :=
+    h_sender_state ▸ uint256_sub_val_of_le _ _ h2
   have h_recipient_val :
       ((ContractResult.getState
         ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })


### PR DESCRIPTION
## Summary
- Replace 2 manual `congrArg` + `simpa` subtraction chain blocks with one-liners using `h_edsl_state ▸ uint256_sub_val_of_le`
- Aligns SimpleToken with the same clean pattern used in Ledger.lean (PR #429)
- Net: -16 lines (4 added, 20 removed), no API changes

## Test plan
- [x] `lake build` passes (all 86 modules, 370 theorems, 0 sorry)
- [x] All CI check scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only simplification that preserves theorems and runtime behavior; risk is limited to potential proof brittleness if the rewritten lemmas change.
> 
> **Overview**
> Simplifies two `SimpleToken` spec-correctness proofs by replacing a multi-step `congrArg`/`simpa` chain for bridging `Uint256.sub` to Nat subtraction with a single rewrite (`h_*_state ▸ uint256_sub_val_of_le`).
> 
> This is a proof-only refactor (net line reduction) with no changes to the spec, EDSL semantics, or public APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0efe57752eafdc896b9efc7b95961c853eda53a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->