### PR TITLE
scripts: harden Lean hygiene parser against comment/string false positives

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -81,7 +81,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
-- **`check_lean_hygiene.py`** - Validates no `#eval` in Compiler/Proofs/ and exactly 1 `allowUnsafeReducibility` (documented trust assumption)
+- **`check_lean_hygiene.py`** - Validates proof hygiene (`#eval/#check/#print/#reduce`, `native_decide`, `sorry`) and exactly 1 `allowUnsafeReducibility`; parsing is comment/string-aware via shared Lean lexer utilities
 
 ```bash
 # Run locally before submitting documentation changes


### PR DESCRIPTION
## Summary
Hardens `scripts/check_lean_hygiene.py` so hygiene checks run on comment/string-aware Lean code, using shared parser utilities already used by other validators.

## Why
`check_lean_hygiene.py` previously mixed ad-hoc parsing approaches and could be misled by markers inside comments/strings (for example `#eval`, `native_decide`, `sorry`, or `allowUnsafeReducibility` text in non-code contexts).

This change makes the checker behavior consistent and less brittle.

## Changes
- Reused shared `strip_lean_comments` from `scripts/property_utils.py`
- Added string-literal scrubbing for hygiene token checks
- Applied unified scrubbed parsing across all four hygiene checks:
  - debug directives
  - `allowUnsafeReducibility` count
  - `sorry` detection
  - `native_decide` detection
- Updated `scripts/README.md` description for `check_lean_hygiene.py`

## Validation
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_axiom_locations.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_storage_layout.py`
- `python3 scripts/check_selectors.py`
- `python3 scripts/check_lean_hygiene.py`

Refs #75

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI validation scripts and mainly reduce false positives by improving parsing; primary risk is missed detections if the new scrubbing logic mishandles edge-case Lean syntax.
> 
> **Overview**
> Makes `scripts/check_lean_hygiene.py` consistently analyze *scrubbed* Lean text by reusing `strip_lean_comments` and additionally blanking string-literal contents, so `#eval/#check/#print/#reduce`, `allowUnsafeReducibility`, `sorry`, and `native_decide` are not accidentally matched inside comments/strings.
> 
> Updates `scripts/README.md` to reflect the strengthened, comment/string-aware hygiene validation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ab2d278cef63c97019fde2f6f726c3145e3e3aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->