### PR TITLE
Shorten congrArg lambdas and remove redundant import

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Ledger.lean
+++ b/Compiler/Proofs/SpecCorrectness/Ledger.lean
@@ -105,7 +105,7 @@ theorem ledger_deposit_correct (state : ContractState) (amount : Nat) (sender : 
           ).storageMap 0 sender).val =
           (Verity.EVM.Uint256.add (state.storageMap 0 sender)
             (Verity.Core.Uint256.ofNat amount)).val := by
-      simpa using congrArg (fun v : Verity.Core.Uint256 => v.val) h_edsl_state
+      simpa using congrArg Verity.Core.Uint256.val h_edsl_state
     have h_add_val :
         (Verity.EVM.Uint256.add (state.storageMap 0 sender)
           (Verity.Core.Uint256.ofNat amount)).val =
@@ -415,7 +415,7 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
               ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
             ).storageMap 0 to).val =
             ((state.storageMap 0 to).val + amount) % Verity.Core.Uint256.modulus := by
-        have h_val := congrArg (fun v : Verity.Core.Uint256 => v.val) h_edsl_state
+        have h_val := congrArg Verity.Core.Uint256.val h_edsl_state
         simpa [uint256_add_val] using h_val
       calc
         (let specTx : DiffTestTypes.Transaction := {
@@ -545,7 +545,7 @@ theorem ledger_deposit_increases (state : ContractState) (amount : Nat) (sender 
   have h_deposit_val_nat :
       (((deposit (Verity.Core.Uint256.ofNat amount)).runState { state with sender := sender }).storageMap 0 sender).val =
         (Verity.EVM.Uint256.add (state.storageMap 0 sender) (Verity.Core.Uint256.ofNat amount)).val := by
-    simpa using congrArg (fun v : Verity.Core.Uint256 => v.val) h_deposit_val
+    simpa using congrArg Verity.Core.Uint256.val h_deposit_val
   -- Rewrite with the addition lemma and the runState definition.
   simpa [h_add] using h_deposit_val_nat
 
@@ -587,7 +587,7 @@ theorem ledger_transfer_preserves_total (state : ContractState) (to : Address) (
       ((Contract.runState (transfer to (Verity.Core.Uint256.ofNat amount))
           { state with sender := sender }).storageMap 0 to).val =
         (state.storageMap 0 to).val + amount := by
-    have h_val := congrArg (fun v : Verity.Core.Uint256 => v.val) h_recipient
+    have h_val := congrArg Verity.Core.Uint256.val h_recipient
     have h_mod : ((state.storageMap 0 to).val + amount) % Verity.Core.Uint256.modulus =
         (state.storageMap 0 to).val + amount := by
       exact Nat.mod_eq_of_lt h3

--- a/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
@@ -97,7 +97,7 @@ theorem ownedCounter_increment_correct_as_owner (state : ContractState) (sender 
           ((state.storage 1).val + 1) % Verity.Core.Uint256.modulus := by
       have h_inc := increment_adds_one_when_owner (s := { state with sender := sender }) h_owner'
       simpa [ContractResult.getState, ContractResult.snd, uint256_add_val] using
-        congrArg (fun v : Verity.Core.Uint256 => v.val) h_inc
+        congrArg Verity.Core.Uint256.val h_inc
     simp [ownedCounterSpec, requireOwner, interpretSpec, ownedCounterEdslToSpecStorage, execFunction, execStmts,
       execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot, h, h_inc_val]
 
@@ -155,7 +155,7 @@ theorem ownedCounter_decrement_correct_as_owner (state : ContractState) (sender 
               (1 % Verity.Core.Uint256.modulus - (state.storage 1).val)) := by
       have h_dec := decrement_subtracts_one_when_owner (s := { state with sender := sender }) h_owner'
       simpa [ContractResult.getState, ContractResult.snd] using
-        (congrArg (fun v : Verity.Core.Uint256 => v.val) h_dec).trans (uint256_sub_val (state.storage 1) 1)
+        (congrArg Verity.Core.Uint256.val h_dec).trans (uint256_sub_val (state.storage 1) 1)
     simp [ownedCounterSpec, requireOwner, interpretSpec, ownedCounterEdslToSpecStorage, execFunction, execStmts,
       execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot, h, h_dec_val]
 

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -190,7 +190,7 @@ theorem token_mint_correct_as_owner (state : ContractState) (to : Address) (amou
         ).storageMap 1 to).val =
         (Verity.EVM.Uint256.add (state.storageMap 1 to)
           (Verity.Core.Uint256.ofNat amount)).val := by
-      simpa using congrArg (fun v : Verity.Core.Uint256 => v.val) h_edsl_map
+      simpa using congrArg Verity.Core.Uint256.val h_edsl_map
     have h_spec_val :
         (let specTx : DiffTestTypes.Transaction := {
           sender := sender
@@ -242,7 +242,7 @@ theorem token_mint_correct_as_owner (state : ContractState) (to : Address) (amou
         ).storage 2).val =
         (Verity.EVM.Uint256.add (state.storage 2)
           (Verity.Core.Uint256.ofNat amount)).val := by
-      simpa using congrArg (fun v : Verity.Core.Uint256 => v.val) h_edsl_supply
+      simpa using congrArg Verity.Core.Uint256.val h_edsl_supply
     have h_spec_val :
         (let specTx : DiffTestTypes.Transaction := {
           sender := sender
@@ -485,7 +485,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
               ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
             ).storageMap 1 to).val =
             ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus := by
-        have h_val := congrArg (fun v : Verity.Core.Uint256 => v.val) h_edsl_state
+        have h_val := congrArg Verity.Core.Uint256.val h_edsl_state
         calc
           ((ContractResult.getState
               ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
@@ -653,7 +653,7 @@ theorem token_mint_increases_supply (state : ContractState) (to : Address) (amou
         ((mint to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
       ).storage 2).val =
       ((state.storage 2).val + amount) % Verity.Core.Uint256.modulus := by
-    have h_edsl_val := congrArg (fun v : Verity.Core.Uint256 => v.val) h_edsl
+    have h_edsl_val := congrArg Verity.Core.Uint256.val h_edsl
     calc
       ((ContractResult.getState
         ((mint to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
@@ -762,7 +762,7 @@ theorem token_transfer_preserves_total_balance (state : ContractState) (to : Add
         ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
       ).storageMap 1 to).val =
       (state.storageMap 1 to).val + amount := by
-    have h_val := congrArg (fun v : Verity.Core.Uint256 => v.val) h_recipient_state
+    have h_val := congrArg Verity.Core.Uint256.val h_recipient_state
     have h_val' :
         (Verity.EVM.Uint256.add (state.storageMap 1 to)
           (Verity.Core.Uint256.ofNat amount)).val =

--- a/Verity/Proofs/Stdlib/SpecInterpreter.lean
+++ b/Verity/Proofs/Stdlib/SpecInterpreter.lean
@@ -38,7 +38,6 @@ import Compiler.ContractSpec
 import Compiler.DiffTestTypes
 import Compiler.Hex
 import Verity.Core
-import Verity.Core.Uint256
 
 namespace Verity.Proofs.Stdlib.SpecInterpreter
 


### PR DESCRIPTION
## Summary
- Replace 11 verbose `congrArg (fun v : Verity.Core.Uint256 => v.val) h` with the equivalent `congrArg Verity.Core.Uint256.val h` across OwnedCounter, SimpleToken, and Ledger proofs
- Remove redundant `import Verity.Core.Uint256` from SpecInterpreter.lean (transitively provided by `import Verity.Core`)
- 4 files changed, net **-1 line**

## Test plan
- [x] `lake build` passes (all 86 modules, 370 theorems, 0 sorry)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes
- [x] `check_lean_hygiene.py` passes
- [x] `check_axiom_locations.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof/readability refactor and an import cleanup; no semantic changes to contract logic or interpreter behavior expected.
> 
> **Overview**
> Refactors multiple Lean spec-correctness proofs (`Ledger`, `OwnedCounter`, `SimpleToken`) by replacing verbose `congrArg (fun v : Verity.Core.Uint256 => v.val)` lambdas with the equivalent `congrArg Verity.Core.Uint256.val`.
> 
> Removes a redundant `import Verity.Core.Uint256` from `Verity/Proofs/Stdlib/SpecInterpreter.lean` since `Verity.Core` already provides it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc3abb59c3576f363fbb15989ef0750727dc5a47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->