### PR TITLE
ContractSpec: recursively decode nested static tuple/fixed-array ABI heads

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -91,12 +91,34 @@ private def featureSpec : ContractSpec := {
       ]
       returnType := some FieldType.uint256
       body := [Stmt.return (Expr.param "x")]
+    },
+    { name := "nestedStaticTupleTail"
+      params := [
+        { name := "u"
+          ty := ParamType.tuple [
+            ParamType.fixedArray ParamType.uint256 2,
+            ParamType.tuple [ParamType.address, ParamType.bool],
+            ParamType.uint256
+          ]
+        },
+        { name := "y", ty := ParamType.uint256 }
+      ]
+      returnType := some FieldType.uint256
+      body := [Stmt.return (Expr.add (Expr.param "u_0_1") (Expr.param "y"))]
+    },
+    { name := "fixedArrayTupleTail"
+      params := [
+        { name := "fa", ty := ParamType.fixedArray (ParamType.tuple [ParamType.uint256, ParamType.bool]) 2 },
+        { name := "q", ty := ParamType.uint256 }
+      ]
+      returnType := some FieldType.uint256
+      body := [Stmt.return (Expr.add (Expr.param "fa_1_0") (Expr.param "q"))]
     }
   ]
 }
 
 #eval! do
-  match compile featureSpec [1, 2, 3, 4, 5, 6, 7] with
+  match compile featureSpec [1, 2, 3, 4, 5, 6, 7, 8, 9] with
   | .error err =>
       throw (IO.userError s!"✗ feature spec compile failed: {err}")
   | .ok ir =>
@@ -110,5 +132,7 @@ private def featureSpec : ContractSpec := {
       assertContains "dynamic array ABI return" rendered ["calldatacopy(64"]
       assertContains "static tuple decode head offsets" rendered ["let t_0 := calldataload(4)", "let t_1 := and(calldataload(36)", "let t_2 := iszero(iszero(calldataload(68)))", "let z := calldataload(100)"]
       assertContains "dynamic tuple keeps offset head word" rendered ["let td_offset := calldataload(4)", "let x := calldataload(36)"]
+      assertContains "nested static tuple decode head offsets" rendered ["let u_0_0 := calldataload(4)", "let u_0_1 := calldataload(36)", "let u_1_0 := and(calldataload(68)", "let u_1_1 := iszero(iszero(calldataload(100)))", "let u_2 := calldataload(132)", "let y := calldataload(164)"]
+      assertContains "fixed array of static tuples decode offsets" rendered ["let fa_0_0 := calldataload(4)", "let fa_0_1 := iszero(iszero(calldataload(36)))", "let fa_1_0 := calldataload(68)", "let fa_1_1 := iszero(iszero(calldataload(100)))", "let q := calldataload(132)"]
 
 end Compiler.ContractSpecFeatureTest


### PR DESCRIPTION
## Summary
This follows #486 and extends calldata decoding for static ABI shapes that were still misclassified/decoded.

### What changed
- Made `isDynamicParamType` recursive to match ABI rules:
  - `fixedArray(T,n)` is dynamic iff `T` is dynamic
  - `tuple(...)` is dynamic iff any component is dynamic
- Made `paramHeadSize` recursive for static nested shapes
- Replaced scalar-only tuple loader with recursive static loader:
  - Supports nested static tuples
  - Supports fixed arrays of static elements (including tuple elements)
  - Preserves bool/address normalization
- Kept scalar fixed-array backward compatibility alias (`name := name_0`)

### Regression tests
`Compiler/ContractSpecFeatureTest.lean` now checks:
- nested static tuple head offsets
- fixed array of static tuples head offsets

## Why
Before this patch, some static nested tuple/fixed-array parameter shapes could be decoded using dynamic-offset logic, producing incorrect locals/offsets.

## Validation
- `lake build Compiler.ContractSpec`
- `lake env lean Compiler/ContractSpecFeatureTest.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core calldata ABI decoding logic for tuples/fixed arrays, which can change generated Yul offsets and break existing contracts if incorrect. Risk is mitigated by added feature tests covering nested static tuple and fixed-array-of-tuple decoding.
> 
> **Overview**
> Fixes calldata decoding for nested *static* ABI shapes by making `isDynamicParamType` and `paramHeadSize` recursive, matching ABI rules for tuples and fixed arrays.
> 
> Replaces the scalar-only static tuple loader with a recursive `genStaticTypeLoads` decoder that can inline-decode nested static tuples and fixed arrays (including tuple elements) while preserving address/bool normalization and a backward-compatible `<name> := <name>_0` alias for scalar fixed arrays.
> 
> Extends `ContractSpecFeatureTest` with new cases asserting correct head offsets for nested static tuples and fixed arrays of static tuples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4cb7a63676de0c10ec90e1a4827fb66c8967216. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->