### PR TITLE
ci: execute AST regression test modules in verify

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -159,6 +159,11 @@ jobs:
           LEAN_NUM_THREADS: 2
         run: lake build
 
+      - name: Run AST pipeline regression modules
+        env:
+          LEAN_NUM_THREADS: 2
+        run: lake build Compiler.ASTCompileTest Compiler.ASTDriverTest
+
       - name: Check for sorry
         run: |
           # Count sorry across all Lean files (matching both 'sorry' and '· sorry')


### PR DESCRIPTION
## Summary
- run AST regression modules in CI explicitly: `Compiler.ASTCompileTest` and `Compiler.ASTDriverTest`
- keep this in the `build` job right after `lake build` so AST-path regressions fail fast in required checks

## Why
- these test modules exist but were not part of default imports/required CI execution
- this left a blind spot where AST compilation/deploy regressions could pass CI unnoticed

## Validation
- `lake build Compiler.ASTCompileTest Compiler.ASTDriverTest`

Closes #364

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds additional Lean build targets; main impact is potential for longer or newly-failing CI runs due to uncovered regressions.
> 
> **Overview**
> The `verify` GitHub Actions workflow now **explicitly builds the AST pipeline regression test modules** after the main `lake build`, running `lake build Compiler.ASTCompileTest Compiler.ASTDriverTest` to ensure AST-path regressions are caught in required checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c69f14f231758a0f31e02dc57d5b60f7241cb40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->