### PR TITLE
CI: enforce compile selector list coverage for non-external specs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,7 +99,7 @@ python3 scripts/check_contract_structure.py
 
 ## Selector & Yul Scripts
 
-- **`check_selectors.py`** - Verifies function selector hashes match between Lean and generated Yul (`compiler/yul` and `compiler/yul-ast` when present)
+- **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present)
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 


### PR DESCRIPTION
## Summary
- harden `scripts/check_selectors.py` to fail when a non-external `ContractSpec` is missing from compile selector tables
- keep external-linked specs exempt from compile-table requirements
- update scripts documentation to describe compile-table consistency checks

## Validation
- python3 scripts/check_selectors.py
- python3 scripts/check_selector_fixtures.py

Refs #294

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI/script hardening that only adds an additional validation check; primary risk is new CI failures if selector tables are currently incomplete.
> 
> **Overview**
> Tightens `scripts/check_selectors.py` to **fail when any non-external `ContractSpec` is missing** from the compile selector tables, while keeping `--link`/external-dependent specs exempt.
> 
> Updates `scripts/README.md` to clarify that `check_selectors.py` checks selector consistency across ContractSpec, compile selector tables, and generated Yul outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce197e0da3ecac4421eb226160a20fcde6f26c9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->