### PR TITLE
scripts: ignore comments/strings in selector fixture scan

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,7 +100,7 @@ python3 scripts/check_contract_structure.py
 ## Selector & Yul Scripts
 
 - **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings with the same shared string-aware parser used by storage checks; enforces compile selector table coverage for all specs except those with non-empty `externals`
-- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes
+- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples and debug strings cannot create false selector expectations
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 
 ```bash

--- a/scripts/fixtures/SelectorFixtures.sol
+++ b/scripts/fixtures/SelectorFixtures.sol
@@ -2,6 +2,14 @@
 pragma solidity ^0.8.33;
 
 contract SelectorFixtures {
+    // Parser guard: this commented signature must not be treated as real.
+    // function commentedOut(uint256 x) external pure returns (uint256) { return x; }
+    /*
+      function alsoCommented(address who) external returns (bool) {
+          return who != address(0);
+      }
+    */
+
     function balanceOf(address account) external view returns (uint256) {
         return account == address(0) ? 0 : 1;
     }
@@ -34,6 +42,11 @@ contract SelectorFixtures {
     }
 
     function submit(bytes calldata blob) external pure returns (uint256) {
+        string memory debugText =
+            "function looksLikeSignature(bytes32 x) external pure returns (uint256)";
+        if (bytes(debugText).length == 0) {
+            return 0;
+        }
         return blob.length;
     }
 }


### PR DESCRIPTION
## Summary
- harden `scripts/check_selector_fixtures.py` to ignore Solidity comments and string literals before extracting function signatures
- prevent false selector expectations when fixture files include commented examples or debug strings containing `function ...`
- extend `scripts/fixtures/SelectorFixtures.sol` with parser-guard examples (commented signatures and string content that looks like a function declaration)
- document the behavior in `scripts/README.md`

## Why
`check_selector_fixtures.py` previously searched raw fixture text with a `function ...` regex. That could treat commented-out examples or string content as real declarations, then fail CI with "Missing solc selector" even though Solidity never compiles those pseudo-signatures.

This change makes fixture parsing resilient and keeps selector conformance checks focused on executable declarations.

## Validation
- `python3 scripts/check_selector_fixtures.py`
- `python3 scripts/check_selectors.py`
- `python3 scripts/keccak256.py --self-test`

Refs #75

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change limited to CI tooling: fixture signature extraction now strips Solidity comments/strings, reducing false failures but could miss signatures if the stripping logic has edge cases.
> 
> **Overview**
> Makes `scripts/check_selector_fixtures.py` ignore Solidity `//`/`/* */` comments and string literals when extracting `function ...` signatures, preventing commented examples or debug strings from generating bogus selector expectations.
> 
> Updates `SelectorFixtures.sol` with commented-out signatures and a string that looks like a function declaration as regression guards, and documents the new behavior in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc4f52b04a21929996cf82184d7cb7afafd94df4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->