### PR TITLE
Harden selector checks against commented Lean code

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,7 +99,7 @@ python3 scripts/check_contract_structure.py
 
 ## Selector & Yul Scripts
 
-- **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); enforces compile selector table coverage for all specs except those with non-empty `externals`
+- **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings before parsing to avoid false positives from commented examples; enforces compile selector table coverage for all specs except those with non-empty `externals`
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 


### PR DESCRIPTION
## Summary
Harden `scripts/check_selectors.py` parsing so selector validation is not affected by commented Lean snippets.

## What changed
- Added `strip_lean_comments` to remove Lean line/block comments while preserving line structure.
- Applied comment stripping to both:
  - `Compiler/Specs.lean` input (ContractSpec parsing)
  - `Compiler/Proofs/IRGeneration/Expr.lean` input (compile selector-list parsing)
- Updated `scripts/README.md` to document comment-aware selector parsing.

## Why
`check_selectors.py` previously parsed raw source text and could misread commented examples containing `functions := [...]`, `externals := [...]`, or `compile ... [..]` forms. That can create false positives/false negatives in CI selector checks.

This keeps selector invariants strict while making parsing robust to harmless comments/docs.

Related to #84

## Validation
- `python3 scripts/check_selectors.py`
- `python3 scripts/check_selector_fixtures.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI helper scripts and only affect how Lean source text is preprocessed before regex parsing. Main risk is false negatives/positives if the comment stripper mishandles edge cases, but it should reduce existing flakiness from commented examples.
> 
> **Overview**
> Hardens selector validation by stripping Lean `--` line comments and nested `/- -/` block comments (while preserving newlines) before `check_selectors.py` parses `Compiler/Specs.lean` and `Compiler/Proofs/IRGeneration/Expr.lean`.
> 
> Updates `scripts/README.md` to document the new comment-aware behavior to avoid false positives from commented examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a0b25b2e9f20759bd2c04552fec96e55ec4fac4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->