### PR TITLE
scripts: canonicalize selector fixtures for user-defined ABI types

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -100,7 +100,7 @@ python3 scripts/check_contract_structure.py
 ## Selector & Yul Scripts
 
 - **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings with the same shared string-aware parser used by storage checks; enforces compile selector table coverage for all specs except those with non-empty `externals`
-- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), includes only `public`/`external` selectors (matching `solc --hashes`), canonicalizes `function(...)`-typed params to ABI `function` signatures, and enforces reverse completeness (every `solc --hashes` signature must be present in extracted fixtures)
+- **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), includes only `public`/`external` selectors (matching `solc --hashes`), canonicalizes ABI-sensitive param forms (`function(...)`, `uint/int` aliases, and user-defined `contract`/`enum`/`type` aliases), and enforces reverse completeness (every `solc --hashes` signature must be present in extracted fixtures)
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 
 ```bash

--- a/scripts/fixtures/SelectorFixtures.sol
+++ b/scripts/fixtures/SelectorFixtures.sol
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.33;
 
+type Wad is uint256;
+
+enum Stage {
+    Init,
+    Done
+}
+
+contract Recipient {}
+
 contract SelectorFixtures {
     // Parser guard: this commented signature must not be treated as real.
     // function commentedOut(uint256 x) external pure returns (uint256) { return x; }
@@ -54,6 +63,20 @@ contract SelectorFixtures {
         function(uint256) external returns (uint256) cb
     ) external pure returns (bool) {
         return cb.address != address(0);
+    }
+
+    function canonicalAliases(
+        Recipient recipient,
+        Wad amount,
+        Stage stage,
+        uint count,
+        int delta
+    ) external pure returns (bool) {
+        return recipient != Recipient(address(0))
+            || Wad.unwrap(amount) > 0
+            || uint8(stage) > 0
+            || count > 0
+            || delta > 0;
     }
 
     function delayedVisibility(uint256 amount)


### PR DESCRIPTION
## Summary
- harden `scripts/check_selector_fixtures.py` ABI canonicalization for fixture extraction
- normalize Solidity shorthand aliases (`uint` -> `uint256`, `int` -> `int256`)
- map user-defined types to ABI canonical forms for selector hashing:
  - `contract` / `interface` / `library` types -> `address`
  - `enum` types -> `uint8`
  - `type X is T` aliases -> canonicalized underlying `T`
- extend `scripts/fixtures/SelectorFixtures.sol` with regression vectors for contract/enum/UDVT alias parameters
- document the expanded canonicalization behavior in `scripts/README.md`

## Why
`solc --hashes` always reports selectors for ABI-canonical signatures. Before this change, fixture extraction could keep source-level user-defined type names and shorthand aliases, causing false mismatches even when selector logic was correct.

This closes a reliability gap in selector conformance checks and is an incremental conformance hardening step for #75.

## Validation
- `python3 scripts/check_selector_fixtures.py`
- `python3 scripts/check_selectors.py`
- `python3 scripts/keccak256.py --self-test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only changes that tighten parsing/canonicalization for CI selector checks; main risk is false positives/negatives in fixture extraction due to regex-based type resolution.
> 
> **Overview**
> Improves `scripts/check_selector_fixtures.py` signature extraction so parameters are canonicalized to ABI forms before selector hashing, including Solidity shorthand (`uint`/`int`) and user-defined types (`contract`/`interface`/`library`→`address`, `enum`→`uint8`, and `type X is T` resolving to canonical `T`, including namespaced aliases).
> 
> Extends `scripts/fixtures/SelectorFixtures.sol` with regression cases covering these aliases, and updates `scripts/README.md` to document the expanded canonicalization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b1bc5f88497c543aaaaad0f9db9a425e775055d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->