### PR TITLE
Proofs: add mapping-slot abstraction boundary

### DIFF
--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -18,7 +18,7 @@
 
 import Compiler.IR
 import Compiler.ContractSpec
-import Compiler.Proofs.MappingEncoding
+import Compiler.Proofs.MappingSlot
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Core
 
@@ -79,14 +79,13 @@ measures from Semantics.lean are reused.
 abbrev evmModulus : Nat := Compiler.Proofs.evmModulus
 
 /-!
-Mapping slots in Yul are derived via keccak(baseSlot, key). For proofs, we model
-them with a tagged encoding so `sload`/`sstore` can route to `mappings` rather
-than flat `storage`. The tag is `2^256`, which is outside the EVM word range,
-so it cannot collide with real storage slots produced by arithmetic.
+Mapping slots in Yul are derived via keccak(baseSlot, key). IR proof semantics
+call through the `MappingSlot` abstraction; the current backend is tagged
+encoding so `sload`/`sstore` can route to `mappings` instead of flat storage.
 -/
 abbrev mappingTag : Nat := Compiler.Proofs.mappingTag
-abbrev encodeMappingSlot := Compiler.Proofs.encodeMappingSlot
-abbrev decodeMappingSlot := Compiler.Proofs.decodeMappingSlot
+abbrev encodeMappingSlot := Compiler.Proofs.abstractMappingSlot
+abbrev decodeMappingSlot := Compiler.Proofs.abstractDecodeMappingSlot
 
 open Compiler.Proofs.YulGeneration in
 mutual

--- a/Compiler/Proofs/MappingSlot.lean
+++ b/Compiler/Proofs/MappingSlot.lean
@@ -1,0 +1,34 @@
+import Compiler.Proofs.MappingEncoding
+
+namespace Compiler.Proofs
+
+/-!
+Mapping slot abstraction used by proof interpreters.
+
+Today this delegates to the tagged encoding model in `MappingEncoding.lean`.
+When issue #259 is implemented, only this module should need backend changes.
+-/
+
+/-- Active proof-model mapping slot encoding backend. -/
+def abstractMappingSlot (baseSlot key : Nat) : Nat :=
+  encodeMappingSlot baseSlot key
+
+/-- Active proof-model mapping slot decoder backend. -/
+def abstractDecodeMappingSlot (slot : Nat) : Option (Nat × Nat) :=
+  decodeMappingSlot slot
+
+/-- Active proof-model nested mapping slot helper. -/
+def abstractNestedMappingSlot (baseSlot key1 key2 : Nat) : Nat :=
+  abstractMappingSlot (abstractMappingSlot baseSlot key1) key2
+
+@[simp] theorem abstractMappingSlot_eq_encode (baseSlot key : Nat) :
+    abstractMappingSlot baseSlot key = encodeMappingSlot baseSlot key := rfl
+
+@[simp] theorem abstractDecodeMappingSlot_eq_decode (slot : Nat) :
+    abstractDecodeMappingSlot slot = decodeMappingSlot slot := rfl
+
+@[simp] theorem abstractNestedMappingSlot_eq_encodeNested (baseSlot key1 key2 : Nat) :
+    abstractNestedMappingSlot baseSlot key1 key2 = encodeNestedMappingSlot baseSlot key1 key2 := by
+  simp [abstractNestedMappingSlot, encodeNestedMappingSlot]
+
+end Compiler.Proofs

--- a/Compiler/Proofs/YulGeneration/Semantics.lean
+++ b/Compiler/Proofs/YulGeneration/Semantics.lean
@@ -1,6 +1,6 @@
 import Compiler.Yul.Ast
 import Compiler.Proofs.IRGeneration.IRInterpreter
-import Compiler.Proofs.MappingEncoding
+import Compiler.Proofs.MappingSlot
 
 namespace Compiler.Proofs.YulGeneration
 
@@ -33,15 +33,14 @@ def selectorExpr : YulExpr :=
   ]
 
 /-!
