### PR TITLE
Replace show+rw with simp only in composition proofs (-8 lines)

### DIFF
--- a/Verity/Proofs/Counter/Correctness.lean
+++ b/Verity/Proofs/Counter/Correctness.lean
@@ -102,8 +102,7 @@ theorem getCount_preserves_wellformedness (s : ContractState) (h : WellFormedSta
 theorem decrement_at_zero_wraps_max (s : ContractState) (h : s.storage 0 = 0) :
   let s' := ((decrement).run s).snd
   s'.storage 0 = EVM.MAX_UINT256 := by
-  show ((decrement).run s).snd.storage 0 = EVM.MAX_UINT256
-  rw [decrement_subtracts_one s, h]
+  simp only [decrement_subtracts_one s, h]
   simp [EVM.MAX_UINT256, EVM.Uint256.sub, Verity.Core.MAX_UINT256,
     Verity.Core.Uint256.sub, Verity.Core.Uint256.modulus,
     Verity.Core.UINT256_MODULUS]

--- a/Verity/Proofs/Ledger/Correctness.lean
+++ b/Verity/Proofs/Ledger/Correctness.lean
@@ -53,8 +53,7 @@ theorem withdraw_getBalance_correct (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
   let s' := ((withdraw amount).run s).snd
   ((getBalance s.sender).run s').fst = EVM.Uint256.sub (s.storageMap 0 s.sender) amount := by
-  show ((getBalance s.sender).run ((withdraw amount).run s).snd).fst = _
-  rw [getBalance_returns_balance]
+  simp only [getBalance_returns_balance]
   exact withdraw_decreases_balance s amount h_balance
 
 /-- After transfer, sender's balance is decreased. -/
@@ -63,8 +62,7 @@ theorem transfer_getBalance_sender_correct (s : ContractState) (to : Address) (a
   (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((transfer to amount).run s).snd
   ((getBalance s.sender).run s').fst = EVM.Uint256.sub (s.storageMap 0 s.sender) amount := by
-  show ((getBalance s.sender).run ((transfer to amount).run s).snd).fst = _
-  rw [getBalance_returns_balance]
+  simp only [getBalance_returns_balance]
   exact transfer_decreases_sender s to amount h_balance h_ne h_no_overflow
 
 /-- After transfer, recipient's balance is increased. -/
@@ -73,8 +71,7 @@ theorem transfer_getBalance_recipient_correct (s : ContractState) (to : Address)
   (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((transfer to amount).run s).snd
   ((getBalance to).run s').fst = EVM.Uint256.add (s.storageMap 0 to) amount := by
-  show ((getBalance to).run ((transfer to amount).run s).snd).fst = _
-  rw [getBalance_returns_balance]
+  simp only [getBalance_returns_balance]
   exact transfer_increases_recipient s to amount h_balance h_ne h_no_overflow
 
 /-! ## Deposit-Withdraw Cancellation

--- a/Verity/Proofs/SimpleToken/Correctness.lean
+++ b/Verity/Proofs/SimpleToken/Correctness.lean
@@ -115,8 +115,7 @@ theorem mint_then_balanceOf_correct (s : ContractState) (to : Address) (amount :
   (h_no_sup_overflow : (s.storage 2 : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((mint to amount).run s).snd
   ((balanceOf to).run s').fst = EVM.Uint256.add (s.storageMap 1 to) amount := by
-  show ((balanceOf to).run ((mint to amount).run s).snd).fst = _
-  rw [balanceOf_returns_balance, mint_increases_balance s to amount h_owner h_no_bal_overflow h_no_sup_overflow]
+  simp only [balanceOf_returns_balance, mint_increases_balance s to amount h_owner h_no_bal_overflow h_no_sup_overflow]
 
 /-- After minting, getTotalSupply returns the increased supply. -/
 theorem mint_then_getTotalSupply_correct (s : ContractState) (to : Address) (amount : Uint256)
@@ -125,8 +124,7 @@ theorem mint_then_getTotalSupply_correct (s : ContractState) (to : Address) (amo
   (h_no_sup_overflow : (s.storage 2 : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((mint to amount).run s).snd
   ((getTotalSupply).run s').fst = EVM.Uint256.add (s.storage 2) amount := by
-  show ((getTotalSupply).run ((mint to amount).run s).snd).fst = _
-  rw [getTotalSupply_returns_supply, mint_increases_supply s to amount h_owner h_no_bal_overflow h_no_sup_overflow]
+  simp only [getTotalSupply_returns_supply, mint_increases_supply s to amount h_owner h_no_bal_overflow h_no_sup_overflow]
 
 /-- After transfer, sender's balance is decreased by the transfer amount. -/
 theorem transfer_then_balanceOf_sender_correct (s : ContractState) (to : Address) (amount : Uint256)
@@ -134,8 +132,7 @@ theorem transfer_then_balanceOf_sender_correct (s : ContractState) (to : Address
   (h_no_overflow : (s.storageMap 1 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((transfer to amount).run s).snd
   ((balanceOf s.sender).run s').fst = EVM.Uint256.sub (s.storageMap 1 s.sender) amount := by
-  show ((balanceOf s.sender).run ((transfer to amount).run s).snd).fst = _
-  rw [balanceOf_returns_balance]
+  simp only [balanceOf_returns_balance]
   exact transfer_decreases_sender_balance s to amount h_balance h_ne h_no_overflow
 
 /-- After transfer, recipient's balance is increased by the transfer amount. -/
@@ -144,8 +141,7 @@ theorem transfer_then_balanceOf_recipient_correct (s : ContractState) (to : Addr
   (h_no_overflow : (s.storageMap 1 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
   let s' := ((transfer to amount).run s).snd
   ((balanceOf to).run s').fst = EVM.Uint256.add (s.storageMap 1 to) amount := by
-  show ((balanceOf to).run ((transfer to amount).run s).snd).fst = _
-  rw [balanceOf_returns_balance]
+  simp only [balanceOf_returns_balance]
   exact transfer_increases_recipient_balance s to amount h_balance h_ne h_no_overflow
 
 /-! ## Summary


### PR DESCRIPTION
## Summary
- Replace `show <expanded-let-binding>; rw [lemma]` with `simp only [lemma]` in composition theorems
- `simp only` both unfolds the `let` binding and rewrites, eliminating the need for the explicit `show` step
- Applied across 3 files: Counter/Correctness, Ledger/Correctness, SimpleToken/Correctness (8 occurrences)

## Test plan
- [x] `lake build` passes (86 modules)
- [x] Axiom location check passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-script-only changes that preserve theorem statements and rely on existing lemmas; risk is limited to potential tactic brittleness or proof maintenance issues.
> 
> **Overview**
> Refactors several Lean correctness/composition proofs to replace explicit `show` + `rw` steps with `simp only` rewrites that unfold the `let`-bound intermediate state and apply the relevant lemma in one step.
> 
> This cleanup is applied across `Counter/Correctness.lean`, `Ledger/Correctness.lean`, and `SimpleToken/Correctness.lean` (including the decrement-at-zero edge case and mint/transfer/withdraw composition theorems), reducing proof boilerplate without changing any stated theorems.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5be174a88e091d318d56c83aa7687ed9bff08f8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->