### PR TITLE
Merge constructor proof simp pairs in SpecCorrectness (-2 lines)

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -57,8 +57,8 @@ theorem owned_constructor_correct (state : ContractState) (initialOwner : Addres
     specResult.success = true ∧
     specResult.finalStorage.getSlot 0 = addressToNat (edslResult.getState.storageAddr 0) := by
   simp [Verity.Examples.Owned.constructor, Contract.run, ownedSpec, interpretSpec,
-    setStorageAddr, Verity.Examples.Owned.owner, Verity.bind, Verity.pure]
-  simp [execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
+    setStorageAddr, Verity.Examples.Owned.owner, Verity.bind, Verity.pure,
+    execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
 
 /-- The `transferOwnership` function correctly transfers ownership when called by owner -/
 theorem transferOwnership_correct_as_owner (state : ContractState) (newOwner : Address) (sender : Address)

--- a/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
@@ -66,8 +66,8 @@ theorem ownedCounter_constructor_correct (state : ContractState) (initialOwner :
     specResult.success = true ∧
     specResult.finalStorage.getSlot 0 = addressToNat (edslResult.getState.storageAddr 0) := by
   simp [Verity.Examples.OwnedCounter.constructor, Contract.run, ownedCounterSpec, interpretSpec,
-    setStorageAddr, Verity.Examples.OwnedCounter.owner, Verity.bind, Verity.pure]
-  simp [execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
+    setStorageAddr, Verity.Examples.OwnedCounter.owner, Verity.bind, Verity.pure,
+    execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
 
 /-- The `increment` function correctly increments when called by owner -/
 theorem ownedCounter_increment_correct_as_owner (state : ContractState) (sender : Address)


### PR DESCRIPTION
## Summary
- Merge consecutive `simp` calls in constructor correctness proofs for Owned and OwnedCounter SpecCorrectness files
- The EDSL unfolding simp and spec execution simp can be a single call

## Test plan
- [x] `lake build` passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof-script refactor (simp list reorganization) with no impact on runtime code or spec semantics; risk is limited to potential proof fragility if simp behavior changes.
> 
> **Overview**
> Simplifies the constructor correctness proofs in `SpecCorrectness/Owned.lean` and `SpecCorrectness/OwnedCounter.lean` by merging two consecutive `simp` calls into one, combining the EDSL-unfolding and spec-execution simp lemma lists.
> 
> No proof statements or goals change; this is a small proof-maintenance refactor that reduces duplication and keeps simplification assumptions in one place.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34d266f595e2082500480c978225fad73d79bb27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->