### PR TITLE
proofs: add emitEvent automation lemmas

### DIFF
--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -279,6 +279,7 @@
     "countOccU_cons_ne",
     "countOcc_cons_eq",
     "countOcc_cons_ne",
+    "emitEvent_emitEvent_events",
     "evm_add_eq_hadd",
     "getMapping2_runState",
     "getMapping2_runValue",


### PR DESCRIPTION
## Summary
Adds event-emission automation lemmas to `Verity.Proofs.Stdlib.Automation` as an incremental step for #79.

## What changed
- Added direct `emitEvent` helper lemmas:
  - `emitEvent_isSuccess`
  - `emitEvent_runValue`
  - `emitEvent_runState`
  - `emitEvent_events_append`
  - `emitEvent_emitEvent_events` (sequential append order)
- Synced theorem manifest:
  - `test/property_manifest.json`

## Validation
- `lake build Verity.Proofs.Stdlib.Automation`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`

## Issue linkage
Refs #79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions with no runtime behavior changes; risk is limited to potential proof/manifest sync issues.
> 
> **Overview**
> Adds a new **Event Emission Helpers** section to `Verity.Proofs.Stdlib.Automation`, introducing simp-friendly lemmas that characterize `emitEvent` as always succeeding, returning `()`, and updating state only by appending a single event to the `events` log (plus a lemma for two sequential emissions appending in order).
> 
> Updates `test/property_manifest.json` to include the new `emitEvent_emitEvent_events` theorem so manifest-based property checks stay in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ba46344ff96ef2b0a821ad56ae9fdf7c7b5b1ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->