### PR TITLE
Add NoDup supply conservation corollaries for SimpleToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/Th0rgal/verity/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/built%20with-Lean%204-blueviolet.svg" alt="Built with Lean 4"></a>
-  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-371-brightgreen.svg" alt="371 Theorems"></a>
+  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-373-brightgreen.svg" alt="373 Theorems"></a>
   <a href="https://github.com/Th0rgal/verity/actions"><img src="https://img.shields.io/github/actions/workflow/status/Th0rgal/verity/verify.yml?label=verify" alt="Verify"></a>
 </p>
 
@@ -28,7 +28,7 @@ source ~/.elan/env
 # 2. Clone and build
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                                    # Verifies all 371 theorems
+lake build                                    # Verifies all 373 theorems
 
 # 3. Generate a new contract
 python3 scripts/generate_contract.py MyContract
@@ -86,7 +86,7 @@ One spec can have many competing implementations - naive, gas-optimized, packed 
 | Owned | 23 | Access control and ownership transfer |
 | OwnedCounter | 48 | Cross-pattern composition, lockout proofs |
 | Ledger | 33 | Deposit/withdraw/transfer with balance conservation |
-| SimpleToken | 59 | Mint/transfer, supply conservation, storage isolation |
+| SimpleToken | 61 | Mint/transfer, supply conservation, storage isolation |
 | ReentrancyExample | 4 | Reentrancy vulnerability vs safe withdrawal |
 
 **Unverified examples**: [CryptoHash](Verity/Examples/CryptoHash.lean) demonstrates external library linking via the [Linker](Compiler/Linker.lean) but has no specs or proofs.
