### PR TITLE
proofs: add owner-guard automation lemma

### DIFF
--- a/test/property_exclusions.json
+++ b/test/property_exclusions.json
@@ -79,6 +79,7 @@
     "modulus_eq_max_uint256_succ",
     "msgSender_runState",
     "msgSender_runValue",
+    "owner_guard_success_implies_storageAddr_eq_sender",
     "require_beq_isSuccess_false_iff_ne",
     "require_beq_isSuccess_true_iff_eq",
     "require_false_isSuccess",

--- a/test/property_manifest.json
+++ b/test/property_manifest.json
@@ -305,6 +305,7 @@
     "modulus_eq_max_uint256_succ",
     "msgSender_runState",
     "msgSender_runValue",
+    "owner_guard_success_implies_storageAddr_eq_sender",
     "require_beq_isSuccess_false_iff_ne",
     "require_beq_isSuccess_true_iff_eq",
     "require_beq_success_implies_eq",


### PR DESCRIPTION
## Summary
- add a reusable stdlib lemma for the common owner-guard bind pattern:
  - `owner_guard_success_implies_storageAddr_eq_sender`
- simplify duplicated owner-check proofs in:
  - `Compiler/Proofs/SpecCorrectness/Owned.lean`
  - `Compiler/Proofs/SpecCorrectness/OwnedCounter.lean`
- sync theorem metadata:
  - `test/property_manifest.json`
  - `test/property_exclusions.json`

## Why
Issue #79 calls out remaining authorization automation gaps. This PR adds a generic lemma that captures the recurring `msgSender -> getStorageAddr -> require (==)` success implication and immediately reuses it in two spec-correctness proofs.

## Validation
- `lake build Verity.Proofs.Stdlib.Automation Compiler.Proofs.SpecCorrectness.Owned Compiler.Proofs.SpecCorrectness.OwnedCounter`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`

Closes part of #79.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only changes that add a derived automation lemma and simplify existing proofs; no runtime semantics or contract logic is modified.
> 
> **Overview**
> Adds a new stdlib proof lemma `owner_guard_success_implies_storageAddr_eq_sender` to capture the common `msgSender >>= getStorageAddr >>= require (==)` authorization guard, letting downstream proofs conclude the caller matches the stored owner when the guard succeeds.
> 
> Refactors `owned_only_owner_can_transfer` (Owned) and `ownedCounter_only_owner_modifies` (OwnedCounter) to use this lemma instead of repeating the inline `require`-based reasoning, and updates `test/property_manifest.json` and `test/property_exclusions.json` to include the new theorem.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfb3920673e557b5dcc56fde7c4af115fea4c6ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->