### PR TITLE
gas: harden calibration parser and support report replay

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,7 +104,7 @@ python3 scripts/check_contract_structure.py
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 - **`check_gas_report.py`** - Validates `lake exe gas-report` output shape, arithmetic consistency of totals, and monotonicity under more conservative static analysis settings
 - **`check_gas_model_coverage.py`** - Verifies that every call emitted in generated Yul has an explicit cost branch in `Compiler/Gas/StaticAnalysis.lean` (prevents silent fallback to unknown-call costs)
-- **`check_gas_calibration.py`** - Compares static bounds (`lake exe gas-report`) against Foundry `--gas-report` measurements for `test/yul/*.t.sol`, requiring runtime bounds + transaction base gas to dominate observed max call gas, deploy bounds + creation/code-deposit overhead to dominate deployment gas, and static-report contracts to be represented in Foundry gas output (unless explicitly allowlisted)
+- **`check_gas_calibration.py`** - Compares static bounds (`lake exe gas-report`) against Foundry `--gas-report` measurements for `test/yul/*.t.sol`, requiring runtime bounds + transaction base gas to dominate observed max call gas, deploy bounds + creation/code-deposit overhead to dominate deployment gas, and static-report contracts to be represented in Foundry gas output (unless explicitly allowlisted). Accepts precomputed `--static-report` and `--foundry-report` files for deterministic replay/debugging.
 
 ```bash
 # Default: check compiler/yul


### PR DESCRIPTION
## Summary
- harden Foundry gas table parsing by accepting numeric cells with separators (e.g. `100,539` / `100_539`)
- add `--foundry-report <path>` to `scripts/check_gas_calibration.py` for deterministic replay/debugging without rerunning `forge test`
- document the new replay mode in `scripts/README.md`

## Why
The calibration gate is a critical CI guardrail for #262. Its parser should be resilient to minor Foundry formatting changes and support replaying captured reports locally to debug CI failures quickly.

## Validation
- `python3 scripts/check_gas_calibration.py`
- `lake exe gas-report > /tmp/gas-report-static.tsv && FOUNDRY_PROFILE=difftest forge test --gas-report --match-path 'test/yul/*.t.sol' > /tmp/foundry-gas-report.txt && python3 scripts/check_gas_calibration.py --static-report /tmp/gas-report-static.tsv --foundry-report /tmp/foundry-gas-report.txt`
- `python3 scripts/check_doc_counts.py`

Refs #262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a CI-critical calibration gate; parsing changes could alter which contracts/functions are considered and cause false pass/fail if the new heuristics mis-handle Foundry output variants.
> 
> **Overview**
> **Gas calibration checks are now easier to replay and more resilient to Foundry formatting.** `check_gas_calibration.py` adds `--foundry-report` to read precomputed `forge test --gas-report` output instead of executing Foundry, enabling deterministic local/CI debugging.
> 
> The Foundry table parser is hardened by accepting numeric cells containing separators (commas/underscores) for deployment gas/size and max function gas, reducing brittleness to minor report formatting changes. Documentation in `scripts/README.md` is updated to describe the new replay mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 330f30626dfd85df3e028fda53b6341872042da4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->