### PR TITLE
scripts: parse non-empty externals for selector exemptions

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,7 +99,7 @@ python3 scripts/check_contract_structure.py
 
 ## Selector & Yul Scripts
 
-- **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present)
+- **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); enforces compile selector table coverage for all specs except those with non-empty `externals`
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 

--- a/scripts/check_selectors.py
+++ b/scripts/check_selectors.py
@@ -73,9 +73,21 @@ def extract_specs(text: str) -> List[SpecInfo]:
             die(f"Missing name for spec {def_name}")
         contract_name = name_match.group(1)
         signatures = extract_functions(block)
-        has_externals = bool(re.search(r"externals\s*:=\s*\[", block))
+        has_externals = has_nonempty_externals(block)
         specs.append(SpecInfo(def_name, contract_name, signatures, has_externals))
     return specs
+
+
+def has_nonempty_externals(spec_block: str) -> bool:
+    """Return True only when a spec has a non-empty externals list."""
+    ext_match = re.search(r"externals\s*:=\s*\[", spec_block)
+    if not ext_match:
+        return False
+    list_start = ext_match.end() - 1
+    list_end = find_matching(spec_block, list_start, "[", "]")
+    if list_end == -1:
+        die("Failed to parse externals list")
+    return bool(spec_block[list_start + 1 : list_end].strip())
 
 
 def extract_functions(spec_block: str) -> List[str]:


### PR DESCRIPTION
## Summary
- fix `scripts/check_selectors.py` to treat only **non-empty** `externals := [...]` lists as external-link exemptions
- keep compile selector table coverage strict for all other specs
- document the exact exemption rule in `scripts/README.md`

## Why
The selector checker previously exempted any spec that declared an `externals` field, even if the list was empty. That creates a false-negative path where a missing `compile ... [selectors]` list can slip through CI.

This change makes the exemption semantics match intent: only contracts that actually require linked external libraries are exempt.

Related to #79 (infrastructure hardening).

## Validation
- `python3 scripts/check_selectors.py`
- `python3 scripts/check_selector_fixtures.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a CI validation script and its documentation; primary risk is newly failing builds for specs previously (incorrectly) exempted.
> 
> **Overview**
> Tightens `scripts/check_selectors.py` so selector-table/Yul coverage exemptions apply only when a ContractSpec’s `externals := [...]` list is **present and non-empty**, preventing empty `externals` declarations from skipping compile selector table coverage checks.
> 
> Updates `scripts/README.md` to document the refined exemption rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d5d48883310e6e805623f3faf4ddb5af2f9ba03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->