### PR TITLE
docs: sync theorem counts to 401 after #517

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/Th0rgal/verity/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/built%20with-Lean%204-blueviolet.svg" alt="Built with Lean 4"></a>
-  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-400-brightgreen.svg" alt="400 Theorems"></a>
+  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-401-brightgreen.svg" alt="401 Theorems"></a>
   <a href="https://github.com/Th0rgal/verity/actions"><img src="https://img.shields.io/github/actions/workflow/status/Th0rgal/verity/verify.yml?label=verify" alt="Verify"></a>
 </p>
 
@@ -28,7 +28,7 @@ source ~/.elan/env
 # 2. Clone and build
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                                    # Verifies all 400 theorems
+lake build                                    # Verifies all 401 theorems
 
 # 3. Generate a new contract
 python3 scripts/generate_contract.py MyContract
@@ -123,7 +123,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-400 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (55% coverage, 180 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+401 theorems across 9 categories, all fully proven. 375 Foundry tests across 32 test suites. 220 covered by property tests (55% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -79,7 +79,7 @@ theorem increment_correct (state : ContractState) :
     finalState.storage countSlot = add (state.storage countSlot) 1
 ```
 
-**Coverage**: All 400 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (55% runtime test coverage).
+**Coverage**: All 401 theorems are formally proven (100% proof coverage). Additionally, 220 theorems have corresponding Foundry property tests (55% runtime test coverage).
 
 **What this guarantees**:
 - Contract behavior matches specification
@@ -689,7 +689,7 @@ Verity provides **strong formal verification** with a **small trusted computing 
 ✅ Contract implementations match specifications (Layer 1)
 ✅ Specifications preserved through compilation (Layer 2)
 ✅ IR semantics equivalent to Yul semantics (Layer 3)
-✅ 400 theorems across 9 categories (220 covered by property tests)
+✅ 401 theorems across 9 categories (220 covered by property tests)
 
 ### What is Trusted (Validated but Not Proven)
 ⚠️ Solidity compiler (solc) - Validated by 70k+ differential tests

--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -13,7 +13,7 @@ export const metadata = {
 
 const banner = (
   <Banner storageKey="verification-complete">
-    400/400 theorems proven — 100% formal verification
+    401/401 theorems proven — 100% formal verification
   </Banner>
 )
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -596,7 +596,7 @@ Time: **~5 minutes** (vs ~30 minutes manual IR)
 
 ### All Tests Pass ✅
 
-**Lean Proofs**: All proofs verified (400 EDSL theorems, 100%)
+**Lean Proofs**: All proofs verified (401 EDSL theorems, 100%)
 ```bash
 $ lake build
 Build completed successfully.
@@ -710,5 +710,5 @@ def ownedSpec : ContractSpec := {
 
 - [Research & Development](/research) — Design decisions and proof techniques
 - [Examples](/examples) — 9 example contracts
-- [Verification](/verification) — 400 proven theorems
+- [Verification](/verification) — 401 proven theorems
 - [GitHub Repository](https://github.com/Th0rgal/verity) — Source code

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -52,7 +52,7 @@ forge --version
 ```bash
 git clone https://github.com/Th0rgal/verity.git
 cd verity
-lake build                # Downloads dependencies and verifies all 400 theorems
+lake build                # Downloads dependencies and verifies all 401 theorems
 ```
 
 The first build downloads Mathlib and compiles everything — expect **20–45 minutes** on first run (Mathlib is large). Subsequent builds are incremental and much faster (seconds to minutes).

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 400 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 401 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 375 Foundry tests across 32 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 400 theorems, all fully proven. 1 documented axiom, 0 sorry.**
+**Compact core, built across 7 iterations. 401 theorems, all fully proven. 1 documented axiom, 0 sorry.**
 
 ## Evolution
 
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (400 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (375 as of 2026-02-18), Lean proofs verify (401 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,11 +7,11 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 400 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 1 axiom documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 401 theorems across 9 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 1 axiom documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-17)
 
-- EDSL theorems: 400 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
+- EDSL theorems: 401 across 9 categories (7 contracts + ReentrancyExample + Stdlib).
 - SimpleStorage: 20 total (Basic 13, Correctness 7).
 - Counter: 28 total (Basic 19, Correctness 10; 1 shared between Basic and Correctness).
 - Owned: 23 total (Basic 19, Correctness 4).
@@ -20,7 +20,7 @@ The compiler is verified with IR preservation proofs and Yul equivalence proofs 
 - Ledger: 33 total (Basic 20, Correctness 6, Conservation 7 — all proven).
 - SafeCounter: 25 total (Basic 17, Correctness 8).
 - ReentrancyExample: 4 total (inline proofs: vulnerability existence, supply invariant).
-- Stdlib: 158 theorems (Math 25, Automation 56, MappingAutomation 37, ListSum 7, AddressAutomation 24; 2 shared between Automation and MappingAutomation).
+- Stdlib: 159 theorems (Math 25, Automation 56, MappingAutomation 37, ListSum 7, AddressAutomation 24; 2 shared between Automation and MappingAutomation).
 
 ## Unified AST Bridge (Issue #364)
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -17,7 +17,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Language**: Lean 4.15.0
 - **Core Size**: 351 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
-- **Theorems**: 400 across 9 categories (400 fully proven, 0 `sorry` placeholders)
+- **Theorems**: 401 across 9 categories (401 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256, address injectivity
 - **Tests**: 375 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
@@ -60,7 +60,7 @@ def bind (x : Contract α) (f : α → Contract β) : Contract β :=
 | Ledger | 33 | Deposit/withdraw/transfer, balance conservation |
 | SafeCounter | 25 | Overflow/underflow revert proofs |
 | ReentrancyExample | 4 | Reentrancy vulnerability proof, supply invariant |
-| Stdlib | 158 | safeMul/safeDiv correctness, automation lemmas |
+| Stdlib | 159 | safeMul/safeDiv correctness, automation lemmas |
 
 ## Proof Techniques
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,10 +6,10 @@
 
 ## Current Status
 
-- ✅ **Layer 1 Complete**: 400 theorems across 9 categories (8 contracts + Stdlib math library)
+- ✅ **Layer 1 Complete**: 401 theorems across 9 categories (8 contracts + Stdlib math library)
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
-- ✅ **Property Testing**: 55% coverage (220/400), all testable properties covered
+- ✅ **Property Testing**: 55% coverage (220/401), all testable properties covered
 - ✅ **Differential Testing**: Production-ready with 70k+ tests
 - ✅ **Trust Reduction Phase 1**: keccak256 axiom + CI validation (PR #43, #46)
 - ✅ **External Linking**: Cryptographic library support (PR #49)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -63,7 +63,7 @@ EVM Bytecode
 | ReentrancyExample | 4 | ✅ Complete | `Verity/Examples/ReentrancyExample.lean` |
 | **Total** | **242** | **✅ 100%** | — |
 
-> **Note**: Stdlib (158 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (400 total properties).
+> **Note**: Stdlib (159 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (401 total properties).
 
 ### Example Property
 
@@ -177,13 +177,13 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ## Property Test Coverage 🎯 **NEAR COMPLETE**
 
-**Status**: 55% coverage (220/400), 180 remaining exclusions all proof-only
+**Status**: 55% coverage (220/401), 181 remaining exclusions all proof-only
 
 ### Current Coverage
 
-- **Total Properties**: 400
+- **Total Properties**: 401
 - **Covered**: 220 (55%)
-- **Excluded**: 180 (all proof-only)
+- **Excluded**: 181 (all proof-only)
 - **Missing**: 0
 
 ### Coverage by Contract
@@ -198,11 +198,11 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 | SimpleToken | 85% (52/61) | 9 proof-only | ✅ High coverage |
 | Counter | 82% (23/28) | 5 proof-only | ✅ High coverage |
 | Ledger | 100% (33/33) | 0 | ✅ Complete |
-| Stdlib | 0% (0/158) | 158 proof-only | — Internal |
+| Stdlib | 0% (0/159) | 159 proof-only | — Internal |
 
 ### Exclusion Categories
 
-**Proof-Only Properties (180 exclusions)**: Internal proof machinery that cannot be tested in Foundry
+**Proof-Only Properties (181 exclusions)**: Internal proof machinery that cannot be tested in Foundry
 - Storage helpers: `setStorage_*`, `getStorage_*`, `setMapping_*`, `getMapping_*`
 - Internal helpers: `isOwner_*` functions tested implicitly
 - Low-level operations used only in proofs

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ function testProperty_StoreRetrieve() public {
 }
 ```
 
-**Coverage**: 220/400 theorems tested (55%), 180 proof-only exclusions documented in `property_exclusions.json`.
+**Coverage**: 220/401 theorems tested (55%), 181 proof-only exclusions documented in `property_exclusions.json`.
 
 ### Differential Tests
 **Pattern**: `Differential<Contract>.t.sol`
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (195 functions, covering 220/400 theorems)
+├── Property*.t.sol           # Property tests (195 functions, covering 220/401 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests


### PR DESCRIPTION
## Summary
- sync docs metadata to current manifest totals after #517:
  - theorems: `401`
  - stdlib count: `159`
  - exclusions: `181`
- update count references across root docs, docs-site pages, and test docs so CI `Check documentation counts` passes.

## Validation
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only numeric updates; no code or proof logic changes, so functional risk is minimal aside from potential count mismatches.
> 
> **Overview**
> Updates documentation references to match the latest proof/manifest totals, bumping reported theorem counts from **400 → 401** across the README, trust/verification docs, docs site pages, and test docs.
> 
> Also refreshes related metrics to stay consistent (e.g., Stdlib **158 → 159** and proof-only exclusions **180 → 181**) so CI doc-count validation reflects the current `property_manifest.json` totals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec2b5adcd73e05ffbbcfebca2defb32a637086ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->