### PR TITLE
scripts: harden selector fixture parsing and expand ABI vectors

### DIFF
--- a/scripts/fixtures/SelectorFixtures.sol
+++ b/scripts/fixtures/SelectorFixtures.sol
@@ -21,4 +21,19 @@ contract SelectorFixtures {
     function burn(address from, uint256 amount) external returns (bool) {
         return from != address(0) && amount > 0;
     }
+
+    function transferBatch(
+        address[] calldata recipients,
+        uint256[] calldata amounts
+    ) external pure returns (uint256) {
+        return recipients.length + amounts.length;
+    }
+
+    function setRoots(bytes32[2] calldata roots) external pure returns (bytes32) {
+        return roots[0];
+    }
+
+    function submit(bytes calldata blob) external pure returns (uint256) {
+        return blob.length;
+    }
 }


### PR DESCRIPTION
## Summary
- harden `scripts/check_selector_fixtures.py` signature extraction to support multiline Solidity function declarations
- parse parameter lists using top-level comma splitting so array/tuple-like syntax does not break selector canonicalization
- normalize fixture parameter declarations by stripping data location/mutability keywords and trailing param names
- expand `scripts/fixtures/SelectorFixtures.sol` with richer vector coverage:
  - dynamic arrays (`address[]`, `uint256[]`)
  - fixed arrays (`bytes32[2]`)
  - dynamic bytes (`bytes`)

This is an incremental conformance-readiness step for #75 by widening selector test-vector realism.

## Validation
- `python3 scripts/check_selector_fixtures.py`
- `python3 scripts/check_selectors.py`
- `python3 scripts/keccak256.py --self-test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/validation script and fixture-only changes; risk is limited to potential false positives/negatives if the new regex/canonicalization mis-parses unusual Solidity syntax.
> 
> **Overview**
> Hardens `scripts/check_selector_fixtures.py` signature extraction by switching from line-based parsing to a DOTALL `FUNCTION_RE`, and by canonicalizing parameter lists via top-level comma splitting plus removal of data-location/mutability keywords, trailing param names, and whitespace normalization.
> 
> Expands `SelectorFixtures.sol` with additional functions covering dynamic arrays, fixed-size arrays, and `bytes` parameters to broaden selector test-vector coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26b923e470d77f34d9c3a8ff04b906bf0f7716df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->