### PR TITLE
Remove redundant transitive imports across 25 files (-41 lines)

### DIFF
--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -1,6 +1,5 @@
 import Std
 import Compiler.Specs
-import Compiler.ContractSpec
 import Compiler.Selector
 import Compiler.Codegen
 import Compiler.Yul.PrettyPrint

--- a/Compiler/Interpreter.lean
+++ b/Compiler/Interpreter.lean
@@ -11,7 +11,6 @@
   Success: Identical results → high confidence in compiler correctness
 -/
 
-import Verity.Core
 import Verity.Examples.SimpleStorage
 import Verity.Examples.Counter
 import Verity.Examples.SafeCounter

--- a/Compiler/Proofs/IRGeneration/Conversions.lean
+++ b/Compiler/Proofs/IRGeneration/Conversions.lean
@@ -9,10 +9,7 @@
 -/
 
 import Compiler.Proofs.IRGeneration.IRInterpreter
-import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
-import Verity.Core
-import Compiler.ContractSpec
 import Compiler.Hex
 
 namespace Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/Expr.lean
+++ b/Compiler/Proofs/IRGeneration/Expr.lean
@@ -11,10 +11,7 @@
 
 import Compiler.Proofs.IRGeneration.IRInterpreter
 import Compiler.Proofs.IRGeneration.Conversions
-import Verity.Proofs.Stdlib.SpecInterpreter
-import Compiler.ContractSpec
 import Compiler.Specs
-import Verity.Core
 
 namespace Compiler.Proofs.IRGeneration
 

--- a/Verity/Proofs/Counter/Basic.lean
+++ b/Verity/Proofs/Counter/Basic.lean
@@ -4,9 +4,6 @@
   Proves that Counter operations satisfy their specifications.
 -/
 
-import Verity.Core
-import Verity.Examples.Counter
-import Verity.EVM.Uint256
 import Verity.Specs.Counter.Spec
 import Verity.Specs.Counter.Invariants
 

--- a/Verity/Proofs/Ledger/Basic.lean
+++ b/Verity/Proofs/Ledger/Basic.lean
@@ -9,12 +9,8 @@
   - All operations preserve non-mapping storage
 -/
 
-import Verity.Core
-import Verity.Examples.Ledger
-import Verity.EVM.Uint256
 import Verity.Specs.Ledger.Spec
 import Verity.Specs.Ledger.Invariants
-import Verity.Stdlib.Math
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.Automation
 

--- a/Verity/Proofs/Owned/Basic.lean
+++ b/Verity/Proofs/Owned/Basic.lean
@@ -7,8 +7,6 @@
   due to require behavior not being fully modeled in the EDSL.
 -/
 
-import Verity.Core
-import Verity.Examples.Owned
 import Verity.Specs.Owned.Spec
 import Verity.Specs.Owned.Invariants
 import Verity.Proofs.Stdlib.Automation

--- a/Verity/Proofs/OwnedCounter/Basic.lean
+++ b/Verity/Proofs/OwnedCounter/Basic.lean
@@ -9,9 +9,6 @@
   - State preservation and well-formedness
 -/
 
-import Verity.Core
-import Verity.Examples.OwnedCounter
-import Verity.EVM.Uint256
 import Verity.Specs.OwnedCounter.Spec
 import Verity.Specs.OwnedCounter.Invariants
 import Verity.Proofs.Stdlib.Automation

--- a/Verity/Proofs/SafeCounter/Basic.lean
+++ b/Verity/Proofs/SafeCounter/Basic.lean
@@ -8,11 +8,7 @@
   - State preservation and well-formedness
 -/
 
-import Verity.Core
-import Verity.Stdlib.Math
 import Verity.Proofs.Stdlib.Math
-import Verity.EVM.Uint256
-import Verity.Examples.SafeCounter
 import Verity.Specs.SafeCounter.Spec
 import Verity.Specs.SafeCounter.Invariants
 

--- a/Verity/Proofs/SimpleStorage/Basic.lean
+++ b/Verity/Proofs/SimpleStorage/Basic.lean
@@ -6,7 +6,6 @@
   Status: Complete — all 13 proofs proven with zero axioms and zero sorry.
 -/
 
-import Verity.Core
 import Verity.Examples.SimpleStorage
 import Verity.Specs.SimpleStorage.Spec
 import Verity.Specs.SimpleStorage.Invariants

--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -10,8 +10,6 @@
 -/
 
 import Verity.Examples.SimpleToken
-import Verity.EVM.Uint256
-import Verity.Stdlib.Math
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.Automation
 import Verity.Specs.SimpleToken.Spec

--- a/Verity/Specs/Counter/Invariants.lean
+++ b/Verity/Specs/Counter/Invariants.lean
@@ -4,7 +4,6 @@
   Defines properties that should always hold, regardless of operations.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 
 namespace Verity.Specs.Counter

