### PR TITLE
proofs: centralize Yul builtin semantics behind one boundary

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Check mapping slot abstraction boundary
         run: python3 scripts/check_mapping_slot_boundary.py
 
+      - name: Check Yul builtin abstraction boundary
+        run: python3 scripts/check_yul_builtin_boundary.py
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/Compiler/Proofs/YulGeneration/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/Builtins.lean
@@ -1,0 +1,116 @@
+import Compiler.Proofs.MappingSlot
+
+namespace Compiler.Proofs.YulGeneration
+
+open Compiler.Proofs
+
+abbrev evmModulus : Nat := Compiler.Proofs.evmModulus
+
+def selectorModulus : Nat := 2 ^ 32
+
+def selectorShift : Nat := 224
+
+def selectorWord (selector : Nat) : Nat :=
+  (selector % selectorModulus) * (2 ^ selectorShift)
+
+def calldataloadWord (selector : Nat) (calldata : List Nat) (offset : Nat) : Nat :=
+  if offset = 0 then
+    selectorWord selector
+  else if offset < 4 then
+    0
+  else
+    let wordOffset := offset - 4
+    if wordOffset % 32 != 0 then
+      0
+    else
+      let idx := wordOffset / 32
+      calldata.getD idx 0 % evmModulus
+
+def evalBuiltinCall
+    (storage : Nat → Nat)
+    (mappings : Nat → Nat → Nat)
+    (sender : Nat)
+    (selector : Nat)
+    (calldata : List Nat)
+    (func : String)
+    (argVals : List Nat) : Option Nat :=
+  if func = "mappingSlot" then
+    match argVals with
+    | [base, key] => some (Compiler.Proofs.abstractMappingSlot base key)
+    | _ => none
+  else if func = "sload" then
+    match argVals with
+    | [slot] => some (Compiler.Proofs.abstractLoadStorageOrMapping storage mappings slot)
+    | _ => none
+  else if func = "add" then
+    match argVals with
+    | [a, b] => some ((a + b) % evmModulus)
+    | _ => none
+  else if func = "sub" then
+    match argVals with
+    | [a, b] => some ((evmModulus + a - b) % evmModulus)
+    | _ => none
+  else if func = "mul" then
+    match argVals with
+    | [a, b] => some ((a * b) % evmModulus)
+    | _ => none
+  else if func = "div" then
+    match argVals with
+    | [a, b] => if b = 0 then some 0 else some (a / b)
+    | _ => none
+  else if func = "mod" then
+    match argVals with
+    | [a, b] => if b = 0 then some 0 else some (a % b)
+    | _ => none
+  else if func = "lt" then
+    match argVals with
+    | [a, b] => some (if a < b then 1 else 0)
+    | _ => none
+  else if func = "gt" then
+    match argVals with
+    | [a, b] => some (if a > b then 1 else 0)
+    | _ => none
+  else if func = "eq" then
+    match argVals with
+    | [a, b] => some (if a = b then 1 else 0)
+    | _ => none
+  else if func = "iszero" then
+    match argVals with
+    | [a] => some (if a = 0 then 1 else 0)
+    | _ => none
+  else if func = "and" then
+    match argVals with
+    | [a, b] => some (a &&& b)
+    | _ => none
+  else if func = "or" then
+    match argVals with
+    | [a, b] => some (a ||| b)
+    | _ => none
+  else if func = "xor" then
+    match argVals with
+    | [a, b] => some (Nat.xor a b)
+    | _ => none
+  else if func = "not" then
+    match argVals with
+    | [a] => some (Nat.xor a (evmModulus - 1))
+    | _ => none
+  else if func = "shl" then
+    match argVals with
+    | [shift, value] => some ((value * (2 ^ shift)) % evmModulus)
+    | _ => none
+  else if func = "shr" then
+    match argVals with
+    | [shift, value] => some (value / (2 ^ shift))
+    | _ => none
+  else if func = "caller" then
+    match argVals with
+    | [] => some sender
+    | _ => none
+  else if func = "calldataload" then
+    match argVals with
+    | [offset] => some (calldataloadWord selector calldata offset)
+    | _ => none
+  else
+    none
+
+end Compiler.Proofs.YulGeneration

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -270,6 +270,7 @@ These components are **not formally verified** but are trusted based on testing,
 - **Specification**: Ethereum Yellow Paper (Byzantium+)
 - **Implementation**: Various EVM implementations (Geth, Foundry, etc.)
 - **Validation**: Ethereum consensus across thousands of nodes
