### PR TITLE
scripts: align selector fixtures with solc visibility rules

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,7 +100,7 @@ python3 scripts/check_contract_structure.py
 ## Selector & Yul Scripts
 
 - **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings with the same shared string-aware parser used by storage checks; enforces compile selector table coverage for all specs except those with non-empty `externals`
-- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), and canonicalizes `function(...)`-typed params to ABI `function` signatures
+- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), includes only `public`/`external` selectors (matching `solc --hashes`), and canonicalizes `function(...)`-typed params to ABI `function` signatures
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 
 ```bash

--- a/scripts/check_selector_fixtures.py
+++ b/scripts/check_selector_fixtures.py
@@ -17,7 +17,7 @@ FIXTURE = ROOT / "scripts" / "fixtures" / "SelectorFixtures.sol"
 SIG_RE = re.compile(r"^([A-Za-z0-9_]+\([^\)]*\))\s*:\s*(0x)?([0-9a-fA-F]{8})$")
 HASH_RE = re.compile(r"^(0x)?([0-9a-fA-F]{8})\s*:\s*([A-Za-z0-9_]+\([^\)]*\))$")
 FUNCTION_START_RE = re.compile(r"\bfunction\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
-VISIBILITY_RE = re.compile(r"\b(external|public|internal|private)\b")
+SELECTOR_VISIBILITY_RE = re.compile(r"\b(external|public)\b")
 IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 ARRAY_SUFFIX_RE = re.compile(r"(\[[0-9]*\]\s*)+$")
 
@@ -208,7 +208,8 @@ def _iter_function_signatures(text: str) -> list[tuple[str, str]]:
             continue
 
         suffix = text[close_paren + 1 : header_end]
-        if not VISIBILITY_RE.search(suffix):
+        # solc --hashes only reports selectors for public/external functions.
+        if not SELECTOR_VISIBILITY_RE.search(suffix):
             continue
 
         params = text[open_paren + 1 : close_paren].strip()

--- a/scripts/fixtures/SelectorFixtures.sol
+++ b/scripts/fixtures/SelectorFixtures.sol
@@ -64,4 +64,14 @@ contract SelectorFixtures {
     {
         return amount;
     }
+
+    // These are intentionally non-selector visibilities and must be ignored by
+    // fixture extraction because solc --hashes does not emit them.
+    function helperInternal(uint256 amount) internal pure returns (uint256) {
+        return amount + 1;
+    }
+
+    function helperPrivate(uint256 amount) private pure returns (uint256) {
+        return amount + 2;
+    }
 }


### PR DESCRIPTION
## Summary
Align selector fixture extraction with `solc --hashes` visibility behavior.

`solc --hashes` emits selectors only for externally callable functions (`public`/`external`), but fixture parsing still accepted `internal`/`private` declarations. That can produce false CI failures when fixtures include helper methods.

## Changes
- `scripts/check_selector_fixtures.py`
  - Restrict function extraction to `public`/`external` visibility tokens only.
  - Keep full-header parsing behavior intact.
- `scripts/fixtures/SelectorFixtures.sol`
  - Add `internal` and `private` helper methods as regression guards.
- `scripts/README.md`
  - Document that fixture extraction includes only `public`/`external` selectors.

## Validation
- `python3 scripts/check_selector_fixtures.py`
- `python3 scripts/check_selectors.py`
- `python3 scripts/keccak256.py --self-test`

Related to #75 as another incremental conformance-hardening step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: confined to CI/verification scripts and fixtures, narrowing selector extraction to better match `solc --hashes` output and reducing false failures.
> 
> **Overview**
> Updates `check_selector_fixtures.py` to **ignore `internal`/`private` functions** when extracting signatures (only `public`/`external` are treated as selector-bearing, matching `solc --hashes`).
> 
> Extends `SelectorFixtures.sol` with `internal` and `private` helper functions as regression guards, and updates `scripts/README.md` to document the visibility rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77e5341902d50725e84069b30324aa8bc08f5043. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->