### PR TITLE
Make Yul interpreter computable, enable #eval validation

### DIFF
--- a/Compiler/Proofs/YulGeneration/Equivalence.lean
+++ b/Compiler/Proofs/YulGeneration/Equivalence.lean
@@ -29,7 +29,7 @@ These helpers wire IR-level execution to Yul runtime execution so we can
 compare results directly in smoke tests.
 -/
 
-noncomputable def interpretYulFromIR (contract : IRContract) (tx : IRTransaction) (state : IRState) : YulResult :=
+def interpretYulFromIR (contract : IRContract) (tx : IRTransaction) (state : IRState) : YulResult :=
   let yulTx : YulTransaction := {
     sender := tx.sender
     functionSelector := tx.functionSelector
@@ -38,7 +38,7 @@ noncomputable def interpretYulFromIR (contract : IRContract) (tx : IRTransaction
   interpretYulRuntime (Compiler.emitYul contract).runtimeCode yulTx state.storage state.mappings
 
 /-- Interpret just a function body as Yul runtime code. -/
-noncomputable def interpretYulBody (fn : IRFunction) (tx : IRTransaction) (state : IRState) : YulResult :=
+def interpretYulBody (fn : IRFunction) (tx : IRTransaction) (state : IRState) : YulResult :=
   let yulTx : YulTransaction := {
     sender := tx.sender
     functionSelector := tx.functionSelector
@@ -120,7 +120,7 @@ def yulResultOfExecWithRollback (rollback : YulState) : YulExecResult → YulRes
         finalMappings := rollback.mappings }
 
 /-- Interpret a function body starting from an aligned IR-derived state. -/
-noncomputable def interpretYulBodyFromState
+def interpretYulBodyFromState
     (fn : IRFunction) (selector : Nat) (state rollback : IRState) : YulResult :=
   let yulState := yulStateOfIR selector state
   let yulRollback := yulStateOfIR selector rollback

--- a/Compiler/Proofs/YulGeneration/Semantics.lean
+++ b/Compiler/Proofs/YulGeneration/Semantics.lean
@@ -350,10 +350,10 @@ set_option allowUnsafeReducibility true in
 attribute [reducible] execYulFuel
 
 
-noncomputable def execYulStmt (state : YulState) (stmt : YulStmt) : YulExecResult :=
+def execYulStmt (state : YulState) (stmt : YulStmt) : YulExecResult :=
   execYulStmtFuel (sizeOf stmt + 1) state stmt
 
-noncomputable def execYulStmts (state : YulState) (stmts : List YulStmt) : YulExecResult :=
+def execYulStmts (state : YulState) (stmts : List YulStmt) : YulExecResult :=
   execYulStmtsFuel (sizeOf stmts + 1) state stmts
 
 structure YulResult where
@@ -363,7 +363,7 @@ structure YulResult where
   finalMappings : Nat → Nat → Nat
 
 /-- Execute a Yul runtime program with selector-aware calldata -/
-noncomputable def interpretYulRuntime (runtimeCode : List YulStmt) (tx : YulTransaction)
+def interpretYulRuntime (runtimeCode : List YulStmt) (tx : YulTransaction)
     (storage : Nat → Nat) (mappings : Nat → Nat → Nat) : YulResult :=
   let initialState := YulState.initial tx storage mappings
   match execYulStmts initialState runtimeCode with
@@ -389,7 +389,7 @@ noncomputable def interpretYulRuntime (runtimeCode : List YulStmt) (tx : YulTran
         finalMappings := mappings }
 
 /-- Interpret a Yul object by executing its runtime code. -/
-noncomputable def interpretYulObject (obj : YulObject) (tx : YulTransaction)
+def interpretYulObject (obj : YulObject) (tx : YulTransaction)
     (storage : Nat → Nat) (mappings : Nat → Nat → Nat) : YulResult :=
   interpretYulRuntime obj.runtimeCode tx storage mappings
 


### PR DESCRIPTION
## Summary
- Remove unnecessary `noncomputable` annotations from 7 Yul interpreter functions in `Semantics.lean` and `Equivalence.lean`
- The `noncomputable` markers were over-cautious — `sizeOf` for `YulStmt`/`List YulStmt` is actually computable (plain inductives with `Repr`)
- Add 2 multi-step smoke tests that exercise `interpretYulRuntime` directly (the same interpreter used by Layer 3 proofs)

## Why This Matters

Previously, `interpretYulRuntime` was `noncomputable`, making it impossible to write:
```lean
#eval interpretYulRuntime runtimeCode testTx testStorage testMappings
```

After this PR, the full Yul interpreter is available for `#eval`, enabling in-Lean validation of axioms and contract behavior against the exact evaluator used by proofs. This follows the AMO-Lean pattern cited in issue #270.

**Functions made computable:**
| File | Function |
|------|----------|
| `Semantics.lean` | `execYulStmt`, `execYulStmts`, `interpretYulRuntime`, `interpretYulObject` |
| `Equivalence.lean` | `interpretYulFromIR`, `interpretYulBody`, `interpretYulBodyFromState` |

No theorem statements changed. No proof goals changed. All existing proofs compile identically.

Closes #270

## Test plan
- [x] `lake build` passes (86/86 modules)
- [x] 2 new `interpretYulRuntime` smoke tests pass (SimpleStorage store/retrieve, Counter increment/getCount)
- [x] All 8 CI check scripts pass
- [x] All existing 24 `native_decide` smoke tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes to interpreter definitions plus additional tests; semantics are unchanged, so risk is limited to potential evaluation/performance differences in Lean tooling.
> 
> **Overview**
> Removes `noncomputable` from key Yul interpreter entry points (`execYulStmt`, `execYulStmts`, `interpretYulRuntime`, `interpretYulObject`) and IR→Yul bridge helpers (`interpretYulFromIR`, `interpretYulBody`, `interpretYulBodyFromState`), enabling direct `#eval`/`native_decide` execution of compiled Yul.
> 
> Adds two new multi-step smoke tests in `SmokeTests.lean` that run `interpretYulRuntime` across sequential transactions (SimpleStorage store→retrieve and Counter increment→getCount), carrying forward the resulting storage/mappings between calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0eb8438e897e24c1a7ebc0fc9aa91f381ae5217. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->