### PR TITLE
ci: check selectors in AST Yul output

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,7 +99,7 @@ python3 scripts/check_contract_structure.py
 
 ## Selector & Yul Scripts
 
-- **`check_selectors.py`** - Verifies function selector hashes match between Lean and generated Yul
+- **`check_selectors.py`** - Verifies function selector hashes match between Lean and generated Yul (`compiler/yul` and `compiler/yul-ast` when present)
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 

--- a/scripts/check_selectors.py
+++ b/scripts/check_selectors.py
@@ -20,6 +20,7 @@ SPEC_FILE = ROOT / "Compiler" / "Specs.lean"
 IR_EXPR_FILE = ROOT / "Compiler" / "Proofs" / "IRGeneration" / "Expr.lean"
 YUL_DIRS = [
     ("yul", YUL_DIR),
+    ("yul-ast", ROOT / "compiler" / "yul-ast"),
 ]
 
 SIMPLE_PARAM_MAP = {


### PR DESCRIPTION
## Summary
- extend `scripts/check_selectors.py` to validate selector case labels in `compiler/yul-ast` in addition to `compiler/yul`
- document the dual-directory behavior in `scripts/README.md`

## Why
CI already generates and compiles AST-path Yul, but selector-label validation only covered the legacy output directory. This closes that gap and hardens the unified AST pipeline checks.

## Validation
- `lake build verity-compiler`
- `./.lake/build/bin/verity-compiler --link examples/external-libs/PoseidonT3.yul --link examples/external-libs/PoseidonT4.yul`
- `./.lake/build/bin/verity-compiler --ast --output compiler/yul-ast`
- `python3 scripts/check_selectors.py`

Refs #364

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only broadens CI validation to an additional generated output directory and updates documentation, with no runtime/compiler behavior changes.
> 
> **Overview**
> Extends `scripts/check_selectors.py` to validate expected selector `case 0x...` labels in both legacy `compiler/yul` output and the AST pipeline output in `compiler/yul-ast` (when present).
> 
> Updates `scripts/README.md` to document that `check_selectors.py` now checks both directories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e8822e71492e7f4810335bf590471800f23779e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->