### PR TITLE
refactor: share duplicate-name helper across compiler modules

### DIFF
--- a/Compiler/ASTDriver.lean
+++ b/Compiler/ASTDriver.lean
@@ -137,17 +137,6 @@ private def compileConstructor (ctor : Option ASTConstructorSpec) : Except Strin
 Fail fast on malformed AST specs before any code generation work.
 -/
 
-private def findDuplicate (xs : List String) : Option String :=
-  let rec go (remaining seen : List String) : Option String :=
-    match remaining with
-    | [] => none
-    | x :: rest =>
-      if seen.contains x then
-        some x
-      else
-        go rest (x :: seen)
-  go xs []
-
 private def ensureNonEmpty (kind name : String) : Except String Unit := do
   if name.trim.isEmpty then
     throw s!"{kind} name cannot be empty"

--- a/Compiler/Linker.lean
+++ b/Compiler/Linker.lean
@@ -226,8 +226,8 @@ end
 private def collectLibraryFunctions (libs : List LibraryFunction) : List String :=
   libs.map (·.name)
 
--- Helper: find the first duplicate in a list
-private def findDuplicate (names : List String) : Option String :=
+/-- Returns the first duplicate string in traversal order, if any. -/
+def findDuplicate (names : List String) : Option String :=
   let rec go : List String → List String → Option String
     | [], _ => none
     | n :: rest, seen =>


### PR DESCRIPTION
## Summary
Refactor to remove duplicated duplicate-name detection logic between AST driver and linker modules.

- Exposed `Compiler.Linker.findDuplicate` as a shared helper.
- Removed the local duplicate implementation from `Compiler.ASTDriver`.
- Kept all validation behavior identical.

## Why
This simplifies the codebase by keeping one source of truth for a core string-name invariant check used across compiler boundaries.

## Dependency impact
- `Compiler.ASTDriver` depends on `Compiler.Linker.findDuplicate` for:
  - duplicate function names in one AST contract spec
  - duplicate parameter names
  - duplicate contract names across all AST specs
- `Compiler.Linker.validateNoDuplicateNames` already uses the same helper for library names.

## Validation (local)
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_axiom_locations.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_storage_layout.py`
- `python3 scripts/check_lean_hygiene.py`
- `lake build verity-compiler Compiler.ASTCompileTest Compiler.ASTDriverTest Compiler.ContractSpecFeatureTest`

All passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only centralizes a small pure helper; behavior should remain the same aside from potential ripple effects if the shared function’s semantics change later.
> 
> **Overview**
> Centralizes duplicate-name detection by deleting the local `findDuplicate` implementation in `Compiler/ASTDriver.lean` and reusing a shared helper instead.
> 
> In `Compiler/Linker.lean`, `findDuplicate` is promoted from `private` to a public `def` (with a brief docstring) so other compiler modules can call it while keeping existing validation logic intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ba1ef7afc408a8ee55899a014c779f4e7ff13e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->