### PR TITLE
scripts: parse selector fixtures from full function headers

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,7 +100,7 @@ python3 scripts/check_contract_structure.py
 ## Selector & Yul Scripts
 
 - **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings with the same shared string-aware parser used by storage checks; enforces compile selector table coverage for all specs except those with non-empty `externals`
-- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, and canonicalizes `function(...)`-typed params to ABI `function` signatures
+- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), and canonicalizes `function(...)`-typed params to ABI `function` signatures
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 
 ```bash

--- a/scripts/fixtures/SelectorFixtures.sol
+++ b/scripts/fixtures/SelectorFixtures.sol
@@ -55,4 +55,13 @@ contract SelectorFixtures {
     ) external pure returns (bool) {
         return cb.address != address(0);
     }
+
+    function delayedVisibility(uint256 amount)
+        virtual
+        public
+        pure
+        returns (uint256)
+    {
+        return amount;
+    }
 }


### PR DESCRIPTION
## Summary
- make selector fixture extraction parse full Solidity function headers instead of requiring visibility immediately after `)`
- keep filtering to real callable definitions by requiring a visibility keyword somewhere before `{`/`;`
- add a regression fixture where `virtual` appears before `public`
- document the header-scanning behavior in scripts docs

## Why
`check_selector_fixtures.py` previously used a regex that only matched declarations where `external|public|internal|private` appeared immediately after the parameter list. Valid declarations with modifiers first (for example, `virtual` before visibility) were skipped, which could silently reduce fixture coverage and miss selector regressions.

This is an incremental conformance-hardening step for #75.

## Validation
- `python3 scripts/check_selector_fixtures.py`
- `python3 scripts/check_selectors.py`
- `python3 scripts/keccak256.py --self-test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes selector-fixture parsing used in CI, which could alter which fixture functions are validated and potentially introduce false positives/negatives in selector checks.
> 
> **Overview**
> Updates `check_selector_fixtures.py` to stop relying on a single regex and instead parse function headers by locating matching parentheses and scanning until `{`/`;`, allowing modifiers (e.g. `virtual`) before visibility while still requiring a visibility keyword to treat a signature as callable.
> 
> Adds a new `SelectorFixtures.sol` regression function with delayed visibility and updates `scripts/README.md` to document the header-scanning behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26a95280dbeb17bde6405544f7d06c7e3263e203. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->