### PR TITLE
Collapse recipient val bridge intermediates (-12 lines)

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Ledger.lean
+++ b/Compiler/Proofs/SpecCorrectness/Ledger.lean
@@ -533,12 +533,8 @@ theorem ledger_deposit_increases (state : ContractState) (amount : Nat) (sender 
       ((deposit (Verity.Core.Uint256.ofNat amount)).runState { state with sender := sender }).storageMap 0 sender =
         Verity.EVM.Uint256.add (state.storageMap 0 sender) (Verity.Core.Uint256.ofNat amount) := by
     simpa [Contract.runState] using h_deposit
-  have h_deposit_val_nat :
-      (((deposit (Verity.Core.Uint256.ofNat amount)).runState { state with sender := sender }).storageMap 0 sender).val =
-        (Verity.EVM.Uint256.add (state.storageMap 0 sender) (Verity.Core.Uint256.ofNat amount)).val := by
-    simpa using congrArg Verity.Core.Uint256.val h_deposit_val
   -- Rewrite with the addition lemma and the runState definition.
-  simpa [h_add] using h_deposit_val_nat
+  simpa [h_add] using congrArg Verity.Core.Uint256.val h_deposit_val
 
 /-- Transfer preserves total balance (sender + recipient) -/
 theorem ledger_transfer_preserves_total (state : ContractState) (to : Address) (amount : Nat) (sender : Address)

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -739,15 +739,7 @@ theorem token_transfer_preserves_total_balance (state : ContractState) (to : Add
       ).storageMap 1 to).val =
       (state.storageMap 1 to).val + amount := by
     have h_val := congrArg Verity.Core.Uint256.val h_recipient_state
-    have h_val' :
-        (Verity.EVM.Uint256.add (state.storageMap 1 to)
-          (Verity.Core.Uint256.ofNat amount)).val =
-        ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus := by
-      exact uint256_add_val (state.storageMap 1 to) amount
-    have h_mod : ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus =
-        (state.storageMap 1 to).val + amount := by
-      exact Nat.mod_eq_of_lt h3
-    simpa [h_val', h_mod] using h_val
+    simpa [uint256_add_val, Nat.mod_eq_of_lt h3] using h_val
   calc
     ((ContractResult.getState
       ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })


### PR DESCRIPTION
## Summary
- **SimpleToken** `token_transfer_preserves_total_balance`: Replace 3 intermediate hypotheses (`h_val`, `h_val'`, `h_mod`) with single `simpa [uint256_add_val, Nat.mod_eq_of_lt h3]` call for the recipient addition bridge
- **Ledger** `ledger_deposit_increases_balance`: Inline `h_deposit_val_nat` (congrArg extraction) directly into the final `simpa` call, eliminating the named intermediate
- Net: **-12 lines** across 2 files

## Test plan
- [x] `lake build` passes (both modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes (370 theorems unchanged)
- [x] `check_lean_hygiene.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of Lean proof terms (no spec/EDSL logic changes); risk is limited to proof breakage if simplifications are incorrect, but behavior is unchanged.
> 
> **Overview**
> Simplifies proof scripts in `Ledger.lean` and `SimpleToken.lean` by collapsing intermediate hypotheses used to bridge `Uint256` arithmetic to `Nat` equalities.
> 
> In `ledger_deposit_increases`, the extracted `.val` equality is inlined directly into the final `simpa`. In `token_transfer_preserves_total_balance`, the recipient-balance `.val` rewrite is reduced to a single `simpa [uint256_add_val, Nat.mod_eq_of_lt h3]` step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab0f834fbb055ecaa2b2d59a867855dd59470f2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->