### PR TITLE
gas: account for CALL forwarded gas in static upper bounds

### DIFF
--- a/Compiler/Gas/Report.lean
+++ b/Compiler/Gas/Report.lean
@@ -13,6 +13,7 @@ open Compiler.Selector
 private structure CliConfig where
   loopIterations : Nat := 8
   unknownCallCost : Nat := 50000
+  unknownForwardedGas : Nat := 50000
   fuel : Nat := 4096
 
 private def parseNatFlag (flag : String) (raw : String) : IO Nat :=
@@ -28,6 +29,7 @@ private def printHelp : IO Unit := do
   IO.println "Options:"
   IO.println "  --loop-iterations <n>   Loop upper bound used by static analysis (default: 8)"
   IO.println "  --unknown-call-cost <n> Fallback cost for unknown builtins/calls (default: 50000)"
+  IO.println "  --unknown-forwarded-gas <n> Fallback forwarded gas for CALL-like builtins (default: 50000)"
   IO.println "  --fuel <n>              Structural recursion fuel for analysis (default: 4096)"
   IO.println "  --help                  Show this help message"
 
@@ -42,6 +44,8 @@ private def parseArgs (args : List String) : IO CliConfig := do
         go tail { cfg with loopIterations := (← parseNatFlag "--loop-iterations" value) }
     | "--unknown-call-cost" :: value :: tail =>
         go tail { cfg with unknownCallCost := (← parseNatFlag "--unknown-call-cost" value) }
+    | "--unknown-forwarded-gas" :: value :: tail =>
+        go tail { cfg with unknownForwardedGas := (← parseNatFlag "--unknown-forwarded-gas" value) }
     | "--fuel" :: value :: tail =>
         go tail { cfg with fuel := (← parseNatFlag "--fuel" value) }
     | flag :: _ =>
@@ -67,9 +71,10 @@ def main (args : List String) : IO Unit := do
     let gasCfg : GasConfig := {
       loopIterations := cli.loopIterations
       unknownCallCost := cli.unknownCallCost
+      unknownForwardedGas := cli.unknownForwardedGas
     }
 
-    IO.println s!"# gas-report loopIterations={cli.loopIterations} unknownCallCost={cli.unknownCallCost} fuel={cli.fuel}"
+    IO.println s!"# gas-report loopIterations={cli.loopIterations} unknownCallCost={cli.unknownCallCost} unknownForwardedGas={cli.unknownForwardedGas} fuel={cli.fuel}"
     IO.println "contract\tdeploy_upper_bound\truntime_upper_bound\ttotal_upper_bound"
 
     let mut totalDeploy := 0


### PR DESCRIPTION
## Summary
- fix a soundness gap in `Compiler/Gas/StaticAnalysis.lean`: CALL-like opcodes now include forwarded gas in the static upper bound
- add `GasConfig.unknownForwardedGas` fallback for non-literal forwarded-gas expressions
- include `callcode` in CALL-like modeling
- expose the new knob in `lake exe gas-report` via `--unknown-forwarded-gas`
- update sanity example for `externalCallProgram` to reflect the corrected bound

## Why
Issue #262 (Phase 1 static gas bounds) requires conservative upper bounds. Previously, this case underestimated:
- `.call "call" [.lit 50000, ...]` was modeled as `36700`, ignoring forwarded `50000` gas.

This change models it as `base + forwardedGas` (or fallback), which restores conservativeness.

Closes #262

## Validation
- `python3 scripts/check_doc_counts.py`
- Lean build/checks via GitHub Actions (local `lake` unavailable in this environment)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core gas-cost modeling, which can materially shift reported bounds and downstream decisions; logic is localized but affects all analyses involving CALL-like operations.
> 
> **Overview**
> **Fixes an underestimation in static gas bounds for external calls.** The static analysis now adds the forwarded-gas argument into the upper-bound for CALL-like builtins (`call`, `callcode`, `delegatecall`, `staticcall`), using a new `GasConfig.unknownForwardedGas` fallback when the forwarded gas isn’t a literal.
> 
> `lake exe gas-report` exposes this via `--unknown-forwarded-gas` and includes it in the report header, and the `externalCallProgram` sanity check is updated to reflect the higher bound.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8808d873f373b0b2d5ad4b395fab81c5d3edadc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->