### PR TITLE
gas: add static-vs-foundry calibration CI check

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -276,6 +276,9 @@ jobs:
       - name: Check static gas report invariants
         run: python3 scripts/check_gas_report.py
 
+      - name: Save static gas report snapshot
+        run: lake exe gas-report > gas-report-static.tsv
+
       - name: Generate property coverage report
         run: python3 scripts/report_property_coverage.py --format=markdown >> $GITHUB_STEP_SUMMARY
 
@@ -293,6 +296,35 @@ jobs:
         with:
           name: difftest-interpreter
           path: .lake/build/bin/difftest-interpreter
+
+      - name: Upload static gas report
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-gas-report
+          path: gas-report-static.tsv
+
+  foundry-gas-calibration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [changes, build]
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download static gas report
+        uses: actions/download-artifact@v4
+        with:
+          name: static-gas-report
+
+      - name: Setup Foundry environment
+        uses: ./.github/actions/setup-foundry
+
+      - name: Check static-vs-foundry gas calibration
+        env:
+          FOUNDRY_PROFILE: difftest
+        run: python3 scripts/check_gas_calibration.py --static-report gas-report-static.tsv
 
   foundry:
     runs-on: ubuntu-latest

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,6 +104,7 @@ python3 scripts/check_contract_structure.py
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 - **`check_gas_report.py`** - Validates `lake exe gas-report` output shape, arithmetic consistency of totals, and monotonicity under more conservative static analysis settings
 - **`check_gas_model_coverage.py`** - Verifies that every call emitted in `compiler/yul/*.yul` has an explicit cost branch in `Compiler/Gas/StaticAnalysis.lean` (prevents silent fallback to unknown-call costs)
