### PR TITLE
gas: add CI invariants check for gas-report

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -270,6 +270,9 @@ jobs:
       - name: Check selector fixtures against solc
         run: python3 scripts/check_selector_fixtures.py
 
+      - name: Check static gas report invariants
+        run: python3 scripts/check_gas_report.py
+
       - name: Generate property coverage report
         run: python3 scripts/report_property_coverage.py --format=markdown >> $GITHUB_STEP_SUMMARY
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -102,6 +102,7 @@ python3 scripts/check_contract_structure.py
 - **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings with the same shared string-aware parser used by storage checks; parses `ParamType` expressions recursively (including `bool`, tuple, array, and fixed-array forms) when extracting Solidity signatures; enforces compile selector table coverage for all specs except those with non-empty `externals`
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), includes only `public`/`external` selectors (matching `solc --hashes`), canonicalizes ABI-sensitive param forms (`function(...)`, `uint/int` aliases, user-defined `contract`/`enum`/`type` aliases, and struct params into canonical tuple signatures), parses both `solc --hashes` output layouts robustly (including nested tuple signatures), and enforces reverse completeness (every `solc --hashes` signature must be present in extracted fixtures)
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
+- **`check_gas_report.py`** - Validates `lake exe gas-report` output shape, arithmetic consistency of totals, and monotonicity under more conservative static analysis settings
 
 ```bash
 # Default: check compiler/yul
@@ -161,7 +162,8 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 2. Selector hash verification (`check_selectors.py`)
 3. Yul compilation check (`check_yul_compiles.py`)
 4. Selector fixture check (`check_selector_fixtures.py`)
-5. Coverage and storage layout reports in workflow summary
+5. Static gas report invariants (`check_gas_report.py`)
+6. Coverage and storage layout reports in workflow summary
 
 **`foundry`** — 8-shard parallel Foundry tests with seed 42
 **`foundry-multi-seed`** — 7-seed flakiness detection (seeds: 0, 1, 42, 123, 999, 12345, 67890)

--- a/scripts/check_gas_report.py
+++ b/scripts/check_gas_report.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Validate `lake exe gas-report` output and basic monotonicity invariants."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class Row:
+    contract: str
+    deploy: int
+    runtime: int
+    total: int
+
+
+def run_gas_report(extra_args: list[str]) -> str:
+    cmd = ["lake", "exe", "gas-report", *extra_args]
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise RuntimeError(f"`{' '.join(cmd)}` failed with exit code {proc.returncode}")
+    return proc.stdout
+
+
+def parse_report(stdout: str) -> tuple[str, list[Row], Row]:
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if len(lines) < 4:
+        raise ValueError(f"Unexpected report shape, expected >=4 non-empty lines, got {len(lines)}")
+
+    config_line = lines[0]
+    if not config_line.startswith("# gas-report "):
+        raise ValueError(f"Missing config header line: {config_line}")
+
+    expected_header = "contract\tdeploy_upper_bound\truntime_upper_bound\ttotal_upper_bound"
+    if lines[1] != expected_header:
+        raise ValueError(f"Unexpected table header: {lines[1]}")
+
+    parsed_rows: list[Row] = []
+    for raw in lines[2:]:
+        parts = raw.split("\t")
+        if len(parts) != 4:
+            raise ValueError(f"Malformed report row: {raw}")
+        name, deploy_s, runtime_s, total_s = parts
+        try:
+            deploy = int(deploy_s)
+            runtime = int(runtime_s)
+            total = int(total_s)
+        except ValueError as exc:
+            raise ValueError(f"Non-numeric gas values in row: {raw}") from exc
+        if total != deploy + runtime:
+            raise ValueError(f"Row total mismatch for {name}: {total} != {deploy} + {runtime}")
+        parsed_rows.append(Row(name, deploy, runtime, total))
+
+    if parsed_rows[-1].contract != "TOTAL":
+        raise ValueError("Last row must be TOTAL")
+
+    return config_line, parsed_rows[:-1], parsed_rows[-1]
+
+
+def validate_totals(rows: list[Row], total_row: Row) -> None:
+    summed_deploy = sum(r.deploy for r in rows)
+    summed_runtime = sum(r.runtime for r in rows)
+    summed_total = sum(r.total for r in rows)
+    if total_row.deploy != summed_deploy:
+        raise ValueError(f"TOTAL deploy mismatch: {total_row.deploy} != {summed_deploy}")
+    if total_row.runtime != summed_runtime:
+        raise ValueError(f"TOTAL runtime mismatch: {total_row.runtime} != {summed_runtime}")
+    if total_row.total != summed_total:
+        raise ValueError(f"TOTAL combined mismatch: {total_row.total} != {summed_total}")
+
+
+def validate_monotonicity(default_rows: list[Row], conservative_rows: list[Row]) -> None:
+    default_by_name = {r.contract: r for r in default_rows}
+    conservative_by_name = {r.contract: r for r in conservative_rows}
+    if default_by_name.keys() != conservative_by_name.keys():
+        raise ValueError("Contract sets differ across gas-report configurations")
+    for name in sorted(default_by_name):
+        default_total = default_by_name[name].total
+        conservative_total = conservative_by_name[name].total
+        if conservative_total < default_total:
+            raise ValueError(
+                f"Monotonicity violated for {name}: conservative total {conservative_total} < default {default_total}"
+            )
+
+
+def main() -> int:
+    try:
+        _, default_rows, default_total = parse_report(run_gas_report([]))
+        validate_totals(default_rows, default_total)
+
+        conservative_args = ["--loop-iterations", "16", "--unknown-call-cost", "80000", "--fuel", "8192"]
+        _, conservative_rows, conservative_total = parse_report(run_gas_report(conservative_args))
+        validate_totals(conservative_rows, conservative_total)
+        validate_monotonicity(default_rows, conservative_rows)
+    except Exception as exc:  # pragma: no cover - CI entrypoint
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print("OK: gas-report output shape, totals, and monotonicity checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_gas_report.py` to validate `lake exe gas-report`
- assert report shape and arithmetic consistency (`TOTAL` row and per-row deploy+runtime)
- assert monotonicity under a stricter conservative configuration (`--loop-iterations 16 --unknown-call-cost 80000 --fuel 8192`)
- run this check in CI (`.github/workflows/verify.yml`, build job)
- document the new checker in `scripts/README.md`

## Why
Issue #262 Phase 1 now has a static estimator and a report CLI, but there was no CI guard to ensure report integrity and configuration behavior stay correct over time.

## Validation
- `python3 scripts/check_gas_report.py`
- `python3 scripts/check_doc_counts.py`

Refs #262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Python-only CI guardrail and documentation, with no changes to production/runtime logic; main impact is potential new CI failures if `gas-report` output or behavior changes.
> 
> **Overview**
> Adds `scripts/check_gas_report.py` to run `lake exe gas-report`, parse its tab-separated output, and fail CI if the report format changes, per-row totals are inconsistent, or the final `TOTAL` row doesn’t match summed values.
> 
> Extends the `verify.yml` build workflow to run this check and compares default vs a more conservative `gas-report` configuration to enforce monotonic (non-decreasing) total gas bounds per contract; documents the new checker in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b3ee7408868230ea28ae41e031dfa745d6351d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->