### PR TITLE
Use term-mode rfl, eliminate redundant hypothesis copies (-15 lines)

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
@@ -174,7 +174,7 @@ theorem safeIncrement_succeeds_below_max (state : ContractState) (sender : Addre
   have h_no_overflow : ((state.storage 0) : Nat) + 1 ≤ Verity.Core.MAX_UINT256 := by
     omega
   -- Note: MAX_UINT256 in Math and Core are equal (both 2^256-1)
-  have h_eq : Verity.Stdlib.Math.MAX_UINT256 = Verity.Core.MAX_UINT256 := by rfl
+  have h_eq : Verity.Stdlib.Math.MAX_UINT256 = Verity.Core.MAX_UINT256 := rfl
   have h_safe : safeAdd (state.storage 0) 1 = some ((state.storage 0) + 1) := by
     unfold safeAdd
     rw [h_eq]

--- a/Verity/Core.lean
+++ b/Verity/Core.lean
@@ -90,13 +90,13 @@ def snd {α : Type} : ContractResult α → ContractState
 -- These ensure that when simp produces `ContractResult.success ...`, further
 -- `.fst`/`.snd` applications are automatically reduced.
 @[simp] theorem fst_success [Inhabited α] (a : α) (s : ContractState) :
-  (ContractResult.success a s).fst = a := by rfl
+  (ContractResult.success a s).fst = a := rfl
 
 @[simp] theorem snd_success (a : α) (s : ContractState) :
-  (ContractResult.success a s).snd = s := by rfl
+  (ContractResult.success a s).snd = s := rfl
 
 @[simp] theorem snd_revert (msg : String) (s : ContractState) :
-  (ContractResult.revert (α := α) msg s).snd = s := by rfl
+  (ContractResult.revert (α := α) msg s).snd = s := rfl
 
 end ContractResult
 
@@ -117,7 +117,7 @@ def Contract.run {α : Type} (c : Contract α) (s : ContractState) : ContractRes
   c s
 
 @[simp] theorem pure_run (a : α) (state : ContractState) :
-  (pure a : Contract α).run state = ContractResult.success a state := by rfl
+  (pure a : Contract α).run state = ContractResult.success a state := rfl
 
 -- Helper: check if result is success
 def ContractResult.isSuccess {α : Type} : ContractResult α → Bool
@@ -160,12 +160,12 @@ def setStorage (s : StorageSlot Uint256) (value : Uint256) : Contract Unit :=
   }
 
 @[simp] theorem getStorage_run (s : StorageSlot Uint256) (state : ContractState) :
-  (getStorage s).run state = ContractResult.success (state.storage s.slot) state := by rfl
+  (getStorage s).run state = ContractResult.success (state.storage s.slot) state := rfl
 
 @[simp] theorem setStorage_run (s : StorageSlot Uint256) (value : Uint256) (state : ContractState) :
   (setStorage s value).run state = ContractResult.success () { state with
     storage := fun slot => if slot == s.slot then value else state.storage slot
-  } := by rfl
+  } := rfl
 
 -- Storage operations for Address
 def getStorageAddr (s : StorageSlot Address) : Contract Address :=
@@ -177,12 +177,12 @@ def setStorageAddr (s : StorageSlot Address) (value : Address) : Contract Unit :
   }
 
 @[simp] theorem getStorageAddr_run (s : StorageSlot Address) (state : ContractState) :
-  (getStorageAddr s).run state = ContractResult.success (state.storageAddr s.slot) state := by rfl
+  (getStorageAddr s).run state = ContractResult.success (state.storageAddr s.slot) state := rfl
 
 @[simp] theorem setStorageAddr_run (s : StorageSlot Address) (value : Address) (state : ContractState) :
   (setStorageAddr s value).run state = ContractResult.success () { state with
     storageAddr := fun slot => if slot == s.slot then value else state.storageAddr slot
-  } := by rfl
+  } := rfl
 
 -- Mapping operations (Address → Uint256)
 def getMapping (s : StorageSlot (Address → Uint256)) (key : Address) : Contract Uint256 :=
@@ -201,7 +201,7 @@ def setMapping (s : StorageSlot (Address → Uint256)) (key : Address) (value : 
   }
 
 @[simp] theorem getMapping_run (s : StorageSlot (Address → Uint256)) (key : Address) (state : ContractState) :
