### PR TITLE
Inline single-use have bindings and convert to term proofs

### DIFF
--- a/Verity/Proofs/Counter/Correctness.lean
+++ b/Verity/Proofs/Counter/Correctness.lean
@@ -48,8 +48,7 @@ theorem decrement_state_preserved_except_count (s : ContractState) :
 theorem getCount_state_preserved (s : ContractState) :
   let s' := ((getCount).run s).snd
   state_preserved_except_count s s' := by
-  have h := getCount_preserves_state s
-  simp [h, state_preserved_except_count, storage_isolated,
+  simp [getCount_preserves_state s, state_preserved_except_count, storage_isolated,
     Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameContext]
 
 /-! ## Combined Spec Proofs

--- a/Verity/Proofs/OwnedCounter/Isolation.lean
+++ b/Verity/Proofs/OwnedCounter/Isolation.lean
@@ -29,22 +29,19 @@ storage, using the count_preserves_owner spec definition.
 /-- Increment preserves all address storage (including owner). -/
 theorem increment_count_preserves_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
-  count_preserves_owner s (increment.run s).snd := by
-  unfold count_preserves_owner
-  exact increment_preserves_owner s h_owner
+  count_preserves_owner s (increment.run s).snd :=
+  increment_preserves_owner s h_owner
 
 /-- Decrement preserves all address storage (including owner). -/
 theorem decrement_count_preserves_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
-  count_preserves_owner s (decrement.run s).snd := by
-  unfold count_preserves_owner
-  exact decrement_preserves_owner s h_owner
+  count_preserves_owner s (decrement.run s).snd :=
+  decrement_preserves_owner s h_owner
 
 /-- Constructor preserves counter storage. -/
 theorem constructor_owner_preserves_count (s : ContractState) (initialOwner : Address) :
-  owner_preserves_count s ((constructor initialOwner).run s).snd := by
-  unfold owner_preserves_count
-  exact constructor_preserves_count s initialOwner
+  owner_preserves_count s ((constructor initialOwner).run s).snd :=
+  constructor_preserves_count s initialOwner
 
 /-! ## Owner operations preserve counter storage (owner_preserves_count)
 
@@ -54,9 +51,8 @@ TransferOwnership doesn't touch the counter value.
 /-- TransferOwnership preserves all uint256 storage (including count). -/
 theorem transferOwnership_owner_preserves_count (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :
-  owner_preserves_count s ((transferOwnership newOwner).run s).snd := by
-  unfold owner_preserves_count
-  exact transferOwnership_preserves_count s newOwner h_owner
+  owner_preserves_count s ((transferOwnership newOwner).run s).snd :=
+  transferOwnership_preserves_count s newOwner h_owner
 
 /-! ## Context preservation
 

--- a/Verity/Proofs/SafeCounter/Correctness.lean
+++ b/Verity/Proofs/SafeCounter/Correctness.lean
@@ -66,8 +66,7 @@ theorem decrement_preserves_storage_isolated (s : ContractState)
 theorem getCount_preserves_context (s : ContractState) :
   let s' := ((getCount).run s).snd
   context_preserved s s' := by
-  have h := getCount_preserves_state s
-  simp [h, Specs.sameContext]
+  simp [getCount_preserves_state s, Specs.sameContext]
 
 /-- getCount preserves well-formedness. -/
 theorem getCount_preserves_wellformedness (s : ContractState) (h : WellFormedState s) :

--- a/Verity/Proofs/SimpleStorage/Correctness.lean
+++ b/Verity/Proofs/SimpleStorage/Correctness.lean
@@ -78,8 +78,7 @@ theorem store_preserves_context (s : ContractState) (value : Uint256) :
 theorem retrieve_preserves_context (s : ContractState) :
   let s' := ((retrieve).run s).snd
   context_preserved s s' := by
-  have h := retrieve_preserves_state s
-  simp [h, Specs.sameContext]
+  simp [retrieve_preserves_state s, Specs.sameContext]
 
 /-- retrieve preserves well-formedness. -/
 theorem retrieve_preserves_wellformedness (s : ContractState) (h : WellFormedState s) :


### PR DESCRIPTION
## Summary
- Converts 4 `unfold X; exact Y` tactic proofs to direct term-mode proofs in `OwnedCounter/Isolation.lean` — Lean's type checker can unify through definition expansion without an explicit `unfold`
- Inlines 3 single-use `have h := expr; simp [h, ...]` into `simp [expr, ...]` across SimpleStorage, Counter, and SafeCounter Correctness files
- Net reduction of 7 lines across 4 files

## Test plan
- [x] `lake build` passes all 86 modules
- [ ] CI pipeline (lake build + Python checks + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure-only changes with no new logic or spec changes; risk is limited to potential proof breakage if definitional unfolding assumptions change.
> 
> **Overview**
> Refactors several Lean proof scripts to be more direct by **inlining single-use `have` bindings into `simp`** for read-only state/context preservation lemmas in `Counter/Correctness.lean`, `SafeCounter/Correctness.lean`, and `SimpleStorage/Correctness.lean`.
> 
> Also simplifies `OwnedCounter/Isolation.lean` by **replacing small tactic blocks (`unfold …; exact …`) with term-style proof assignments**, relying on definitional unfolding during type checking; no theorem statements or specs change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b917742bf483ebd53bab79f7a7b80a74e7735d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->