### PR TITLE
core: add isSubset reflection lemmas for finite sets

### DIFF
--- a/Verity/Core/FiniteSet.lean
+++ b/Verity/Core/FiniteSet.lean
@@ -149,11 +149,11 @@ theorem mem_elements_insert [DecidableEq α] (a b : α) (s : FiniteSet α) :
   · intro h
     intro x hx
     have hAll := List.all_eq_true.mp h
-    exact (decide_eq_true_iff.mp (hAll x hx))
+    exact (FiniteSet.mem_def x t).2 (decide_eq_true_iff.mp (hAll x hx))
   · intro h
     apply List.all_eq_true.mpr
     intro x hx
-    exact decide_eq_true_iff.mpr (h x hx)
+    exact decide_eq_true_iff.mpr ((FiniteSet.mem_def x t).1 (h x ((FiniteSet.mem_def x s).2 hx)))
 
 /-- `isSubset = false` iff propositional subset does not hold. -/
 @[simp] theorem isSubset_eq_false [DecidableEq α] (s t : FiniteSet α) :


### PR DESCRIPTION
## Summary
Adds subset-reflection lemmas for finite-set APIs so proofs can move between boolean checks and propositional subset facts without manual list-level rewrites.

## Changes
- `FiniteSet`:
  - add `[simp]` lemma `isSubset_eq_true : s.isSubset t = true ↔ s.subset t`
  - add `[simp]` lemma `isSubset_eq_false : s.isSubset t = false ↔ ¬ s.subset t`
- `FiniteAddressSet`:
  - add wrapper `[simp]` lemmas `isSubset_eq_true` / `isSubset_eq_false`
- `FiniteNatSet`:
  - add wrapper `[simp]` lemmas `isSubset_eq_true` / `isSubset_eq_false`

## Why
This is foundational proof ergonomics for the remaining ERC20/ERC721 workstreams where subset checks are naturally expressed as booleans in executable code but required as propositions in invariants.

Refs #73
Refs #69

## Validation
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_lean_hygiene.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely adds Lean theorems/`[simp]` lemmas with no changes to executable logic; main risk is unintended simp rewriting in downstream proofs.
> 
> **Overview**
> Adds `[simp]` reflection lemmas `isSubset_eq_true` and `isSubset_eq_false` so boolean `s.isSubset t` can be rewritten to/from propositional `s.subset t` (and its negation) in `FiniteSet`.
> 
> Mirrors the same `[simp]` lemmas for `FiniteAddressSet` and `FiniteNatSet` by delegating to the underlying `FiniteSet` proofs, improving proof ergonomics without changing set operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 519bb810533915a18d6c23c60b594f21addd8ffd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->