### PR TITLE
Inline redundant have intermediates across 6 proof files (-60 lines)

### DIFF
--- a/Verity/Proofs/Counter/Basic.lean
+++ b/Verity/Proofs/Counter/Basic.lean
@@ -75,9 +75,7 @@ theorem increment_meets_spec (s : ContractState) :
 theorem increment_adds_one (s : ContractState) :
   let s' := ((increment).run s).snd
   s'.storage 0 = EVM.Uint256.add (s.storage 0) 1 := by
-  have h := increment_meets_spec s
-  simp [increment_spec] at h
-  exact h.1
+  have h := increment_meets_spec s; simp [increment_spec] at h; exact h.1
 
 /-! ## decrement Correctness -/
 
@@ -99,9 +97,7 @@ theorem decrement_meets_spec (s : ContractState) :
 theorem decrement_subtracts_one (s : ContractState) :
   let s' := ((decrement).run s).snd
   s'.storage 0 = EVM.Uint256.sub (s.storage 0) 1 := by
-  have h := decrement_meets_spec s
-  simp [decrement_spec] at h
-  exact h.1
+  have h := decrement_meets_spec s; simp [decrement_spec] at h; exact h.1
 
 /-! ## getCount Correctness -/
 
@@ -113,9 +109,7 @@ theorem getCount_meets_spec (s : ContractState) :
 theorem getCount_reads_count_value (s : ContractState) :
   let result := ((getCount).run s).fst
   result = s.storage 0 := by
-  have h := getCount_meets_spec s
-  simp [getCount_spec] at h
-  exact h
+  simpa [getCount_spec] using getCount_meets_spec s
 
 /-! ## Composition Properties -/
 
