### PR TITLE
core: add FiniteNatSet helper API for token-id sets

### DIFF
--- a/Verity/Core/FiniteSet.lean
+++ b/Verity/Core/FiniteSet.lean
@@ -6,7 +6,7 @@
   balance-conservation properties (e.g. Ledger sum proofs, issue #65).
 
   Key operations: empty, insert, remove, member, sum.
-  Key types: FiniteSet α, FiniteAddressSet.
+  Key types: FiniteSet α, FiniteAddressSet, FiniteNatSet.
   Key theorems: insert_of_not_mem, mem_elements_insert, sum_empty.
 -/
 
@@ -168,5 +168,60 @@ def contains (addr : Address) (s : FiniteAddressSet) : Bool :=
     FiniteSet.contains_eq_false addr s.addresses
 
 end FiniteAddressSet
+
+/-- Finite set of natural numbers. -/
+structure FiniteNatSet where
+  nats : FiniteSet Nat
+  deriving Repr
+
+namespace FiniteNatSet
+
+/-- Create an empty nat set. -/
+def empty : FiniteNatSet :=
+  ⟨FiniteSet.empty⟩
+
+/-- Number of tracked nat values. -/
+def card (s : FiniteNatSet) : Nat :=
+  s.nats.card
+
+/-- Nat membership proposition. -/
+def mem (s : FiniteNatSet) (n : Nat) : Prop :=
+  n ∈ s.nats
+
+instance : Membership Nat FiniteNatSet where
+  mem := mem
+
+/-- Insert a nat into the set. -/
+def insert (n : Nat) (s : FiniteNatSet) : FiniteNatSet :=
+  ⟨s.nats.insert n⟩
+
+/-- Remove a nat from the set. -/
+def remove (n : Nat) (s : FiniteNatSet) : FiniteNatSet :=
+  ⟨s.nats.remove n⟩
+
+/-- Boolean nat membership test. -/
+def contains (n : Nat) (s : FiniteNatSet) : Bool :=
+  s.nats.contains n
+
+@[simp] theorem card_empty : (empty : FiniteNatSet).card = 0 := rfl
+
+@[simp] theorem mem_def (n : Nat) (s : FiniteNatSet) :
+    n ∈ s ↔ n ∈ s.nats.elements := Iff.rfl
+
+@[simp] theorem mem_insert (a b : Nat) (s : FiniteNatSet) :
+    a ∈ s.insert b ↔ a = b ∨ a ∈ s := by
+  simpa [FiniteNatSet.mem] using FiniteSet.mem_elements_insert a b s.nats
+
+@[simp] theorem contains_eq_true (n : Nat) (s : FiniteNatSet) :
+    s.contains n = true ↔ n ∈ s := by
+  simpa [FiniteNatSet.mem, FiniteNatSet.contains] using
+    FiniteSet.contains_eq_true n s.nats
+
+@[simp] theorem contains_eq_false (n : Nat) (s : FiniteNatSet) :
+    s.contains n = false ↔ n ∉ s := by
+  simpa [FiniteNatSet.mem, FiniteNatSet.contains] using
+    FiniteSet.contains_eq_false n s.nats
+
+end FiniteNatSet
 
 end Verity.Core


### PR DESCRIPTION
## Summary
- add `FiniteNatSet` as a concrete wrapper over `FiniteSet Nat`
- provide the same ergonomic surface as `FiniteAddressSet`: `empty`, `card`, `insert`, `remove`, `contains`, and `Membership` support
- add simp lemmas for `card_empty`, `mem_def`, `mem_insert`, and `contains` truth/false reflection

## Why
Issue #73 (ERC721) calls out token-ID tracking over finite sets. This PR provides a small, reusable foundation so ERC721 work can reason about token ID sets without list plumbing or ad-hoc wrappers.

## Validation
- `python3 scripts/check_doc_counts.py`

Refs #73

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new helper type and lemmas without changing existing `FiniteSet`/`FiniteAddressSet` behavior, so impact is isolated to new nat-set usage.
> 
> **Overview**
> Adds `FiniteNatSet`, a concrete wrapper over `FiniteSet Nat`, mirroring the `FiniteAddressSet` API (`empty`, `card`, `insert`, `remove`, `contains`, and `Membership` instance) for token-id style tracking.
> 
> Includes new `simp` lemmas (`card_empty`, `mem_def`, `mem_insert`, `contains_eq_true/false`) to make proofs about nat-set membership and `contains`/`mem` reflection straightforward.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41af73c96b4c65e53f00625ec647387790f59ef7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->