### PR TITLE
Inline single-use intermediates in Compiler proofs

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -139,19 +139,16 @@ theorem only_owner_can_transfer (state : ContractState) (newOwner : Address) (se
     ((transferOwnership newOwner).run { state with sender := sender }).isSuccess = true →
     state.storageAddr 0 = sender := by
   intro h_success
-  have h_onlyOwner :
-      ((onlyOwner).run { state with sender := sender }).isSuccess = true := by
-    simpa [transferOwnership, Contract.run] using
-      (Verity.Proofs.Stdlib.Automation.bind_isSuccess_left
-        (m1 := onlyOwner)
-        (m2 := fun _ => setStorageAddr owner newOwner)
-        (state := { state with sender := sender })
-        h_success)
   have h_require_success :
       ((require (sender == state.storageAddr 0) "Caller is not the owner").run
         { state with sender := sender }).isSuccess = true := by
-    simpa [onlyOwner, isOwner, msgSender, getStorageAddr, Contract.run, Verity.bind, Verity.pure]
-      using h_onlyOwner
+    simpa [onlyOwner, isOwner, msgSender, getStorageAddr, Contract.run, Verity.bind, Verity.pure,
+      transferOwnership] using
+      Verity.Proofs.Stdlib.Automation.bind_isSuccess_left
+        (m1 := onlyOwner)
+        (m2 := fun _ => setStorageAddr owner newOwner)
+        (state := { state with sender := sender })
+        h_success
   exact (require_beq_success_implies_eq sender (state.storageAddr 0)
     "Caller is not the owner" _ h_require_success).symm
 


### PR DESCRIPTION
## Summary
- **Counter.lean**: Inline 3 single-use `have` bindings (`h1lt`, `hle`, `hgt`) into their sole use sites
- **Owned.lean**: Collapse two-step `h_onlyOwner` → `h_require_success` chain into a single `have` by adding the function unfold to the `simpa` call
- **OwnedCounter.lean**: Same chain collapse as Owned.lean

Net -12 lines across 3 files. All proofs verified, no behavioral changes.

## Test plan
- [x] `lake build` passes (86 modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes
- [x] `check_axiom_locations.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that removes intermediate `have` bindings and adjusts `simpa`/unfolding; no runtime or spec semantics are changed, with main risk being brittle proof automation/regression in elaboration.
> 
> **Overview**
> Refactors several Lean proofs in `SpecCorrectness` to inline single-use `have` bindings and collapse intermediate lemmas, reducing proof verbosity without changing statements.
> 
> In `Counter.lean`, the decrement `evalExpr` equivalence proof now inlines modulus/inequality helper facts directly into `Nat.mod_eq_of_lt`, `Uint256.sub_eq_of_le`, and `Uint256.sub_val_of_gt` calls. In `Owned.lean` and `OwnedCounter.lean`, the “`onlyOwner` then `require`” success chain is collapsed into a single `simpa` over `bind_isSuccess_left` by unfolding `transferOwnership`/`increment` in the same step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38c804a56db7d6bc965b520bf08760224ecd3c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->