### PR TITLE
Minor proof cleanups: term-mode, import, style (-6 lines)

### DIFF
--- a/Verity/Proofs/SafeCounter/Basic.lean
+++ b/Verity/Proofs/SafeCounter/Basic.lean
@@ -40,8 +40,7 @@ theorem getCount_preserves_state (s : ContractState) :
 
 /-- Helper: relate EVM modular add to Nat addition when bounded. -/
 theorem evm_add_eq_of_no_overflow (a b : Uint256) (_h : (a : Nat) + (b : Nat) ≤ MAX_UINT256) :
-  add a b = a + b := by
-  rfl
+  add a b = a + b := rfl
 
 /-- Helper: unfold increment when no overflow -/
 private theorem increment_unfold (s : ContractState)

--- a/Verity/Proofs/SimpleToken/Correctness.lean
+++ b/Verity/Proofs/SimpleToken/Correctness.lean
@@ -91,20 +91,16 @@ theorem mint_preserves_owner (s : ContractState) (to : Address) (amount : Uint25
   (h_no_bal_overflow : (s.storageMap 1 to : Nat) + (amount : Nat) ≤ MAX_UINT256)
   (h_no_sup_overflow : (s.storage 2 : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((mint to amount).run s).snd
-  s'.storageAddr 0 = s.storageAddr 0 := by
-  obtain ⟨_, _, _, h_owner_pres, _, _⟩ :=
-    mint_meets_spec_when_owner s to amount h_owner h_no_bal_overflow h_no_sup_overflow
-  exact h_owner_pres
+  s'.storageAddr 0 = s.storageAddr 0 :=
+  (mint_meets_spec_when_owner s to amount h_owner h_no_bal_overflow h_no_sup_overflow).2.2.2.1
 
 /-- Transfer does not change the owner address. -/
 theorem transfer_preserves_owner (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 1 s.sender ≥ amount)
   (h_no_overflow : s.sender ≠ to → (s.storageMap 1 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((transfer to amount).run s).snd
-  s'.storageAddr 0 = s.storageAddr 0 := by
-  obtain ⟨_, _, _, _, h_owner_pres, _⟩ :=
-    transfer_meets_spec_when_sufficient s to amount h_balance h_no_overflow
-  exact h_owner_pres
+  s'.storageAddr 0 = s.storageAddr 0 :=
+  (transfer_meets_spec_when_sufficient s to amount h_balance h_no_overflow).2.2.2.2.1
 
 /-! ## End-to-End Composition
 

--- a/Verity/Proofs/Stdlib/MappingAutomation.lean
+++ b/Verity/Proofs/Stdlib/MappingAutomation.lean
@@ -14,7 +14,6 @@
   Status: All lemmas fully proven with zero sorry.
 -/
 
-import Verity.Core
 import Verity.Proofs.Stdlib.Automation
 
 namespace Verity.Proofs.Stdlib.MappingAutomation


### PR DESCRIPTION
## Summary
- Convert `obtain ⟨...⟩ := ...; exact h` to term-mode tuple projections (`.2.2.2.1`) in `SimpleToken/Correctness.lean`
- Remove redundant `import Verity.Core` in `MappingAutomation.lean` (already imported transitively via `Automation`)
- Use term-mode `:= rfl` instead of tactic-mode `:= by\n  rfl` in `SafeCounter/Basic.lean`

## Test plan
- [x] `lake build` passes (86 modules)
- [x] Axiom location check passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 53e3b8b36b74bbdd7a99fbd4b420ca285f17eed4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->