### PR TITLE
Remove dead interpretSpecFull, add sorry/native_decide hygiene checks

### DIFF
--- a/scripts/check_lean_hygiene.py
+++ b/scripts/check_lean_hygiene.py
@@ -4,12 +4,16 @@
 Validates:
 1. No debug commands (#eval, #check, #print, #reduce) in proof files
 2. Exactly 1 allowUnsafeReducibility (documented trust assumption)
+3. No sorry in any Lean files (proof completeness)
+4. No native_decide in proof files outside smoke tests (kernel bypass)
 
 Usage:
     python3 scripts/check_lean_hygiene.py
 """
 
 from __future__ import annotations
+
+import re
 
 from property_utils import ROOT, die, report_errors
 
@@ -53,10 +57,74 @@ def main() -> None:
             f"found {unsafe_count}: {unsafe_locations}"
         )
 
+    # Check 3: No sorry in any Lean file (global proof completeness)
+    # Track block comment nesting to skip /- ... -/ and /-! ... -/ comments.
+    sorry_re = re.compile(r"\bsorry\b")
+    sorry_count = 0
+    for lean_file in ROOT.rglob("*.lean"):
+        if ".lake" in str(lean_file):
+            continue
+        rel = lean_file.relative_to(ROOT)
+        block_depth = 0
+        for i, line in enumerate(lean_file.read_text().splitlines(), 1):
+            # Update block comment depth
+            j = 0
+            code_parts: list[str] = []
+            line_len = len(line)
+            while j < line_len:
+                if block_depth > 0:
+                    if j + 1 < line_len and line[j] == "-" and line[j + 1] == "/":
+                        block_depth -= 1
+                        j += 2
+                    elif j + 1 < line_len and line[j] == "/" and line[j + 1] == "-":
+                        block_depth += 1
+                        j += 2
+                    else:
+                        j += 1
+                else:
+                    if j + 1 < line_len and line[j] == "/" and line[j + 1] == "-":
+                        block_depth += 1
+                        j += 2
+                    else:
+                        code_parts.append(line[j])
+                        j += 1
+            code = "".join(code_parts)
+            # Skip line comments
+            comment_idx = code.find("--")
+            if comment_idx >= 0:
+                code = code[:comment_idx]
+            # Remove string literals
+            code = re.sub(r'"[^"]*"', '', code)
+            if sorry_re.search(code):
+                sorry_count += 1
+                errors.append(f"{rel}:{i}: found sorry (incomplete proof)")
+
+    # Check 4: No native_decide in proof files (except smoke tests)
+    # native_decide bypasses the kernel and is acceptable only in smoke tests
+    # that check generated code strings, not in mathematical proofs.
+    native_decide_count = 0
+    for proof_dir in proof_dirs:
+        for lean_file in proof_dir.rglob("*.lean"):
+            rel = lean_file.relative_to(ROOT)
+            # Smoke tests legitimately use native_decide for string comparisons
+            if "SmokeTest" in lean_file.name:
+                continue
+            for i, line in enumerate(lean_file.read_text().splitlines(), 1):
+                stripped = line.lstrip()
+                if stripped.startswith("--"):
+                    continue
+                if "native_decide" in stripped:
+                    native_decide_count += 1
+                    errors.append(
+                        f"{rel}:{i}: found native_decide in proof file "
+                        f"(bypasses kernel — use decide or other tactics)"
+                    )
+
     report_errors(errors, "Lean hygiene check failed")
     print(
         f"Lean hygiene check passed "
-        f"(0 debug commands in proofs, {unsafe_count} allowUnsafeReducibility)."
+        f"(0 debug commands in proofs, {unsafe_count} allowUnsafeReducibility, "
+        f"0 sorry, 0 native_decide in proofs)."
     )
 
 


### PR DESCRIPTION
## Summary
- Remove `interpretSpecFull` from `SpecInterpreter.lean` — 42 lines of dead code with zero callers anywhere in the codebase. The fuel-based building blocks (`execFunctionFuel`, `execConstructorFuel`) remain available for future use.
- Update 3 doc-comments that referenced the removed function.
- Strengthen `check_lean_hygiene.py` with two new checks:
  - **Global `sorry` detection**: scans all `.lean` files (excluding `.lake/`), properly handling nested block comments (`/- -/`), line comments (`--`), and string literals to avoid false positives.
  - **`native_decide` detection** in proof files: flags kernel-bypassing `native_decide` in `Compiler/Proofs` and `Verity/Proofs`, while exempting `SmokeTests` files where it's appropriate for string comparisons.

## Test plan
- [x] `lake build` passes (86/86 modules)
- [x] `check_lean_hygiene.py` passes with new checks (0 sorry, 0 native_decide in proofs)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes
- [x] `check_axiom_locations.py` passes
- [x] `check_property_coverage.py` passes
- [x] `check_contract_structure.py` passes
- [x] `check_selectors.py` passes
- [x] `check_storage_layout.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly deletes dead code and adds stricter CI-style static checks; main risk is false positives/negatives in the new `sorry`/comment parsing causing hygiene failures.
> 
> **Overview**
> Removes the unused fuel-based top-level interpreter `interpretSpecFull` from `SpecInterpreter.lean` and updates nearby doc comments to reference only `execFunctionFuel`/`execConstructorFuel`.
> 
> Strengthens `scripts/check_lean_hygiene.py` by adding repo-wide detection of `sorry` (skipping nested block comments, line comments, and string literals) and flagging `native_decide` usages in proof directories except `*SmokeTest*` files, updating the success output accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd8a5198b16d8c123fd2de78b35ee190db6cb27d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->