@@ -123,7 +123,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-371 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (59% coverage, 151 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+373 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (59% coverage, 153 proof-only exclusions). 2 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -79,7 +79,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: All 371 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (59% runtime test coverage).
+**Coverage**: All 373 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (59% runtime test coverage).
 
 **What this guarantees**:
 - Contract behavior matches specification
@@ -713,7 +713,7 @@ Verity provides **strong formal verification** with a **small trusted computing 
 ✅ Contract implementations match specifications (Layer 1)
 ✅ Specifications preserved through compilation (Layer 2)
 ✅ IR semantics equivalent to Yul semantics (Layer 3)
-✅ 371 theorems across 9 categories (220 covered by property tests)
+✅ 373 theorems across 9 categories (220 covered by property tests)
 
 ### What is Trusted (Validated but Not Proven)
 ⚠️ Solidity compiler (solc) - Validated by 70k+ differential tests

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 
 const banner = (
   <Banner storageKey="verification-complete">
-    371/371 theorems proven — 100% formal verification
+    373/373 theorems proven — 100% formal verification
   </Banner>
 )
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -596,7 +596,7 @@ Time: **~5 minutes** (vs ~30 minutes manual IR)
 
 ### All Tests Pass ✅
 
-**Lean Proofs**: All proofs verified (371 EDSL theorems, 100%)
+**Lean Proofs**: All proofs verified (373 EDSL theorems, 100%)
 ```bash
 $ lake build
 Build completed successfully.
@@ -710,5 +710,5 @@ def ownedSpec : ContractSpec := {
 
 - [Research & Development](/research) — Design decisions and proof techniques
 - [Examples](/examples) — 9 example contracts
-- [Verification](/verification) — 371 proven theorems
+- [Verification](/verification) — 373 proven theorems
 - [GitHub Repository](https://github.com/Th0rgal/verity) — Source code

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -52,7 +52,7 @@ forge --version
 ```bash
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                # Downloads dependencies and verifies all 371 theorems
+lake build                # Downloads dependencies and verifies all 373 theorems
 ```
 
 The first build downloads Mathlib and compiles everything — expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 371 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 373 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 371 theorems, all fully proven. 2 documented axioms, 0 sorry.**
+**Compact core, built across 7 iterations. 373 theorems, all fully proven. 2 documented axioms, 0 sorry.**
 
 ## Evolution
 
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (371 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (373 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,15 +7,15 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 371 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 373 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 2 axioms documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-17)
 
-- EDSL theorems: 371 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
+- EDSL theorems: 373 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
 - SimpleStorage: 20 total (Basic 13, Correctness 7).
 - Counter: 28 total (Basic 19, Correctness 10; 1 shared between Basic and Correctness).
 - Owned: 23 total (Basic 19, Correctness 4).
-- SimpleToken: 59 total (Basic 37, Correctness 10, Supply 3, Isolation 9).
+- SimpleToken: 61 total (Basic 37, Correctness 10, Supply 5, Isolation 9).
 - OwnedCounter: 48 total (Basic 29, Correctness 5, Isolation 14).
 - Ledger: 33 total (Basic 20, Correctness 6, Conservation 7 — all proven).
 - SafeCounter: 25 total (Basic 17, Correctness 8).
@@ -253,6 +253,8 @@ This lets proofs reason about both the success path and the revert path of guard
 | 1 | `constructor_establishes_supply_bounds` | Constructor establishes supply invariant |
 | 2 | `mint_sum_equation` | `new_sum = old_sum + count(to) * amount` |
 | 3 | `transfer_sum_equation` | `new_sum + count(sender)*amt = old_sum + count(to)*amt` |
+| 4 | `mint_sum_singleton_to` | Mint sum equation for singleton recipient list |
+| 5 | `transfer_sum_preserved_unique` | For unique sender & to: `new_sum = old_sum` |
 
 Transfer proofs now handle self-transfer by modeling it as a no-op (preloading balances and applying a zero delta), so `sender != to` is no longer required. Supply conservation still uses exact sum equations rather than the `supply_bounds_balances` invariant, which cannot be preserved for lists with duplicate addresses.
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -17,7 +17,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Language**: Lean 4.15.0
 - **Core Size**: 350 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
-- **Theorems**: 371 across 9 categories (371 fully proven, 0 `sorry` placeholders)
+- **Theorems**: 373 across 9 categories (373 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 2 documented axioms (see AXIOMS.md) — keccak256, address injectivity
 - **Tests**: 375 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
@@ -55,7 +55,7 @@ def bind (x : Contract α) (f : α → Contract β) : Contract β :=
 | SimpleStorage | 20 | Store/retrieve roundtrip, state isolation |
 | Counter | 28 | Arithmetic, composition, decrement-at-zero |
 | Owned | 23 | Access control, ownership transfer |
-| SimpleToken | 59 | Mint/transfer, supply conservation, storage isolation |
+| SimpleToken | 61 | Mint/transfer, supply conservation, storage isolation |
 | OwnedCounter | 48 | Cross-pattern composition, lockout proofs |
 | Ledger | 33 | Deposit/withdraw/transfer, balance conservation |
 | SafeCounter | 25 | Overflow/underflow revert proofs |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,10 +6,10 @@
 
 ## Current Status
 
-- ✅ **Layer 1 Complete**: 371 theorems across 9 categories (8 contracts + Stdlib math library)
+- ✅ **Layer 1 Complete**: 373 theorems across 9 categories (8 contracts + Stdlib math library)
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
-- ✅ **Property Testing**: 59% coverage (220/371), all testable properties covered
+- ✅ **Property Testing**: 59% coverage (220/373), all testable properties covered
 - ✅ **Differential Testing**: Production-ready with 70k+ tests
 - ✅ **Trust Reduction Phase 1**: keccak256 axiom + CI validation (PR #43, #46)
 - ✅ **External Linking**: Cryptographic library support (PR #49)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -58,12 +58,12 @@ EVM Bytecode
 | Owned | 23 | ✅ Complete | `Verity/Proofs/Owned/` |
 | OwnedCounter | 48 | ✅ Complete | `Verity/Proofs/OwnedCounter/` |
 | Ledger | 33 | ✅ Complete | `Verity/Proofs/Ledger/` |
-| SimpleToken | 59 | ✅ Complete | `Verity/Proofs/SimpleToken/` |
+| SimpleToken | 61 | ✅ Complete | `Verity/Proofs/SimpleToken/` |
 | CryptoHash | 0 | ⬜ No specs | `Verity/Examples/CryptoHash.lean` |
 | ReentrancyExample | 4 | ✅ Complete | `Verity/Examples/ReentrancyExample.lean` |
-| **Total** | **240** | **✅ 100%** | — |
+| **Total** | **242** | **✅ 100%** | — |
 
-> **Note**: Stdlib (131 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (371 total properties).
+> **Note**: Stdlib (131 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (373 total properties).
 
 ### Example Property
 
@@ -177,13 +177,13 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ## Property Test Coverage 🎯 **NEAR COMPLETE**
 
-**Status**: 59% coverage (220/371), 151 remaining exclusions all proof-only
+**Status**: 59% coverage (220/373), 153 remaining exclusions all proof-only
 
 ### Current Coverage
 
-- **Total Properties**: 371
+- **Total Properties**: 373
 - **Covered**: 220 (59%)
-- **Excluded**: 151 (all proof-only)
+- **Excluded**: 153 (all proof-only)
 - **Missing**: 0
 
 ### Coverage by Contract
@@ -195,14 +195,14 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 | SimpleStorage | 95% (19/20) | 1 proof-only | ✅ Near-complete |
 | Owned | 87% (20/23) | 3 proof-only | ✅ Near-complete |
 | OwnedCounter | 92% (44/48) | 4 proof-only | ✅ Near-complete |
-| SimpleToken | 88% (52/59) | 7 proof-only | ✅ High coverage |
+| SimpleToken | 85% (52/61) | 9 proof-only | ✅ High coverage |
 | Counter | 82% (23/28) | 5 proof-only | ✅ High coverage |
 | Ledger | 100% (33/33) | 0 | ✅ Complete |
 | Stdlib | 0% (0/131) | 131 proof-only | — Internal |
 
 ### Exclusion Categories
 
-**Proof-Only Properties (151 exclusions)**: Internal proof machinery that cannot be tested in Foundry
+**Proof-Only Properties (153 exclusions)**: Internal proof machinery that cannot be tested in Foundry
 - Storage helpers: `setStorage_*`, `getStorage_*`, `setMapping_*`, `getMapping_*`
 - Internal helpers: `isOwner_*` functions tested implicitly
 - Low-level operations used only in proofs

--- a/examples/solidity/README.md
+++ b/examples/solidity/README.md
@@ -12,7 +12,7 @@ These Solidity contracts serve as **reference implementations** for Verity's dif
 | `Owned.sol` | `Verity/Examples/Owned.lean` | 23 theorems | Access control (owner-only functions) |
 | `OwnedCounter.sol` | `Verity/Examples/OwnedCounter.lean` | 48 theorems | Combined access control + counter |
 | `Ledger.sol` | `Verity/Examples/Ledger.lean` | 33 theorems | Balance mapping (deposit/withdraw/transfer) |
-| `SimpleToken.sol` | `Verity/Examples/SimpleToken.lean` | 59 theorems | Token with mint/transfer + supply invariants |
+| `SimpleToken.sol` | `Verity/Examples/SimpleToken.lean` | 61 theorems | Token with mint/transfer + supply invariants |
 | `ReentrancyExample.sol` | `Verity/Examples/ReentrancyExample.lean` | 4 theorems | Reentrancy guard pattern |
 
 ## How Testing Works

--- a/test/PropertySimpleToken.t.sol
+++ b/test/PropertySimpleToken.t.sol
@@ -8,7 +8,7 @@ import "./yul/YulTestBase.sol";
  * @notice Property-based tests extracted from formally verified Lean theorems
  * @dev Maps theorems from Verity/Proofs/SimpleToken/*.lean to executable tests
  *
- * This file extracts 59 proven theorems into Foundry property tests:
+ * This file extracts 61 proven theorems into Foundry property tests:
  * - Basic properties (constructor, mint, transfer, getters)
  * - Supply conservation (total supply invariant)
  * - Isolation properties (storage independence)

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ function testProperty_StoreRetrieve() public {
 }
 ```
 
-**Coverage**: 220/371 theorems tested (59%), 151 proof-only exclusions documented in `property_exclusions.json`.
+**Coverage**: 220/373 theorems tested (59%), 153 proof-only exclusions documented in `property_exclusions.json`.
 
 ### Differential Tests
 **Pattern**: `Differential<Contract>.t.sol`
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (195 functions, covering 220/371 theorems)
+├── Property*.t.sol           # Property tests (195 functions, covering 220/373 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests

--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -24,10 +24,12 @@
     "getMapping_reads_balance",
     "getStorageAddr_reads_owner",
     "getStorage_reads_supply",
+    "mint_sum_singleton_to",
     "setMapping_preserves_other_addresses",
     "setMapping_updates_balance",
     "setStorageAddr_updates_owner",
-    "setStorage_updates_supply"
+    "setStorage_updates_supply",
+    "transfer_sum_preserved_unique"
   ],
   "Stdlib": [
     "SpecStorage_getMapping_setMapping_diff_slot",

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -232,6 +232,7 @@
     "mint_reverts_supply_overflow",
     "mint_reverts_when_not_owner",
     "mint_sum_equation",
+    "mint_sum_singleton_to",
     "mint_supply_storage_isolated",
     "mint_then_balanceOf_correct",
     "mint_then_getTotalSupply_correct",
@@ -251,6 +252,7 @@
     "transfer_reverts_recipient_overflow",
     "transfer_self_preserves_balance",
     "transfer_sum_equation",
+    "transfer_sum_preserved_unique",
     "transfer_supply_storage_isolated",
     "transfer_then_balanceOf_recipient_correct",
     "transfer_then_balanceOf_sender_correct"


### PR DESCRIPTION
## Summary
- Add `mint_sum_singleton_to`: for lists where `to` appears exactly once, mint adds exactly `amount` to the balance sum
- Add `transfer_sum_preserved_unique`: for lists where sender and to each appear exactly once, transfer preserves the balance sum exactly
- These close the documented gap in `Supply.lean` (lines 130-135) about NoDup conservation, providing the strongest practical conservation statements

These are the SimpleToken analogs of Ledger's existing `deposit_sum_singleton_sender` and `transfer_sum_preserved_unique` from `Conservation.lean`. The proof pattern is identical: specialize the general `countOcc`-based equation with `h_once : countOcc target addrs = 1`, then simplify.

**Theorem count**: 371 → 373 (2 new public theorems)

## Test plan
- [x] `lake build` passes (86/86 modules)
- [x] `check_property_manifest_sync.py` passes
- [x] `check_doc_counts.py` passes (all 17 files updated)
- [x] `check_property_coverage.py` passes (2 new proof-only exclusions)
- [x] `check_lean_hygiene.py` passes
- [x] `check_axiom_locations.py` passes
- [x] `check_contract_structure.py` passes
- [x] `check_selectors.py` passes
- [x] `check_storage_layout.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof/documentation/manifest updates with no changes to runtime contract or compiler behavior; main risk is mismatched counts/manifests causing CI or docs drift.
> 
> **Overview**
> Adds two new SimpleToken supply conservation theorems in `Verity/Proofs/SimpleToken/Supply.lean`: `mint_sum_singleton_to` (when the recipient appears once in the address list, total balances increase by exactly `amount`) and `transfer_sum_preserved_unique` (when sender and recipient each appear once, the total balance sum is preserved).
> 
> Updates theorem counts and verification status across README/docs-site/docs, and extends the property-test bookkeeping (`property_manifest.json`, `property_exclusions.json`, and related docs/comments) to account for the two additional proof-only theorems, increasing `SimpleToken` from 59→61 and overall from 371→373.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9916562ae698373457da751ca0b679a4caac03ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->