### PR TITLE
ci: consolidate legacy/AST Yul solc checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -251,24 +251,11 @@ jobs:
       - name: Setup solc
         uses: ./.github/actions/setup-solc
 
-      - name: Compile generated Yul with solc
-        run: python3 scripts/check_yul_compiles.py
-
-      - name: Compile AST-generated Yul with solc
+      - name: Compile generated Yul with solc (legacy + AST)
         run: |
-          shopt -s nullglob
-          ast_files=(compiler/yul-ast/*.yul)
-          if [ "${#ast_files[@]}" -eq 0 ]; then
-            echo "::error::No AST-generated Yul files found in compiler/yul-ast"
-            exit 1
-          fi
-
-          for file in "${ast_files[@]}"; do
-            echo "Compiling $file"
-            solc --strict-assembly --bin "$file" >/dev/null
-          done
-
-          echo "✓ AST Yul->EVM compilation check passed (${#ast_files[@]} files)."
+          python3 scripts/check_yul_compiles.py \
+            --dir compiler/yul \
+            --dir compiler/yul-ast
 
       - name: Check selector fixtures against solc
         run: python3 scripts/check_selector_fixtures.py

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -101,7 +101,18 @@ python3 scripts/check_contract_structure.py
 
 - **`check_selectors.py`** - Verifies function selector hashes match between Lean and generated Yul
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes
-- **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc
+- **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
+
+```bash
+# Default: check compiler/yul
+python3 scripts/check_yul_compiles.py
+
+# Check multiple directories and assert legacy/AST bytecode parity
+python3 scripts/check_yul_compiles.py \
+  --dir compiler/yul \
+  --dir compiler/yul-ast \
+  --compare-dirs compiler/yul compiler/yul-ast
+```
 
 ## Contract Scaffold Generator
 
@@ -175,4 +186,3 @@ To add test coverage for a proven theorem:
    ```
 
 3. If the property cannot be tested in Foundry (e.g., proof-only helper), add it to `test/property_exclusions.json`
-

--- a/scripts/check_yul_compiles.py
+++ b/scripts/check_yul_compiles.py
@@ -7,16 +7,41 @@ that all generated Yul can be compiled to bytecode by solc.
 
 from __future__ import annotations
 
+import argparse
+import re
 import subprocess
 from pathlib import Path
 
-from property_utils import YUL_DIR, report_errors
-YUL_DIRS = [YUL_DIR]
+from property_utils import ROOT, YUL_DIR, report_errors
 
 
-def collect_yul_files() -> list[Path]:
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compile generated Yul with solc and optionally compare bytecode parity."
+    )
+    parser.add_argument(
+        "--dir",
+        dest="dirs",
+        action="append",
+        help="Yul directory to check (repeatable). Default: compiler/yul",
+    )
+    parser.add_argument(
+        "--compare-dirs",
+        nargs=2,
+        metavar=("DIR_A", "DIR_B"),
+        help="Compare compiled bytecode parity by filename between two Yul directories.",
+    )
+    return parser.parse_args()
+
+
+def resolve_dir(path_str: str) -> Path:
+    path = Path(path_str)
+    return path if path.is_absolute() else (ROOT / path)
+
+
+def collect_yul_files(yul_dirs: list[Path]) -> list[Path]:
     files: list[Path] = []
-    for yul_dir in YUL_DIRS:
+    for yul_dir in yul_dirs:
         if not yul_dir.exists():
             continue
         files.extend(sorted(yul_dir.glob("*.yul")))
@@ -33,23 +58,78 @@ def run_solc(path: Path) -> tuple[int, str, str]:
     return result.returncode, result.stdout, result.stderr
 
 
+def extract_bytecode(stdout: str) -> str | None:
+    lines = stdout.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() == "Binary representation:" and index + 1 < len(lines):
+            candidate = lines[index + 1].strip()
+            if re.fullmatch(r"[0-9a-fA-F]+", candidate):
+                return candidate.lower()
+
+    hex_lines = [line.strip() for line in lines if re.fullmatch(r"[0-9a-fA-F]+", line.strip())]
+    if hex_lines:
+        return max(hex_lines, key=len).lower()
+
+    return None
+
+
+def index_by_filename(files: list[Path], root: Path) -> dict[str, Path]:
+    return {path.relative_to(root).name: path for path in files}
+
+
 def main() -> None:
-    files = collect_yul_files()
+    args = parse_args()
+    yul_dirs = [resolve_dir(d) for d in (args.dirs or [str(YUL_DIR)])]
+    files = collect_yul_files(yul_dirs)
     if not files:
-        raise SystemExit("No generated Yul files found in compiler/yul")
+        checked = ", ".join(str(path) for path in yul_dirs)
+        raise SystemExit(f"No generated Yul files found in: {checked}")
 
     failures: list[str] = []
+    bytecode_by_file: dict[Path, str] = {}
     for path in files:
         code, stdout, stderr = run_solc(path)
         if code != 0:
             failures.append(f"{path}: solc failed\n{stderr.strip()}")
             continue
-        if not stdout.strip():
-            failures.append(f"{path}: solc returned no output")
+        bytecode = extract_bytecode(stdout)
+        if bytecode is None:
+            failures.append(f"{path}: could not parse bytecode from solc output")
+            continue
+        bytecode_by_file[path] = bytecode
+
+    if args.compare_dirs is not None:
+        dir_a = resolve_dir(args.compare_dirs[0])
+        dir_b = resolve_dir(args.compare_dirs[1])
+        files_a = sorted(dir_a.glob("*.yul"))
+        files_b = sorted(dir_b.glob("*.yul"))
+        by_name_a = index_by_filename(files_a, dir_a)
+        by_name_b = index_by_filename(files_b, dir_b)
+
+        names_a = set(by_name_a.keys())
+        names_b = set(by_name_b.keys())
+        only_a = sorted(names_a - names_b)
+        only_b = sorted(names_b - names_a)
+        if only_a:
+            failures.append(f"{dir_b} missing files present in {dir_a}: {', '.join(only_a)}")
+        if only_b:
+            failures.append(f"{dir_a} missing files present in {dir_b}: {', '.join(only_b)}")
+
+        for name in sorted(names_a & names_b):
+            path_a = by_name_a[name]
+            path_b = by_name_b[name]
+            bytecode_a = bytecode_by_file.get(path_a)
+            bytecode_b = bytecode_by_file.get(path_b)
+            if bytecode_a is None or bytecode_b is None:
+                continue
+            if bytecode_a != bytecode_b:
+                failures.append(f"Bytecode mismatch for {name}: {path_a} vs {path_b}")
 
     report_errors(failures, "Yul->EVM compilation failed")
 
-    print(f"Yul->EVM compilation check passed ({len(files)} files).")
+    print(f"Yul->EVM compilation check passed ({len(files)} files across {len(yul_dirs)} dirs).")
+    if args.compare_dirs is not None:
+        print(f"Bytecode parity check passed: {args.compare_dirs[0]} == {args.compare_dirs[1]}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace duplicated workflow shell blocks with a single scripted Yul compilation check
- extend `scripts/check_yul_compiles.py` to support multiple `--dir` inputs
- add optional `--compare-dirs` mode for bytecode parity diagnostics by filename
- update `scripts/README.md` with examples for both default and multi-directory usage

## Why
The build job now verifies both legacy (`compiler/yul`) and AST (`compiler/yul-ast`) outputs through one maintained code path, reducing CI drift and improving reliability of issue #364 migration checks.

## Validation
- `lake build verity-compiler`
- `./.lake/build/bin/verity-compiler --link examples/external-libs/PoseidonT3.yul --link examples/external-libs/PoseidonT4.yul`
- `./.lake/build/bin/verity-compiler --ast --output compiler/yul-ast`
- `python3 scripts/check_yul_compiles.py --dir compiler/yul --dir compiler/yul-ast`
- `python3 scripts/check_yul_compiles.py`

Part of #364

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates CI gating by changing how Yul compilation is validated and adds bytecode parsing/comparison logic, which could introduce new false failures if solc output formats vary or directories differ unexpectedly.
> 
> **Overview**
> CI now runs a single `check_yul_compiles.py` step to compile both legacy (`compiler/yul`) and AST (`compiler/yul-ast`) generated Yul, replacing the duplicated workflow shell loop.
> 
> `scripts/check_yul_compiles.py` is extended to accept multiple `--dir` inputs, parse compiled bytecode from `solc` output, and optionally `--compare-dirs` to assert per-filename bytecode parity across two directories; `scripts/README.md` documents the new usage and examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fba8464eced6ab7f7f5697c8d45d60a2918c891. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->