### PR TITLE
refactor: remove legacy FieldType.mapping constructor

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -61,7 +61,6 @@ inductive MappingType
 inductive FieldType
   | uint256
   | address
-  | mapping   -- Address → Uint256 (legacy, equivalent to mappingTyped (.simple .address))
   | mappingTyped (mt : MappingType)  -- Flexible mapping types (#154)
   deriving Repr, BEq
 
@@ -94,7 +93,6 @@ structure Param where
 def FieldType.toIRType : FieldType → IRType
   | uint256 => IRType.uint256
   | address => IRType.address
-  | mapping => IRType.uint256  -- Mappings return uint256
   | mappingTyped _ => IRType.uint256  -- All mappings return uint256
 
 def ParamType.toIRType : ParamType → IRType
@@ -242,7 +240,7 @@ def findFieldSlot (fields : List Field) (name : String) : Option Nat :=
 -- Helper: Is field a mapping? (legacy or typed)
 def isMapping (fields : List Field) (name : String) : Bool :=
   fields.find? (·.name == name) |>.any fun f =>
-    f.ty == FieldType.mapping || match f.ty with
+    match f.ty with
     | FieldType.mappingTyped _ => true
     | _ => false
 

--- a/Compiler/Specs.lean
+++ b/Compiler/Specs.lean
@@ -153,7 +153,7 @@ def ownedSpec : ContractSpec := {
 def ledgerSpec : ContractSpec := {
   name := "Ledger"
   fields := [
-    { name := "balances", ty := FieldType.mapping }
+    { name := "balances", ty := FieldType.mappingTyped (.simple .address) }
   ]
   constructor := none
   functions := [
@@ -264,7 +264,7 @@ def simpleTokenSpec : ContractSpec := {
   name := "SimpleToken"
   fields := [
     { name := "owner", ty := FieldType.address },
-    { name := "balances", ty := FieldType.mapping },
+    { name := "balances", ty := FieldType.mappingTyped (.simple .address) },
     { name := "totalSupply", ty := FieldType.uint256 }
   ]
   constructor := some {

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -206,7 +206,7 @@ forge create SimpleStorage --from 0x... --private-key ...
 ```lean
 fields := [
   { name := "owner", ty := FieldType.address },     -- slot 0
-  { name := "balances", ty := FieldType.mapping },  -- slot 1
+  { name := "balances", ty := FieldType.mappingTyped (.simple .address) },  -- slot 1
   { name := "totalSupply", ty := FieldType.uint256 } -- slot 2
 ]
 ```
@@ -410,7 +410,7 @@ Define reusable logic shared across multiple external functions. Internal functi
 ```lean
 def mySpec : ContractSpec := {
   name := "MyContract"
-  fields := [{ name := "balances", ty := FieldType.mapping }]
+  fields := [{ name := "balances", ty := FieldType.mappingTyped (.simple .address) }]
   functions := [
     -- Internal helper (not exposed)
     { name := "addBalance"
@@ -458,7 +458,7 @@ Emit EVM events for standards compliance (ERC20 Transfer/Approval, etc.):
 ```lean
 def tokenSpec : ContractSpec := {
   name := "Token"
-  fields := [{ name := "balances", ty := FieldType.mapping }]
+  fields := [{ name := "balances", ty := FieldType.mappingTyped (.simple .address) }]
   events := [
     { name := "Transfer"
       params := [

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -363,7 +363,7 @@ Add your contract to `Compiler/Specs.lean`:
 def tipJarSpec : ContractSpec := {
   name := "TipJar"
   fields := [
-    { name := "tips", ty := FieldType.mapping }
+    { name := "tips", ty := FieldType.mappingTyped (.simple .address) }
   ]
   constructor := none
   functions := [


### PR DESCRIPTION
## Summary

- Remove the legacy `FieldType.mapping` constructor from the `FieldType` inductive type in `ContractSpec.lean`
- Replace its two usages in `ledgerSpec` and `simpleTokenSpec` with the equivalent `FieldType.mappingTyped (.simple .address)`
- Simplify the `isMapping` helper to only match on `mappingTyped` (removing the dead `== FieldType.mapping ||` branch)
- Update documentation examples in `compiler.mdx` and `first-contract.mdx`

The `FieldType.mapping` variant was explicitly annotated as "legacy, equivalent to `mappingTyped (.simple .address)`" — both compiled to identical Yul output via `isMapping`/`compileMappingSlotRead`/`compileMappingSlotWrite`. Removing it eliminates a dead code path and ensures all mapping fields use the typed representation uniformly.

## Changes

| File | Change |
|------|--------|
| `Compiler/ContractSpec.lean` | Remove `mapping` constructor, `toIRType` case, simplify `isMapping` |
| `Compiler/Specs.lean` | `FieldType.mapping` → `FieldType.mappingTyped (.simple .address)` in 2 specs |
| `docs-site/content/compiler.mdx` | Update 3 code examples |
| `docs-site/content/guides/first-contract.mdx` | Update 1 code example |

Net: **-2 lines** across 4 files.

## Test plan

- [x] All 86 Lean modules build successfully
- [x] All CI check scripts pass (manifest, coverage, doc counts, structure, axioms, storage layout, hygiene, selectors, Yul compilation)
- [x] No `sorry`, 371 theorems, 2 axioms unchanged
- [x] Generated Yul output unchanged (7 contracts compile to identical bytecode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor removing a deprecated type constructor and updating call sites/docs; runtime behavior should be unchanged aside from potential downstream compile breaks for external specs still using `FieldType.mapping`.
> 
> **Overview**
> **Removes the legacy `FieldType.mapping` variant** from `Compiler/ContractSpec.lean`, including its `toIRType` case, and simplifies `isMapping` to only recognize `FieldType.mappingTyped`.
> 
> Updates the built-in contract specs (`ledgerSpec`, `simpleTokenSpec`) and documentation examples to use the explicit typed form `FieldType.mappingTyped (.simple .address)` for address→uint256 mappings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c50e367b533dec4fd938b40310b2c060dce193b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->