### PR TITLE
gas: harden Foundry gas-report parsing against table drift

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,7 +104,7 @@ python3 scripts/check_contract_structure.py
 - **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc and can compare bytecode parity between directories
 - **`check_gas_report.py`** - Validates `lake exe gas-report` output shape, arithmetic consistency of totals, and monotonicity under more conservative static analysis settings
 - **`check_gas_model_coverage.py`** - Verifies that every call emitted in generated Yul has an explicit cost branch in `Compiler/Gas/StaticAnalysis.lean` (prevents silent fallback to unknown-call costs)
-- **`check_gas_calibration.py`** - Compares static bounds (`lake exe gas-report`) against Foundry `--gas-report` measurements for `test/yul/*.t.sol`, requiring runtime bounds + transaction base gas to dominate observed max call gas, deploy bounds + creation/code-deposit overhead to dominate deployment gas, and static-report contracts to be represented in Foundry gas output (unless explicitly allowlisted). Accepts precomputed `--static-report` and `--foundry-report` files for deterministic replay/debugging.
+- **`check_gas_calibration.py`** - Compares static bounds (`lake exe gas-report`) against Foundry `--gas-report` measurements for `test/yul/*.t.sol`, requiring runtime bounds + transaction base gas to dominate observed max call gas, deploy bounds + creation/code-deposit overhead to dominate deployment gas, and static-report contracts to be represented in Foundry gas output (unless explicitly allowlisted). Parsing is header-driven (not fixed-column) to tolerate Foundry table layout drift. Accepts precomputed `--static-report` and `--foundry-report` files for deterministic replay/debugging.
 
 ```bash
 # Default: check compiler/yul


### PR DESCRIPTION
## Summary
- harden `check_gas_calibration.py` Foundry parsing by using table header names instead of fixed column indexes
- keep numeric parsing tolerant (`1,234` / `1_234`) while making runtime/deploy extraction resilient to table layout drift
- document this parser robustness in `scripts/README.md`

## Why
Foundry `--gas-report` formatting can change column ordering/spacing across versions. Fixed-column parsing is fragile and can cause false CI failures or silent misreads.

## Validation
- `python3 scripts/check_gas_calibration.py --static-report /tmp/gas-report-static.tsv --foundry-report /tmp/foundry-gas-report-current.txt`
- `python3 scripts/check_gas_calibration.py`
- `python3 scripts/check_doc_counts.py`

Related to #262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a CI-critical calibration check; incorrect header detection or unexpected report formats could cause false failures or missed mismatches, though the change is localized to parsing logic.
> 
> **Overview**
> Updates `scripts/check_gas_calibration.py` to extract deployment/runtime gas values by **parsing table headers and dynamically locating columns** (via new `parse_table_cells`/`table_index`) instead of relying on fixed column indexes.
> 
> Updates `scripts/README.md` to document that `check_gas_calibration.py` is now *header-driven* to better tolerate Foundry gas-report table layout drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 579a50b89220677757756ae96512eca0cf97713a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->