### PR TITLE
scripts: enforce selector fixture extraction completeness

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,7 +100,7 @@ python3 scripts/check_contract_structure.py
 ## Selector & Yul Scripts
 
 - **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings with the same shared string-aware parser used by storage checks; enforces compile selector table coverage for all specs except those with non-empty `externals`
-- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), includes only `public`/`external` selectors (matching `solc --hashes`), and canonicalizes `function(...)`-typed params to ABI `function` signatures
+- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), includes only `public`/`external` selectors (matching `solc --hashes`), canonicalizes `function(...)`-typed params to ABI `function` signatures, and enforces reverse completeness (every `solc --hashes` signature must be present in extracted fixtures)
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 
 ```bash

--- a/scripts/check_selector_fixtures.py
+++ b/scripts/check_selector_fixtures.py
@@ -269,8 +269,13 @@ def main() -> None:
     signatures = load_fixture_signatures()
     solc_hashes = run_solc_hashes()
     keccak_hashes = run_keccak(signatures)
+    signature_set = set(signatures)
 
     errors: list[str] = []
+    for signature in sorted(solc_hashes):
+        if signature not in signature_set:
+            errors.append(f"Fixture extraction missed solc selector signature: {signature}")
+
     for signature in signatures:
         solc_selector = solc_hashes.get(signature)
         if solc_selector is None:


### PR DESCRIPTION
## Summary
- enforce reverse completeness in `scripts/check_selector_fixtures.py`
- fail when `solc --hashes` reports selector signatures not found by fixture extraction
- document the new completeness invariant in `scripts/README.md`

## Why
`check_selector_fixtures.py` already verified extracted signatures against `solc`, but it did not verify the reverse direction. If fixture extraction missed a real public/external function, the check could still pass. This closes that gap and hardens selector conformance coverage.

## Validation
- `python3 scripts/check_selector_fixtures.py`
- `python3 scripts/check_selectors.py`
- `python3 scripts/keccak256.py --self-test`

Related to #75.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI/script-only change that tightens validation logic and adds documentation; main risk is new CI failures if fixture extraction has edge cases.
> 
> **Overview**
> Strengthens selector fixture validation by adding a **reverse completeness** check: `scripts/check_selector_fixtures.py` now errors if `solc --hashes` reports any signature that fixture extraction did not find, closing a gap where missing extracted functions could still pass.
> 
> Updates `scripts/README.md` to document this stricter completeness invariant for `check_selector_fixtures.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f4ba730aaa7450223939ed16f82fbb883638c3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->