### PR TITLE
fix: update stale comment and fix generate_contract.py for FieldType.mapping removal

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -237,7 +237,7 @@ Automatically compile a ContractSpec to IRContract.
 def findFieldSlot (fields : List Field) (name : String) : Option Nat :=
   fields.findIdx? (·.name == name)
 
--- Helper: Is field a mapping? (legacy or typed)
+-- Helper: Is field a mapping?
 def isMapping (fields : List Field) (name : String) : Bool :=
   fields.find? (·.name == name) |>.any fun f =>
     match f.ty with

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -68,6 +68,8 @@ class Field:
     @property
     def compiler_field_type(self) -> str:
         """FieldType variant for Compiler/Specs.lean."""
+        if self.ty == "mapping":
+            return "FieldType.mappingTyped (.simple .address)"
         if self.ty == "mapping_uint":
             return "FieldType.mappingTyped (.simple .uint256)"
         return f"FieldType.{self.ty}"


### PR DESCRIPTION
## Summary

Two follow-up fixes from PR #462 (which removed the legacy `FieldType.mapping` constructor):

- **`Compiler/ContractSpec.lean`**: Updated stale `isMapping` comment from "Is field a mapping? (legacy or typed)" to "Is field a mapping?" — the legacy variant no longer exists
- **`scripts/generate_contract.py`**: Fixed bug where `compiler_field_type` fell through to `f"FieldType.{self.ty}"` when `self.ty == "mapping"`, producing the now-removed `FieldType.mapping`. Added explicit branch that generates `FieldType.mappingTyped (.simple .address)` instead

## Before/After

Running `generate_contract.py --fields "balances:mapping"`:

| | Generated code |
|---|---|
| Before | `{ name := "balances", ty := FieldType.mapping }` (broken — constructor removed) |
| After | `{ name := "balances", ty := FieldType.mappingTyped (.simple .address) }` |

## Test plan

- [x] All 86 Lean modules build successfully
- [x] All CI check scripts pass
- [x] `generate_contract.py --dry-run` produces correct `FieldType.mappingTyped (.simple .address)` for mapping fields
- [x] `mapping(uint256)` and `address` types still generate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small compatibility fix plus a comment update; behavior only changes in scaffolding output for `mapping` fields.
> 
> **Overview**
> Fixes `scripts/generate_contract.py` so `--fields "...:mapping"` emits `FieldType.mappingTyped (.simple .address)` instead of the removed `FieldType.mapping`, preventing generated compiler specs from failing to build.
> 
> Also updates a stale comment in `Compiler/ContractSpec.lean` to reflect that only typed mappings remain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 666f617cdf934b21577780d104c9b8633d045baa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->