### PR TITLE
scripts: preserve string literals while stripping Lean comments

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,7 +77,7 @@ Properties are excluded in `test/property_exclusions.json` for valid reasons:
 These CI-critical scripts validate cross-layer consistency:
 
 - **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
-- **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, Compiler, and AST layers; strips Lean comments/docstrings before parsing to avoid false positives from commented examples, detects intra-contract slot collisions, derives Spec slot usage from `Verity/Specs/*/Spec.lean` literal state accesses, enforces Spec↔EDSL slot/type parity for compiled non-external contracts, enforces ASTSpec coverage for non-external compiler specs, and checks AST-vs-Compiler slot/type drift
+- **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, Compiler, and AST layers; strips Lean comments/docstrings before parsing (while preserving string literals) to avoid false positives from commented examples, detects intra-contract slot collisions, derives Spec slot usage from `Verity/Specs/*/Spec.lean` literal state accesses, enforces Spec↔EDSL slot/type parity for compiled non-external contracts, enforces ASTSpec coverage for non-external compiler specs, and checks AST-vs-Compiler slot/type drift
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
@@ -99,7 +99,7 @@ python3 scripts/check_contract_structure.py
 
 ## Selector & Yul Scripts
 
-- **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings before parsing to avoid false positives from commented examples; enforces compile selector table coverage for all specs except those with non-empty `externals`
+- **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings before parsing (while preserving string literals) to avoid false positives from commented examples; enforces compile selector table coverage for all specs except those with non-empty `externals`
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 

--- a/scripts/check_selectors.py
+++ b/scripts/check_selectors.py
@@ -59,14 +59,39 @@ def find_matching(text: str, start: int, open_ch: str, close_ch: str) -> int:
 
 
 def strip_lean_comments(text: str) -> str:
-    """Strip Lean line/block comments while preserving line structure."""
+    """Strip Lean line/block comments while preserving line structure.
+
+    Comment markers inside string literals are treated as plain text.
+    """
     out: list[str] = []
     i = 0
     n = len(text)
     block_depth = 0
+    in_string = False
+    escaped = False
     while i < n:
         ch = text[i]
         nxt = text[i + 1] if i + 1 < n else ""
+
+        # Inside string literal: keep characters verbatim.
+        if in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+
+        # Start string literal.
+        if block_depth == 0 and ch == '"':
+            in_string = True
+            escaped = False
+            out.append(ch)
+            i += 1
+            continue
 
         # Start of nested block comment: /- ... -/
         if ch == "/" and nxt == "-":

--- a/scripts/check_storage_layout.py
+++ b/scripts/check_storage_layout.py
@@ -63,14 +63,39 @@ SPEC_MAPPING2_SLOT_RE = re.compile(r"\bs'?\.(?:storageMap2)\s+(\d+)\b")
 
 
 def strip_lean_comments(text: str) -> str:
-    """Strip Lean line/block comments while preserving line structure."""
+    """Strip Lean line/block comments while preserving line structure.
+
+    Comment markers inside string literals are treated as plain text.
+    """
     out: list[str] = []
     i = 0
     n = len(text)
     block_depth = 0
+    in_string = False
+    escaped = False
     while i < n:
         ch = text[i]
         nxt = text[i + 1] if i + 1 < n else ""
+
+        # Inside string literal: keep characters verbatim.
+        if in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+
+        # Start string literal.
+        if block_depth == 0 and ch == '"':
+            in_string = True
+            escaped = False
+            out.append(ch)
+            i += 1
+            continue
 
         # Start of nested block comment: /- ... -/
         if ch == "/" and nxt == "-":


### PR DESCRIPTION
## Summary
- make Lean comment stripping string-aware in `check_storage_layout.py` and `check_selectors.py`
- keep comment/docstring stripping behavior, but treat `--` and `/- -/` markers inside string literals as plain text
- update `scripts/README.md` to document preserved string-literal behavior

## Why
Both validators parse Lean text using regex after stripping comments. The previous stripper could mis-handle string literals containing comment markers, causing false parse failures or missed invariants. This hardens parser behavior as specs evolve with richer string messages.

Fixes #84

## Validation
- `python3 scripts/check_storage_layout.py`
- `python3 scripts/check_storage_layout.py --format=markdown`
- `python3 scripts/check_selectors.py`
- `python3 scripts/check_selector_fixtures.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized parsing change in CI-only scripts; main risk is edge cases in the new string handling causing missed comment stripping or parsing regressions.
> 
> **Overview**
> Hardens Lean comment/docstring stripping in `check_storage_layout.py` and `check_selectors.py` by tracking string-literal state (including escapes) so `--` and `/- -/` inside quoted strings are not treated as comments.
> 
> Updates `scripts/README.md` to document the new *preserve string literals* behavior for these validators, reducing false positives when regex-parsing Lean sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7638ff2eb1af567a3fef451706455aa44689fd8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->