### PR TITLE
scripts: handle Lean raw strings in hygiene/comment parsing

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -81,7 +81,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
-- **`check_lean_hygiene.py`** - Validates proof hygiene (`#eval/#check/#print/#reduce`, `native_decide`, `sorry`) and exactly 1 `allowUnsafeReducibility`; parsing is comment/string-aware via shared Lean lexer utilities
+- **`check_lean_hygiene.py`** - Validates proof hygiene (`#eval/#check/#print/#reduce`, `native_decide`, `sorry`) and exactly 1 `allowUnsafeReducibility`; parsing is comment/string-aware (including Lean raw strings) via shared Lean lexer utilities
 
 ```bash
 # Run locally before submitting documentation changes

--- a/scripts/check_lean_hygiene.py
+++ b/scripts/check_lean_hygiene.py
@@ -17,13 +17,87 @@ import re
 
 from property_utils import ROOT, report_errors, strip_lean_comments
 
-STRING_RE = re.compile(r'"(?:\\.|[^"\\])*"')
 SORRY_RE = re.compile(r"\bsorry\b")
 
 
 def scrub_lean_code(text: str) -> str:
     """Remove comments and string literal contents from Lean source text."""
-    return STRING_RE.sub('""', strip_lean_comments(text))
+    return _strip_lean_strings(strip_lean_comments(text))
+
+
+def _strip_lean_strings(text: str) -> str:
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_string = False
+    raw_hashes: int | None = None
+
+    while i < n:
+        ch = text[i]
+
+        if raw_hashes is not None:
+            if ch == "\n":
+                out.append("\n")
+                i += 1
+                continue
+            if ch == '"':
+                j = i + 1
+                hashes = 0
+                while j < n and text[j] == "#" and hashes < raw_hashes:
+                    hashes += 1
+                    j += 1
+                if hashes == raw_hashes:
+                    out.append('"')
+                    out.extend("#" * hashes)
+                    i = j
+                    raw_hashes = None
+                    continue
+            out.append(" ")
+            i += 1
+            continue
+
+        if in_string:
+            if ch == "\n":
+                out.append("\n")
+                i += 1
+                continue
+            if ch == "\\" and i + 1 < n:
+                out.extend([" ", " "])
+                i += 2
+                continue
+            if ch == '"':
+                out.append('"')
+                in_string = False
+                i += 1
+                continue
+            out.append(" ")
+            i += 1
+            continue
+
+        if ch == '"':
+            out.append('"')
+            in_string = True
+            i += 1
+            continue
+
+        if ch == "r":
+            j = i + 1
+            hashes = 0
+            while j < n and text[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and text[j] == '"':
+                out.append("r")
+                out.extend("#" * hashes)
+                out.append('"')
+                i = j + 1
+                raw_hashes = hashes
+                continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
 
 
 def line_starts_with_command(line: str, cmd: str) -> bool:


### PR DESCRIPTION
## Summary
Improve script reliability by adding Lean raw string awareness to hygiene/comment parsing.

### Changes
- `scripts/property_utils.py`
  - Extended `strip_lean_comments` to treat Lean raw strings (`r"..."`, `r#"..."#`, etc.) as string literals so comment markers inside raw strings are never interpreted as comments.
- `scripts/check_lean_hygiene.py`
  - Replaced regex-only string scrubbing with parser-based string stripping that handles both normal and raw Lean strings while preserving line structure.
- `scripts/README.md`
  - Documented raw-string-aware parsing behavior.

## Why
Without raw-string handling, comment-like/debug-like tokens inside raw strings could trigger false CI failures (or hide real lines by misparsing), reducing trust in hygiene checks.

## Validation
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_storage_layout.py`
- `python3 scripts/check_selectors.py`
- `python3 scripts/check_selector_fixtures.py`
- `python3 scripts/keccak256.py --self-test`

Part of #75 (CI conformance/reliability hardening).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI-gating parsing logic for Lean sources; the new raw-string-aware scanners could introduce edge-case false positives/negatives if the lexer handling is imperfect.
> 
> **Overview**
> Improves Lean source parsing in CI scripts to correctly handle Lean *raw string literals* (`r"..."`, `r#"..."#`, etc.), preventing comment markers inside raw strings from being misinterpreted.
> 
> `strip_lean_comments` is extended to treat raw strings as string regions, and `check_lean_hygiene.py` replaces its regex-based string scrubbing with a small scanner that strips both normal and raw strings while preserving line structure for accurate line-numbered errors. Documentation is updated to note raw-string-aware parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 532a2c5eff54857e3cf3763f15cd5b28de283954. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->