### PR TITLE
Replace verbose calc blocks with Eq.trans (-103 lines)

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Ledger.lean
+++ b/Compiler/Proofs/SpecCorrectness/Ledger.lean
@@ -105,19 +105,7 @@ theorem ledger_deposit_correct (state : ContractState) (amount : Nat) (sender : 
           ).storageMap 0 sender).val =
           ((state.storageMap 0 sender).val + amount) % Verity.Core.Uint256.modulus := by
       simpa [uint256_add_val] using congrArg Verity.Core.Uint256.val h_edsl_state
-    calc
-      (let specTx : DiffTestTypes.Transaction := {
-        sender := sender
-        functionName := "deposit"
-        args := [amount]
-      };
-      let specResult :=
-        interpretSpec ledgerSpec (ledgerEdslToSpecStorageWithAddrs state [sender]) specTx;
-      specResult.finalStorage.getMapping 0 (addressToNat sender))
-          = ((state.storageMap 0 sender).val + amount) % Verity.Core.Uint256.modulus := h_spec_val
-      _ = ((ContractResult.getState
-            ((deposit (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-          ).storageMap 0 sender).val := h_edsl_val.symm
+    exact h_spec_val.trans h_edsl_val.symm
 
 /-- The `withdraw` function correctly subtracts when balance is sufficient -/
 theorem ledger_withdraw_correct_sufficient (state : ContractState) (amount : Nat) (sender : Address)
@@ -176,19 +164,7 @@ theorem ledger_withdraw_correct_sufficient (state : ContractState) (amount : Nat
           ).storageMap 0 sender).val =
           (state.storageMap 0 sender).val - amount :=
       h_edsl_state ▸ uint256_sub_val_of_le _ _ h
-    calc
-      (let specTx : DiffTestTypes.Transaction := {
-        sender := sender
-        functionName := "withdraw"
-        args := [amount]
-      };
-      let specResult :=
-        interpretSpec ledgerSpec (ledgerEdslToSpecStorageWithAddrs state [sender]) specTx;
-      specResult.finalStorage.getMapping 0 (addressToNat sender))
-          = (state.storageMap 0 sender).val - amount := h_spec_val
-      _ = ((ContractResult.getState
-            ((withdraw (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-          ).storageMap 0 sender).val := h_edsl_val.symm
+    exact h_spec_val.trans h_edsl_val.symm
 
 /-- The `withdraw` function correctly reverts when balance is insufficient -/
 theorem ledger_withdraw_reverts_insufficient (state : ContractState) (amount : Nat) (sender : Address)
@@ -355,19 +331,7 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
             ).storageMap 0 sender).val =
             (state.storageMap 0 sender).val - amount :=
         h_edsl_state ▸ uint256_sub_val_of_le _ _ h
-      calc
-        (let specTx : DiffTestTypes.Transaction := {
-          sender := sender
-          functionName := "transfer"
-          args := [addressToNat to, amount]
-        };
-        let specResult :=
-          interpretSpec ledgerSpec (ledgerEdslToSpecStorageWithAddrs state [sender, to]) specTx;
-        specResult.finalStorage.getMapping 0 (addressToNat sender))
-            = (state.storageMap 0 sender).val - amount := h_spec_val
-        _ = ((ContractResult.getState
-              ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-            ).storageMap 0 sender).val := h_edsl_val.symm
+      exact h_spec_val.trans h_edsl_val.symm
     · -- Spec recipient mapping equals EDSL recipient mapping
       have h_spec_val :
           (let specTx : DiffTestTypes.Transaction := {
@@ -400,19 +364,7 @@ theorem ledger_transfer_correct_sufficient (state : ContractState) (to : Address
             ).storageMap 0 to).val =
             ((state.storageMap 0 to).val + amount) % Verity.Core.Uint256.modulus := by
         simpa [uint256_add_val] using congrArg Verity.Core.Uint256.val h_edsl_state
-      calc
-        (let specTx : DiffTestTypes.Transaction := {
-          sender := sender
-          functionName := "transfer"
-          args := [addressToNat to, amount]
-        };
-        let specResult :=
-          interpretSpec ledgerSpec (ledgerEdslToSpecStorageWithAddrs state [sender, to]) specTx;
-        specResult.finalStorage.getMapping 0 (addressToNat to))
-            = ((state.storageMap 0 to).val + amount) % Verity.Core.Uint256.modulus := h_spec_val
-        _ = ((ContractResult.getState
-              ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-            ).storageMap 0 to).val := h_edsl_val.symm
+      exact h_spec_val.trans h_edsl_val.symm
 
 /-- The `transfer` function correctly reverts when balance is insufficient -/
 theorem ledger_transfer_reverts_insufficient (state : ContractState) (to : Address) (amount : Nat) (sender : Address)

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -206,19 +206,7 @@ theorem token_mint_correct_as_owner (state : ContractState) (to : Address) (amou
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
         addressToNat_mod_eq, h, h_bal_mod_eq, h_bal_ge, h_sup_mod_eq, h_sup_ge,
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
-    calc
-      (let specTx : DiffTestTypes.Transaction := {
-        sender := sender
-        functionName := "mint"
-        args := [addressToNat to, amount]
-      };
-      let specResult := interpretSpec simpleTokenSpec
-        (tokenEdslToSpecStorageWithAddrs state [to]) specTx;
-      specResult.finalStorage.getMapping 1 (addressToNat to))
-          = ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus := h_spec_val
-      _ = ((ContractResult.getState
-          ((mint to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-        ).storageMap 1 to).val := h_edsl_map_val.symm
+    exact h_spec_val.trans h_edsl_map_val.symm
   · -- Total supply update matches EDSL
     have h_edsl_supply :
         (ContractResult.getState
@@ -251,19 +239,7 @@ theorem token_mint_correct_as_owner (state : ContractState) (to : Address) (amou
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq,
         addressToNat_mod_eq, h, h_bal_mod_eq, h_bal_ge, h_sup_mod_eq, h_sup_ge,
         List.lookup, BEq.beq, beq_iff_eq, decide_eq_true_eq, String.decEq]
-    calc
-      (let specTx : DiffTestTypes.Transaction := {
-        sender := sender
-        functionName := "mint"
-        args := [addressToNat to, amount]
-      };
-      let specResult := interpretSpec simpleTokenSpec
-        (tokenEdslToSpecStorageWithAddrs state [to]) specTx;
-      specResult.finalStorage.getSlot 2)
-          = ((state.storage 2).val + amount) % Verity.Core.Uint256.modulus := h_spec_val
-      _ = ((ContractResult.getState
-          ((mint to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-        ).storage 2).val := h_edsl_supply_val.symm
+    exact h_spec_val.trans h_edsl_supply_val.symm
 
 /-- The `mint` function correctly reverts when called by non-owner -/
 theorem token_mint_reverts_as_nonowner (state : ContractState) (to : Address) (amount : Nat) (sender : Address)
@@ -422,19 +398,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
             ).storageMap 1 sender).val =
             (state.storageMap 1 sender).val - amount :=
         h_edsl_state ▸ uint256_sub_val_of_le _ _ h
-      calc
-        (let specTx : DiffTestTypes.Transaction := {
-          sender := sender
-          functionName := "transfer"
-          args := [addressToNat to, amount]
-        };
-        let specResult := interpretSpec simpleTokenSpec
-          (tokenEdslToSpecStorageWithAddrs state [sender, to]) specTx;
-        specResult.finalStorage.getMapping 1 (addressToNat sender))
-            = (state.storageMap 1 sender).val - amount := h_spec_val
-        _ = ((ContractResult.getState
-              ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-            ).storageMap 1 sender).val := h_edsl_val.symm
+      exact h_spec_val.trans h_edsl_val.symm
     · -- Recipient mapping equals EDSL mapping
       have h_spec_val :
           (let specTx : DiffTestTypes.Transaction := {
@@ -470,19 +434,7 @@ theorem token_transfer_correct_sufficient (state : ContractState) (to : Address)
             ).storageMap 1 to).val =
             ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus := by
         simpa [uint256_add_val] using congrArg Verity.Core.Uint256.val h_edsl_state
-      calc
-        (let specTx : DiffTestTypes.Transaction := {
-          sender := sender
-          functionName := "transfer"
-          args := [addressToNat to, amount]
-        };
-        let specResult := interpretSpec simpleTokenSpec
-          (tokenEdslToSpecStorageWithAddrs state [sender, to]) specTx;
-        specResult.finalStorage.getMapping 1 (addressToNat to))
-            = ((state.storageMap 1 to).val + amount) % Verity.Core.Uint256.modulus := h_spec_val
-        _ = ((ContractResult.getState
-              ((transfer to (Verity.Core.Uint256.ofNat amount)).run { state with sender := sender })
-            ).storageMap 1 to).val := h_edsl_val.symm
+      exact h_spec_val.trans h_edsl_val.symm
 
 /-- The `transfer` function correctly reverts when balance is insufficient -/
 theorem token_transfer_reverts_insufficient (state : ContractState) (to : Address) (amount : Nat) (sender : Address)

--- a/Verity/Proofs/Ledger/Correctness.lean
+++ b/Verity/Proofs/Ledger/Correctness.lean
@@ -100,15 +100,8 @@ theorem deposit_withdraw_cancel (s : ContractState) (amount : Uint256)
   have h_balance' : s1.storageMap 0 s.sender ≥ amount := by
     simpa [s1, h_inc] using h_balance
   have h_wd := withdraw_decreases_balance (s := s1) amount h_balance'
-  -- Rewrite through the deposit result
-  have h_wd' := h_wd
-  rw [h_sender] at h_wd'
-  rw [h_inc] at h_wd'
-  have h_cancel :
-      EVM.Uint256.sub (EVM.Uint256.add (s.storageMap 0 s.sender) amount) amount =
-      s.storageMap 0 s.sender :=
-    EVM.Uint256.sub_add_cancel (s.storageMap 0 s.sender) amount
-  simpa [s1, h_cancel] using h_wd'
+  rw [h_sender, h_inc] at h_wd
+  simpa [s1, EVM.Uint256.sub_add_cancel (s.storageMap 0 s.sender) amount] using h_wd
 
 /-! ## Summary
 


### PR DESCRIPTION
## Summary
- Replaces 8 verbose two-step `calc` blocks with `exact h_spec_val.trans h_edsl_val.symm` in Ledger and SimpleToken SpecCorrectness proofs — each `calc` block was a simple transitivity that expanded `let` bindings over 12 lines when a single `Eq.trans` suffices
- Eliminates a copy-and-rewrite pattern (`have h_wd' := h_wd; rw [...] at h_wd'`) in `Ledger/Correctness.lean` by rewriting `h_wd` in place and inlining the `h_cancel` binding
- Net reduction: **-103 lines** across 3 files

## Files Changed
- `Compiler/Proofs/SpecCorrectness/Ledger.lean` — 4 calc blocks replaced (-48 lines)
- `Compiler/Proofs/SpecCorrectness/SimpleToken.lean` — 4 calc blocks replaced (-48 lines)
- `Verity/Proofs/Ledger/Correctness.lean` — copy pattern eliminated (-7 lines)

## Test plan
- [x] `lake build` passes all 86 modules
- [ ] CI pipeline (lake build + Python checks + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that shortens equality chaining and rewrites; no runtime, spec, or contract semantics are changed, but it could cause minor proof breakage if any lemma orientation assumptions were relied upon.
> 
> **Overview**
> Simplifies several Lean proof steps by replacing verbose two-step `calc` equality chains with direct transitivity (`h_spec_val.trans h_edsl_val.symm`) in `SpecCorrectness` proofs for `Ledger` and `SimpleToken`.
> 
> Also streamlines the `deposit_withdraw_cancel` proof in `Verity/Proofs/Ledger/Correctness.lean` by rewriting `h_wd` in place and inlining the previous cancellation lemma binding, reducing proof noise without changing stated results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea5f06165e993f0e711b15e9fdf2b5e47d8fc64d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->