### PR TITLE
Collapse absurd patterns, flatten obtain, inline eta-lambdas (-8 lines)

### DIFF
--- a/Verity/Proofs/Ledger/Basic.lean
+++ b/Verity/Proofs/Ledger/Basic.lean
@@ -86,8 +86,7 @@ theorem deposit_preserves_other_balances (s : ContractState) (amount : Uint256)
   (addr : Address) (h_ne : addr ≠ s.sender) :
   let s' := ((deposit amount).run s).snd
   s'.storageMap 0 addr = s.storageMap 0 addr := by
-  rw [deposit_unfold]; simp [ContractResult.snd, beq_iff_eq]
-  intro h_eq; exact absurd h_eq h_ne
+  rw [deposit_unfold]; simp [ContractResult.snd, beq_iff_eq, h_ne]
 
 /-! ## Withdraw Correctness -/
 

--- a/Verity/Proofs/Ledger/Conservation.lean
+++ b/Verity/Proofs/Ledger/Conservation.lean
@@ -114,7 +114,7 @@ theorem transfer_sum_equation (s : ContractState) (to : Address) (amount : Uint2
     (fun addr => s.storageMap 0 addr)
     (fun addr => ((transfer to amount).run s).snd.storageMap 0 addr)
     s.sender to amount h_ne h_sender_bal h_recip_bal'
-    (fun addr h1 h2 => h_other_bal.1 addr h1 h2)
+    h_other_bal.1
 
 /-- Corollary: for NoDup lists where sender and to each appear once,
     the total sum is exactly preserved by transfer. -/

--- a/Verity/Proofs/Ledger/Correctness.lean
+++ b/Verity/Proofs/Ledger/Correctness.lean
@@ -29,8 +29,7 @@ theorem transfer_preserves_wellformedness (s : ContractState) (to : Address) (am
   WellFormedState s' := by
   have h_spec := transfer_meets_spec s to amount h_balance (fun _ => h_no_overflow)
   simp [transfer_spec, h_ne, beq_iff_eq] at h_spec
-  obtain ⟨_, _, _, _, _, h_ctx⟩ := h_spec
-  obtain ⟨h_sender, h_this, _h_value, _h_time⟩ := h_ctx
+  obtain ⟨_, _, _, _, _, h_sender, h_this, _, _⟩ := h_spec
   constructor
   · exact h_sender ▸ h.sender_nonempty
   · exact h_this ▸ h.contract_nonempty

--- a/Verity/Proofs/SafeCounter/Basic.lean
+++ b/Verity/Proofs/SafeCounter/Basic.lean
@@ -72,9 +72,7 @@ theorem increment_meets_spec (s : ContractState)
   simp only [ContractResult.snd, increment_spec]
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
   · simp [evm_add_eq_of_no_overflow (s.storage 0) 1 h_no_overflow]
-  · intro slot h_ne
-    simp [beq_iff_eq]
-    intro h_eq; exact absurd h_eq h_ne
+  · intro slot h_ne; simp [beq_iff_eq, h_ne]
   · rfl
   · rfl
   · exact Specs.sameContext_rfl _
@@ -92,8 +90,7 @@ theorem increment_preserves_other_slots (s : ContractState)
   let s' := ((increment).run s).snd
   s'.storage slot = s.storage slot := by
   rw [increment_unfold s h_no_overflow]
-  simp [ContractResult.snd, beq_iff_eq]
-  intro h_eq; exact absurd h_eq h_ne
+  simp [ContractResult.snd, beq_iff_eq, h_ne]
 
 theorem increment_reverts_overflow (s : ContractState)
   (h_overflow : (s.storage 0 : Nat) + 1 > MAX_UINT256) :
@@ -135,9 +132,7 @@ theorem decrement_meets_spec (s : ContractState)
   simp only [ContractResult.snd, decrement_spec]
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
   · simp [HSub.hSub, sub]
-  · intro slot h_ne
-    simp [beq_iff_eq]
-    intro h_eq; exact absurd h_eq h_ne
+  · intro slot h_ne; simp [beq_iff_eq, h_ne]
   · rfl
   · rfl
   · exact Specs.sameContext_rfl _
@@ -155,8 +150,7 @@ theorem decrement_preserves_other_slots (s : ContractState)
   let s' := ((decrement).run s).snd
   s'.storage slot = s.storage slot := by
   rw [decrement_unfold s h_no_underflow]
-  simp [ContractResult.snd, beq_iff_eq]
-  intro h_eq; exact absurd h_eq h_ne
+  simp [ContractResult.snd, beq_iff_eq, h_ne]
 
 theorem decrement_reverts_underflow (s : ContractState)
   (h_underflow : s.storage 0 = 0) :

--- a/Verity/Proofs/SimpleToken/Supply.lean
+++ b/Verity/Proofs/SimpleToken/Supply.lean
@@ -85,7 +85,7 @@ theorem mint_sum_equation (s : ContractState) (to : Address) (amount : Uint256)
   exact map_sum_point_update
     (fun addr => s.storageMap 1 addr)
     (fun addr => ((mint to amount).run s).snd.storageMap 1 addr)
-    to amount h_bal (fun addr h_ne => h_other.1 addr h_ne)
+    to amount h_bal h_other.1
 
 /-- Exact sum conservation equation for transfer:
     new_sum + count(sender, addrs) * amount = old_sum + count(to, addrs) * amount.
@@ -112,7 +112,7 @@ theorem transfer_sum_equation (s : ContractState) (to : Address) (amount : Uint2
     (fun addr => s.storageMap 1 addr)
     (fun addr => ((transfer to amount).run s).snd.storageMap 1 addr)
     s.sender to amount h_ne h_sender_bal h_recip_bal'
-    (fun addr h1 h2 => h_other_bal.1 addr h1 h2)
+    h_other_bal.1
 
 /-! ## Summary
 


### PR DESCRIPTION
## Summary
- Collapse 5 two-line `simp [beq_iff_eq]; intro h_eq; exact absurd h_eq h_ne` patterns into single-line `simp [beq_iff_eq, h_ne]` in `SafeCounter/Basic.lean` (4 sites) and `Ledger/Basic.lean` (1 site)
- Flatten chained double `obtain` into single nested destructuring in `Ledger/Correctness.lean`
- Replace 3 eta-redundant `(fun addr h1 h2 => f.1 addr h1 h2)` lambdas with direct `f.1` projection in `Conservation.lean` and `Supply.lean`

## Test plan
- [x] `lake build` passes (all 86 modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes (371 theorems)
- [x] `check_axiom_locations.py` passes
- [ ] CI foundry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to proof script refactors with no modifications to contract semantics or specs; main risk is minor proof brittleness if upstream lemmas or simp behavior changes.
> 
> **Overview**
> Simplifies several Lean proofs by collapsing repeated `simp` + `absurd` blocks into single `simp [..., h_ne]` steps in `Ledger/Basic.lean` and `SafeCounter/Basic.lean`.
> 
> Refactors proof plumbing by flattening `obtain` destructuring in `Ledger/Correctness.lean` and removing eta-expanded lambdas in list-sum conservation proofs (`Ledger/Conservation.lean`, `SimpleToken/Supply.lean`) by passing projections like `h_other_bal.1` directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 049f8df8b61d79982d3c2a5c4742781186ac6934. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->