### PR TITLE
gas: calibrate static deploy bounds against Foundry reports

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,7 +104,7 @@ python3 scripts/check_contract_structure.py
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 - **`check_gas_report.py`** - Validates `lake exe gas-report` output shape, arithmetic consistency of totals, and monotonicity under more conservative static analysis settings
 - **`check_gas_model_coverage.py`** - Verifies that every call emitted in `compiler/yul/*.yul` has an explicit cost branch in `Compiler/Gas/StaticAnalysis.lean` (prevents silent fallback to unknown-call costs)
-- **`check_gas_calibration.py`** - Compares static runtime bounds (`lake exe gas-report`) against Foundry `--gas-report` measurements for `test/yul/*.t.sol`, requiring static bounds + transaction base gas to dominate observed max call gas
+- **`check_gas_calibration.py`** - Compares static bounds (`lake exe gas-report`) against Foundry `--gas-report` measurements for `test/yul/*.t.sol`, requiring runtime bounds + transaction base gas to dominate observed max call gas and deploy bounds + creation/code-deposit overhead to dominate deployment gas
 
 ```bash
 # Default: check compiler/yul
@@ -169,7 +169,7 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 6. Save static gas report artifact (`gas-report-static.tsv`)
 7. Coverage and storage layout reports in workflow summary
 
-**`foundry-gas-calibration`** — Static-vs-Foundry gas calibration check (`check_gas_calibration.py`) using build-artifact static report + Foundry gas report
+**`foundry-gas-calibration`** — Static-vs-Foundry gas calibration check (`check_gas_calibration.py`) using build-artifact static report + Foundry gas report (runtime + deployment)
 **`foundry`** — 8-shard parallel Foundry tests with seed 42
 **`foundry-multi-seed`** — 7-seed flakiness detection (seeds: 0, 1, 42, 123, 999, 12345, 67890)
 

--- a/scripts/check_gas_calibration.py
+++ b/scripts/check_gas_calibration.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Cross-check static runtime gas bounds against Foundry gas measurements."""
+"""Cross-check static gas bounds against Foundry gas measurements."""
 
 from __future__ import annotations
 
@@ -15,6 +15,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_FOUNDRY_PATH_GLOB = "test/yul/*.t.sol"
 # Slightly above intrinsic transaction base to absorb calldata overhead in Foundry calls.
 TX_BASE_GAS = 22000
+CREATE_TX_BASE_GAS = 53000
+CODE_DEPOSIT_GAS_PER_BYTE = 200
 
 STATIC_HEADER = "contract\tdeploy_upper_bound\truntime_upper_bound\ttotal_upper_bound"
 
@@ -38,6 +40,18 @@ def parse_args() -> argparse.Namespace:
         default=TX_BASE_GAS,
         help="Fixed call overhead added when comparing static runtime upper bound to Foundry call gas.",
     )
+    parser.add_argument(
+        "--create-tx-base-gas",
+        type=int,
+        default=CREATE_TX_BASE_GAS,
+        help="Fixed deployment transaction overhead (tx base + create surcharge).",
+    )
+    parser.add_argument(
+        "--code-deposit-gas-per-byte",
+        type=int,
+        default=CODE_DEPOSIT_GAS_PER_BYTE,
+        help="Gas charged per deployed runtime bytecode byte.",
+    )
     return parser.parse_args()
 
 
@@ -59,7 +73,7 @@ def run_command(cmd: list[str], env: dict[str, str] | None = None) -> str:
     return proc.stdout
 
 
-def load_static_runtime_bounds(path: Path | None) -> dict[str, int]:
+def load_static_bounds(path: Path | None) -> dict[str, tuple[int, int]]:
     if path is None:
         stdout = run_command(["lake", "exe", "gas-report"])
     else:
@@ -71,7 +85,7 @@ def load_static_runtime_bounds(path: Path | None) -> dict[str, int]:
     if lines[1] != STATIC_HEADER:
         raise ValueError(f"Unexpected static report header: {lines[1]}")
 
-    bounds: dict[str, int] = {}
+    bounds: dict[str, tuple[int, int]] = {}
     for raw in lines[2:]:
         parts = raw.split("\t")
         if len(parts) != 4:
@@ -79,10 +93,11 @@ def load_static_runtime_bounds(path: Path | None) -> dict[str, int]:
         contract, deploy, runtime, total = parts
         if contract == "TOTAL":
             continue
+        deploy_n = int(deploy)
         runtime_n = int(runtime)
-        if int(total) != int(deploy) + runtime_n:
+        if int(total) != deploy_n + runtime_n:
             raise ValueError(f"Invalid static total arithmetic for {contract}")
-        bounds[contract] = runtime_n
+        bounds[contract] = (deploy_n, runtime_n)
 
     if not bounds:
         raise ValueError("No contract rows found in static gas report")
@@ -96,22 +111,29 @@ def run_foundry_gas_report(match_path: str) -> str:
     return run_command(cmd, env=env)
 
 
-def parse_foundry_runtime_max(stdout: str) -> dict[str, int]:
+def parse_foundry_report(stdout: str) -> tuple[dict[str, int], dict[str, tuple[int, int]]]:
     contract_header = re.compile(r"\|\s+[^|]*:(?P<name>[A-Za-z0-9_]+)\s+Contract\s*\|")
-    observed: dict[str, int] = {}
+    observed_runtime: dict[str, int] = {}
+    observed_deploy: dict[str, tuple[int, int]] = {}
     current: str | None = None
+    expect_deploy_row = False
 
     for raw in stdout.splitlines():
         m = contract_header.search(raw)
         if m:
             current = m.group("name")
-            observed.setdefault(current, 0)
+            observed_runtime.setdefault(current, 0)
+            expect_deploy_row = False
             continue
 
         if current is None or "|" not in raw:
             continue
         stripped = raw.strip()
-        if stripped.startswith("| Function Name") or stripped.startswith("| Deployment Cost"):
+        if stripped.startswith("| Deployment Cost"):
+            expect_deploy_row = True
+            continue
+        if stripped.startswith("| Function Name"):
+            expect_deploy_row = False
             continue
         if set(stripped) <= {"|", "-", "+", "=", "╭", "╰", "╮", "╯"}:
             continue
@@ -119,6 +141,12 @@ def parse_foundry_runtime_max(stdout: str) -> dict[str, int]:
         cols = [part.strip() for part in raw.split("|")]
         if len(cols) < 7:
             continue
+
+        if expect_deploy_row and cols[1].isdigit() and cols[2].isdigit():
+            observed_deploy[current] = (int(cols[1]), int(cols[2]))
+            expect_deploy_row = False
+            continue
+
         fn_name = cols[1]
         if not fn_name or fn_name in {"Function Name", "Deployment Cost"}:
             continue
@@ -128,26 +156,56 @@ def parse_foundry_runtime_max(stdout: str) -> dict[str, int]:
             continue
 
         max_gas = int(max_col)
-        if max_gas > observed[current]:
-            observed[current] = max_gas
+        if max_gas > observed_runtime[current]:
+            observed_runtime[current] = max_gas
 
-    observed = {k: v for k, v in observed.items() if v > 0}
-    if not observed:
+    observed_runtime = {k: v for k, v in observed_runtime.items() if v > 0}
+    if not observed_runtime:
         raise ValueError("No Foundry function gas rows parsed from gas report output")
-    return observed
+    if not observed_deploy:
+        raise ValueError("No Foundry deployment rows parsed from gas report output")
+    return observed_runtime, observed_deploy
 
 
-def validate_bounds(static_runtime: dict[str, int], foundry_max: dict[str, int], tx_base_gas: int) -> list[str]:
+def validate_runtime_bounds(
+    static_bounds: dict[str, tuple[int, int]],
+    foundry_runtime: dict[str, int],
+    tx_base_gas: int,
+) -> list[str]:
     failures: list[str] = []
-    for contract, observed in sorted(foundry_max.items()):
-        static = static_runtime.get(contract)
+    for contract, observed in sorted(foundry_runtime.items()):
+        static = static_bounds.get(contract)
         if static is None:
             failures.append(f"{contract}: missing in static gas report")
             continue
-        bound = static + tx_base_gas
+        _, static_runtime = static
+        bound = static_runtime + tx_base_gas
         if observed > bound:
             failures.append(
-                f"{contract}: foundry max {observed} exceeds static+txBase {bound} (static={static}, txBase={tx_base_gas})"
+                f"{contract}: foundry max {observed} exceeds static+txBase {bound} (static={static_runtime}, txBase={tx_base_gas})"
+            )
+    return failures
+
+
+def validate_deploy_bounds(
+    static_bounds: dict[str, tuple[int, int]],
+    foundry_deploy: dict[str, tuple[int, int]],
+    create_tx_base_gas: int,
+    code_deposit_gas_per_byte: int,
+) -> list[str]:
+    failures: list[str] = []
+    for contract, (observed_deploy, deploy_size) in sorted(foundry_deploy.items()):
+        static = static_bounds.get(contract)
+        if static is None:
+            failures.append(f"{contract}: missing in static gas report")
+            continue
+        static_deploy, _ = static
+        bound = static_deploy + create_tx_base_gas + code_deposit_gas_per_byte * deploy_size
+        if observed_deploy > bound:
+            failures.append(
+                f"{contract}: deployment {observed_deploy} exceeds static+createOverhead {bound} "
+                f"(staticDeploy={static_deploy}, createTxBase={create_tx_base_gas}, "
+                f"depositPerByte={code_deposit_gas_per_byte}, deploySize={deploy_size})"
             )
     return failures
 
@@ -155,10 +213,18 @@ def validate_bounds(static_runtime: dict[str, int], foundry_max: dict[str, int],
 def main() -> int:
     args = parse_args()
     try:
-        static_runtime = load_static_runtime_bounds(args.static_report)
+        static_bounds = load_static_bounds(args.static_report)
         foundry_stdout = run_foundry_gas_report(args.match_path)
-        foundry_max = parse_foundry_runtime_max(foundry_stdout)
-        failures = validate_bounds(static_runtime, foundry_max, args.tx_base_gas)
+        foundry_runtime, foundry_deploy = parse_foundry_report(foundry_stdout)
+        failures = validate_runtime_bounds(static_bounds, foundry_runtime, args.tx_base_gas)
+        failures.extend(
+            validate_deploy_bounds(
+                static_bounds,
+                foundry_deploy,
+                args.create_tx_base_gas,
+                args.code_deposit_gas_per_byte,
+            )
+        )
     except Exception as exc:  # pragma: no cover - CI entrypoint
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
@@ -169,10 +235,13 @@ def main() -> int:
             print(f"  - {line}", file=sys.stderr)
         return 1
 
-    overlap = sorted(set(static_runtime).intersection(foundry_max))
+    runtime_overlap = sorted(set(static_bounds).intersection(foundry_runtime))
+    deploy_overlap = sorted(set(static_bounds).intersection(foundry_deploy))
     print(
-        "OK: static runtime bounds dominate Foundry max function gas "
-        f"for {len(overlap)} contracts (using tx_base_gas={args.tx_base_gas})"
+        "OK: static bounds dominate Foundry gas "
+        f"(runtime contracts={len(runtime_overlap)}, deploy contracts={len(deploy_overlap)}, "
+        f"tx_base_gas={args.tx_base_gas}, create_tx_base_gas={args.create_tx_base_gas}, "
+        f"code_deposit_gas_per_byte={args.code_deposit_gas_per_byte})"
     )
     return 0
 


### PR DESCRIPTION
## Summary
- extend `scripts/check_gas_calibration.py` to validate static deploy bounds in addition to runtime call bounds
- parse Foundry deployment rows (`Deployment Cost`, `Deployment Size`) and compare against conservative static deploy envelope
- document the expanded calibration scope in `scripts/README.md`

## Calibration rules
- Runtime: `foundry_max_function_gas <= static_runtime_upper_bound + tx_base_gas`
- Deploy: `foundry_deploy_gas <= static_deploy_upper_bound + create_tx_base_gas + code_deposit_gas_per_byte * deployment_size`

Default constants:
- `tx_base_gas = 22000`
- `create_tx_base_gas = 53000` (`G_transaction + G_txcreate`)
- `code_deposit_gas_per_byte = 200`

## Validation
- `python3 scripts/check_gas_calibration.py`
- `python3 scripts/check_doc_counts.py`

Refs #262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: expands a CI gate by adding new parsing/validation of Foundry deployment output, which could introduce false failures if report formats vary or constants are miscalibrated.
> 
> **Overview**
> Extends `scripts/check_gas_calibration.py` from *runtime-only* calibration to also validate **deployment gas** against static deploy bounds plus configurable creation and code-deposit overhead (`--create-tx-base-gas`, `--code-deposit-gas-per-byte`).
> 
> The script now parses Foundry’s `Deployment Cost`/size rows alongside per-function max gas, validates both runtime and deploy envelopes, and reports separate runtime/deploy contract overlap counts; `scripts/README.md` is updated to reflect the expanded (runtime + deployment) calibration scope in CI/docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f7793584b6d0fc47125775d52fea52292119250. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->