### PR TITLE
Fix stale coverage number, docs URL, and generator imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The compiler validates function names, arities, and prevents name collisions. Se
 
 | | |
 |---|---|
-| [Docs Site](https://verity.thomas.md/) | Full documentation site with guides and DSL reference |
+| [Docs Site](https://verity.thomasm.ar/) | Full documentation site with guides and DSL reference |
 | [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) | What's verified, what's trusted, trust reduction roadmap |
 | [`AXIOMS.md`](AXIOMS.md) | All 2 axioms with soundness justifications |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Coding conventions, workflow, PR guidelines |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,7 +62,7 @@ Example output:
    Covered:    52 ( 88.1%)
    Excluded:     7 (proof-only)
 
-Overall: 67% coverage (220/326 properties)
+Overall: 59% coverage (220/371 properties)
 ```
 
 ### Property Exclusions

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -408,7 +408,7 @@ def gen_spec(cfg: ContractConfig) -> str:
             spec_defs.append(f"  True")
         spec_defs.append("")
 
-    imports = ["import Verity.Core", "import Verity.Specs.Common"]
+    imports = ["import Verity.Specs.Common"]
     opens = ["open Verity"]
     if _needs_uint256_import(cfg):
         imports.append("import Verity.EVM.Uint256")
@@ -460,7 +460,6 @@ def gen_invariants(cfg: ContractConfig) -> str:
   ContractState instances used with {cfg.name}.
 -/
 
-import Verity.Core
 import Verity.Specs.Common
 
 namespace Verity.Specs.{cfg.name}
@@ -537,7 +536,6 @@ def gen_basic_proofs(cfg: ContractConfig) -> str:
         proof_stubs.append("")
 
     imports = [
-        "import Verity.Core",
         f"import Verity.Examples.{cfg.name}",
         f"import Verity.Specs.{cfg.name}.Spec",
         f"import Verity.Specs.{cfg.name}.Invariants",
@@ -583,10 +581,6 @@ def gen_correctness_proofs(cfg: ContractConfig) -> str:
   Status: Scaffold — proofs need implementation.
 -/
 
-import Verity.Core
-import Verity.Examples.{cfg.name}
-import Verity.Specs.{cfg.name}.Spec
-import Verity.Specs.{cfg.name}.Invariants
 import Verity.Proofs.{cfg.name}.Basic
 
 namespace Verity.Proofs.{cfg.name}.Correctness


### PR DESCRIPTION
## Summary
- **scripts/README.md**: Example output showed `67% coverage (220/326 properties)` which is stale from when there were fewer theorems. Corrected to `59% coverage (220/371 properties)`
- **README.md**: Two different documentation URLs (`verity.thomas.md` vs `verity.thomasm.ar`). Standardized to `verity.thomasm.ar` which is used in the more prominent location
- **scripts/generate_contract.py**: Removed redundant `import Verity.Core` from 3 generated templates (Spec.lean, Invariants.lean, Correctness.lean) — all existing files get this transitively through `Verity.Specs.Common` or other imports

## Test plan
- [x] `lake build` passes (all 86 modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_contract_structure.py` passes
- [x] `check_property_manifest.py` passes
- [x] `check_doc_counts.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits plus a minor generator template change that only affects newly scaffolded files and should be covered by builds/import resolution.
> 
> **Overview**
> Fixes documentation drift by standardizing the docs URL in `README.md` and updating the example property-test coverage line in `scripts/README.md` to match the current theorem/property totals.
> 
> Simplifies Lean scaffold output from `scripts/generate_contract.py` by removing redundant `import Verity.Core` from generated `Spec.lean`, `Invariants.lean`, and `Correctness.lean` templates (relying on existing transitive imports).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8dbbb69c95f1db927275e7709e026bd11bb28b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->