### PR TITLE
proofs: add require state/bind automation lemmas

### DIFF
--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -319,6 +319,27 @@ theorem require_success_implies_cond (cond : Bool) (msg : String) (state : Contr
     -- When cond = true, we're done
     rfl
 
+-- require preserves state regardless of branch
+@[simp] theorem require_state (cond : Bool) (msg : String) (state : ContractState) :
+    (require cond msg).runState state = state := by
+  by_cases h : cond
+  · simp [require, Contract.runState, h]
+  · simp [require, Contract.runState, h]
+
+-- If the guard is true, binding after require is exactly the continuation.
+@[simp] theorem require_bind_true_run (cond : Bool) (msg : String) (k : Unit → Contract α)
+    (state : ContractState) (h : cond = true) :
+    (Verity.bind (require cond msg) k).run state = (k ()) state := by
+  subst h
+  simp [Verity.bind, require, Contract.run]
+
+-- If the guard is false, bind short-circuits to revert and never runs continuation.
+@[simp] theorem require_bind_false_run (cond : Bool) (msg : String) (k : Unit → Contract α)
+    (state : ContractState) (h : cond = false) :
+    (Verity.bind (require cond msg) k).run state = ContractResult.revert msg state := by
+  subst h
+  simp [Verity.bind, require, Contract.run]
+
 /-!
 ## Address Equality Lemmas
 -/


### PR DESCRIPTION
## Summary
- add missing `require_state` lemma promised by `Automation.lean` docs
- add guard-composition lemmas for `bind` after `require`:
  - `require_bind_true_run`
  - `require_bind_false_run`

## Why
Issue #79 tracks remaining stdlib automation gaps. This PR strengthens a high-frequency authorization/proof pattern by making `require` + continuation behavior simplify directly in proofs, and it fixes a doc-to-code mismatch (`require_state` was documented but absent).

## Validation
- `lake build Verity.Proofs.Stdlib.Automation`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`

Part of #79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Proof-only change, but it extends the global `simp` lemma set for `require`/`bind`, which can affect simplification behavior (and potentially break or change existing proofs) across the proof suite.
> 
> **Overview**
> Adds missing `require_state` and two new `[simp]` lemmas that normalize `Verity.bind (require …) k` to either the continuation (when the guard is `true`) or a `revert` result (when `false`).
> 
> This improves proof automation around the common `require`-then-continue pattern by making state preservation and branch short-circuiting simplify directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7eb27bac991ee44c531b59d3ee43ae7a7a9a62d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->