+- **Proof-model boundary**: Runtime builtin-call semantics are centralized in `Compiler/Proofs/YulGeneration/Builtins.lean` and consumed by both IR and Yul proof interpreters, reducing migration risk for issue #294 to a single backend touchpoint.
 
 **Mitigation Strategies**:
 1. **Differential Testing**:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,7 +78,8 @@ These CI-critical scripts validate cross-layer consistency:
 
 - **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
 - **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, Compiler, and AST layers; strips Lean comments/docstrings with a shared string-aware parser (so `--` and `/- -/` inside string literals are preserved), detects intra-contract slot collisions, derives Spec slot usage from `Verity/Specs/*/Spec.lean` literal state accesses, enforces Spec↔EDSL slot/type parity for compiled non-external contracts, enforces ASTSpec coverage for non-external compiler specs, and checks AST-vs-Compiler slot/type drift
-- **`check_mapping_slot_boundary.py`** - Enforces the mapping-slot abstraction boundary for proof interpreters: only `Compiler/Proofs/MappingSlot.lean` may import `MappingEncoding`; runtime interpreters must import `MappingSlot`, reference `abstractMappingSlot` plus `abstractLoadStorageOrMapping`/`abstractStoreStorageOrMapping`/`abstractStoreMappingEntry`, and avoid legacy mapping internals (`mappingTag`/`encodeMappingSlot`/`decodeMappingSlot`) including local aliases
+- **`check_mapping_slot_boundary.py`** - Enforces the mapping-slot abstraction boundary for proof interpreters: only `Compiler/Proofs/MappingSlot.lean` may import `MappingEncoding`; builtin dispatch in `Compiler/Proofs/YulGeneration/Builtins.lean` must route through `abstractMappingSlot`/`abstractLoadStorageOrMapping`; runtime interpreters must import `MappingSlot`, use `abstractStoreStorageOrMapping`/`abstractStoreMappingEntry`, and avoid legacy mapping internals (`mappingTag`/`encodeMappingSlot`/`decodeMappingSlot`) including local aliases
+- **`check_yul_builtin_boundary.py`** - Enforces a centralized Yul builtin semantics boundary: runtime interpreters must import `Compiler/Proofs/YulGeneration/Builtins.lean`, call `evalBuiltinCall`, and avoid inline builtin dispatch branches (`func = "add"`, `func = "sload"`, etc.)
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
@@ -164,8 +165,9 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 6. Property manifest sync (`check_property_manifest_sync.py`)
 7. Storage layout consistency (`check_storage_layout.py`)
 8. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-9. Lean hygiene (`check_lean_hygiene.py`)
