### PR TITLE
scripts: canonicalize function-typed selector fixture params

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,7 +100,7 @@ python3 scripts/check_contract_structure.py
 ## Selector & Yul Scripts
 
 - **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings with the same shared string-aware parser used by storage checks; enforces compile selector table coverage for all specs except those with non-empty `externals`
-- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples and debug strings cannot create false selector expectations
+- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, and canonicalizes `function(...)`-typed params to ABI `function` signatures
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 
 ```bash

--- a/scripts/fixtures/SelectorFixtures.sol
+++ b/scripts/fixtures/SelectorFixtures.sol
@@ -49,4 +49,10 @@ contract SelectorFixtures {
         }
         return blob.length;
     }
+
+    function callWithCallback(
+        function(uint256) external returns (uint256) cb
+    ) external pure returns (bool) {
+        return cb.address != address(0);
+    }
 }


### PR DESCRIPTION
## Summary
- harden `scripts/check_selector_fixtures.py` canonicalization for Solidity `function`-typed parameters
- correctly reduce full function type declarations (including return clauses) to ABI canonical `function` (with array suffix if present)
- add a Solidity fixture case that includes a function-typed parameter to prevent regressions
- document the behavior in `scripts/README.md`

## Why
`solc --hashes` reports selectors using ABI-canonical parameter types. For function-typed params, the canonical type is `function`, but our fixture parser previously kept internal type details (e.g. `returns (...)`) and produced mismatched signatures.

That could produce false CI failures and leaves a real parser edge case untested.

## Validation
- `python3 scripts/check_selector_fixtures.py`
- `python3 scripts/check_selectors.py`
- `python3 scripts/keccak256.py --self-test`

Refs #75

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI validation scripts and a fixture contract, but could affect selector-check outcomes if canonicalization is wrong.
> 
> **Overview**
> Updates `check_selector_fixtures.py` to more accurately canonicalize parameter types by safely dropping trailing parameter names and normalizing Solidity `function(...)` parameter types to ABI-canonical `function` (preserving any array suffix).
> 
> Extends `SelectorFixtures.sol` with a `function`-typed callback parameter case and documents the new canonicalization behavior in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1743c73b6ee3f57e69d4ddc809d9a34f1c99aaa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->