### PR TITLE
ContractSpec: support storage-word dynamic array returns

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -119,12 +119,18 @@ private def featureSpec : ContractSpec := {
       returnType := none
       returns := [ParamType.bytes]
       body := [Stmt.returnBytes "data"]
+    },
+    { name := "extSloadsLike"
+      params := [{ name := "slots", ty := ParamType.array ParamType.bytes32 }]
+      returnType := none
+      returns := [ParamType.array ParamType.uint256]
+      body := [Stmt.returnStorageWords "slots"]
     }
   ]
 }
 
 #eval! do
-  match compile featureSpec [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] with
+  match compile featureSpec [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] with
   | .error err =>
       throw (IO.userError s!"✗ feature spec compile failed: {err}")
   | .ok ir =>
@@ -141,5 +147,6 @@ private def featureSpec : ContractSpec := {
       assertContains "nested static tuple decode head offsets" rendered ["let u_0_0 := calldataload(4)", "let u_0_1 := calldataload(36)", "let u_1_0 := and(calldataload(68)", "let u_1_1 := iszero(iszero(calldataload(100)))", "let u_2 := calldataload(132)", "let y := calldataload(164)"]
       assertContains "fixed array of static tuples decode offsets" rendered ["let fa_0_0 := calldataload(4)", "let fa_0_1 := iszero(iszero(calldataload(36)))", "let fa_1_0 := calldataload(68)", "let fa_1_1 := iszero(iszero(calldataload(100)))", "let q := calldataload(132)"]
       assertContains "dynamic bytes ABI return" rendered ["calldatacopy(64, data_data_offset, data_length)", "mstore(add(64, data_length), 0)", "return(0, add(64, and(add(data_length, 31), not(31))))"]
+      assertContains "storage-word array return ABI" rendered ["let __slot := calldataload(add(slots_data_offset, mul(__i, 32)))", "mstore(add(64, mul(__i, 32)), sload(__slot))", "return(0, add(64, mul(slots_length, 32)))"]
 
 end Compiler.ContractSpecFeatureTest

--- a/Verity/Proofs/Stdlib/SpecInterpreter.lean
+++ b/Verity/Proofs/Stdlib/SpecInterpreter.lean
@@ -335,6 +335,11 @@ def execStmt (ctx : EvalContext) (fields : List Field) (paramNames : List String
       -- Dynamic-bytes return encoding is a codegen concern.
       some (ctx, { state with returnValue := none, halted := true })
 
+  | Stmt.returnStorageWords _name =>
+      -- The spec interpreter models scalar returnValue only.
+      -- Dynamic array return encoding/storage reads are codegen concerns.
+      some (ctx, { state with returnValue := none, halted := true })
+
   | Stmt.stop =>
       some (ctx, { state with halted := true })
 


### PR DESCRIPTION
## Summary
- add `Stmt.returnStorageWords name` to `Compiler.ContractSpec`
- codegen ABI-encodes `uint256[]` by iterating a dynamic calldata word array and `sload`-ing each slot
- keep `SpecInterpreter` parity by modeling this as dynamic-return codegen behavior (same treatment as `returnArray`/`returnBytes`)
- add feature regression coverage in `Compiler/ContractSpecFeatureTest.lean`

## Why
`morpho-verity` still had a manual Yul dispatch shim for `extSloads(bytes32[]) -> bytes32[]`.
This change provides a first-class compiler path for that pattern and removes one high-risk post-generation patch point.

## Validation
- `lake build Compiler.ContractSpec Compiler.ContractSpecFeatureTest`
- `lake build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler codegen for ABI return paths and introduces new storage-reading behavior, so mistakes could lead to incorrect return encoding or unintended storage access; coverage is added but runtime semantics remain sensitive.
> 
> **Overview**
> Adds `Stmt.returnStorageWords` to the `ContractSpec` DSL and codegen, emitting Yul that ABI-encodes a `uint256[]` by iterating a calldata `bytes32[]` of storage slots and `sload`-ing each slot into the return buffer.
> 
> Updates `SpecInterpreter` to recognize `returnStorageWords` as a *codegen-only* dynamic return (matching `returnArray`/`returnBytes` behavior), and extends `ContractSpecFeatureTest` with a regression case (`extSloadsLike`) that asserts the generated Yul loop/return shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8eec5834b1ed1990967470dbf2a5d5065a1aa81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->