### PR TITLE
Inline single-use have intermediates, collapse have/obtain (-13 lines)

### DIFF
--- a/Verity/Proofs/OwnedCounter/Basic.lean
+++ b/Verity/Proofs/OwnedCounter/Basic.lean
@@ -260,9 +260,7 @@ theorem constructor_preserves_wellformedness (s : ContractState) (initialOwner :
   have h_spec := constructor_meets_spec s initialOwner
   rcases h_spec with ⟨h_set, _h_other_addr, h_same⟩
   rcases h_same with ⟨_h_storage, _h_map, h_ctx⟩
-  have h_sender := h_ctx.1
-  have h_this := h_ctx.2.1
-  exact ⟨h_sender ▸ h.sender_nonempty, h_this ▸ h.contract_nonempty, h_set ▸ h_owner⟩
+  exact ⟨h_ctx.1 ▸ h.sender_nonempty, h_ctx.2.1 ▸ h.contract_nonempty, h_set ▸ h_owner⟩
 
 theorem increment_preserves_wellformedness (s : ContractState)
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) :

--- a/Verity/Proofs/SimpleToken/Correctness.lean
+++ b/Verity/Proofs/SimpleToken/Correctness.lean
@@ -48,8 +48,7 @@ theorem transfer_reverts_insufficient_balance (s : ContractState) (to : Address)
     msgSender, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst]
-  have h_not_ge : ¬(s.storageMap 1 s.sender ≥ amount) := Nat.not_le.mpr h_insufficient
-  simp [h_not_ge]
+  simp [show ¬(s.storageMap 1 s.sender ≥ amount) from Nat.not_le.mpr h_insufficient]
 
 /-! ## Invariant Preservation
 
@@ -67,12 +66,7 @@ theorem mint_preserves_wellformedness (s : ContractState) (to : Address) (amount
   WellFormedState s' := by
   have h_spec := mint_meets_spec_when_owner s to amount h_owner h_no_bal_overflow h_no_sup_overflow
   obtain ⟨_, _, _, h_owner_pres, _, h_ctx⟩ := h_spec
-  have h_sender_pres := h_ctx.1
-  have h_this_pres := h_ctx.2.1
-  constructor
-  · exact h_sender_pres ▸ h.sender_nonempty
-  · exact h_this_pres ▸ h.contract_nonempty
-  · exact h_owner_pres ▸ h.owner_nonempty
+  exact ⟨h_ctx.1 ▸ h.sender_nonempty, h_ctx.2.1 ▸ h.contract_nonempty, h_owner_pres ▸ h.owner_nonempty⟩
 
 /-- Transfer preserves well-formedness when balance is sufficient and no overflow.
     Owner, context all remain intact across transfers. -/
@@ -83,12 +77,7 @@ theorem transfer_preserves_wellformedness (s : ContractState) (to : Address) (am
   WellFormedState s' := by
   have h_spec := transfer_meets_spec_when_sufficient s to amount h_balance h_no_overflow
   obtain ⟨_, _, _, _, h_owner_pres, _h_storage, _h_addr_pres, h_ctx⟩ := h_spec
-  have h_sender_pres := h_ctx.1
-  have h_this_pres := h_ctx.2.1
-  constructor
-  · exact h_sender_pres ▸ h.sender_nonempty
-  · exact h_this_pres ▸ h.contract_nonempty
-  · exact h_owner_pres ▸ h.owner_nonempty
+  exact ⟨h_ctx.1 ▸ h.sender_nonempty, h_ctx.2.1 ▸ h.contract_nonempty, h_owner_pres ▸ h.owner_nonempty⟩
 
 /-! ## Owner Stability
 
@@ -103,8 +92,8 @@ theorem mint_preserves_owner (s : ContractState) (to : Address) (amount : Uint25
   (h_no_sup_overflow : (s.storage 2 : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((mint to amount).run s).snd
   s'.storageAddr 0 = s.storageAddr 0 := by
-  have h := mint_meets_spec_when_owner s to amount h_owner h_no_bal_overflow h_no_sup_overflow
-  obtain ⟨_, _, _, h_owner_pres, _, _⟩ := h
+  obtain ⟨_, _, _, h_owner_pres, _, _⟩ :=
+    mint_meets_spec_when_owner s to amount h_owner h_no_bal_overflow h_no_sup_overflow
   exact h_owner_pres
 
 /-- Transfer does not change the owner address. -/
@@ -113,8 +102,8 @@ theorem transfer_preserves_owner (s : ContractState) (to : Address) (amount : Ui
   (h_no_overflow : s.sender ≠ to → (s.storageMap 1 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((transfer to amount).run s).snd
   s'.storageAddr 0 = s.storageAddr 0 := by
-  have h := transfer_meets_spec_when_sufficient s to amount h_balance h_no_overflow
-  obtain ⟨_, _, _, _, h_owner_pres, _⟩ := h
+  obtain ⟨_, _, _, _, h_owner_pres, _⟩ :=
+    transfer_meets_spec_when_sufficient s to amount h_balance h_no_overflow
   exact h_owner_pres
 
 /-! ## End-to-End Composition


### PR DESCRIPTION
## Summary
- Inline 4 single-use `have h_sender/h_this/h_sender_pres/h_this_pres` intermediates into direct projections (`h_ctx.1`/`h_ctx.2.1`) in `OwnedCounter/Basic.lean` and `SimpleToken/Correctness.lean`
- Collapse 2 `have h := X; obtain ... := h; exact ...` chains into `obtain ... := X; exact ...` in `mint_preserves_owner` and `transfer_preserves_owner`
- Inline `h_not_ge` into `simp` call in `transfer_reverts_insufficient_balance`
- Replace `constructor` + 3 bullet proofs with single `exact ⟨...⟩` in mint/transfer wellformedness proofs

## Test plan
- [x] `lake build` passes (all 86 modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes (371 theorems)
- [x] `check_axiom_locations.py` passes
- [ ] CI foundry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that preserves theorem statements and behavior; risk is limited to potential proof brittleness or compilation failures.
> 
> **Overview**
> Simplifies several Lean correctness proofs in `OwnedCounter/Basic.lean` and `SimpleToken/Correctness.lean` by inlining single-use `have` bindings and collapsing `have`→`obtain` chains into direct `obtain` destructuring.
> 
> The changes also streamline well-formedness preservation proofs by replacing multi-step `constructor`/bullet proofs with a single tuple `exact` and inlining a one-off negated inequality into a `simp` call; no theorem statements or logical claims change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f0f4f58db6420e850eb507c91e5b9993815ea50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->