### PR TITLE
Merge two-step simp only+simp into single simp calls (-5 lines)

### DIFF
--- a/Verity/Proofs/Owned/Basic.lean
+++ b/Verity/Proofs/Owned/Basic.lean
@@ -128,11 +128,10 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  simp only [transferOwnership, onlyOwner, isOwner, owner,
+  simp [transferOwnership, onlyOwner, isOwner, owner,
     msgSender, getStorageAddr, setStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
-  simp [h_owner]
+    Contract.run, ContractResult.snd, ContractResult.fst, h_owner]
 
 theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
   (h_is_owner : s.sender = s.storageAddr 0) :

--- a/Verity/Proofs/Owned/Correctness.lean
+++ b/Verity/Proofs/Owned/Correctness.lean
@@ -27,11 +27,11 @@ The fundamental access control property: non-owners cannot transfer ownership.
 theorem transferOwnership_reverts_when_not_owner (s : ContractState) (newOwner : Address)
   (h_not_owner : s.sender ≠ s.storageAddr 0) :
   ∃ msg, (transferOwnership newOwner).run s = ContractResult.revert msg s := by
-  simp only [transferOwnership, onlyOwner, isOwner, owner,
+  simp [transferOwnership, onlyOwner, isOwner, owner,
     msgSender, getStorageAddr, setStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
-  simp [address_beq_false_of_ne s.sender (s.storageAddr 0) h_not_owner]
+    Contract.run, ContractResult.snd, ContractResult.fst,
+    address_beq_false_of_ne s.sender (s.storageAddr 0) h_not_owner]
 
 /-! ## Invariant Preservation -/
 
@@ -53,11 +53,10 @@ theorem constructor_transferOwnership_getOwner (s : ContractState) (initialOwner
   let s1 := ((constructor initialOwner).run s).snd
   let s2 := ((transferOwnership newOwner).run s1).snd
   ((getOwner).run s2).fst = newOwner := by
-  simp only [constructor, transferOwnership, onlyOwner, isOwner, owner, getOwner,
+  simp [constructor, transferOwnership, onlyOwner, isOwner, owner, getOwner,
     msgSender, getStorageAddr, setStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
-  simp [h_sender]
+    Contract.run, ContractResult.snd, ContractResult.fst, h_sender]
 
 /-- After ownership transfer, the previous owner can no longer transfer.
     Proves that ownership is truly transferred, not just copied. -/

--- a/Verity/Proofs/OwnedCounter/Basic.lean
+++ b/Verity/Proofs/OwnedCounter/Basic.lean
@@ -24,10 +24,10 @@ open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne)
 
 private theorem onlyOwner_reverts (s : ContractState) (h : s.sender ≠ s.storageAddr 0) :
     onlyOwner s = ContractResult.revert "Caller is not the owner" s := by
-  simp only [onlyOwner, isOwner, owner, msgSender, getStorageAddr,
+  simp [onlyOwner, isOwner, owner, msgSender, getStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    ContractResult.snd, ContractResult.fst]
-  simp [address_beq_false_of_ne s.sender (s.storageAddr 0) h]
+    ContractResult.snd, ContractResult.fst,
+    address_beq_false_of_ne s.sender (s.storageAddr 0) h]
 
 private theorem guarded_reverts (f : Unit → Contract α) (s : ContractState)
     (h : s.sender ≠ s.storageAddr 0) :
@@ -107,11 +107,10 @@ theorem increment_unfold (s : ContractState)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  simp only [increment, onlyOwner, isOwner, owner, count,
+  simp [increment, onlyOwner, isOwner, owner, count,
     msgSender, getStorageAddr, getStorage, setStorage,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
-  simp [h_owner]
+    Contract.run, ContractResult.snd, ContractResult.fst, h_owner]
 
 theorem increment_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -152,11 +151,10 @@ theorem decrement_unfold (s : ContractState)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  simp only [decrement, onlyOwner, isOwner, owner, count,
+  simp [decrement, onlyOwner, isOwner, owner, count,
     msgSender, getStorageAddr, getStorage, setStorage,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
-  simp [h_owner]
+    Contract.run, ContractResult.snd, ContractResult.fst, h_owner]
 
 theorem decrement_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -196,11 +194,10 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  simp only [transferOwnership, onlyOwner, isOwner, owner,
+  simp [transferOwnership, onlyOwner, isOwner, owner,
     msgSender, getStorageAddr, setStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
-  simp [h_owner]
+    Contract.run, ContractResult.snd, ContractResult.fst, h_owner]
 
 theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :


### PR DESCRIPTION
## Summary
- Replace `simp only [defs...]; simp [hypothesis]` with `simp [defs..., hypothesis]` in 6 proof helpers
- The two-step pattern (unfold definitions then close with a hypothesis) can be a single `simp` call
- Applied across Owned/Basic.lean (1), Owned/Correctness.lean (2), OwnedCounter/Basic.lean (4 — onlyOwner_reverts, increment_unfold, decrement_unfold, transferOwnership_unfold)

## Test plan
- [x] `lake build` passes (86 modules)
- [x] Axiom location check passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that should be behavior-preserving, with limited risk mainly around simp performance/termination or brittleness in future proof maintenance.
> 
> **Overview**
> Refactors several Lean proof helpers in `Owned` and `OwnedCounter` to **collapse two-step `simp only [...]` then `simp [...]` sequences into a single `simp [...]` invocation**, inlining the hypothesis (e.g., `h_owner`, `h_sender`, `h_not_owner`) into the same simp set.
> 
> This is a proof-maintenance cleanup only; it does not change contract logic or specifications, but it may subtly affect proof search/simp behavior in the touched theorems (e.g., `transferOwnership_unfold`, guard revert proofs, and `increment`/`decrement` unfolds).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18bae53a24a2d4eed2a3db484585a29d4850e728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->