### PR TITLE
gas: require static contract coverage in calibration

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,7 +104,7 @@ python3 scripts/check_contract_structure.py
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 - **`check_gas_report.py`** - Validates `lake exe gas-report` output shape, arithmetic consistency of totals, and monotonicity under more conservative static analysis settings
 - **`check_gas_model_coverage.py`** - Verifies that every call emitted in generated Yul has an explicit cost branch in `Compiler/Gas/StaticAnalysis.lean` (prevents silent fallback to unknown-call costs)
-- **`check_gas_calibration.py`** - Compares static bounds (`lake exe gas-report`) against Foundry `--gas-report` measurements for `test/yul/*.t.sol`, requiring runtime bounds + transaction base gas to dominate observed max call gas and deploy bounds + creation/code-deposit overhead to dominate deployment gas
+- **`check_gas_calibration.py`** - Compares static bounds (`lake exe gas-report`) against Foundry `--gas-report` measurements for `test/yul/*.t.sol`, requiring runtime bounds + transaction base gas to dominate observed max call gas, deploy bounds + creation/code-deposit overhead to dominate deployment gas, and static-report contracts to be represented in Foundry gas output (unless explicitly allowlisted)
 
 ```bash
 # Default: check compiler/yul


### PR DESCRIPTION
## Summary
- tighten `check_gas_calibration.py` to fail when a contract appears in static gas report but has no Foundry gas-report measurements
- add `--allow-missing-contract` escape hatch for intentional exceptions
- update `scripts/README.md` to document stricter coverage behavior

## Why
Current calibration only validates overlap and can silently pass if a static-report contract drifts out of Foundry coverage entirely. This keeps issue #262 calibration continuously representative.

## Validation
- `python3 scripts/check_gas_calibration.py`
- `python3 scripts/check_doc_counts.py`

Refs #262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CI validation logic so previously passing runs may now fail if Foundry stops reporting a contract; behavior is controllable via a new allowlist flag but impacts build stability and calibration signal.
> 
> **Overview**
> Makes `scripts/check_gas_calibration.py` fail when a contract appears in the static gas report but has no corresponding Foundry `--gas-report` runtime or deployment measurement, preventing silent gaps in calibration coverage.
> 
> Adds `--allow-missing-contract` (repeatable) to explicitly exempt known omissions, and updates `scripts/README.md` to document the stricter coverage requirement and allowlist behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efb999801c63af235fce881f11cb5d9c7a709ef2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->