@@ -124,18 +118,14 @@ theorem increment_getCount_correct (s : ContractState) :
   let result := ((getCount).run s').fst
   result = EVM.Uint256.add (s.storage 0) 1 := by
   have h_inc := increment_adds_one s
-  have h_get := getCount_reads_count_value (((increment).run s).snd)
-  simp only [h_inc] at h_get
-  exact h_get
+  simpa only [h_inc] using getCount_reads_count_value (((increment).run s).snd)
 
 theorem decrement_getCount_correct (s : ContractState) :
   let s' := ((decrement).run s).snd
   let result := ((getCount).run s').fst
   result = EVM.Uint256.sub (s.storage 0) 1 := by
   have h_dec := decrement_subtracts_one s
-  have h_get := getCount_reads_count_value (((decrement).run s).snd)
-  simp only [h_dec] at h_get
-  exact h_get
+  simpa only [h_dec] using getCount_reads_count_value (((decrement).run s).snd)
 
 theorem increment_twice_adds_two (s : ContractState) :
   let s' := ((increment).run s).snd

--- a/Verity/Proofs/Owned/Basic.lean
+++ b/Verity/Proofs/Owned/Basic.lean
@@ -73,9 +73,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((constructor initialOwner).run s).snd
   s'.storageAddr 0 = initialOwner := by
-  have h := constructor_meets_spec s initialOwner
-  simp [constructor_spec] at h
-  exact h.1
+  have h := constructor_meets_spec s initialOwner; simp [constructor_spec] at h; exact h.1
 
 /-! ## getOwner Correctness -/
 
@@ -87,9 +85,7 @@ theorem getOwner_meets_spec (s : ContractState) :
 theorem getOwner_returns_owner (s : ContractState) :
   let result := ((getOwner).run s).fst
   result = s.storageAddr 0 := by
-  have h := getOwner_meets_spec s
-  simp [getOwner_spec] at h
-  exact h
+  simpa [getOwner_spec] using getOwner_meets_spec s
 
 theorem getOwner_preserves_state (s : ContractState) :
   let s' := ((getOwner).run s).snd
@@ -107,9 +103,7 @@ theorem isOwner_meets_spec (s : ContractState) :
 theorem isOwner_returns_correct_value (s : ContractState) :
   let result := ((isOwner).run s).fst
   result = (s.sender == s.storageAddr 0) := by
-  have h := isOwner_meets_spec s
-  simp [isOwner_spec] at h
-  exact h
+  simpa [isOwner_spec] using isOwner_meets_spec s
 
 /-! ## transferOwnership Correctness
 
@@ -164,9 +158,7 @@ theorem constructor_getOwner_correct (s : ContractState) (initialOwner : Address
   let result := ((getOwner).run s').fst
   result = initialOwner := by
   have h_constr := constructor_sets_owner s initialOwner
-  have h_get := getOwner_returns_owner (((constructor initialOwner).run s).snd)
-  simp only [h_constr] at h_get
-  exact h_get
+  simpa only [h_constr] using getOwner_returns_owner (((constructor initialOwner).run s).snd)
 
 /-! ## State Preservation -/
 

--- a/Verity/Proofs/SafeCounter/Correctness.lean
+++ b/Verity/Proofs/SafeCounter/Correctness.lean
@@ -31,8 +31,7 @@ theorem increment_preserves_context (s : ContractState)
   (h_no_overflow : (s.storage 0 : Nat) + 1 ≤ MAX_UINT256) :
   let s' := ((increment).run s).snd
   context_preserved s s' := by
-  have h := increment_meets_spec s h_no_overflow
-  simp [increment_spec] at h
+  have h := increment_meets_spec s h_no_overflow; simp [increment_spec] at h
   exact ⟨h.2.2.2.2.1, h.2.2.2.2.2⟩
 
 /-- decrement preserves context (sender, thisAddress). -/
@@ -40,8 +39,7 @@ theorem decrement_preserves_context (s : ContractState)
   (h_no_underflow : s.storage 0 ≥ 1) :
   let s' := ((decrement).run s).snd
   context_preserved s s' := by
-  have h := decrement_meets_spec s h_no_underflow
-  simp [decrement_spec] at h
+  have h := decrement_meets_spec s h_no_underflow; simp [decrement_spec] at h
   exact ⟨h.2.2.2.2.1, h.2.2.2.2.2⟩
 
 /-- increment preserves storage isolation. -/
@@ -49,8 +47,7 @@ theorem increment_preserves_storage_isolated (s : ContractState)
   (h_no_overflow : (s.storage 0 : Nat) + 1 ≤ MAX_UINT256) :
   let s' := ((increment).run s).snd
   storage_isolated s s' := by
-  simp [storage_isolated]
-  intro slot h_ne
+  simp [storage_isolated]; intro slot h_ne
   exact increment_preserves_other_slots s h_no_overflow slot h_ne
 
 /-- decrement preserves storage isolation. -/
@@ -58,8 +55,7 @@ theorem decrement_preserves_storage_isolated (s : ContractState)
   (h_no_underflow : s.storage 0 ≥ 1) :
   let s' := ((decrement).run s).snd
   storage_isolated s s' := by
-  simp [storage_isolated]
-  intro slot h_ne
+  simp [storage_isolated]; intro slot h_ne
   exact decrement_preserves_other_slots s h_no_underflow slot h_ne
 
 /-- getCount preserves context (trivially, read-only). -/
@@ -103,9 +99,7 @@ theorem decrement_getCount_correct (s : ContractState)
   let s' := ((decrement).run s).snd
   ((getCount).run s').fst = sub (s.storage 0) 1 := by
   have h_dec := decrement_subtracts_one s h_no_underflow
-  have h_get := getCount_returns_count ((decrement).run s).snd
-  simp only [h_dec] at h_get
-  exact h_get
+  simpa only [h_dec] using getCount_returns_count ((decrement).run s).snd
 
 /-! ## Summary
 

--- a/Verity/Proofs/SimpleStorage/Correctness.lean
+++ b/Verity/Proofs/SimpleStorage/Correctness.lean
@@ -42,29 +42,22 @@ Prove that store satisfies each invariant from Invariants.lean individually.
 theorem store_preserves_storage_isolated (s : ContractState) (value : Uint256) (slot : Nat) :
   let s' := ((store value).run s).snd
   storage_isolated s s' slot := by
-  simp [storage_isolated]
-  intro h_ne
-  have h := store_meets_spec s value
-  simp [store_spec] at h
-  exact h.2.1 slot h_ne
+  simp [storage_isolated]; intro h_ne
+  have h := store_meets_spec s value; simp [store_spec] at h; exact h.2.1 slot h_ne
 
 /-- store preserves address storage. -/
 theorem store_preserves_addr_storage (s : ContractState) (value : Uint256) :
   let s' := ((store value).run s).snd
   addr_storage_unchanged s s' := by
   simp [addr_storage_unchanged]
-  have h := store_meets_spec s value
-  simp [store_spec] at h
-  exact h.2.2.1
+  have h := store_meets_spec s value; simp [store_spec] at h; exact h.2.2.1
 
 /-- store preserves mapping storage. -/
 theorem store_preserves_map_storage (s : ContractState) (value : Uint256) :
   let s' := ((store value).run s).snd
   map_storage_unchanged s s' := by
   simp [map_storage_unchanged]
-  have h := store_meets_spec s value
-  simp [store_spec] at h
-  exact h.2.2.2.1
+  have h := store_meets_spec s value; simp [store_spec] at h; exact h.2.2.2.1
 
 /-- store preserves context (sender, thisAddress). -/
 theorem store_preserves_context (s : ContractState) (value : Uint256) :

--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -107,16 +107,12 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((constructor initialOwner).run s).snd
   s'.storageAddr 0 = initialOwner := by
-  have h := constructor_meets_spec s initialOwner
-  simp [constructor_spec] at h
-  exact h.1
+  have h := constructor_meets_spec s initialOwner; simp [constructor_spec] at h; exact h.1
 
 theorem constructor_sets_supply_zero (s : ContractState) (initialOwner : Address) :
   let s' := ((constructor initialOwner).run s).snd
   s'.storage 2 = 0 := by
-  have h := constructor_meets_spec s initialOwner
-  simp [constructor_spec] at h
-  exact h.2.1
+  have h := constructor_meets_spec s initialOwner; simp [constructor_spec] at h; exact h.2.1
 
 /-! ## Mint Correctness
 
@@ -202,8 +198,7 @@ theorem mint_increases_balance (s : ContractState) (to : Address) (amount : Uint
   let s' := ((mint to amount).run s).snd
   s'.storageMap 1 to = EVM.Uint256.add (s.storageMap 1 to) amount := by
   have h := mint_meets_spec_when_owner s to amount h_owner h_no_bal_overflow h_no_sup_overflow
-  simp [mint_spec] at h
-  exact h.1
+  simp [mint_spec] at h; exact h.1
 
 theorem mint_increases_supply (s : ContractState) (to : Address) (amount : Uint256)
   (h_owner : s.sender = s.storageAddr 0)
@@ -212,8 +207,7 @@ theorem mint_increases_supply (s : ContractState) (to : Address) (amount : Uint2
   let s' := ((mint to amount).run s).snd
   s'.storage 2 = EVM.Uint256.add (s.storage 2) amount := by
   have h := mint_meets_spec_when_owner s to amount h_owner h_no_bal_overflow h_no_sup_overflow
-  simp [mint_spec] at h
-  exact h.2.1
+  simp [mint_spec] at h; exact h.2.1
 
 -- Mint reverts on balance overflow
 theorem mint_reverts_balance_overflow (s : ContractState) (to : Address) (amount : Uint256)
@@ -353,8 +347,7 @@ theorem transfer_decreases_sender_balance (s : ContractState) (to : Address) (am
   let s' := ((transfer to amount).run s).snd
   s'.storageMap 1 s.sender = EVM.Uint256.sub (s.storageMap 1 s.sender) amount := by
   have h := transfer_meets_spec_when_sufficient s to amount h_balance (fun _ => h_no_overflow)
-  simp [transfer_spec, h_ne, beq_iff_eq] at h
-  exact h.2.1
+  simp [transfer_spec, h_ne, beq_iff_eq] at h; exact h.2.1
 
 theorem transfer_increases_recipient_balance (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 1 s.sender ≥ amount)
@@ -363,16 +356,14 @@ theorem transfer_increases_recipient_balance (s : ContractState) (to : Address) 
   let s' := ((transfer to amount).run s).snd
   s'.storageMap 1 to = EVM.Uint256.add (s.storageMap 1 to) amount := by
   have h := transfer_meets_spec_when_sufficient s to amount h_balance (fun _ => h_no_overflow)
-  simp [transfer_spec, h_ne, beq_iff_eq] at h
-  exact h.2.2.1
+  simp [transfer_spec, h_ne, beq_iff_eq] at h; exact h.2.2.1
 
 theorem transfer_self_preserves_balance (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 1 s.sender ≥ amount) :
   let s' := ((transfer s.sender amount).run s).snd
   s'.storageMap 1 s.sender = s.storageMap 1 s.sender := by
   have h := transfer_meets_spec_when_sufficient s s.sender amount h_balance (fun h => absurd rfl h)
-  simp [transfer_spec, beq_iff_eq] at h
-  exact h.2.1
+  simp [transfer_spec, beq_iff_eq] at h; exact h.2.1
 
 -- Transfer reverts on recipient balance overflow
 theorem transfer_reverts_recipient_overflow (s : ContractState) (to : Address) (amount : Uint256)
@@ -398,9 +389,7 @@ theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :
 theorem balanceOf_returns_balance (s : ContractState) (addr : Address) :
   let result := ((balanceOf addr).run s).fst
   result = s.storageMap 1 addr := by
-  have h := balanceOf_meets_spec s addr
-  simp [balanceOf_spec] at h
-  exact h
+  simpa [balanceOf_spec] using balanceOf_meets_spec s addr
 
 theorem balanceOf_preserves_state (s : ContractState) (addr : Address) :
   let s' := ((balanceOf addr).run s).snd
@@ -415,9 +404,7 @@ theorem getTotalSupply_meets_spec (s : ContractState) :
 theorem getTotalSupply_returns_supply (s : ContractState) :
   let result := ((getTotalSupply).run s).fst
   result = s.storage 2 := by
-  have h := getTotalSupply_meets_spec s
-  simp [getTotalSupply_spec] at h
-  exact h
+  simpa [getTotalSupply_spec] using getTotalSupply_meets_spec s
 
 theorem getTotalSupply_preserves_state (s : ContractState) :
   let s' := ((getTotalSupply).run s).snd
@@ -432,9 +419,7 @@ theorem getOwner_meets_spec (s : ContractState) :
 theorem getOwner_returns_owner (s : ContractState) :
   let result := ((getOwner).run s).fst
   result = s.storageAddr 0 := by
-  have h := getOwner_meets_spec s
-  simp [getOwner_spec] at h
-  exact h
+  simpa [getOwner_spec] using getOwner_meets_spec s
 
 theorem getOwner_preserves_state (s : ContractState) :
   let s' := ((getOwner).run s).snd

--- a/Verity/Proofs/Stdlib/Math.lean
+++ b/Verity/Proofs/Stdlib/Math.lean
@@ -18,27 +18,22 @@ open Verity.Stdlib.Math
 /-- safeAdd returns the sum when no overflow occurs. -/
 theorem safeAdd_some (a b : Uint256) (h : (a : Nat) + (b : Nat) ≤ MAX_UINT256) :
   safeAdd a b = some (a + b) := by
-  simp only [safeAdd]
-  have h_not : ¬((a : Nat) + (b : Nat) > MAX_UINT256) := Nat.not_lt.mpr h
-  simp [h_not]
+  simp [safeAdd, Nat.not_lt.mpr h]
 
 /-- safeAdd returns none on overflow. -/
 theorem safeAdd_none (a b : Uint256) (h : (a : Nat) + (b : Nat) > MAX_UINT256) :
   safeAdd a b = none := by
-  simp only [safeAdd]
-  simp [h]
+  simp [safeAdd, h]
 
 /-- safeAdd with zero on the left returns the other operand (when within bounds). -/
 theorem safeAdd_zero_left (b : Uint256) (h : (b : Nat) ≤ MAX_UINT256) :
   safeAdd 0 b = some b := by
-  have h_not : ¬((b : Nat) > MAX_UINT256) := Nat.not_lt.mpr h
-  simp [safeAdd, h_not]
+  simp [safeAdd, Nat.not_lt.mpr h]
 
 /-- safeAdd with zero on the right returns the other operand (when within bounds). -/
 theorem safeAdd_zero_right (a : Uint256) (h : (a : Nat) ≤ MAX_UINT256) :
   safeAdd a 0 = some a := by
-  have h_not : ¬((a : Nat) > MAX_UINT256) := Nat.not_lt.mpr h
-  simp [safeAdd, h_not]
+  simp [safeAdd, Nat.not_lt.mpr h]
 
 /-- safeAdd is commutative. -/
 theorem safeAdd_comm (a b : Uint256) :
@@ -55,15 +50,12 @@ theorem safeAdd_result_bounded (a b : Uint256) (c : Uint256)
 /-- safeSub returns the difference when no underflow occurs. -/
 theorem safeSub_some (a b : Uint256) (h : (a : Nat) ≥ (b : Nat)) :
   safeSub a b = some (a - b) := by
-  simp only [safeSub]
-  have h_not : ¬((b : Nat) > (a : Nat)) := Nat.not_lt.mpr h
-  simp [h_not]
+  simp [safeSub, Nat.not_lt.mpr h]
 
 /-- safeSub returns none on underflow. -/
 theorem safeSub_none (a b : Uint256) (h : (b : Nat) > (a : Nat)) :
   safeSub a b = none := by
-  simp only [safeSub]
-  simp [h]
+  simp [safeSub, h]
 
 /-- safeSub of zero from any value is always safe. -/
 theorem safeSub_zero (a : Uint256) :
@@ -92,15 +84,12 @@ theorem safeSub_result_le (a b : Uint256) (c : Uint256)
 /-- safeMul returns the product when no overflow occurs. -/
 theorem safeMul_some (a b : Uint256) (h : (a : Nat) * (b : Nat) ≤ MAX_UINT256) :
   safeMul a b = some (a * b) := by
-  simp only [safeMul]
-  have h_not : ¬((a : Nat) * (b : Nat) > MAX_UINT256) := Nat.not_lt.mpr h
-  simp [h_not]
+  simp [safeMul, Nat.not_lt.mpr h]
 
 /-- safeMul returns none on overflow. -/
 theorem safeMul_none (a b : Uint256) (h : (a : Nat) * (b : Nat) > MAX_UINT256) :
   safeMul a b = none := by
-  simp only [safeMul]
-  simp [h]
+  simp [safeMul, h]
 
 /-- safeMul of zero is always safe and returns zero. -/
 theorem safeMul_zero_left (b : Uint256) :
@@ -115,14 +104,12 @@ theorem safeMul_zero_right (a : Uint256) :
 /-- safeMul of one returns the other operand (when within bounds). -/
 theorem safeMul_one_left (b : Uint256) (h : (b : Nat) ≤ MAX_UINT256) :
   safeMul 1 b = some b := by
-  have h_not : ¬((b : Nat) > MAX_UINT256) := Nat.not_lt.mpr h
-  simp [safeMul, h_not]
+  simp [safeMul, Nat.not_lt.mpr h]
 
 /-- safeMul of one returns the other operand (when within bounds). -/
 theorem safeMul_one_right (a : Uint256) (h : (a : Nat) ≤ MAX_UINT256) :
   safeMul a 1 = some a := by
-  have h_not : ¬((a : Nat) > MAX_UINT256) := Nat.not_lt.mpr h
-  simp [safeMul, h_not]
+  simp [safeMul, Nat.not_lt.mpr h]
 
 /-- safeMul is commutative. -/
 theorem safeMul_comm (a b : Uint256) :
@@ -140,8 +127,7 @@ theorem safeDiv_some (a b : Uint256) (h : b ≠ 0) :
 /-- safeDiv returns none when divisor is zero. -/
 theorem safeDiv_none (a : Uint256) :
   safeDiv a 0 = none := by
-  simp only [safeDiv]
-  simp
+  simp [safeDiv]
 
 /-- safeDiv of zero always returns zero (when divisor is nonzero). -/
 theorem safeDiv_zero_numerator (b : Uint256) (h : b ≠ 0) :


### PR DESCRIPTION
## Summary
- Inline single-use `have` bindings that serve only as intermediate steps before `simp`/`exact`
- Two main patterns eliminated:
  - `have h_not := Nat.not_lt.mpr h; simp [h_not]` → `simp [..., Nat.not_lt.mpr h]` (7 instances in Math.lean)
  - `have h := X; simp [Y] at h; exact h.N` → single line or `simpa [Y] using X` (20+ instances across 5 files)
- Also merges `simp only [safeFn]; simp [h]` → `simp [safeFn, h]` where safe
- Files changed: Math.lean, SimpleToken/Basic.lean, Counter/Basic.lean, Owned/Basic.lean, SafeCounter/Correctness.lean, SimpleStorage/Correctness.lean

## Test plan
- [x] `lake build` passes — all 86 modules built, all 371 theorems verified
- [x] All 11 Python check scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof-term simplification (mostly `simp`/`simpa` rewrites) with no functional or spec changes; risk is limited to potential proof fragility if tactic behavior changes.
> 
> **Overview**
> Refactors multiple Lean proof scripts to inline single-use intermediate `have` bindings and collapse `have`/`simp`/`exact` sequences into one-liners (often via `simpa ... using ...`).
> 
> This cleanup is applied across Counter, Owned, SafeCounter, SimpleStorage, SimpleToken, and stdlib `Math` proofs, including simplifying `safe*` arithmetic lemmas by pushing `Nat.not_lt.mpr` directly into `simp`, with no changes to theorem statements or contract/spec behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 597c6c0478ecc5e7880f22d68e2295698fbefbbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->