### PR TITLE
Remove redundant proof intermediates across 3 files (-17 lines)

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Counter.lean
+++ b/Compiler/Proofs/SpecCorrectness/Counter.lean
@@ -73,22 +73,15 @@ private theorem evalExpr_decrement_eq (state : ContractState) (sender : Address)
     -- Reduce evalExpr to the same expression
     simp [evalExpr, SpecStorage.getSlot, List.lookup, hidx, h1mod, h, h_sub]  -- result matches
   · -- Underflow case: val = 0, so result is modulus - 1 on both sides.
-    have hlt : (state.storage 0).val < 1 := Nat.lt_of_not_ge h
-    have h0 : (state.storage 0).val = 0 := by
-      exact (Nat.lt_one_iff.mp hlt)
-    have hgt : (1 : Verity.Core.Uint256).val > (state.storage 0).val := by
-      simp [h0]
+    have h0 : (state.storage 0).val = 0 := Nat.lt_one_iff.mp (Nat.lt_of_not_ge h)
+    have hgt : (1 : Verity.Core.Uint256).val > (state.storage 0).val := by simp [h0]
     have h_sub : (sub (state.storage 0) 1).val =
         (modulus - ((1 : Verity.Core.Uint256).val - (state.storage 0).val)) % modulus := by
       simpa using (Verity.Core.Uint256.sub_val_of_gt (a := state.storage 0) (b := (1 : Verity.Core.Uint256)) hgt)
-    have hlt_mod : modulus - (1 - (state.storage 0).val) < modulus := by
-      -- With val = 0, this is modulus - 1 < modulus.
-      have hle : (1 : Nat) ≤ modulus := Nat.succ_le_of_lt Verity.Core.Uint256.modulus_pos
-      have hpos : 0 < (1 : Nat) := by decide
-      simpa [h0] using (Nat.sub_lt_of_pos_le hpos hle)
     have h_mod : (modulus - (1 - (state.storage 0).val)) % modulus =
         modulus - (1 - (state.storage 0).val) := by
-      exact Nat.mod_eq_of_lt hlt_mod
+      apply Nat.mod_eq_of_lt
+      simpa [h0] using Nat.sub_lt_of_pos_le Nat.one_pos (Nat.succ_le_of_lt Verity.Core.Uint256.modulus_pos)
     simp [evalExpr, SpecStorage.getSlot, List.lookup, hidx, h1mod, h, h0, h_sub, h_mod]
 
 /- Correctness Theorems -/

--- a/Verity/Proofs/Ledger/Conservation.lean
+++ b/Verity/Proofs/Ledger/Conservation.lean
@@ -74,11 +74,7 @@ theorem withdraw_sum_equation (s : ContractState) (amount : Uint256)
     (addrs.map (fun addr => ((withdraw amount).run s).snd.storageMap 0 addr)).sum
       + countOccU s.sender addrs * amount
     = (addrs.map (fun addr => s.storageMap 0 addr)).sum := by
-  have h_dec_raw := withdraw_decreases_balance s amount h_balance
-  have h_dec :
-      ((withdraw amount).run s).snd.storageMap 0 s.sender =
-        s.storageMap 0 s.sender - amount := by
-    exact h_dec_raw
+  have h_dec := withdraw_decreases_balance s amount h_balance
   have h_other : ∀ addr, addr ≠ s.sender →
     ((withdraw amount).run s).snd.storageMap 0 addr = s.storageMap 0 addr := by
     intro addr h_ne
@@ -128,10 +124,6 @@ theorem transfer_sum_equation (s : ContractState) (to : Address) (amount : Uint2
   have h_spec := transfer_meets_spec s to amount h_balance (fun _ => h_no_overflow)
   simp [transfer_spec, h_ne, beq_iff_eq] at h_spec
   obtain ⟨h_sender_bal, h_recip_bal, h_other_bal, _, _, _⟩ := h_spec
-  have h_sender_bal' :
-      ((transfer to amount).run s).snd.storageMap 0 s.sender =
-        s.storageMap 0 s.sender - amount := by
-    exact h_sender_bal
   have h_recip_bal' :
       ((transfer to amount).run s).snd.storageMap 0 to =
         s.storageMap 0 to + amount := by
@@ -140,7 +132,7 @@ theorem transfer_sum_equation (s : ContractState) (to : Address) (amount : Uint2
   exact map_sum_transfer_eq
     (fun addr => s.storageMap 0 addr)
     (fun addr => ((transfer to amount).run s).snd.storageMap 0 addr)
-    s.sender to amount h_ne h_sender_bal' h_recip_bal'
+    s.sender to amount h_ne h_sender_bal h_recip_bal'
     (fun addr h1 h2 => h_other_bal.1 addr h1 h2)
 
 /-- Corollary: for NoDup lists where sender and to each appear once,

--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -350,9 +350,7 @@ theorem transfer_preserves_supply_when_sufficient (s : ContractState) (to : Addr
   have h := transfer_meets_spec_when_sufficient s to amount h_balance h_no_overflow
   simp [transfer_spec] at h
   have h_storage : Specs.sameStorage s ((transfer to amount).run s).snd := by
-    by_cases h_eq : s.sender = to
-    · simpa [h_eq] using h.2.2.2.2.2.1
-    · simpa [h_eq] using h.2.2.2.2.2.1
+    exact h.2.2.2.2.2.1
   have h_eq : ((transfer to amount).run s).snd.storage = s.storage := by
     simpa [Specs.sameStorage] using h_storage
   simpa using congrArg (fun f => f 2) h_eq


### PR DESCRIPTION
## Summary
- **SimpleToken/Basic.lean**: Remove `by_cases` with identical branches in `transfer_preserves_supply_when_sufficient` — both branches produced the same result via `h.2.2.2.2.2.1`
- **Ledger/Conservation.lean**: Remove trivial hypothesis renames (`h_dec_raw` → `h_dec` via `exact`, `h_sender_bal` → `h_sender_bal'` via `exact`) — use originals directly
- **Counter.lean**: Collapse redundant intermediates in `evalExpr_decrement_eq` underflow case — merge `hlt`+`h0` into one line, `hlt_mod`+`h_mod` into `apply`+`simpa`, use `Nat.one_pos` instead of `by decide`
- Net: **-17 lines** across 3 files

## Test plan
- [x] `lake build` passes (all 86 modules, 370 theorems, 0 sorry)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes
- [x] `check_lean_hygiene.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactors that remove redundant steps without touching executable code or theorem interfaces; risk is limited to potential proof fragility/regressions in Lean automation.
> 
> **Overview**
> Simplifies several Lean proofs by removing redundant intermediate lemmas/renames and collapsing trivial `by_cases` branches.
> 
> In `Counter.lean`, the decrement underflow branch is shortened by deriving `val = 0` directly and inlining the modulus-bound argument for `Nat.mod_eq_of_lt`. In `Ledger/Conservation.lean` and `SimpleToken/Basic.lean`, proofs now reuse existing hypotheses directly (e.g., `withdraw_decreases_balance`, `h_sender_bal`, and `sameStorage`) instead of rewrapping them with `exact` or duplicating identical branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccbb8928942432a57d55989f1283b99b55757e58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->