### PR TITLE
Add evm_add_eq_hadd lemma, simplify conservation proofs (-3 lines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/Th0rgal/verity/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/built%20with-Lean%204-blueviolet.svg" alt="Built with Lean 4"></a>
-  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-370-brightgreen.svg" alt="370 Theorems"></a>
+  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-371-brightgreen.svg" alt="371 Theorems"></a>
   <a href="https://github.com/Th0rgal/verity/actions"><img src="https://img.shields.io/github/actions/workflow/status/Th0rgal/verity/verify.yml?label=verify" alt="Verify"></a>
 </p>
 
@@ -28,7 +28,7 @@ source ~/.elan/env
 # 2. Clone and build
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                                    # Verifies all 370 theorems
+lake build                                    # Verifies all 371 theorems
 
 # 3. Generate a new contract
 python3 scripts/generate_contract.py MyContract
@@ -123,7 +123,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-370 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (59% coverage, 150 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+371 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (59% coverage, 151 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -79,7 +79,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: All 370 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (59% runtime test coverage).
+**Coverage**: All 371 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (59% runtime test coverage).
 
 **What this guarantees**:
 - Contract behavior matches specification
@@ -713,7 +713,7 @@ Verity provides **strong formal verification** with a **small trusted computing 
 ✅ Contract implementations match specifications (Layer 1)
 ✅ Specifications preserved through compilation (Layer 2)
 ✅ IR semantics equivalent to Yul semantics (Layer 3)
-✅ 370 theorems across 9 categories (220 covered by property tests)
+✅ 371 theorems across 9 categories (220 covered by property tests)
 
 ### What is Trusted (Validated but Not Proven)
 ⚠️ Solidity compiler (solc) - Validated by 70k+ differential tests

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -336,6 +336,10 @@ theorem addressToNat_beq_false_of_ne (a b : Address) (h : a ≠ b) :
 @[simp] theorem one_mod_modulus : (1 % Verity.Core.Uint256.modulus) = 1 :=
   Nat.mod_eq_of_lt (by decide : (1 : Nat) < Verity.Core.Uint256.modulus)
 
+/-- EVM.Uint256.add is definitionally equal to HAdd (+). -/
+theorem evm_add_eq_hadd (a b : Verity.Core.Uint256) :
+    Verity.EVM.Uint256.add a b = a + b := rfl
+
 -- Helper: EVM add (Uint256) matches modular Nat addition.
 theorem uint256_add_val (a : Verity.Core.Uint256) (amount : Nat) :
     (Verity.EVM.Uint256.add a (Verity.Core.Uint256.ofNat amount)).val =

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 
 const banner = (
   <Banner storageKey="verification-complete">
-    370/370 theorems proven — 100% formal verification
+    371/371 theorems proven — 100% formal verification
   </Banner>
 )
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -596,7 +596,7 @@ Time: **~5 minutes** (vs ~30 minutes manual IR)
 
 ### All Tests Pass ✅
 
-**Lean Proofs**: All proofs verified (370 EDSL theorems, 100%)
+**Lean Proofs**: All proofs verified (371 EDSL theorems, 100%)
 ```bash
 $ lake build
 Build completed successfully.
@@ -710,5 +710,5 @@ def ownedSpec : ContractSpec := {
 
 - [Research & Development](/research) — Design decisions and proof techniques
 - [Examples](/examples) — 9 example contracts
-- [Verification](/verification) — 370 proven theorems
+- [Verification](/verification) — 371 proven theorems
 - [GitHub Repository](https://github.com/Th0rgal/verity) — Source code

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -52,7 +52,7 @@ forge --version
 ```bash
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                # Downloads dependencies and verifies all 370 theorems
+lake build                # Downloads dependencies and verifies all 371 theorems
 ```
 
 The first build downloads Mathlib and compiles everything — expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 370 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 371 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 370 theorems, all fully proven. 2 documented axioms, 0 sorry.**
+**Compact core, built across 7 iterations. 371 theorems, all fully proven. 2 documented axioms, 0 sorry.**
 
 ## Evolution
 
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (370 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (371 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,11 +7,11 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 370 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 371 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-17)
 
-- EDSL theorems: 370 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
+- EDSL theorems: 371 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
 - SimpleStorage: 20 total (Basic 13, Correctness 7).
 - Counter: 28 total (Basic 19, Correctness 10; 1 shared between Basic and Correctness).
 - Owned: 23 total (Basic 19, Correctness 4).
@@ -20,7 +20,7 @@ The compiler is verified with IR preservation proofs and Yul equivalence proofs 
 - Ledger: 33 total (Basic 20, Correctness 6, Conservation 7 — all proven).
 - SafeCounter: 25 total (Basic 17, Correctness 8).
 - ReentrancyExample: 4 total (inline proofs: vulnerability existence, supply invariant).
-- Stdlib: 130 theorems (Math 25, Automation 55, MappingAutomation 37, ListSum 7; 2 shared between Automation and MappingAutomation).
+- Stdlib: 131 theorems (Math 25, Automation 55, MappingAutomation 37, ListSum 7; 2 shared between Automation and MappingAutomation).
 
 ## Unified AST Bridge (Issue #364)
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -17,7 +17,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Language**: Lean 4.15.0
 - **Core Size**: 350 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
-- **Theorems**: 370 across 9 categories (370 fully proven, 0 `sorry` placeholders)
+- **Theorems**: 371 across 9 categories (371 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 2 documented axioms (see AXIOMS.md) — keccak256, address injectivity
 - **Tests**: 375 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
@@ -60,7 +60,7 @@ def bind (x : Contract α) (f : α → Contract β) : Contract β :=
 | Ledger | 33 | Deposit/withdraw/transfer, balance conservation |
 | SafeCounter | 25 | Overflow/underflow revert proofs |
 | ReentrancyExample | 4 | Reentrancy vulnerability proof, supply invariant |
-| Stdlib | 130 | safeMul/safeDiv correctness, automation lemmas |
+| Stdlib | 131 | safeMul/safeDiv correctness, automation lemmas |
 
 ## Proof Techniques
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,10 +6,10 @@
 
 ## Current Status
 
-- ✅ **Layer 1 Complete**: 370 theorems across 9 categories (8 contracts + Stdlib math library)
+- ✅ **Layer 1 Complete**: 371 theorems across 9 categories (8 contracts + Stdlib math library)
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
-- ✅ **Property Testing**: 59% coverage (220/370), all testable properties covered
+- ✅ **Property Testing**: 59% coverage (220/371), all testable properties covered
 - ✅ **Differential Testing**: Production-ready with 70k+ tests
 - ✅ **Trust Reduction Phase 1**: keccak256 axiom + CI validation (PR #43, #46)
 - ✅ **External Linking**: Cryptographic library support (PR #49)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -63,7 +63,7 @@ EVM Bytecode
 | ReentrancyExample | 4 | ✅ Complete | `Verity/Examples/ReentrancyExample.lean` |
 | **Total** | **240** | **✅ 100%** | — |
 
-> **Note**: Stdlib (130 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (370 total properties).
+> **Note**: Stdlib (131 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (371 total properties).
 
 ### Example Property
 
@@ -177,13 +177,13 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ## Property Test Coverage 🎯 **NEAR COMPLETE**
 
-**Status**: 59% coverage (220/370), 150 remaining exclusions all proof-only
+**Status**: 59% coverage (220/371), 151 remaining exclusions all proof-only
 
 ### Current Coverage
 
-- **Total Properties**: 370
+- **Total Properties**: 371
 - **Covered**: 220 (59%)
-- **Excluded**: 150 (all proof-only)
+- **Excluded**: 151 (all proof-only)
 - **Missing**: 0
 
 ### Coverage by Contract
@@ -198,11 +198,11 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 | SimpleToken | 88% (52/59) | 7 proof-only | ✅ High coverage |
 | Counter | 82% (23/28) | 5 proof-only | ✅ High coverage |
 | Ledger | 100% (33/33) | 0 | ✅ Complete |
-| Stdlib | 0% (0/130) | 130 proof-only | — Internal |
+| Stdlib | 0% (0/131) | 131 proof-only | — Internal |
 
 ### Exclusion Categories
 
-**Proof-Only Properties (150 exclusions)**: Internal proof machinery that cannot be tested in Foundry
+**Proof-Only Properties (151 exclusions)**: Internal proof machinery that cannot be tested in Foundry
 - Storage helpers: `setStorage_*`, `getStorage_*`, `setMapping_*`, `getMapping_*`
 - Internal helpers: `isOwner_*` functions tested implicitly
 - Low-level operations used only in proofs

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ function testProperty_StoreRetrieve() public {
 }
 ```
 
-**Coverage**: 220/370 theorems tested (59%), 150 proof-only exclusions documented in `property_exclusions.json`.
+**Coverage**: 220/371 theorems tested (59%), 151 proof-only exclusions documented in `property_exclusions.json`.
 
 ### Differential Tests
 **Pattern**: `Differential<Contract>.t.sol`
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (195 functions, covering 220/370 theorems)
+├── Property*.t.sol           # Property tests (195 functions, covering 220/371 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -47,6 +47,7 @@
     "countOccU_cons_ne",
     "countOcc_cons_eq",
     "countOcc_cons_ne",
+    "evm_add_eq_hadd",
     "getMapping2_runState",
     "getMapping2_runValue",
     "getMappingUint_runState",

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -273,6 +273,7 @@
     "countOccU_cons_ne",
     "countOcc_cons_eq",
     "countOcc_cons_ne",
+    "evm_add_eq_hadd",
     "getMapping2_runState",
     "getMapping2_runValue",
     "getMappingUint_runState",


### PR DESCRIPTION
## Summary
- Add `evm_add_eq_hadd` lemma to `Automation.lean`: `EVM.Uint256.add a b = a + b := rfl` — definitional equality that replaces the repeated 4-argument `simpa [Verity.EVM.Uint256.add, Verity.Core.Uint256.add, HAdd.hAdd, Verity.Core.Uint256.add_comm]` unfolding pattern
- Replace 5 verbose 2-line `simpa` blocks with 1-line `simpa [evm_add_eq_hadd]` across `Ledger/Conservation.lean` and `SimpleToken/Supply.lean`
- Inline eta-redundant `h_other` lambda in `deposit_sum_equation` (was `fun addr h_ne => deposit_preserves_other_balances s amount addr h_ne`, now just `deposit_preserves_other_balances s amount`)
- Eliminate `h_sender_bal'` identity wrapper in `transfer_sum_equation` (was `by exact h_sender_bal`)
- Convert `h_le` from tactic to term-mode (`by exact` → `:=`)

## Test plan
- [x] `lake build` passes (all 86 modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes (371 theorems)
- [x] `check_axiom_locations.py` passes
- [ ] CI foundry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor plus documentation/manifest count updates; no runtime/compiler logic changes, with minimal risk beyond potential proof/metadata desync.
> 
> **Overview**
> Adds a new automation lemma `evm_add_eq_hadd` (definitional equality between `Verity.EVM.Uint256.add` and `+`) and rewrites Ledger and SimpleToken sum conservation proofs to use `simpa [evm_add_eq_hadd]`, removing repetitive unfolding/eta wrappers.
> 
> Bumps reported theorem/coverage counts across README, trust/verification docs, and the docs site from **370 → 371**, and updates `test/property_manifest.json` plus `property_exclusions.json` to include the new proof-only lemma.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32be2a9d4fbf4ce16a107a5349aebb872af9c9e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->