+- **`check_gas_calibration.py`** - Compares static runtime bounds (`lake exe gas-report`) against Foundry `--gas-report` measurements for `test/yul/*.t.sol`, requiring static bounds + transaction base gas to dominate observed max call gas
 
 ```bash
 # Default: check compiler/yul
@@ -165,8 +166,10 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 3. Yul compilation check (`check_yul_compiles.py`)
 4. Selector fixture check (`check_selector_fixtures.py`)
 5. Static gas report invariants (`check_gas_report.py`)
-6. Coverage and storage layout reports in workflow summary
+6. Save static gas report artifact (`gas-report-static.tsv`)
+7. Coverage and storage layout reports in workflow summary
 
+**`foundry-gas-calibration`** — Static-vs-Foundry gas calibration check (`check_gas_calibration.py`) using build-artifact static report + Foundry gas report
 **`foundry`** — 8-shard parallel Foundry tests with seed 42
 **`foundry-multi-seed`** — 7-seed flakiness detection (seeds: 0, 1, 42, 123, 999, 12345, 67890)
 

--- a/scripts/check_gas_calibration.py
+++ b/scripts/check_gas_calibration.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Cross-check static runtime gas bounds against Foundry gas measurements."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_FOUNDRY_PATH_GLOB = "test/yul/*.t.sol"
+# Slightly above intrinsic transaction base to absorb calldata overhead in Foundry calls.
+TX_BASE_GAS = 22000
+
+STATIC_HEADER = "contract\tdeploy_upper_bound\truntime_upper_bound\ttotal_upper_bound"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--static-report",
+        type=Path,
+        default=None,
+        help="Path to precomputed `lake exe gas-report` output. If omitted, runs `lake exe gas-report`.",
+    )
+    parser.add_argument(
+        "--match-path",
+        default=DEFAULT_FOUNDRY_PATH_GLOB,
+        help="Foundry --match-path pattern used when collecting gas report.",
+    )
+    parser.add_argument(
+        "--tx-base-gas",
+        type=int,
+        default=TX_BASE_GAS,
+        help="Fixed call overhead added when comparing static runtime upper bound to Foundry call gas.",
+    )
+    return parser.parse_args()
+
+
+def run_command(cmd: list[str], env: dict[str, str] | None = None) -> str:
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    if proc.returncode != 0:
+        if proc.stdout:
+            sys.stderr.write(proc.stdout)
+        if proc.stderr:
+            sys.stderr.write(proc.stderr)
+        raise RuntimeError(f"`{' '.join(cmd)}` failed with exit code {proc.returncode}")
+    return proc.stdout
+
+
+def load_static_runtime_bounds(path: Path | None) -> dict[str, int]:
+    if path is None:
+        stdout = run_command(["lake", "exe", "gas-report"])
+    else:
+        stdout = path.read_text(encoding="utf-8")
+
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if len(lines) < 4:
+        raise ValueError("Static gas report is too short")
+    if lines[1] != STATIC_HEADER:
+        raise ValueError(f"Unexpected static report header: {lines[1]}")
+
+    bounds: dict[str, int] = {}
+    for raw in lines[2:]:
+        parts = raw.split("\t")
+        if len(parts) != 4:
+            raise ValueError(f"Malformed static gas row: {raw}")
+        contract, deploy, runtime, total = parts
+        if contract == "TOTAL":
+            continue
+        runtime_n = int(runtime)
+        if int(total) != int(deploy) + runtime_n:
+            raise ValueError(f"Invalid static total arithmetic for {contract}")
+        bounds[contract] = runtime_n
+
+    if not bounds:
+        raise ValueError("No contract rows found in static gas report")
+    return bounds
+
+
+def run_foundry_gas_report(match_path: str) -> str:
+    env = dict(os.environ)
+    env.setdefault("FOUNDRY_PROFILE", "difftest")
+    cmd = ["forge", "test", "--gas-report", "--match-path", match_path]
+    return run_command(cmd, env=env)
+
+
+def parse_foundry_runtime_max(stdout: str) -> dict[str, int]:
+    contract_header = re.compile(r"\|\s+[^|]*:(?P<name>[A-Za-z0-9_]+)\s+Contract\s*\|")
+    observed: dict[str, int] = {}
+    current: str | None = None
+
+    for raw in stdout.splitlines():
+        m = contract_header.search(raw)
+        if m:
+            current = m.group("name")
+            observed.setdefault(current, 0)
+            continue
+
+        if current is None or "|" not in raw:
+            continue
+        stripped = raw.strip()
+        if stripped.startswith("| Function Name") or stripped.startswith("| Deployment Cost"):
+            continue
+        if set(stripped) <= {"|", "-", "+", "=", "╭", "╰", "╮", "╯"}:
+            continue
+
+        cols = [part.strip() for part in raw.split("|")]
+        if len(cols) < 7:
+            continue
+        fn_name = cols[1]
+        if not fn_name or fn_name in {"Function Name", "Deployment Cost"}:
+            continue
+
+        max_col = cols[5]
+        if not max_col.isdigit():
+            continue
+
+        max_gas = int(max_col)
+        if max_gas > observed[current]:
+            observed[current] = max_gas
+
+    observed = {k: v for k, v in observed.items() if v > 0}
+    if not observed:
+        raise ValueError("No Foundry function gas rows parsed from gas report output")
+    return observed
+
+
+def validate_bounds(static_runtime: dict[str, int], foundry_max: dict[str, int], tx_base_gas: int) -> list[str]:
+    failures: list[str] = []
+    for contract, observed in sorted(foundry_max.items()):
+        static = static_runtime.get(contract)
+        if static is None:
+            failures.append(f"{contract}: missing in static gas report")
+            continue
+        bound = static + tx_base_gas
+        if observed > bound:
+            failures.append(
+                f"{contract}: foundry max {observed} exceeds static+txBase {bound} (static={static}, txBase={tx_base_gas})"
+            )
+    return failures
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        static_runtime = load_static_runtime_bounds(args.static_report)
+        foundry_stdout = run_foundry_gas_report(args.match_path)
+        foundry_max = parse_foundry_runtime_max(foundry_stdout)
+        failures = validate_bounds(static_runtime, foundry_max, args.tx_base_gas)
+    except Exception as exc:  # pragma: no cover - CI entrypoint
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if failures:
+        print("ERROR: static-vs-foundry gas calibration check failed:", file=sys.stderr)
+        for line in failures:
+            print(f"  - {line}", file=sys.stderr)
+        return 1
+
+    overlap = sorted(set(static_runtime).intersection(foundry_max))
+    print(
+        "OK: static runtime bounds dominate Foundry max function gas "
+        f"for {len(overlap)} contracts (using tx_base_gas={args.tx_base_gas})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_gas_calibration.py` to calibrate static runtime gas bounds against Foundry `--gas-report` output for Yul tests
- wire a new CI job `foundry-gas-calibration` that compares build-artifact static report output to live Foundry gas measurements
- persist static report from `build` as `gas-report-static.tsv` artifact and document the new checker/job in `scripts/README.md`

## Why
Issue #262 Phase-1 calls out validating static estimates against Foundry gas reports. This adds an automated guard for that calibration path so regressions are caught in CI.

## Calibration Rule
For each overlapping contract, require:

`foundry_max_function_gas <= static_runtime_upper_bound + tx_overhead`

with a conservative fixed `tx_overhead=22000` (intrinsic transaction base plus small calldata overhead headroom).

## Validation
- `python3 scripts/check_gas_report.py`
- `python3 scripts/check_gas_model_coverage.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_gas_calibration.py`
- `lake exe gas-report > /tmp/gas-report-static.tsv && python3 scripts/check_gas_calibration.py --static-report /tmp/gas-report-static.tsv`

Refs #262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI pipeline structure and adds a new cross-tool validation that depends on parsing Foundry output, which may cause intermittent CI failures if formats or gas report behavior change.
> 
> **Overview**
> Adds a new `scripts/check_gas_calibration.py` script that parses the static `lake exe gas-report` TSV and compares each contract’s runtime upper bound (plus a configurable tx base overhead) against Foundry `forge test --gas-report` max function gas.
> 
> Updates CI (`verify.yml`) to persist a `gas-report-static.tsv` artifact from the `build` job and introduces a new `foundry-gas-calibration` job that downloads this artifact and runs the calibration check; documents the new checker/job in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a4252f2c9bd0898218f1649cb7d9c3a7b19fec5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->