### PR TITLE
Fix invalid hex literals and type error in RandomGen.lean

### DIFF
--- a/Compiler/RandomGen.lean
+++ b/Compiler/RandomGen.lean
@@ -114,8 +114,8 @@ private def addressPool : List Address :=
   [ Verity.Core.Address.ofNat 0xa11ce
   , Verity.Core.Address.ofNat 0xb0b
   , Verity.Core.Address.ofNat 0xca201
-  , Verity.Core.Address.ofNat 0xdave
-  , Verity.Core.Address.ofNat 0xeve
+  , Verity.Core.Address.ofNat 0xda7e
+  , Verity.Core.Address.ofNat 0xe7e
   , (0 : Address)                                                  -- zero address
   , Verity.Core.Address.ofNat (2^160 - 1)                         -- max address
   , Verity.Core.Address.ofNat 1                                    -- address(1)
@@ -279,11 +279,11 @@ open Compiler.DiffTestTypes
 def main (args : List String) : IO Unit := do
   match args with
   | [contractType, countStr, seedStr] =>
-    let count := match countStr.toNat? with
-      | some n => n
+    let count ← match countStr.toNat? with
+      | some n => pure n
       | none => throw <| IO.userError s!"Invalid count: {countStr}"
-    let seed := match seedStr.toNat? with
-      | some n => n
+    let seed ← match seedStr.toNat? with
+      | some n => pure n
       | none => throw <| IO.userError s!"Invalid seed: {seedStr}"
     let contractTypeEnum? : Option ContractType := match contractType with
       | "SimpleStorage" => some ContractType.simpleStorage


### PR DESCRIPTION
## Summary

- Fixes `0xdave` and `0xeve` which contain non-hex character `v` — replaced with `0xda7e` and `0xe7e`
- Fixes pre-existing `let x := match ... | none => throw` type mismatch (Nat vs IO) — changed to `let x ← match` with `pure n`

Found by Bugbot review on #469. The hex literal issue was introduced in #469 and the type error was pre-existing but masked by Lake's `.olean` cache.

## Test plan

- [x] `lake build Compiler.RandomGen` compiles successfully
- [x] `lake build difftest-interpreter` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fixes to test-data constants and CLI argument parsing; no security-sensitive logic or behavioral changes beyond corrected parsing failures.
> 
> **Overview**
> Fixes compilation issues in `Compiler/RandomGen.lean` by replacing invalid hex address literals (`0xdave`, `0xeve`) with valid ones in the random address pool.
> 
> Updates the CLI `main` to bind `count` and `seed` via `let … ← match` and `pure` so the `none => throw` branches typecheck in `IO`, improving argument-parse error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d621728dea4655b382a69843617a3658ed801620. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->