### PR TITLE
gas: enforce static model coverage for emitted Yul builtins

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Check Lean hygiene
         run: python3 scripts/check_lean_hygiene.py
 
+      - name: Check static gas model builtin coverage
+        run: python3 scripts/check_gas_model_coverage.py
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/Compiler/Gas/StaticAnalysis.lean
+++ b/Compiler/Gas/StaticAnalysis.lean
@@ -39,7 +39,17 @@ def builtinBaseCost (cfg : GasConfig) (name : String) : Nat :=
   else if name = "mstore" then 3
   else if name = "mload" then 3
   else if name = "calldataload" then 3
+  else if name = "calldatasize" then 2
+  else if name = "callvalue" then 2
   else if name = "caller" then 2
+  else if name = "codesize" then 2
+  /- Copy costs depend on payload length and memory expansion.
+     Use conservative constants to avoid unknown-call fallback explosions. -/
+  else if name = "codecopy" then 5000
+  else if name = "datacopy" then 5000
+  /- `dataoffset`/`datasize` compile to immediate constants; model as verylow. -/
+  else if name = "dataoffset" then 3
+  else if name = "datasize" then 3
   else if name = "mappingSlot" then 42
   else if name = "add" then 3
   else if name = "sub" then 3

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -103,6 +103,7 @@ python3 scripts/check_contract_structure.py
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), includes only `public`/`external` selectors (matching `solc --hashes`), canonicalizes ABI-sensitive param forms (`function(...)`, `uint/int` aliases, user-defined `contract`/`enum`/`type` aliases, and struct params into canonical tuple signatures), parses both `solc --hashes` output layouts robustly (including nested tuple signatures), and enforces reverse completeness (every `solc --hashes` signature must be present in extracted fixtures)
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 - **`check_gas_report.py`** - Validates `lake exe gas-report` output shape, arithmetic consistency of totals, and monotonicity under more conservative static analysis settings
+- **`check_gas_model_coverage.py`** - Verifies that every call emitted in `compiler/yul/*.yul` has an explicit cost branch in `Compiler/Gas/StaticAnalysis.lean` (prevents silent fallback to unknown-call costs)
 
 ```bash
 # Default: check compiler/yul
@@ -156,6 +157,7 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 6. Property manifest sync (`check_property_manifest_sync.py`)
 7. Storage layout consistency (`check_storage_layout.py`)
 8. Lean hygiene (`check_lean_hygiene.py`)
+9. Static gas model builtin coverage (`check_gas_model_coverage.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/check_gas_model_coverage.py
+++ b/scripts/check_gas_model_coverage.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Ensure static gas builtin coverage matches generated Yul call sites."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from property_utils import ROOT
+
+STATIC_ANALYSIS = ROOT / "Compiler" / "Gas" / "StaticAnalysis.lean"
+YUL_DIR = ROOT / "compiler" / "yul"
+
+FUNCTION_DEF_RE = re.compile(r"\bfunction\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+CALL_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+MODELED_CALL_RE = re.compile(r'name\s*=\s*"([A-Za-z_][A-Za-z0-9_]*)"')
+
+NON_CALL_KEYWORDS = {"function", "if", "switch", "object", "code"}
+
+
+def load_modeled_calls() -> set[str]:
+    text = STATIC_ANALYSIS.read_text(encoding="utf-8")
+    return set(MODELED_CALL_RE.findall(text))
+
+
+def strip_inline_comments(line: str) -> str:
+    idx = line.find("/*")
+    if idx != -1:
+        return line[:idx]
+    return line
+
+
+def collect_yul_calls() -> set[str]:
+    calls: set[str] = set()
+    for yul_path in sorted(YUL_DIR.glob("*.yul")):
+        function_names: set[str] = set()
+        for line in yul_path.read_text(encoding="utf-8").splitlines():
+            clean = strip_inline_comments(line)
+            fn_match = FUNCTION_DEF_RE.search(clean)
+            if fn_match:
+                function_names.add(fn_match.group(1))
+            for match in CALL_RE.finditer(clean):
+                name = match.group(1)
+                if name in NON_CALL_KEYWORDS or name in function_names:
+                    continue
+                calls.add(name)
+    return calls
+
+
+def main() -> int:
+    if not STATIC_ANALYSIS.exists():
+        print(f"ERROR: missing {STATIC_ANALYSIS}", file=sys.stderr)
+        return 1
+    if not YUL_DIR.exists():
+        print(f"ERROR: missing {YUL_DIR}", file=sys.stderr)
+        return 1
+
+    modeled = load_modeled_calls()
+    emitted = collect_yul_calls()
+
+    missing = sorted(emitted - modeled)
+    if missing:
+        print("ERROR: Static gas model is missing emitted Yul calls:", file=sys.stderr)
+        for name in missing:
+            print(f"  - {name}", file=sys.stderr)
+        return 1
+
+    print(f"OK: static gas model covers all emitted Yul calls ({len(emitted)} names)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add explicit static gas costs for Yul builtins emitted by current compiler output (`calldatasize`, `callvalue`, `codesize`, `codecopy`, `datacopy`, `dataoffset`, `datasize`)
- add `scripts/check_gas_model_coverage.py` to ensure every call emitted in `compiler/yul/*.yul` has an explicit branch in `Compiler/Gas/StaticAnalysis.lean`
- wire the new check into the fast `checks` CI job and document it in `scripts/README.md`

## Why
`Compiler/Gas/StaticAnalysis.lean` currently has an unknown-call fallback. When emitted builtins miss explicit branches, gas bounds stay conservative but become needlessly loose and can drift silently as compiler output evolves.

This PR makes builtin coverage explicit and enforced in CI, which is a Phase-1 reliability increment for #262.

## Validation
- `python3 scripts/check_gas_model_coverage.py`
- `python3 scripts/check_gas_report.py`
- `lake build Compiler.Gas.StaticAnalysis`
- `python3 scripts/check_doc_counts.py`

Refs #262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the static gas cost table and adds a CI gate that can fail builds when compiler-emitted Yul builtins lack explicit modeling. Risk is moderate because it changes gas upper-bound calculations and introduces a new cross-artifact consistency check.
> 
> **Overview**
> **Static gas analysis coverage is tightened and enforced.** `Compiler/Gas/StaticAnalysis.lean` adds explicit base-cost branches for newly emitted Yul builtins (e.g., `calldatasize`, `callvalue`, `codesize`, `codecopy`, `datacopy`, `dataoffset`, `datasize`) to avoid falling back to the unknown-call cost.
> 
> **CI now rejects drift between emitted Yul calls and the gas model.** A new `scripts/check_gas_model_coverage.py` scans `compiler/yul/*.yul` for call sites and fails if any are missing from the Lean cost table; it’s wired into the fast `checks` job in `verify.yml` and documented in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aa3dd7768d86944091c4b692aecf5a15ce1c70e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->