-  (getMapping s key).run state = ContractResult.success (state.storageMap s.slot key) state := by rfl
+  (getMapping s key).run state = ContractResult.success (state.storageMap s.slot key) state := rfl
 
 @[simp] theorem setMapping_run (s : StorageSlot (Address → Uint256)) (key : Address) (value : Uint256) (state : ContractState) :
   (setMapping s key value).run state = ContractResult.success () { state with
@@ -213,7 +213,7 @@ def setMapping (s : StorageSlot (Address → Uint256)) (key : Address) (value : 
         (state.knownAddresses slot).insert key
       else
         state.knownAddresses slot
-  } := by rfl
+  } := rfl
 
 -- Double mapping operations (Address → Address → Uint256) (#154)
 def getMapping2 (s : StorageSlot (Address → Address → Uint256)) (key1 key2 : Address) : Contract Uint256 :=
@@ -228,14 +228,14 @@ def setMapping2 (s : StorageSlot (Address → Address → Uint256)) (key1 key2 :
 
 -- Full-result simp lemmas for double mappings
 @[simp] theorem getMapping2_run (s : StorageSlot (Address → Address → Uint256)) (key1 key2 : Address) (state : ContractState) :
-  (getMapping2 s key1 key2).run state = ContractResult.success (state.storageMap2 s.slot key1 key2) state := by rfl
+  (getMapping2 s key1 key2).run state = ContractResult.success (state.storageMap2 s.slot key1 key2) state := rfl
 
 @[simp] theorem setMapping2_run (s : StorageSlot (Address → Address → Uint256)) (key1 key2 : Address) (value : Uint256) (state : ContractState) :
   (setMapping2 s key1 key2 value).run state = ContractResult.success () { state with
     storageMap2 := fun slot addr1 addr2 =>
       if slot == s.slot && addr1 == key1 && addr2 == key2 then value
       else state.storageMap2 slot addr1 addr2
-  } := by rfl
+  } := rfl
 
 -- Uint256-keyed mapping operations (#154)
 def getMappingUint (s : StorageSlot (Uint256 → Uint256)) (key : Uint256) : Contract Uint256 :=
@@ -250,14 +250,14 @@ def setMappingUint (s : StorageSlot (Uint256 → Uint256)) (key : Uint256) (valu
 
 -- Full-result simp lemmas for uint mappings
 @[simp] theorem getMappingUint_run (s : StorageSlot (Uint256 → Uint256)) (key : Uint256) (state : ContractState) :
-  (getMappingUint s key).run state = ContractResult.success (state.storageMapUint s.slot key) state := by rfl
+  (getMappingUint s key).run state = ContractResult.success (state.storageMapUint s.slot key) state := rfl
 
 @[simp] theorem setMappingUint_run (s : StorageSlot (Uint256 → Uint256)) (key : Uint256) (value : Uint256) (state : ContractState) :
   (setMappingUint s key value).run state = ContractResult.success () { state with
     storageMapUint := fun slot k =>
       if slot == s.slot && k == key then value
       else state.storageMapUint slot k
-  } := by rfl
+  } := rfl
 
 -- Event emission (#153)
 def emitEvent (name : String) (args : List Uint256) (indexedArgs : List Uint256 := []) : Contract Unit :=
@@ -268,7 +268,7 @@ def emitEvent (name : String) (args : List Uint256) (indexedArgs : List Uint256 
 @[simp] theorem emitEvent_run (name : String) (args : List Uint256) (indexedArgs : List Uint256) (state : ContractState) :
   (emitEvent name args indexedArgs).run state = ContractResult.success () { state with
     events := state.events ++ [{ name := name, args := args, indexedArgs := indexedArgs }]
-  } := by rfl
+  } := rfl
 
 -- Read-only context accessors
 def msgSender : Contract Address :=
@@ -284,16 +284,16 @@ def blockTimestamp : Contract Uint256 :=
   fun state => ContractResult.success state.blockTimestamp state
 
 @[simp] theorem msgSender_run (state : ContractState) :
-  msgSender.run state = ContractResult.success state.sender state := by rfl
+  msgSender.run state = ContractResult.success state.sender state := rfl
 
 @[simp] theorem contractAddress_run (state : ContractState) :
-  contractAddress.run state = ContractResult.success state.thisAddress state := by rfl
+  contractAddress.run state = ContractResult.success state.thisAddress state := rfl
 
 @[simp] theorem msgValue_run (state : ContractState) :
-  msgValue.run state = ContractResult.success state.msgValue state := by rfl
+  msgValue.run state = ContractResult.success state.msgValue state := rfl
 
 @[simp] theorem blockTimestamp_run (state : ContractState) :
-  blockTimestamp.run state = ContractResult.success state.blockTimestamp state := by rfl
+  blockTimestamp.run state = ContractResult.success state.blockTimestamp state := rfl
 
 -- Require guard (explicit failure on condition = false)
 def require (condition : Bool) (message : String) : Contract Unit :=
@@ -303,10 +303,10 @@ def require (condition : Bool) (message : String) : Contract Unit :=
 
 -- Simp lemmas for require
 @[simp] theorem require_true (msg : String) (s : ContractState) :
-  (require true msg).run s = ContractResult.success () s := by rfl
+  (require true msg).run s = ContractResult.success () s := rfl
 
 @[simp] theorem require_false (msg : String) (s : ContractState) :
-  (require false msg).run s = ContractResult.revert msg s := by rfl
+  (require false msg).run s = ContractResult.revert msg s := rfl
 
 theorem require_succeeds (cond : Bool) (msg : String) (s : ContractState) :
   cond = true → (require cond msg).run s = ContractResult.success () s := by
@@ -327,7 +327,7 @@ This eliminates a trust assumption noted in issue #146.
 
 -- Left identity: bind (pure a) f = f a
 @[simp] theorem Contract.bind_pure_left (a : α) (f : α → Contract β) :
-    bind (pure a) f = f a := by rfl
+    bind (pure a) f = f a := rfl
 
 -- Right identity: bind m pure = m
 @[simp] theorem Contract.bind_pure_right (m : Contract α) :

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -41,20 +41,20 @@ open Compiler.Hex
 -- Lemmas for isSuccess
 @[simp]
 theorem isSuccess_success {α : Type} (a : α) (s : ContractState) :
-    (ContractResult.success a s).isSuccess = true := by rfl
+    (ContractResult.success a s).isSuccess = true := rfl
 
 @[simp]
 theorem isSuccess_revert {α : Type} (msg : String) (s : ContractState) :
-    (ContractResult.revert msg s : ContractResult α).isSuccess = false := by rfl
+    (ContractResult.revert msg s : ContractResult α).isSuccess = false := rfl
 
 -- Lemmas for getState
 @[simp]
 theorem getState_success {α : Type} (a : α) (s : ContractState) :
-    (ContractResult.success a s).getState = s := by rfl
+    (ContractResult.success a s).getState = s := rfl
 
 @[simp]
 theorem getState_revert {α : Type} (msg : String) (s : ContractState) :
-    (ContractResult.revert msg s : ContractResult α).getState = s := by rfl
+    (ContractResult.revert msg s : ContractResult α).getState = s := rfl
 
 /-!
 ## Basic Storage Operation Lemmas

--- a/Verity/Proofs/Stdlib/ListSum.lean
+++ b/Verity/Proofs/Stdlib/ListSum.lean
@@ -102,19 +102,13 @@ theorem map_sum_point_decrease
       rw [Verity.Core.Uint256.add_assoc delta (List.map f' rest).sum _]
       rw [← Verity.Core.Uint256.add_assoc (f target - delta) delta _]
       rw [h_cancel]
-      have h_congr := congrArg (fun x => f target + x) ih
-      have h_congr' := h_congr
-      simp [Verity.Core.Uint256.mul_comm,
-        Verity.Core.Uint256.add_assoc] at h_congr'
-      exact h_congr'
+      simpa [Verity.Core.Uint256.mul_comm,
+        Verity.Core.Uint256.add_assoc] using congrArg (fun x => f target + x) ih
     · simp [h, h_other a h, countOccU_cons_ne a target rest h]
-      have h_congr := congrArg (fun x => f a + x) ih
-      have h_congr' := h_congr
-      simp [Verity.Core.Uint256.mul_comm,
+      simpa [Verity.Core.Uint256.mul_comm,
         Verity.Core.Uint256.add_assoc,
         Verity.Core.Uint256.add_left_comm,
-        Verity.Core.Uint256.add_comm] at h_congr'
-      exact h_congr'
+        Verity.Core.Uint256.add_comm] using congrArg (fun x => f a + x) ih
 
 /-! ## Generic List Sum Lemma: Transfer (Two-Point Update) -/
 
@@ -143,11 +137,8 @@ theorem map_sum_transfer_eq
       rw [Verity.Core.Uint256.add_assoc d (List.map f' rest).sum _]
       rw [← Verity.Core.Uint256.add_assoc (f src - d) d _]
       rw [h_cancel]
-      have h_congr := congrArg (fun x => f src + x) ih
-      have h_congr' := h_congr
-      simp [Verity.Core.Uint256.mul_comm,
-        Verity.Core.Uint256.add_assoc] at h_congr'
-      exact h_congr'
+      simpa [Verity.Core.Uint256.mul_comm,
+        Verity.Core.Uint256.add_assoc] using congrArg (fun x => f src + x) ih
     · by_cases ha_d : a = dst
       · simp [ha_d, h_dst]
         have h_ne_sym : dst ≠ src := Ne.symm h_ne
@@ -156,21 +147,15 @@ theorem map_sum_transfer_eq
         rw [← Verity.Core.Uint256.add_assoc d (f dst) _]
         rw [Verity.Core.Uint256.add_comm d (f dst)]
         rw [Verity.Core.Uint256.add_assoc (f dst) d _]
-        have h_congr := congrArg (fun x => f dst + (d + x)) ih
         calc
           f dst + (d + ((List.map f' rest).sum + d * countOccU src rest))
               = f dst + (d + ((List.map f rest).sum + d * countOccU dst rest)) := by
-                  have h_congr' := h_congr
-                  simp [Verity.Core.Uint256.mul_comm] at h_congr'
-                  exact h_congr'
+                  simpa [Verity.Core.Uint256.mul_comm] using congrArg (fun x => f dst + (d + x)) ih
           _ = f dst + ((List.map f rest).sum + (d + d * countOccU dst rest)) := by
                   rw [← Verity.Core.Uint256.add_assoc d (List.map f rest).sum _]
                   rw [Verity.Core.Uint256.add_comm d (List.map f rest).sum]
                   rw [← Verity.Core.Uint256.add_assoc (List.map f rest).sum d _]
       · simp [h_other a ha_s ha_d, countOccU_cons_ne a src rest ha_s, countOccU_cons_ne a dst rest ha_d]
-        have h_congr := congrArg (fun x => f a + x) ih
-        have h_congr' := h_congr
-        simp [Verity.Core.Uint256.add_assoc] at h_congr'
-        exact h_congr'
+        simpa [Verity.Core.Uint256.add_assoc] using congrArg (fun x => f a + x) ih
 
 end Verity.Proofs.Stdlib.ListSum

--- a/Verity/Stdlib/Math.lean
+++ b/Verity/Stdlib/Math.lean
@@ -62,9 +62,9 @@ def requireSomeUint (opt : Option Uint256) (message : String) : Contract Uint256
 
 -- Full-result simp lemmas for requireSomeUint
 @[simp] theorem requireSomeUint_some (v : Uint256) (msg : String) (s : ContractState) :
-  (requireSomeUint (some v) msg).run s = ContractResult.success v s := by rfl
+  (requireSomeUint (some v) msg).run s = ContractResult.success v s := rfl
 
 @[simp] theorem requireSomeUint_none (msg : String) (s : ContractState) :
-  (requireSomeUint none msg).run s = ContractResult.revert msg s := by rfl
+  (requireSomeUint none msg).run s = ContractResult.revert msg s := rfl
 
 end Verity.Stdlib.Math

--- a/docs-site/content/core.mdx
+++ b/docs-site/content/core.mdx
@@ -154,13 +154,13 @@ Every storage operation, context accessor, and event function has a full-result 
 ```lean
 -- Full-result form (preferred for new proofs):
 @[simp] theorem getStorage_run (s : StorageSlot Uint256) (state : ContractState) :
-  (getStorage s).run state = ContractResult.success (state.storage s.slot) state := by rfl
+  (getStorage s).run state = ContractResult.success (state.storage s.slot) state := rfl
 
 @[simp] theorem require_true (msg : String) (s : ContractState) :
-  (require true msg).run s = ContractResult.success () s := by rfl
+  (require true msg).run s = ContractResult.success () s := rfl
 
 @[simp] theorem require_false (msg : String) (s : ContractState) :
-  (require false msg).run s = ContractResult.revert msg s := by rfl
+  (require false msg).run s = ContractResult.revert msg s := rfl
 ```
 
 Legacy `_fst`/`_snd` projection lemmas also exist but the full-result forms above are preferred — they prove success, value, and state in one shot. Most simple properties can be proven by `simp only [...]` with the right set of definitions.


### PR DESCRIPTION
## Summary
- Replace `by rfl` with `rfl` across 29 theorem proofs in 5 Lean files + 1 docs file — canonical Lean 4 idiom avoids entering tactic mode for definitional equality
- Eliminate 5 redundant `have h_congr' := h_congr` copies in ListSum.lean by using `simpa [...] using congrArg ...` directly

## Test plan
- [x] `lake build` passes (all 370 theorems verified)
- [x] All 11 Python check scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof- and documentation-level refactors that keep statements/behavior the same; risk is limited to potential Lean elaboration/simp regressions if any lemma formatting subtly affects automation.
> 
> **Overview**
> Swaps tactic-mode `by rfl` proofs for term-mode `rfl` across core `@[simp]` lemmas and related proof helpers (`Verity/Core.lean`, `Verity/Stdlib/Math.lean`, `Verity/Proofs/Stdlib/Automation.lean`, and a small tweak in `SafeCounter.lean`), without changing definitions or theorem statements.
> 
> Simplifies `Verity/Proofs/Stdlib/ListSum.lean` by removing redundant intermediate hypotheses (`have h_congr' := h_congr`) and using `simpa ... using congrArg ...` directly, and updates the docs snippet in `docs-site/content/core.mdx` to match the new lemma style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 726c6a59f3c25ad8316d5482ba96d687a3e685b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->