--- a/Verity/Specs/Counter/Spec.lean
+++ b/Verity/Specs/Counter/Spec.lean
@@ -2,7 +2,6 @@
   Formal specifications for Counter operations.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 import Verity.EVM.Uint256
 import Verity.Examples.Counter

--- a/Verity/Specs/Ledger/Invariants.lean
+++ b/Verity/Specs/Ledger/Invariants.lean
@@ -2,7 +2,6 @@
   State invariants for Ledger contract.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 
 namespace Verity.Specs.Ledger

--- a/Verity/Specs/Ledger/Spec.lean
+++ b/Verity/Specs/Ledger/Spec.lean
@@ -2,7 +2,6 @@
   Formal specifications for Ledger operations.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 import Verity.Specs.Common.Sum
 import Verity.EVM.Uint256

--- a/Verity/Specs/Owned/Invariants.lean
+++ b/Verity/Specs/Owned/Invariants.lean
@@ -4,7 +4,6 @@
   Defines properties that should always hold, regardless of operations.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 
 namespace Verity.Specs.Owned

--- a/Verity/Specs/Owned/Spec.lean
+++ b/Verity/Specs/Owned/Spec.lean
@@ -2,7 +2,6 @@
   Formal specifications for Owned operations.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 import Verity.Examples.Owned
 

--- a/Verity/Specs/OwnedCounter/Invariants.lean
+++ b/Verity/Specs/OwnedCounter/Invariants.lean
@@ -5,7 +5,6 @@
   owner operations don't touch count, and count operations don't touch owner.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 
 namespace Verity.Specs.OwnedCounter

--- a/Verity/Specs/OwnedCounter/Spec.lean
+++ b/Verity/Specs/OwnedCounter/Spec.lean
@@ -2,7 +2,6 @@
   Formal specifications for OwnedCounter operations.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 import Verity.EVM.Uint256
 import Verity.Examples.OwnedCounter

--- a/Verity/Specs/SafeCounter/Invariants.lean
+++ b/Verity/Specs/SafeCounter/Invariants.lean
@@ -5,7 +5,6 @@
   The key invariant is that the count stays within [0, MAX_UINT256].
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 import Verity.Stdlib.Math
 

--- a/Verity/Specs/SafeCounter/Spec.lean
+++ b/Verity/Specs/SafeCounter/Spec.lean
@@ -2,7 +2,6 @@
   Formal specifications for SafeCounter operations.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 import Verity.Stdlib.Math
 import Verity.EVM.Uint256

--- a/Verity/Specs/SimpleStorage/Invariants.lean
+++ b/Verity/Specs/SimpleStorage/Invariants.lean
@@ -2,7 +2,6 @@
   State invariants for SimpleStorage contract.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 
 namespace Verity.Specs.SimpleStorage

--- a/Verity/Specs/SimpleStorage/Spec.lean
+++ b/Verity/Specs/SimpleStorage/Spec.lean
@@ -2,7 +2,6 @@
   Formal specifications for SimpleStorage operations.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 
 namespace Verity.Specs.SimpleStorage

--- a/Verity/Specs/SimpleToken/Invariants.lean
+++ b/Verity/Specs/SimpleToken/Invariants.lean
@@ -2,7 +2,6 @@
   State invariants for SimpleToken contract.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 import Verity.EVM.Uint256
 

--- a/Verity/Specs/SimpleToken/Spec.lean
+++ b/Verity/Specs/SimpleToken/Spec.lean
@@ -2,7 +2,6 @@
   Formal specifications for SimpleToken operations.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 import Verity.EVM.Uint256
 


### PR DESCRIPTION
## Summary
- Remove 41 redundant `import` lines across 25 files in Specs/, Proofs/, and Compiler/
- All removed imports are transitively provided by other imports in the same file
- Three categories:
  - **14 Specs files**: `import Verity.Core` redundant via `import Verity.Specs.Common`
  - **7 Basic.lean proof files**: Various imports (`Verity.Core`, `Verity.EVM.Uint256`, `Verity.Examples.*`, `Verity.Stdlib.Math`) redundant via Spec and Stdlib imports
  - **4 Compiler files**: `Verity.Core`, `Compiler.ContractSpec`, `Verity.Proofs.Stdlib.SpecInterpreter` redundant via other imports

## Test plan
- [x] `lake build` passes (all 370 theorems verified, 0 sorry)
- [x] All 11 Python check scripts pass
- [x] No semantic changes — pure import cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only deletions with no logic changes; risk is limited to potential missing transitive dependencies causing build failures.
> 
> **Overview**
> Removes a set of redundant `import` statements across compiler, specs, and proof modules by relying on transitive imports already pulled in by remaining dependencies (e.g., dropping direct `Verity.Core`, `Compiler.ContractSpec`, and `Verity.Proofs.Stdlib.SpecInterpreter` imports).
> 
> This is an import-only cleanup (net -41 lines) intended to keep build/proof behavior unchanged while reducing boilerplate and tightening module dependency lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77f6c911c763043b863c19262611f3900ad771aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->