### PR TITLE
refactor(ast-driver): enforce 4-byte selector range

### DIFF
--- a/Compiler/ASTDriver.lean
+++ b/Compiler/ASTDriver.lean
@@ -174,6 +174,12 @@ private def validateSelectorUniqueness (specName : String) (selectors : List Nat
   | some dup => throw s!"Duplicate selector in {specName}: {dup}"
   | none => pure ()
 
+private def validateSelectorRange (specName : String) (selectors : List Nat) : Except String Unit := do
+  let upperBound := (2 : Nat) ^ 32
+  for selector in selectors do
+    if selector >= upperBound then
+      throw s!"Selector out of 4-byte range in {specName}: {natToHex selector}"
+
 /-!
 ## Function Compilation
 
@@ -206,6 +212,7 @@ def compileSpec (spec : ASTContractSpec) (selectors : List Nat) : Except String 
   validateSpec spec
   if spec.functions.length != selectors.length then
     throw s!"Selector count mismatch for {spec.name}: {selectors.length} selectors for {spec.functions.length} functions"
+  validateSelectorRange spec.name selectors
   validateSelectorUniqueness spec.name selectors
   let functions := (spec.functions.zip selectors).map fun (fn, sel) =>
     compileFunction sel fn

--- a/Compiler/ASTDriverTest.lean
+++ b/Compiler/ASTDriverTest.lean
@@ -132,4 +132,21 @@ private def badDuplicateSelectorsSpec : ASTContractSpec := {
   | .ok _ =>
     throw (IO.userError "✗ expected duplicate selectors to be rejected")
 
+private def badOutOfRangeSelectorSpec : ASTContractSpec := {
+  name := "BadOutOfRangeSelector"
+  functions := [
+    { name := "f", params := [], returnType := .unit, body := Stmt.stop }
+  ]
+}
+
+#eval! do
+  match compileSpec badOutOfRangeSelectorSpec [((2 : Nat) ^ 32)] with
+  | .error err =>
+    if contains err "out of 4-byte range" then
+      IO.println "✓ Out-of-range selectors rejected in compileSpec"
+    else
+      throw (IO.userError s!"✗ unexpected out-of-range selector error: {err}")
+  | .ok _ =>
+    throw (IO.userError "✗ expected out-of-range selector to be rejected")
+
 end Compiler.ASTDriverTest


### PR DESCRIPTION
## Summary
- add selector range validation in `compileSpec` so selectors must fit Solidity's 4-byte ABI selector width
- keep existing selector count/uniqueness checks unchanged
- add regression test proving direct `compileSpec` calls reject out-of-range selectors

## Why
`compileSpec` is a boundary that can be called directly outside the `computeSelectors` path. Enforcing selector width here makes the invariant explicit and machine-checked at the boundary.

## Dependency impact
- `Compiler/Main.lean` -> `Compiler.ASTDriver.compileAllAST` -> `compileSpec`
- any direct users of `compileSpec` now receive early, explicit errors for selectors `>= 2^32`

## Validation
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_axiom_locations.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_storage_layout.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_gas_calibration.py`
- `python3 scripts/check_gas_model_coverage.py`
- `python3 scripts/check_gas_report.py`
- `lake build Compiler.ASTCompileTest Compiler.ASTDriverTest`
- `lake build verity-compiler`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, deterministic validation check at the `compileSpec` boundary and a regression test; behavior only changes for invalid selectors (>= `2^32`).
> 
> **Overview**
> **`compileSpec` now validates selector width.** A new `validateSelectorRange` check rejects any selector `>= (2 : Nat) ^ 32` (i.e., outside the 4-byte ABI range) before uniqueness checking.
> 
> **Tests updated.** Adds a regression case in `ASTDriverTest` asserting that direct `compileSpec` calls fail with an explicit error for out-of-range selectors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1723565b348e8efc059edd480da6dc33eb3fc08c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->