### PR TITLE
Add CI guard for MappingSlot abstraction boundary

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Check static gas model builtin coverage
         run: python3 scripts/check_gas_model_coverage.py
 
+      - name: Check mapping slot abstraction boundary
+        run: python3 scripts/check_mapping_slot_boundary.py
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,6 +78,7 @@ These CI-critical scripts validate cross-layer consistency:
 
 - **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
 - **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, Compiler, and AST layers; strips Lean comments/docstrings with a shared string-aware parser (so `--` and `/- -/` inside string literals are preserved), detects intra-contract slot collisions, derives Spec slot usage from `Verity/Specs/*/Spec.lean` literal state accesses, enforces Spec↔EDSL slot/type parity for compiled non-external contracts, enforces ASTSpec coverage for non-external compiler specs, and checks AST-vs-Compiler slot/type drift
+- **`check_mapping_slot_boundary.py`** - Enforces the mapping-slot abstraction boundary for proof interpreters: only `Compiler/Proofs/MappingSlot.lean` may import `MappingEncoding`, and runtime interpreters must reference `abstractMappingSlot`/`abstractDecodeMappingSlot`
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
@@ -162,8 +163,9 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 5. Documentation count validation (`check_doc_counts.py`)
 6. Property manifest sync (`check_property_manifest_sync.py`)
 7. Storage layout consistency (`check_storage_layout.py`)
-8. Lean hygiene (`check_lean_hygiene.py`)
-9. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+8. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+9. Lean hygiene (`check_lean_hygiene.py`)
+10. Static gas model builtin coverage (`check_gas_model_coverage.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/check_mapping_slot_boundary.py
+++ b/scripts/check_mapping_slot_boundary.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Ensure proof interpreters depend on the MappingSlot abstraction boundary.
+
+This guard supports issue #259 migration by preventing new direct imports of
+`Compiler.Proofs.MappingEncoding` outside `Compiler/Proofs/MappingSlot.lean`.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROOFS_DIR = ROOT / "Compiler" / "Proofs"
+
+ALLOWED_MAPPING_ENCODING_IMPORTERS = {
+    PROOFS_DIR / "MappingSlot.lean",
+}
+
+REQUIRED_ABSTRACTION_IMPORTS = {
+    PROOFS_DIR / "IRGeneration" / "IRInterpreter.lean",
+    PROOFS_DIR / "YulGeneration" / "Semantics.lean",
+}
+
+IMPORT_MAPPING_ENCODING_RE = re.compile(r"^\s*import\s+Compiler\.Proofs\.MappingEncoding\s*$", re.MULTILINE)
+IMPORT_MAPPING_SLOT_RE = re.compile(r"^\s*import\s+Compiler\.Proofs\.MappingSlot\s*$", re.MULTILINE)
+ABSTRACT_SLOT_REF_RE = re.compile(r"Compiler\.Proofs\.abstractMappingSlot")
+ABSTRACT_DECODE_REF_RE = re.compile(r"Compiler\.Proofs\.abstractDecodeMappingSlot")
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    for lean_file in PROOFS_DIR.rglob("*.lean"):
+        text = lean_file.read_text(encoding="utf-8")
+
+        if IMPORT_MAPPING_ENCODING_RE.search(text) and lean_file not in ALLOWED_MAPPING_ENCODING_IMPORTERS:
+            rel = lean_file.relative_to(ROOT)
+            errors.append(
+                f"{rel}: direct import of Compiler.Proofs.MappingEncoding is disallowed; "
+                "import Compiler.Proofs.MappingSlot instead"
+            )
+
+    for lean_file in REQUIRED_ABSTRACTION_IMPORTS:
+        text = lean_file.read_text(encoding="utf-8")
+        rel = lean_file.relative_to(ROOT)
+
+        if not IMPORT_MAPPING_SLOT_RE.search(text):
+            errors.append(f"{rel}: missing required import Compiler.Proofs.MappingSlot")
+
+        if not ABSTRACT_SLOT_REF_RE.search(text):
+            errors.append(f"{rel}: missing reference to Compiler.Proofs.abstractMappingSlot")
+
+        if not ABSTRACT_DECODE_REF_RE.search(text):
+            errors.append(f"{rel}: missing reference to Compiler.Proofs.abstractDecodeMappingSlot")
+
+    if errors:
+        print("Mapping slot boundary check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print("✓ Mapping slot boundary is enforced")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_mapping_slot_boundary.py` to enforce the MappingSlot boundary in proof code
- require only `Compiler/Proofs/MappingSlot.lean` to import `MappingEncoding`
- require IR/Yul proof interpreters to import and reference `abstractMappingSlot` + `abstractDecodeMappingSlot`
- wire the new check into the fast `checks` CI job
- document the check in `scripts/README.md`

## Why
Issue #259 is migrating proof mapping slots to real keccak-based layout. The migration depends on keeping a single backend seam (`Compiler/Proofs/MappingSlot.lean`). This guard prevents regressions where interpreters or new proof files bypass that seam.

## Validation
- `python3 scripts/check_mapping_slot_boundary.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_lean_hygiene.py`

Refs #259

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds an additional static guard; main risk is false positives/negatives from the regex-based scan causing unexpected CI failures.
> 
> **Overview**
> Adds a new CI guard, `scripts/check_mapping_slot_boundary.py`, to enforce the `MappingSlot` abstraction boundary during the fast `checks` workflow.
> 
> The script blocks direct `import Compiler.Proofs.MappingEncoding` anywhere under `Compiler/Proofs` except `Compiler/Proofs/MappingSlot.lean`, and asserts that key interpreter files import `Compiler.Proofs.MappingSlot` and reference `abstractMappingSlot`/`abstractDecodeMappingSlot`. Documentation (`scripts/README.md`) and the GitHub Actions workflow (`verify.yml`) are updated to include the new check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d568d96732572468e9081c251155d6b63bbd8ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->