### PR TITLE
refactor(ast-driver): validate specs at compileSpec boundary

### DIFF
--- a/Compiler/ASTDriver.lean
+++ b/Compiler/ASTDriver.lean
@@ -175,8 +175,6 @@ private def validateSpec (spec : ASTContractSpec) : Except String Unit := do
   | none => pure ()
 
 private def validateAllSpecs (specs : List ASTContractSpec) : Except String Unit := do
-  for spec in specs do
-    validateSpec spec
   match findDuplicate (specs.map (·.name)) with
   | some dup => throw s!"Duplicate contract name in AST specs: {dup}"
   | none => pure ()
@@ -210,6 +208,7 @@ existing `Codegen.emitYul` → `Yul.render` pipeline for output.
 -/
 
 def compileSpec (spec : ASTContractSpec) (selectors : List Nat) : Except String IRContract := do
+  validateSpec spec
   if spec.functions.length != selectors.length then
     throw s!"Selector count mismatch for {spec.name}: {selectors.length} selectors for {spec.functions.length} functions"
   let functions := (spec.functions.zip selectors).map fun (fn, sel) =>

--- a/Compiler/ASTDriverTest.lean
+++ b/Compiler/ASTDriverTest.lean
@@ -81,4 +81,37 @@ private def badConstructorReturnSpec : ASTContractSpec := {
   | .ok _ =>
     throw (IO.userError "✗ expected constructor return(...) to be rejected")
 
+private def badEmptyContractNameSpec : ASTContractSpec := {
+  name := "   "
+  functions := []
+}
+
+#eval! do
+  match compileSpec badEmptyContractNameSpec [] with
+  | .error err =>
+    if contains err "Contract name cannot be empty" then
+      IO.println "✓ Empty contract name rejected in compileSpec"
+    else
+      throw (IO.userError s!"✗ unexpected empty-name error: {err}")
+  | .ok _ =>
+    throw (IO.userError "✗ expected empty contract name to be rejected")
+
+private def badDuplicateFunctionsSpec : ASTContractSpec := {
+  name := "BadDuplicateFunctions"
+  functions := [
+    { name := "dup", params := [], returnType := .unit, body := Stmt.stop },
+    { name := "dup", params := [], returnType := .unit, body := Stmt.stop }
+  ]
+}
+
+#eval! do
+  match compileSpec badDuplicateFunctionsSpec [0, 1] with
+  | .error err =>
+    if contains err "Duplicate function name" then
+      IO.println "✓ Duplicate function names rejected in compileSpec"
+    else
+      throw (IO.userError s!"✗ unexpected duplicate-function error: {err}")
+  | .ok _ =>
+    throw (IO.userError "✗ expected duplicate function names to be rejected")
+
 end Compiler.ASTDriverTest


### PR DESCRIPTION
## Summary
- move per-contract AST invariant checks to the `compileSpec` boundary
- keep `validateAllSpecs` focused on cross-spec uniqueness (duplicate contract names)
- add AST driver regression tests for invalid direct `compileSpec` inputs:
  - empty contract name
  - duplicate function names

## Why
`compileSpec` is a public compilation entry point used outside `compileAllAST` tests/flows. Validating at this boundary makes malformed specs fail fast regardless of call path, while reducing duplicated per-spec validation in the global pass.

## Dependency impact
- `Compiler/Main.lean` calls `compileAllAST`, which still enforces global duplicate contract-name checks before iterating.
- each `compileSpec` call now enforces per-contract invariants directly.

## Validation
- `python3 scripts/check_storage_layout.py`
- `python3 scripts/check_lean_hygiene.py`
- `lake build verity-compiler Compiler.ASTDriverTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `compileSpec` entrypoint to error on previously unchecked malformed specs (e.g., empty names, duplicate functions), which can break external callers but doesn’t affect runtime codegen semantics for valid inputs.
> 
> **Overview**
> `compileSpec` now **always validates per-contract AST invariants** (non-empty contract/function/parameter names, no duplicate parameter or function names) before doing selector checks or generating IR/Yul, instead of relying on a separate global pass.
> 
> `validateAllSpecs` is narrowed to only enforce **cross-spec uniqueness** (duplicate contract names). New `ASTDriverTest` cases ensure direct `compileSpec` calls reject an empty contract name and duplicate function names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c67248b3a7dd328bc9d6ba306d8fec0d3c64ca19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->