-Mapping slots in Yul are derived via keccak(baseSlot, key). For proofs, we model
-them with a tagged encoding so `sload`/`sstore` can route to `mappings` rather
-than flat `storage`. The tag is `2^256`, which is outside the EVM word range,
-so it cannot collide with real storage slots produced by arithmetic.
+Mapping slots in Yul are derived via keccak(baseSlot, key). Proof semantics call
+through the `MappingSlot` abstraction; the current backend is tagged encoding so
+`sload`/`sstore` can route to `mappings` rather than flat `storage`.
 -/
 
 abbrev mappingTag : Nat := Compiler.Proofs.mappingTag
-abbrev encodeMappingSlot := Compiler.Proofs.encodeMappingSlot
-abbrev decodeMappingSlot := Compiler.Proofs.decodeMappingSlot
+abbrev encodeMappingSlot := Compiler.Proofs.abstractMappingSlot
+abbrev decodeMappingSlot := Compiler.Proofs.abstractDecodeMappingSlot
 
 /-! ## Execution State -/
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -241,7 +241,7 @@ These components are **not formally verified** but are trusted based on testing,
 **Assumption**: The keccak256-based storage slot calculation used by Solidity (and Verity's compiled Yul) for mapping entries is collision-free in practice — distinct `(key, baseSlot)` pairs produce distinct storage slot addresses.
 
 **Details**:
-- **Lean proof model**: Mapping slots use `mappingTag = 2^256` (defined in `Compiler/Proofs/MappingEncoding.lean:14`) as an out-of-range tag to route mapping storage. A mapping access `storageMap[slot][addr]` is encoded as slot `mappingTag + baseSlot * maxKeys + addressToNat(addr)`. Since `mappingTag = 2^256` exceeds the EVM word range (0 to 2^256-1), mapping slots are guaranteed to never collide with direct storage slots in the proof model.
+- **Lean proof model**: Mapping slots are routed through `Compiler/Proofs/MappingSlot.lean`, whose current backend delegates to the tagged model in `Compiler/Proofs/MappingEncoding.lean` (`mappingTag = 2^256`). A mapping access is encoded as `mappingTag + normalize(baseSlot) * 2^256 + (key % 2^256)`, so mapping slots are disjoint from direct storage slots in the proof model.
 - **Yul implementation**: Mappings use `keccak256(abi.encodePacked(key, baseSlot))` to derive a storage slot address, then read/write via `sload`/`sstore`.
 - **The gap**: The Lean proofs reason about a tag-based separation model. The Yul code uses hash-based slot derivation. These are equivalent only if (1) keccak256 mapping slots never collide with each other or with direct storage slots (0, 1, 2, ...), and (2) the tag-based Lean encoding is injective (distinct `(slot, addr)` pairs produce distinct encoded values).
 


### PR DESCRIPTION
## Summary
This PR adds a first-class mapping-slot abstraction layer for proof semantics, as groundwork for #259.

## Changes
- Added `Compiler/Proofs/MappingSlot.lean` with backend-facing APIs:
  - `abstractMappingSlot`
  - `abstractDecodeMappingSlot`
  - `abstractNestedMappingSlot`
- Routed IR and Yul proof interpreters through the new abstraction module instead of directly importing `MappingEncoding.lean`.
- Updated trust assumptions docs to reference the new abstraction boundary.

## Why
Issue #259 requires swapping the current tagged mapping-slot model for keccak-based Solidity slot derivation. This PR isolates the backend touchpoint so that migration can be performed by changing one module instead of patching call sites across interpreters/proofs.

## Validation
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_lean_hygiene.py`

Related: #259

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor/indirection of mapping-slot encoding in proof semantics with no functional behavior change expected; risk is limited to miswiring the new abstraction or import paths.
> 
> **Overview**
> Introduces a new proof-level abstraction module, `Compiler/Proofs/MappingSlot.lean`, that centralizes mapping-slot encode/decode (and nested slot) operations behind `abstractMappingSlot`/`abstractDecodeMappingSlot`.
> 
> Updates the IR and Yul proof interpreters to import `MappingSlot` and use its abstracted mapping-slot functions instead of directly depending on `MappingEncoding`, and refreshes `TRUST_ASSUMPTIONS.md` to point to the new boundary and updated tagged-encoding description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce80dedfa199efc42a65c3cbc39bf4ffc8e5ac71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->