-10. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+9. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+10. Lean hygiene (`check_lean_hygiene.py`)
+11. Static gas model builtin coverage (`check_gas_model_coverage.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/check_mapping_slot_boundary.py
+++ b/scripts/check_mapping_slot_boundary.py
@@ -23,6 +23,8 @@ REQUIRED_ABSTRACTION_IMPORTS = {
     PROOFS_DIR / "YulGeneration" / "Semantics.lean",
 }
 
+BUILTINS_FILE = PROOFS_DIR / "YulGeneration" / "Builtins.lean"
+
 IMPORT_MAPPING_ENCODING_RE = re.compile(r"^\s*import\s+Compiler\.Proofs\.MappingEncoding\s*$", re.MULTILINE)
 IMPORT_MAPPING_SLOT_RE = re.compile(r"^\s*import\s+Compiler\.Proofs\.MappingSlot\s*$", re.MULTILINE)
 ABSTRACT_SLOT_REF_RE = re.compile(r"Compiler\.Proofs\.abstractMappingSlot")
@@ -55,12 +57,6 @@ def main() -> int:
         if not IMPORT_MAPPING_SLOT_RE.search(text):
             errors.append(f"{rel}: missing required import Compiler.Proofs.MappingSlot")
 
-        if not ABSTRACT_SLOT_REF_RE.search(text):
-            errors.append(f"{rel}: missing reference to Compiler.Proofs.abstractMappingSlot")
-
-        if not ABSTRACT_LOAD_REF_RE.search(text):
-            errors.append(f"{rel}: missing reference to Compiler.Proofs.abstractLoadStorageOrMapping")
-
         if not ABSTRACT_STORE_REF_RE.search(text):
             errors.append(f"{rel}: missing reference to Compiler.Proofs.abstractStoreStorageOrMapping")
 
@@ -78,6 +74,18 @@ def main() -> int:
                 f"{rel}: legacy mapping symbol names (mappingTag/encodeMappingSlot/decodeMappingSlot) "
                 "are disallowed; use abstractMapping* names directly"
             )
+
+    builtins_text = BUILTINS_FILE.read_text(encoding="utf-8")
+    builtins_rel = BUILTINS_FILE.relative_to(ROOT)
+
+    if not IMPORT_MAPPING_SLOT_RE.search(builtins_text):
+        errors.append(f"{builtins_rel}: missing required import Compiler.Proofs.MappingSlot")
+
+    if not ABSTRACT_SLOT_REF_RE.search(builtins_text):
+        errors.append(f"{builtins_rel}: missing reference to Compiler.Proofs.abstractMappingSlot")
+
+    if not ABSTRACT_LOAD_REF_RE.search(builtins_text):
+        errors.append(f"{builtins_rel}: missing reference to Compiler.Proofs.abstractLoadStorageOrMapping")
 
     if errors:
         print("Mapping slot boundary check failed:", file=sys.stderr)

--- a/scripts/check_yul_builtin_boundary.py
+++ b/scripts/check_yul_builtin_boundary.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Ensure runtime interpreters use centralized Yul builtin semantics.
+
+Issue #294 tracks replacing hand-rolled Yul semantics with EVMYulLean. This
+guard keeps builtin-call dispatch centralized in one module so that migration is
+a backend swap instead of duplicated edits.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROOFS_DIR = ROOT / "Compiler" / "Proofs"
+BUILTINS_FILE = PROOFS_DIR / "YulGeneration" / "Builtins.lean"
+
+RUNTIME_INTERPRETERS = [
+    PROOFS_DIR / "IRGeneration" / "IRInterpreter.lean",
+    PROOFS_DIR / "YulGeneration" / "Semantics.lean",
+]
+
+IMPORT_BUILTINS_RE = re.compile(r"^\s*import\s+Compiler\.Proofs\.YulGeneration\.Builtins\s*$", re.MULTILINE)
+BUILTIN_CALL_RE = re.compile(r"Compiler\.Proofs\.YulGeneration\.evalBuiltinCall")
+INLINE_DISPATCH_RE = re.compile(
+    r'func\s*=\s*"(?:mappingSlot|sload|add|sub|mul|div|mod|lt|gt|eq|iszero|and|or|xor|not|shl|shr|caller|calldataload)"'
+)
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    if not BUILTINS_FILE.exists():
+        errors.append(f"{BUILTINS_FILE.relative_to(ROOT)}: missing builtin boundary module")
+
+    for lean_file in RUNTIME_INTERPRETERS:
+        text = lean_file.read_text(encoding="utf-8")
+        rel = lean_file.relative_to(ROOT)
+
+        if not IMPORT_BUILTINS_RE.search(text):
+            errors.append(f"{rel}: missing import Compiler.Proofs.YulGeneration.Builtins")
+
+        if not BUILTIN_CALL_RE.search(text):
+            errors.append(f"{rel}: missing call to Compiler.Proofs.YulGeneration.evalBuiltinCall")
+
+        if INLINE_DISPATCH_RE.search(text):
+            errors.append(
+                f"{rel}: inline builtin dispatch detected; move builtin semantics to "
+                "Compiler/Proofs/YulGeneration/Builtins.lean"
+            )
+
+    if errors:
+        print("Yul builtin boundary check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print("✓ Yul builtin boundary is enforced")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- centralize Yul builtin-call semantics into `Compiler/Proofs/YulGeneration/Builtins.lean`
- route both proof interpreters (`IRInterpreter` and `YulGeneration/Semantics`) through a single `evalBuiltinCall` entrypoint
- add a fast CI boundary guard (`scripts/check_yul_builtin_boundary.py`) so builtin dispatch logic cannot drift back into interpreter files
- update existing mapping-boundary check/docs to account for builtin centralization and keep mapping abstraction enforcement intact

## Why
Issue #294 (EVMYulLean integration) needs a clean seam where hand-rolled Yul semantics can be replaced safely. This PR removes duplicated builtin semantics from two interpreters and enforces one boundary module, reducing migration risk and review surface for future semantics swaps.

## Validation
- `python3 scripts/check_yul_builtin_boundary.py`
- `python3 scripts/check_mapping_slot_boundary.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_lean_hygiene.py`

`lake` is unavailable in this environment (`lake: command not found`), so full Lean compile is delegated to CI.

Refs #294

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proof interpreter semantics by refactoring builtin dispatch; while intended to be behavior-preserving, any mismatch in argument handling or builtin routing could change proof-model execution and downstream equivalence proofs.
> 
> **Overview**
> Centralizes runtime Yul builtin-call semantics into `Compiler/Proofs/YulGeneration/Builtins.lean` (e.g., arithmetic ops, `sload`, `caller`, `calldataload`), and updates both `IRInterpreter.lean` and `YulGeneration/Semantics.lean` to delegate call evaluation via `evalBuiltinCall` instead of maintaining duplicated inline dispatch logic.
> 
> Adds a new CI boundary check (`scripts/check_yul_builtin_boundary.py`) and wires it into `verify.yml` to enforce the shared builtin entrypoint and forbid inline `func = "..."` branches; updates the mapping-slot boundary check/docs to account for the new builtins module while keeping `abstractMappingSlot`/`abstractLoadStorageOrMapping` usage enforced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbe53eae82c35444025ba7428373c38c54896970. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->