### PR TITLE
proofs: add require-beq iff authorization lemmas

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -145,8 +145,8 @@ theorem owned_only_owner_can_transfer (state : ContractState) (newOwner : Addres
         (m2 := fun _ => setStorageAddr owner newOwner)
         (state := { state with sender := sender })
         h_success
-  exact (require_beq_success_implies_eq sender (state.storageAddr 0)
-    "Caller is not the owner" _ h_require_success).symm
+  exact (require_beq_isSuccess_true_iff_eq sender (state.storageAddr 0)
+    "Caller is not the owner" _).1 h_require_success |>.symm
 
 /-- Constructor sets initial owner correctly -/
 theorem owned_constructor_sets_owner (state : ContractState) (initialOwner : Address) (sender : Address) :

--- a/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
@@ -286,8 +286,8 @@ theorem ownedCounter_only_owner_modifies (state : ContractState) (sender : Addre
             setStorage count (Verity.EVM.Uint256.add current 1)))
         (state := { state with sender := sender })
         h_success
-  exact (require_beq_success_implies_eq sender (state.storageAddr 0)
-    "Caller is not the owner" _ h_require_success).symm
+  exact (require_beq_isSuccess_true_iff_eq sender (state.storageAddr 0)
+    "Caller is not the owner" _).1 h_require_success |>.symm
 
 /-- Owner and count slots are independent -/
 theorem ownedCounter_slots_independent (state : ContractState) (newOwner : Address) (sender : Address)

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -945,6 +945,27 @@ theorem require_beq_success_implies_eq (a b : Address) (msg : String)
     a = b :=
   (address_beq_eq_true_iff_eq a b).1 (require_success_implies_cond (cond := a == b) (msg := msg) (state := s) h)
 
+/-- `require (a == b) msg` succeeds exactly when `a = b`. -/
+theorem require_beq_isSuccess_true_iff_eq (a b : Address) (msg : String) (s : ContractState) :
+    ((Verity.require (a == b) msg).run s).isSuccess = true ↔ a = b := by
+  constructor
+  · intro h
+    exact require_beq_success_implies_eq a b msg s h
+  · intro h_eq
+    subst h_eq
+    simp [Verity.require]
+
+/-- `require (a == b) msg` fails exactly when `a ≠ b`. -/
+theorem require_beq_isSuccess_false_iff_ne (a b : Address) (msg : String) (s : ContractState) :
+    ((Verity.require (a == b) msg).run s).isSuccess = false ↔ a ≠ b := by
+  constructor
+  · intro h_false h_eq
+    subst h_eq
+    simp [Verity.require] at h_false
+  · intro h_ne
+    have h_beq_false : (a == b) = false := address_beq_false_of_ne a b h_ne
+    simp [Verity.require, h_beq_false]
+
 -- All lemmas in this file are fully proven with zero sorry, zero axioms.
 
 end Verity.Proofs.Stdlib.Automation

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -305,6 +305,8 @@
     "modulus_eq_max_uint256_succ",
     "msgSender_runState",
     "msgSender_runValue",
+    "require_beq_isSuccess_false_iff_ne",
+    "require_beq_isSuccess_true_iff_eq",
     "require_beq_success_implies_eq",
     "require_false_isSuccess",
     "require_success_implies_cond",


### PR DESCRIPTION
## Summary
- add two generic authorization lemmas in `Automation.lean` for `require (a == b)` success/failure iff equality/inequality
- simplify owner-guard helper proofs in spec-correctness modules to use the new iff lemma directly
- sync `test/property_manifest.json` for new stdlib theorem entries

## Why
Issue #79 still tracks missing generic authorization automation. These lemmas remove repetitive two-step proof patterns around owner checks and make future owner-guard proofs shorter and more direct.

## Validation
- `lake build Verity.Proofs.Stdlib.Automation Compiler.Proofs.SpecCorrectness.Owned Compiler.Proofs.SpecCorrectness.OwnedCounter`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`

Refs #79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely proof/automation changes with no runtime behavior impact; risk is limited to potential proof breakage or manifest-sync issues.
> 
> **Overview**
> Adds two new stdlib automation theorems, `require_beq_isSuccess_true_iff_eq` and `require_beq_isSuccess_false_iff_ne`, giving *iff* characterizations of `require (a == b)` success/failure vs equality/inequality.
> 
> Refactors `Owned.lean` and `OwnedCounter.lean` helper proofs to use the new `↔` lemma directly (replacing the prior one-way `require_beq_success_implies_eq` pattern), and updates `test/property_manifest.json` to include the new theorem entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f021349f9f6ea7130cb423e66b2dd7cfede2854c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->