### PR TITLE
Standardize SpecCorrectness theorem naming with contract prefixes

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Counter.lean
+++ b/Compiler/Proofs/SpecCorrectness/Counter.lean
@@ -81,7 +81,7 @@ private theorem evalExpr_decrement_eq (state : ContractState) (sender : Address)
 /- Correctness Theorems -/
 
 /-- The `increment` function correctly increments the counter with modular arithmetic -/
-theorem increment_correct (state : ContractState) (sender : Address) :
+theorem counter_increment_correct (state : ContractState) (sender : Address) :
     let edslFinal := (increment.runState { state with sender := sender })
     let specTx : DiffTestTypes.Transaction := {
       sender := sender
@@ -97,7 +97,7 @@ theorem increment_correct (state : ContractState) (sender : Address) :
   rfl
 
 /-- The `decrement` function correctly decrements the counter with modular arithmetic -/
-theorem decrement_correct (state : ContractState) (sender : Address) :
+theorem counter_decrement_correct (state : ContractState) (sender : Address) :
     let edslFinal := (decrement.runState { state with sender := sender })
     let specTx : DiffTestTypes.Transaction := {
       sender := sender
@@ -118,7 +118,7 @@ theorem decrement_correct (state : ContractState) (sender : Address) :
     exact evalExpr_decrement_eq state sender
 
 /-- The `getCount` function correctly retrieves the counter value -/
-theorem getCount_correct (state : ContractState) (sender : Address) :
+theorem counter_getCount_correct (state : ContractState) (sender : Address) :
     let edslValue := (getCount.runValue { state with sender := sender }).val
     let specTx : DiffTestTypes.Transaction := {
       sender := sender
@@ -134,13 +134,13 @@ theorem getCount_correct (state : ContractState) (sender : Address) :
 /- Helper Properties -/
 
 /-- `getCount` does not modify storage -/
-theorem getCount_preserves_state (state : ContractState) (sender : Address) :
+theorem counter_getCount_preserves_state (state : ContractState) (sender : Address) :
     let finalState := getCount.runState { state with sender := sender }
     finalState.storage 0 = state.storage 0 := by
   simp [getCount, Contract.runState, getStorage, count]
 
 /-- Incrementing then decrementing returns to original value (when not wrapping) -/
-theorem increment_decrement_roundtrip (state : ContractState) (sender : Address)
+theorem counter_increment_decrement_roundtrip (state : ContractState) (sender : Address)
     (_h : (state.storage 0).val < Verity.Core.MAX_UINT256) :
     let afterInc := increment.runState { state with sender := sender }
     let afterDec := decrement.runState { afterInc with sender := sender }
@@ -151,7 +151,7 @@ theorem increment_decrement_roundtrip (state : ContractState) (sender : Address)
   exact Verity.EVM.Uint256.sub_add_cancel (state.storage 0) 1
 
 /-- Decrementing then incrementing returns to original value (when not wrapping) -/
-theorem decrement_increment_roundtrip (state : ContractState) (sender : Address)
+theorem counter_decrement_increment_roundtrip (state : ContractState) (sender : Address)
     (_h : (state.storage 0).val > 0) :
     let afterDec := decrement.runState { state with sender := sender }
     let afterInc := increment.runState { afterDec with sender := sender }

--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -61,7 +61,7 @@ theorem owned_constructor_correct (state : ContractState) (initialOwner : Addres
     execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
 
 /-- The `transferOwnership` function correctly transfers ownership when called by owner -/
-theorem transferOwnership_correct_as_owner (state : ContractState) (newOwner : Address) (sender : Address)
+theorem owned_transferOwnership_correct_as_owner (state : ContractState) (newOwner : Address) (sender : Address)
     (h : state.storageAddr 0 = sender) :
     let edslResult := (transferOwnership newOwner).run { state with sender := sender }
     let specTx : DiffTestTypes.Transaction := {
@@ -87,7 +87,7 @@ theorem transferOwnership_correct_as_owner (state : ContractState) (newOwner : A
       evalExpr, SpecStorage.getSlot, SpecStorage.setSlot, h, addressToNat_mod_eq]
 
 /-- The `transferOwnership` function correctly reverts when called by non-owner -/
-theorem transferOwnership_reverts_as_nonowner (state : ContractState) (newOwner : Address) (sender : Address)
+theorem owned_transferOwnership_reverts_as_nonowner (state : ContractState) (newOwner : Address) (sender : Address)
     (h : state.storageAddr 0 ≠ sender) :
     let edslResult := (transferOwnership newOwner).run { state with sender := sender }
     let specTx : DiffTestTypes.Transaction := {
@@ -110,7 +110,7 @@ theorem transferOwnership_reverts_as_nonowner (state : ContractState) (newOwner 
       addressToNat_beq_false_of_ne sender (state.storageAddr 0) (Ne.symm h)]
 
 /-- The `getOwner` function correctly retrieves the owner address -/
-theorem getOwner_correct (state : ContractState) (sender : Address) :
+theorem owned_getOwner_correct (state : ContractState) (sender : Address) :
     let edslAddr := getOwner.runValue { state with sender := sender }
     let specTx : DiffTestTypes.Transaction := {
       sender := sender
@@ -126,13 +126,13 @@ theorem getOwner_correct (state : ContractState) (sender : Address) :
 /- Helper Properties -/
 
 /-- `getOwner` does not modify storage -/
-theorem getOwner_preserves_state (state : ContractState) (sender : Address) :
+theorem owned_getOwner_preserves_state (state : ContractState) (sender : Address) :
     let finalState := getOwner.runState { state with sender := sender }
     finalState.storageAddr 0 = state.storageAddr 0 := by
   simp [Verity.Examples.Owned.getOwner, Contract.runState, getStorageAddr, Verity.Examples.Owned.owner]
 
 /-- Only owner can transfer ownership -/
-theorem only_owner_can_transfer (state : ContractState) (newOwner : Address) (sender : Address) :
+theorem owned_only_owner_can_transfer (state : ContractState) (newOwner : Address) (sender : Address) :
     ((transferOwnership newOwner).run { state with sender := sender }).isSuccess = true →
     state.storageAddr 0 = sender := by
   intro h_success
@@ -150,13 +150,13 @@ theorem only_owner_can_transfer (state : ContractState) (newOwner : Address) (se
     "Caller is not the owner" _ h_require_success).symm
 
 /-- Constructor sets initial owner correctly -/
-theorem constructor_sets_owner (state : ContractState) (initialOwner : Address) (sender : Address) :
+theorem owned_constructor_sets_owner (state : ContractState) (initialOwner : Address) (sender : Address) :
     let finalState := (constructor initialOwner).runState { state with sender := sender }
     finalState.storageAddr 0 = initialOwner := by
   simp [Verity.Examples.Owned.constructor, Contract.runState, setStorageAddr, Verity.Examples.Owned.owner, Verity.bind]
 
 /-- TransferOwnership updates owner when authorized -/
-theorem transferOwnership_updates_owner (state : ContractState) (newOwner : Address) (sender : Address)
+theorem owned_transferOwnership_updates_owner (state : ContractState) (newOwner : Address) (sender : Address)
     (h : state.storageAddr 0 = sender) :
     let finalState := (Verity.Examples.Owned.transferOwnership newOwner).runState { state with sender := sender }
     finalState.storageAddr 0 = newOwner := by


### PR DESCRIPTION
## Summary
- Adds consistent contract-name prefixes to all SpecCorrectness theorems in Counter, SimpleStorage, and Owned
- These three files had unprefixed names (`increment_correct`, `store_correct`, `transferOwnership_correct_as_owner`) while the other four contracts (Ledger, OwnedCounter, SafeCounter, SimpleToken) consistently used prefixes (`ledger_deposit_correct`, `ownedCounter_increment_correct_as_owner`, etc.)
- Also renames `edslToSpecStorage` → `simpleStorageEdslToSpecStorage` in SimpleStorage for consistency with other files

| File | Before | After |
|------|--------|-------|
| Counter | `increment_correct` | `counter_increment_correct` |
| SimpleStorage | `store_correct` | `simpleStorage_store_correct` |
| Owned | `transferOwnership_correct_as_owner` | `owned_transferOwnership_correct_as_owner` |

## Test plan
- [x] `lake build` passes (all 86 modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_contract_structure.py` passes
- [x] `check_property_manifest.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely mechanical renames in proof modules; risk is limited to breaking downstream references/imports that relied on the old theorem/helper names.
> 
> **Overview**
> Standardizes theorem naming in `Compiler/Proofs/SpecCorrectness` by renaming Counter/Owned/SimpleStorage correctness and helper-property theorems to include a contract prefix (e.g., `counter_*`, `owned_*`, `simpleStorage_*`).
> 
> Also renames SimpleStorage’s state conversion helper from `edslToSpecStorage` to `simpleStorageEdslToSpecStorage` and updates call sites accordingly; no proof logic or spec/EDSL semantics are changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a80f9451b7fae1a1a2419ab77fe5561894a1c4e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->