### PR TITLE
gas: add contract-level static upper-bound report CLI

### DIFF
--- a/Compiler/Gas/Report.lean
+++ b/Compiler/Gas/Report.lean
@@ -1,0 +1,94 @@
+import Compiler.Specs
+import Compiler.Selector
+import Compiler.ContractSpec
+import Compiler.Codegen
+import Compiler.Gas.StaticAnalysis
+
+namespace Compiler.Gas
+
+open Compiler
+open Compiler.ContractSpec
+open Compiler.Selector
+
+private structure CliConfig where
+  loopIterations : Nat := 8
+  unknownCallCost : Nat := 50000
+  fuel : Nat := 4096
+
+private def parseNatFlag (flag : String) (raw : String) : IO Nat :=
+  match raw.toNat? with
+  | some n => pure n
+  | none => throw <| IO.userError s!"Invalid Nat for {flag}: {raw}"
+
+private def printHelp : IO Unit := do
+  IO.println "Static gas upper-bound report for Verity contracts"
+  IO.println ""
+  IO.println "Usage: lake exe gas-report [options]"
+  IO.println ""
+  IO.println "Options:"
+  IO.println "  --loop-iterations <n>   Loop upper bound used by static analysis (default: 8)"
+  IO.println "  --unknown-call-cost <n> Fallback cost for unknown builtins/calls (default: 50000)"
+  IO.println "  --fuel <n>              Structural recursion fuel for analysis (default: 4096)"
+  IO.println "  --help                  Show this help message"
+
+private def parseArgs (args : List String) : IO CliConfig := do
+  let rec go (rest : List String) (cfg : CliConfig) : IO CliConfig := do
+    match rest with
+    | [] => pure cfg
+    | "--help" :: _ =>
+        printHelp
+        throw <| IO.userError "help"
+    | "--loop-iterations" :: value :: tail =>
+        go tail { cfg with loopIterations := (← parseNatFlag "--loop-iterations" value) }
+    | "--unknown-call-cost" :: value :: tail =>
+        go tail { cfg with unknownCallCost := (← parseNatFlag "--unknown-call-cost" value) }
+    | "--fuel" :: value :: tail =>
+        go tail { cfg with fuel := (← parseNatFlag "--fuel" value) }
+    | flag :: _ =>
+        throw <| IO.userError s!"Unknown argument: {flag}. Use --help for usage."
+  go args {}
+
+private def compileAndBound (cfg : GasConfig) (fuel : Nat) (spec : ContractSpec) : IO (String × Nat × Nat) := do
+  let selectors ← computeSelectors spec
+  match Compiler.ContractSpec.compile spec selectors with
+  | .error err => throw <| IO.userError s!"Failed to compile {spec.name}: {err}"
+  | .ok irContract =>
+      let yulObj := Compiler.emitYul irContract
+      let deployBound := stmtsUpperBound cfg fuel yulObj.deployCode
+      let runtimeBound := stmtsUpperBound cfg fuel yulObj.runtimeCode
+      pure (spec.name, deployBound, runtimeBound)
+
+private def printRow (name : String) (deploy runtime : Nat) : IO Unit :=
+  IO.println s!"{name}\t{deploy}\t{runtime}\t{deploy + runtime}"
+
+def main (args : List String) : IO Unit := do
+  try
+    let cli ← parseArgs args
+    let gasCfg : GasConfig := {
+      loopIterations := cli.loopIterations
+      unknownCallCost := cli.unknownCallCost
+    }
+
+    IO.println s!"# gas-report loopIterations={cli.loopIterations} unknownCallCost={cli.unknownCallCost} fuel={cli.fuel}"
+    IO.println "contract\tdeploy_upper_bound\truntime_upper_bound\ttotal_upper_bound"
+
+    let mut totalDeploy := 0
+    let mut totalRuntime := 0
+
+    for spec in Compiler.Specs.allSpecs do
+      let (name, deployBound, runtimeBound) ← compileAndBound gasCfg cli.fuel spec
+      totalDeploy := totalDeploy + deployBound
+      totalRuntime := totalRuntime + runtimeBound
+      printRow name deployBound runtimeBound
+
+    IO.println s!"TOTAL\t{totalDeploy}\t{totalRuntime}\t{totalDeploy + totalRuntime}"
+  catch e =>
+    if e.toString == "help" then
+      pure ()
+    else
+      throw e
+
+end Compiler.Gas
+
+def main (args : List String) : IO Unit :=
+  Compiler.Gas.main args

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -19,3 +19,6 @@ lean_exe «difftest-interpreter» where
 
 lean_exe «random-gen» where
   root := `Compiler.RandomGen
+
+lean_exe «gas-report» where
+  root := `Compiler.Gas.Report


### PR DESCRIPTION
## Summary
- add a new `gas-report` Lean executable that computes static gas upper bounds for all built-in Verity contract specs
- wire the executable into `lakefile.lean`
- expose tuning flags for the static analysis model (`--loop-iterations`, `--unknown-call-cost`, `--fuel`)

## Why
Phase-1 gas static analysis exists, but there was no end-to-end path to compute bounds on actual compiled contracts. This PR makes the analysis operational for every built-in contract and gives a deterministic report that can be compared over time.

Refs #262

## Validation
- `lake build Compiler.Gas.Report`
- `lake exe gas-report`
- `lake exe gas-report --loop-iterations 16 --unknown-call-cost 80000 --fuel 8192`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new reporting executable and wiring in `lakefile.lean` without changing compilation or analysis logic used elsewhere; risk is mainly around build/CLI behavior and report correctness.
> 
> **Overview**
> Adds a new `lake exe gas-report` CLI that compiles each spec in `Compiler.Specs.allSpecs`, runs the static analysis (`stmtsUpperBound`) over deploy and runtime Yul, and prints a tabular per-contract + total gas upper-bound report.
> 
> The CLI includes basic flag parsing and help output, exposing tuning knobs for the analysis model via `--loop-iterations`, `--unknown-call-cost`, and `--fuel`, and is registered as a new executable in `lakefile.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a3c20b44e8fb176d32d93037621f26bb5fbeafd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->