### PR TITLE
Harden storage layout consistency guards in CI

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,7 +77,7 @@ Properties are excluded in `test/property_exclusions.json` for valid reasons:
 These CI-critical scripts validate cross-layer consistency:
 
 - **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
-- **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, Compiler, and AST layers; detects intra-contract slot collisions and AST-vs-Compiler slot/type drift
+- **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, Compiler, and AST layers; detects intra-contract slot collisions, enforces bidirectional EDSL↔Spec parity, enforces ASTSpec coverage for non-external compiler specs, and checks AST-vs-Compiler slot/type drift
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)


### PR DESCRIPTION
## Summary
- strengthen `check_storage_layout.py` with bidirectional EDSL↔Spec parity checks
- add AST coverage validation so every non-external `ContractSpec` must be present in `Compiler/ASTSpecs.lean`
- keep external-linked specs (e.g. `CryptoHash`) exempt from AST coverage requirements
- document the expanded checks in `scripts/README.md`

## Why
Current storage checks validated Spec/EDSL in one direction and did not enforce ASTSpec coverage against compiler specs. This could allow silent drift where contracts lose Spec slot declarations or AST wiring without failing CI.

## Validation
- `python3 scripts/check_storage_layout.py`
- `python3 scripts/check_storage_layout.py --format=markdown`

Refs #84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-critical validation logic is tightened, which may introduce new failures due to parsing/coverage edge cases or previously-undetected drift, but it doesn’t change runtime contract behavior.
> 
> **Overview**
> Tightens `scripts/check_storage_layout.py` to catch more cross-layer storage drift in CI by enforcing **bidirectional** EDSL↔Spec parity (previously one-way) and adding an **ASTSpecs coverage** check.
> 
> The script now parses `externals := [...]` in `Compiler/Specs.lean` to exempt external-linked contracts, and fails if any non-external `ContractSpec` is missing from `Compiler/ASTSpecs.lean` (or vice versa). `scripts/README.md` is updated to document these expanded validations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9226bf3f0ffdfa615f7584ee701b53b03b7d85ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->