### PR TITLE
gas: verify modeled call coverage for generated legacy+AST Yul

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -255,6 +255,12 @@ jobs:
       - name: Generate Yul (unified AST path)
         run: ./.lake/build/bin/verity-compiler --ast --output compiler/yul-ast
 
+      - name: Check static gas model coverage on generated Yul (legacy + AST)
+        run: |
+          python3 scripts/check_gas_model_coverage.py \
+            --dir compiler/yul \
+            --dir compiler/yul-ast
+
       - name: Keccak-256 self-test (validate hash implementation)
         run: python3 scripts/keccak256.py --self-test
 

--- a/scripts/check_gas_model_coverage.py
+++ b/scripts/check_gas_model_coverage.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -10,13 +11,25 @@ from pathlib import Path
 from property_utils import ROOT
 
 STATIC_ANALYSIS = ROOT / "Compiler" / "Gas" / "StaticAnalysis.lean"
-YUL_DIR = ROOT / "compiler" / "yul"
+DEFAULT_YUL_DIR = ROOT / "compiler" / "yul"
 
 FUNCTION_DEF_RE = re.compile(r"\bfunction\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 CALL_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 MODELED_CALL_RE = re.compile(r'name\s*=\s*"([A-Za-z_][A-Za-z0-9_]*)"')
 
 NON_CALL_KEYWORDS = {"function", "if", "switch", "object", "code"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dir",
+        dest="dirs",
+        action="append",
+        default=[],
+        help="Yul directory to scan (repeatable). Default: compiler/yul",
+    )
+    return parser.parse_args()
 
 
 def load_modeled_calls() -> set[str]:
@@ -30,31 +43,48 @@ def strip_comments(text: str) -> str:
     return text
 
 
-def collect_yul_calls() -> set[str]:
+def normalize_scan_dirs(raw_dirs: list[str]) -> list[Path]:
+    if not raw_dirs:
+        return [DEFAULT_YUL_DIR]
+    scan_dirs: list[Path] = []
+    for raw in raw_dirs:
+        path = Path(raw)
+        if not path.is_absolute():
+            path = ROOT / path
+        scan_dirs.append(path)
+    return scan_dirs
+
+
+def collect_yul_calls(scan_dirs: list[Path]) -> set[str]:
     calls: set[str] = set()
-    for yul_path in sorted(YUL_DIR.glob("*.yul")):
-        source = strip_comments(yul_path.read_text(encoding="utf-8"))
-        function_names = set(FUNCTION_DEF_RE.findall(source))
-        for line in source.splitlines():
-            clean = line.strip()
-            for match in CALL_RE.finditer(clean):
-                name = match.group(1)
-                if name in NON_CALL_KEYWORDS or name in function_names:
-                    continue
-                calls.add(name)
+    for scan_dir in scan_dirs:
+        for yul_path in sorted(scan_dir.glob("*.yul")):
+            source = strip_comments(yul_path.read_text(encoding="utf-8"))
+            function_names = set(FUNCTION_DEF_RE.findall(source))
+            for line in source.splitlines():
+                clean = line.strip()
+                for match in CALL_RE.finditer(clean):
+                    name = match.group(1)
+                    if name in NON_CALL_KEYWORDS or name in function_names:
+                        continue
+                    calls.add(name)
     return calls
 
 
 def main() -> int:
+    args = parse_args()
+    scan_dirs = normalize_scan_dirs(args.dirs)
+
     if not STATIC_ANALYSIS.exists():
         print(f"ERROR: missing {STATIC_ANALYSIS}", file=sys.stderr)
         return 1
-    if not YUL_DIR.exists():
-        print(f"ERROR: missing {YUL_DIR}", file=sys.stderr)
-        return 1
+    for scan_dir in scan_dirs:
+        if not scan_dir.exists():
+            print(f"ERROR: missing {scan_dir}", file=sys.stderr)
+            return 1
 
     modeled = load_modeled_calls()
-    emitted = collect_yul_calls()
+    emitted = collect_yul_calls(scan_dirs)
 
     missing = sorted(emitted - modeled)
     if missing:
@@ -63,7 +93,8 @@ def main() -> int:
             print(f"  - {name}", file=sys.stderr)
         return 1
 
-    print(f"OK: static gas model covers all emitted Yul calls ({len(emitted)} names)")
+    scanned = ", ".join(str(p.relative_to(ROOT)) if p.is_relative_to(ROOT) else str(p) for p in scan_dirs)
+    print(f"OK: static gas model covers all emitted Yul calls ({len(emitted)} names) across: {scanned}")
     return 0
 
 


### PR DESCRIPTION
## Summary
- extend `scripts/check_gas_model_coverage.py` with repeatable `--dir` inputs (default remains `compiler/yul`)
- run a second coverage check in CI `build` after generating both legacy and AST Yul outputs
- document the generated-legacy+AST coverage check in `scripts/README.md`

## Why
`compiler/yul-ast` is generated in CI and can diverge from the tracked legacy Yul output. The fast `checks` job validates tracked `compiler/yul`, but without a post-generation check we can miss newly emitted calls in the AST pipeline and silently fall back to `unknownCallCost`.

This keeps Phase-1 success criteria for #262 tighter by validating modeled-call coverage against both generated outputs.

Refs #262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and scripting-only change that tightens validation; main risk is additional build failures if the AST pipeline emits previously-unmodeled calls.
> 
> **Overview**
> Adds CI enforcement that the static gas model covers *all calls emitted* by both legacy and AST-generated Yul by running `check_gas_model_coverage.py` over `compiler/yul` and `compiler/yul-ast` after Yul generation.
> 
> Updates `scripts/check_gas_model_coverage.py` to accept repeatable `--dir` inputs (defaulting to `compiler/yul`) and improves reporting to list scanned directories; documentation is updated accordingly in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2128a9b9709253ca644ef932db023d239bd449f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->