### PR TITLE
scripts: enforce Spec slot coverage in storage layout checks

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,7 +77,7 @@ Properties are excluded in `test/property_exclusions.json` for valid reasons:
 These CI-critical scripts validate cross-layer consistency:
 
 - **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
-- **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, Compiler, and AST layers; detects intra-contract slot collisions, enforces bidirectional EDSL↔Spec parity, enforces ASTSpec coverage for non-external compiler specs, and checks AST-vs-Compiler slot/type drift
+- **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, Compiler, and AST layers; detects intra-contract slot collisions, derives Spec slot usage from `Verity/Specs/*/Spec.lean` literal state accesses, enforces Spec↔EDSL slot/type parity for compiled non-external contracts, enforces ASTSpec coverage for non-external compiler specs, and checks AST-vs-Compiler slot/type drift
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)


### PR DESCRIPTION
## Summary
- make `scripts/check_storage_layout.py` parse literal slot accesses in `Verity/Specs/*/Spec.lean`
- enforce Spec ↔ EDSL slot/type parity for compiled non-external contracts
- keep external-linked contracts exempt from Spec coverage requirements
- update `scripts/README.md` to document the stricter Spec-layer validation

## Why
`check_storage_layout.py` previously attempted to extract `StorageSlot` declarations from Spec files, but Spec files do not define those declarations. That made the Spec-layer check effectively a no-op for missing/incorrect Spec slot coverage.

This PR turns that check into a real invariant and catches drift earlier in CI.

## Validation
- `python3 scripts/check_storage_layout.py`
- `python3 scripts/check_storage_layout.py --format=markdown`

Partially addresses #84.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI-critical validation logic and may introduce new failures for existing specs that previously passed due to the Spec check being effectively a no-op; however it’s isolated to tooling and doesn’t affect runtime code.
> 
> **Overview**
> `check_storage_layout.py` now derives Spec-layer storage slot usage by parsing literal state accesses in `Verity/Specs/*/Spec.lean` (via new Spec slot regexes and `extract_spec_slots`), instead of trying to read `StorageSlot` declarations that don’t exist there.
> 
> It adds a stricter Spec↔EDSL validation (`check_spec_edsl_consistency`) that enforces slot/type parity for contracts present in `Compiler/Specs.lean`, while continuing to exempt compiler specs marked as external-linked. Documentation in `scripts/README.md` is updated to reflect the stronger Spec-layer checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1ce0637acd34f7787c9da133713d0bfe08da2e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->