### PR TITLE
Inline single-use intermediates in SafeCounter and Ledger proofs

### DIFF
--- a/Verity/Proofs/SafeCounter/Basic.lean
+++ b/Verity/Proofs/SafeCounter/Basic.lean
@@ -58,11 +58,10 @@ private theorem increment_unfold (s : ContractState)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  have h_safe := safeAdd_some (s.storage 0) 1 h_no_overflow
   simp only [increment, getStorage, setStorage, count, requireSomeUint,
     Verity.bind, Bind.bind, Verity.pure, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
-    h_safe]
+    safeAdd_some (s.storage 0) 1 h_no_overflow]
 
 theorem increment_meets_spec (s : ContractState)
   (h_no_overflow : (s.storage 0 : Nat) + 1 ≤ MAX_UINT256) :
@@ -95,11 +94,10 @@ theorem increment_preserves_other_slots (s : ContractState)
 theorem increment_reverts_overflow (s : ContractState)
   (h_overflow : (s.storage 0 : Nat) + 1 > MAX_UINT256) :
   ∃ msg, (increment).run s = ContractResult.revert msg s := by
-  have h_none := safeAdd_none (s.storage 0) 1 h_overflow
   simp [increment, getStorage, setStorage, count, requireSomeUint,
     Verity.bind, Bind.bind, Verity.pure, Pure.pure,
     Verity.require, Contract.run, ContractResult.snd, ContractResult.fst,
-    h_none]
+    safeAdd_none (s.storage 0) 1 h_overflow]
 
 /-! ## Decrement Correctness -/
 
@@ -118,11 +116,10 @@ private theorem decrement_unfold (s : ContractState)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  have h_safe := safeSub_some (s.storage 0) 1 h_no_underflow
   simp only [decrement, getStorage, setStorage, count, requireSomeUint,
     Verity.bind, Bind.bind, Verity.pure, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
-    h_safe]
+    safeSub_some (s.storage 0) 1 h_no_underflow]
 
 theorem decrement_meets_spec (s : ContractState)
   (h_no_underflow : (s.storage 0 : Nat) ≥ 1) :
@@ -155,14 +152,10 @@ theorem decrement_preserves_other_slots (s : ContractState)
 theorem decrement_reverts_underflow (s : ContractState)
   (h_underflow : s.storage 0 = 0) :
   ∃ msg, (decrement).run s = ContractResult.revert msg s := by
-  have h_gt : (1 : Nat) > (s.storage 0 : Nat) := by
-    rw [h_underflow]
-    decide
-  have h_none := safeSub_none (s.storage 0) 1 h_gt
   simp [decrement, getStorage, setStorage, count, requireSomeUint,
     Verity.bind, Bind.bind, Verity.pure, Pure.pure,
     Verity.require, Contract.run, ContractResult.snd, ContractResult.fst,
-    h_none]
+    safeSub_none (s.storage 0) 1 (show (1 : Nat) > (s.storage 0 : Nat) by rw [h_underflow]; decide)]
 
 /-! ## State Preservation -/
 


### PR DESCRIPTION
## Summary
- **SafeCounter/Basic.lean**: Inline 4 single-use `have` bindings (`h_safe`, `h_none`, `h_gt`) into their sole use sites in `increment_unfold`, `decrement_unfold`, `increment_reverts_overflow`, and `decrement_reverts_underflow`
- **Ledger/Basic.lean**: Inline 5 single-use `have` bindings (`h_balance'`, `h_safe`, `h_none`) into `simp` calls in `transfer_unfold_self`, `transfer_unfold_other`, and `transfer_reverts_recipient_overflow`

Net -11 lines across 2 files. All proofs verified, no behavioral changes.

## Test plan
- [x] `lake build` passes (86 modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes
- [x] `check_axiom_locations.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that primarily rearranges `simp` inputs; no runtime or spec behavior changes, with minimal risk beyond potential proof fragility.
> 
> **Overview**
> Refactors Lean proofs in `Verity/Proofs/Ledger/Basic.lean` and `Verity/Proofs/SafeCounter/Basic.lean` by inlining several single-use `have` bindings directly into `simp` arguments.
> 
> This reduces local proof boilerplate in transfer/increment/decrement overflow/underflow lemmas without changing any contract logic or theorem statements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc0c36fa16924ad9b73d43c569a8d6e3aac3112b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->