### PR TITLE
ci: validate unified AST output in verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -239,6 +239,9 @@ jobs:
             --link examples/external-libs/PoseidonT3.yul \
             --link examples/external-libs/PoseidonT4.yul
 
+      - name: Generate Yul (unified AST path)
+        run: ./.lake/build/bin/verity-compiler --ast --output compiler/yul-ast
+
       - name: Keccak-256 self-test (validate hash implementation)
         run: python3 scripts/keccak256.py --self-test
 
@@ -250,6 +253,22 @@ jobs:
 
       - name: Compile generated Yul with solc
         run: python3 scripts/check_yul_compiles.py
+
+      - name: Compile AST-generated Yul with solc
+        run: |
+          shopt -s nullglob
+          ast_files=(compiler/yul-ast/*.yul)
+          if [ "${#ast_files[@]}" -eq 0 ]; then
+            echo "::error::No AST-generated Yul files found in compiler/yul-ast"
+            exit 1
+          fi
+
+          for file in "${ast_files[@]}"; do
+            echo "Compiling $file"
+            solc --strict-assembly --bin "$file" >/dev/null
+          done
+
+          echo "✓ AST Yul->EVM compilation check passed (${#ast_files[@]} files)."
 
       - name: Check selector fixtures against solc
         run: python3 scripts/check_selector_fixtures.py


### PR DESCRIPTION
## Summary
- add a dedicated build-step to generate Yul via the unified AST compiler path (`--ast`)
- add a solc strict-assembly compilation check for AST-generated Yul artifacts
- fail fast if no AST artifacts are produced

## Why
Recent work wired the unified AST pipeline into the CLI, but CI only exercised the legacy ContractSpec path end-to-end. This adds a direct CI guard so AST-path regressions are caught before merge.

## Validation
- `lake build verity-compiler`
- `./.lake/build/bin/verity-compiler --ast --output compiler/yul-ast`
- `for file in compiler/yul-ast/*.yul; do solc --strict-assembly --bin "$file" >/dev/null; done`

Refs #364

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds extra build/compile validation; main risk is increased runtime or new failures if the AST Yul output directory/format changes.
> 
> **Overview**
> Adds a new CI step in `verify.yml` to generate Yul via the unified AST compiler path (`verity-compiler --ast --output compiler/yul-ast`).
> 
> Extends verification by compiling each AST-produced `.yul` file with `solc --strict-assembly`, failing fast when no AST artifacts are produced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cb397712e4dbe002d38d1f08cc0f5a52416721e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->