### PR TITLE
Collapse addition bridge steps into single simpa calls (-33 lines)

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Ledger.lean
+++ b/Compiler/Proofs/SpecCorrectness/Ledger.lean
@@ -103,14 +103,9 @@ theorem ledger_deposit_correct (state : ContractState) (amount : Nat) (sender : 
         ((ContractResult.getState
             ((deposit (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
           ).storageMap 0 sender).val =
-          (Verity.EVM.Uint256.add (state.storageMap 0 sender)
-            (Verity.Core.Uint256.ofNat amount)).val := by
-      simpa using congrArg Verity.Core.Uint256.val h_edsl_state
-    have h_add_val :
-        (Verity.EVM.Uint256.add (state.storageMap 0 sender)
-          (Verity.Core.Uint256.ofNat amount)).val =
           ((state.storageMap 0 sender).val + amount) % Verity.Core.Uint256.modulus := by
-      simpa using (uint256_add_val (state.storageMap 0 sender) amount)
+      have h_val := congrArg Verity.Core.Uint256.val h_edsl_state
+      simpa [uint256_add_val] using h_val
     calc
       (let specTx : DiffTestTypes.Transaction := {
         sender := sender
@@ -121,10 +116,6 @@ theorem ledger_deposit_correct (state : ContractState) (amount : Nat) (sender : 
         interpretSpec ledgerSpec (ledgerEdslToSpecStorageWithAddrs state [sender]) specTx;
       specResult.finalStorage.getMapping 0 (addressToNat sender))
           = ((state.storageMap 0 sender).val + amount) % Verity.Core.Uint256.modulus := h_spec_val
-      _ = (Verity.EVM.Uint256.add (state.storageMap 0 sender)
-            (Verity.Core.Uint256.ofNat amount)).val := by
-            symm
-            exact h_add_val
       _ = ((ContractResult.getState
             ((deposit (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
           ).storageMap 0 sender).val := by

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -188,9 +188,9 @@ theorem token_mint_correct_as_owner (state : ContractState) (to : Address) (amou
         ((ContractResult.getState
           ((mint to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
         ).storageMap 1 to).val =
-        (Verity.EVM.Uint256.add (state.storageMap 1 to)
-          (Verity.Core.Uint256.ofNat amount)).val := by
-      simpa using congrArg Verity.Core.Uint256.val h_edsl_map
+        ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus := by
+      have h_val := congrArg Verity.Core.Uint256.val h_edsl_map
+      simpa [uint256_add_val] using h_val
     have h_spec_val :
         (let specTx : DiffTestTypes.Transaction := {
           sender := sender
@@ -217,10 +217,6 @@ theorem token_mint_correct_as_owner (state : ContractState) (to : Address) (amou
         (tokenEdslToSpecStorageWithAddrs state [to]) specTx;
       specResult.finalStorage.getMapping 1 (addressToNat to))
           = ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus := h_spec_val
-      _ = (Verity.EVM.Uint256.add (state.storageMap 1 to)
-            (Verity.Core.Uint256.ofNat amount)).val := by
-            symm
-            exact uint256_add_val (state.storageMap 1 to) amount
       _ = ((ContractResult.getState
           ((mint to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
         ).storageMap 1 to).val := by
@@ -240,9 +236,9 @@ theorem token_mint_correct_as_owner (state : ContractState) (to : Address) (amou
         ((ContractResult.getState
           ((mint to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
         ).storage 2).val =
-        (Verity.EVM.Uint256.add (state.storage 2)
-          (Verity.Core.Uint256.ofNat amount)).val := by
-      simpa using congrArg Verity.Core.Uint256.val h_edsl_supply
+        ((state.storage 2).val + amount) % Verity.Core.Uint256.modulus := by
+      have h_val := congrArg Verity.Core.Uint256.val h_edsl_supply
+      simpa [uint256_add_val] using h_val
     have h_spec_val :
         (let specTx : DiffTestTypes.Transaction := {
           sender := sender
@@ -269,10 +265,6 @@ theorem token_mint_correct_as_owner (state : ContractState) (to : Address) (amou
         (tokenEdslToSpecStorageWithAddrs state [to]) specTx;
       specResult.finalStorage.getSlot 2)
           = ((state.storage 2).val + amount) % Verity.Core.Uint256.modulus := h_spec_val
-      _ = (Verity.EVM.Uint256.add (state.storage 2)
-            (Verity.Core.Uint256.ofNat amount)).val := by
-            symm
-            exact uint256_add_val (state.storage 2) amount
       _ = ((ContractResult.getState
           ((mint to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
         ).storage 2).val := by
@@ -486,15 +478,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
             ).storageMap 1 to).val =
             ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus := by
         have h_val := congrArg Verity.Core.Uint256.val h_edsl_state
-        calc
-          ((ContractResult.getState
-              ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-            ).storageMap 1 to).val
-              = (Verity.EVM.Uint256.add (state.storageMap 1 to)
-                (Verity.Core.Uint256.ofNat amount)).val := by
-                    simpa using h_val
-          _ = ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus := by
-                    exact uint256_add_val (state.storageMap 1 to) amount
+        simpa [uint256_add_val] using h_val
       calc
         (let specTx : DiffTestTypes.Transaction := {
           sender := sender
@@ -654,15 +638,7 @@ theorem token_mint_increases_supply (state : ContractState) (to : Address) (amou
       ).storage 2).val =
       ((state.storage 2).val + amount) % Verity.Core.Uint256.modulus := by
     have h_edsl_val := congrArg Verity.Core.Uint256.val h_edsl
-    calc
-      ((ContractResult.getState
-        ((mint to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-      ).storage 2).val
-          = (Verity.EVM.Uint256.add (state.storage 2)
-            (Verity.Core.Uint256.ofNat amount)).val := by
-              simpa using h_edsl_val
-      _ = ((state.storage 2).val + amount) % Verity.Core.Uint256.modulus := by
-              exact uint256_add_val (state.storage 2) amount
+    simpa [uint256_add_val] using h_edsl_val
   -- Since sum < modulus, the mod is identity
   have h_mod : ((state.storage 2).val + amount) % Verity.Core.Uint256.modulus =
       (state.storage 2).val + amount := by


### PR DESCRIPTION
## Summary
- Replace multi-step `calc` chains that bridge `EVM.add` to `Nat` arithmetic with single `simpa [uint256_add_val] using congrArg ...` calls
- Merges three separate proof steps (`.val` extraction via `congrArg`, `uint256_add_val` application, intermediate hypothesis) into one line each
- Applies to 4 addition bridges in SimpleToken and 1 in Ledger:
  - `token_mint_correct_as_owner` mapping update (3-step calc → 2-step)
  - `token_mint_correct_as_owner` supply update (3-step calc → 2-step)
  - `token_transfer_correct_sufficient` recipient mapping (inner 9-line calc → 2-line simpa)
  - `token_mint_increases_supply` (inner 9-line calc → 2-line simpa)
  - `ledger_deposit_correct` (3-step calc → 2-step, eliminates `h_add_val` intermediate)
- Net: **-33 lines** across 2 files

## Test plan
- [x] `lake build Compiler.Proofs.SpecCorrectness.SimpleToken` passes
- [x] `lake build Compiler.Proofs.SpecCorrectness.Ledger` passes
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes (370 theorems unchanged)
- [x] `check_lean_hygiene.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactor that only rearranges lemma applications (`congrArg` + `uint256_add_val`) and removes intermediate steps; no runtime or spec logic changes.
> 
> **Overview**
> Simplifies the addition “bridge” steps in SpecCorrectness proofs for `Ledger` and `SimpleToken` by replacing multi-step `calc` chains and intermediate lemmas (e.g., separate `.val` extraction and `uint256_add_val` application) with single `simpa [uint256_add_val]` rewrites.
> 
> This reduces proof verbosity across `ledger_deposit_correct` and multiple `SimpleToken` theorems (mint mapping/supply updates, transfer recipient update, and mint-increases-supply) without changing the statements or functional behavior—just the proof structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a53db46fadb49292cf023d67b1034e5d1c451c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->