### PR TITLE
chore: upgrade Lean toolchain to v4.22.0

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Counter.lean
+++ b/Compiler/Proofs/SpecCorrectness/Counter.lean
@@ -60,7 +60,7 @@ private theorem evalExpr_decrement_eq (state : ContractState) (sender : Address)
   have hidx :
       (List.findIdx? (fun f : Field => f.name == "count")
           (([{ name := "count", ty := FieldType.uint256 }] : List Field))) = some 0 := by
-    simp [List.findIdx?]
+    decide
   by_cases h : (state.storage 0).val ≥ 1
   · -- No underflow: both sides are val - 1.
     have h_sub : (sub (state.storage 0) 1).val = (state.storage 0).val - 1 := by

--- a/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
@@ -280,7 +280,7 @@ theorem safeIncrement_correct (state : ContractState) (sender : Address) :
     -- Unfold spec interpreter to compute finalStorage.getSlot 0
     -- The require passes, so storage is updated to newCount
     -- Combine with the EDSL storage computation
-    simpa [h_edsl_storage_val] using (increment_spec_storage state sender h_gt')
+    exact (increment_spec_storage state sender h_gt').trans h_edsl_storage_val.symm
 
 /- Helper Properties -/
 
@@ -361,7 +361,7 @@ theorem safeDecrement_correct (state : ContractState) (sender : Address) :
         simpa [ContractResult.getState, Verity.EVM.Uint256.sub,
           Verity.Core.Uint256.sub, one_mod_modulus, h_ge, Nat.mod_eq_of_lt h_lt_mod] using h_edsl_storage
       -- Spec: require passes and setStorage stores (count - 1)
-      simpa [h_edsl_storage_val] using (decrement_spec_storage state sender h_ge)
+      exact (decrement_spec_storage state sender h_ge).trans h_edsl_storage_val.symm
   · -- Underflow: count < 1, both EDSL and spec fail
     have h_lt : (state.storage 0 : Nat) < 1 := by omega
     constructor

--- a/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleToken.lean
@@ -486,8 +486,14 @@ theorem token_balanceOf_correct (state : ContractState) (addr : Address) (sender
     specResult.success = true ∧
     specResult.returnValue = some edslValue.val := by
   unfold balanceOf Contract.runValue simpleTokenSpec interpretSpec tokenEdslToSpecStorageWithAddrs
+  have hidx_bal :
+      List.findIdx? (fun x => x.name == "balances")
+        ([{ name := "owner", ty := FieldType.address },
+          { name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) },
+          { name := "totalSupply", ty := FieldType.uint256 }] : List Field) = some 1 := by
+    decide
   simp [getMapping, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getMapping,
-    balances]
+    balances, hidx_bal]
 
 /-- The `getTotalSupply` function correctly retrieves total supply -/
 theorem token_getTotalSupply_correct (state : ContractState) (sender : Address) :
@@ -501,11 +507,17 @@ theorem token_getTotalSupply_correct (state : ContractState) (sender : Address) 
     specResult.success = true ∧
     specResult.returnValue = some edslValue := by
   unfold getTotalSupply Contract.runValue simpleTokenSpec interpretSpec tokenEdslToSpecStorageWithAddrs
+  have hidx_supply :
+      List.findIdx? (fun x => x.name == "totalSupply")
+        ([{ name := "owner", ty := FieldType.address },
+          { name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) },
+          { name := "totalSupply", ty := FieldType.uint256 }] : List Field) = some 2 := by
+    decide
   have h_slot : (List.lookup 2 [(0, (state.storageAddr 0).val), (2, (state.storage 2).val)]).getD 0
       = (state.storage 2).val := by
     simp [(by decide : (0:Nat) ≠ 2)]
   simp [getStorage, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot,
-    totalSupply, h_slot]
+    totalSupply, h_slot, hidx_supply]
 
 /-- The `getOwner` function correctly retrieves owner -/
 theorem token_getOwner_correct (state : ContractState) (sender : Address) :
@@ -519,8 +531,14 @@ theorem token_getOwner_correct (state : ContractState) (sender : Address) :
     specResult.success = true ∧
     specResult.returnValue = some (edslAddr.val) := by
   unfold getOwner Contract.runValue simpleTokenSpec interpretSpec tokenEdslToSpecStorageWithAddrs
+  have hidx_owner :
+      List.findIdx? (fun x => x.name == "owner")
+        ([{ name := "owner", ty := FieldType.address },
+          { name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) },
+          { name := "totalSupply", ty := FieldType.uint256 }] : List Field) = some 0 := by
+    decide
   simp [getStorageAddr, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot,
-    owner]
+    owner, hidx_owner]
 
 /- Helper Properties -/
 

--- a/Verity/Core/Uint256.lean
+++ b/Verity/Core/Uint256.lean
@@ -452,10 +452,13 @@ theorem sub_add_cancel_of_lt {a b : Uint256} (ha : a.val < modulus) (hb : b.val 
           calc b
             _ ≤ a + b := hb_le
             _ = (a + b) % m := hmod.symm
+        have hb_le_modulus : b ≤ (a + b) % modulus := by
+          simpa [m] using hb_le'
         -- No overflow: direct cancellation.
-        show (sub (add ⟨a, ha'⟩ ⟨b, hb'⟩) ⟨b, hb'⟩).val = a
-        simp only [add, sub, ofNat, val_ofNat, if_pos hb_le']
-        calc ((a + b) % m - b) % m
+        calc
+          (sub (add ⟨a, ha'⟩ ⟨b, hb'⟩) ⟨b, hb'⟩).val = ((a + b) % m - b) % m := by
+            simp [add, sub, ofNat, hb_le_modulus, m]
+          _ = ((a + b) % m - b) % m := rfl
           _ = (a + b - b) % m := by rw [hmod]
           _ = a % m := by rw [Nat.add_sub_cancel]
           _ = a := Nat.mod_eq_of_lt ha''
@@ -518,9 +521,9 @@ theorem sub_add_cancel_of_lt {a b : Uint256} (ha : a.val < modulus) (hb : b.val 
           calc
             (aU + bU - bU).val = (sub (add aU bU) bU).val := rfl
             _ = (m - (bU.val - (add aU bU).val)) % m := by
-                simp [sub_val_of_gt, hgt']
+                simp [sub_val_of_gt, hgt', m]
             _ = (m - (b - (a + b) % m)) % m := by
-                simp [aU, bU, add, ofNat]
+                simp [aU, bU, add, ofNat, m]
         calc
           (aU + bU - bU).val = (m - (b - (a + b) % m)) % m := hval'
           _ = (m - (b - (a + b - m))) % m := by

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -32,6 +32,148 @@ namespace Verity.Proofs.Stdlib.Automation
 
 open Verity
 open Verity.Proofs.Stdlib.SpecInterpreter
+open Compiler.ContractSpec
+
+/-!
+## Index Normalization Helpers
+
+Lean 4.22 is less eager to reduce `List.findIdx?` inside large interpreter terms.
+These simp lemmas keep field/parameter lookup deterministic in spec-correctness proofs.
+-/
+
+@[simp] theorem findIdx_owner_ownedCounter :
+    List.findIdx? (fun x : Field => x.name == "owner")
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "count", ty := FieldType.uint256 }] : List Field) = some 0 := by
+  decide
+
+@[simp] theorem findIdx_owner_ownedCounter_decide :
+    List.findIdx? (fun x : Field => decide (x.name = "owner"))
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "count", ty := FieldType.uint256 }] : List Field) = some 0 := by
+  decide
+
+@[simp] theorem findIdx_count_ownedCounter :
+    List.findIdx? (fun x : Field => x.name == "count")
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "count", ty := FieldType.uint256 }] : List Field) = some 1 := by
+  decide
+
+@[simp] theorem findIdx_count_ownedCounter_decide :
+    List.findIdx? (fun x : Field => decide (x.name = "count"))
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "count", ty := FieldType.uint256 }] : List Field) = some 1 := by
+  decide
+
+@[simp] theorem findIdx_count_safeCounter :
+    List.findIdx? (fun x : Field => x.name == "count")
+      ([{ name := "count", ty := FieldType.uint256 }] : List Field) = some 0 := by
+  decide
+
+@[simp] theorem findIdx_count_safeCounter_decide :
+    List.findIdx? (fun x : Field => decide (x.name = "count"))
+      ([{ name := "count", ty := FieldType.uint256 }] : List Field) = some 0 := by
+  decide
+
+@[simp] theorem findIdx_balances_simpleToken :
+    List.findIdx? (fun x : Field => x.name == "balances")
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) },
+        { name := "totalSupply", ty := FieldType.uint256 }] : List Field) = some 1 := by
+  decide
+
+@[simp] theorem findIdx_balances_simpleToken_decide :
+    List.findIdx? (fun x : Field => decide (x.name = "balances"))
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) },
+        { name := "totalSupply", ty := FieldType.uint256 }] : List Field) = some 1 := by
+  decide
+
+@[simp] theorem findIdx_owner_simpleToken :
+    List.findIdx? (fun x : Field => x.name == "owner")
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) },
+        { name := "totalSupply", ty := FieldType.uint256 }] : List Field) = some 0 := by
+  decide
+
+@[simp] theorem findIdx_owner_simpleToken_decide :
+    List.findIdx? (fun x : Field => decide (x.name = "owner"))
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) },
+        { name := "totalSupply", ty := FieldType.uint256 }] : List Field) = some 0 := by
+  decide
+
+@[simp] theorem findIdx_totalSupply_simpleToken :
+    List.findIdx? (fun x : Field => x.name == "totalSupply")
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) },
+        { name := "totalSupply", ty := FieldType.uint256 }] : List Field) = some 2 := by
+  decide
+
+@[simp] theorem findIdx_totalSupply_simpleToken_decide :
+    List.findIdx? (fun x : Field => decide (x.name = "totalSupply"))
+      ([{ name := "owner", ty := FieldType.address },
+        { name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) },
+        { name := "totalSupply", ty := FieldType.uint256 }] : List Field) = some 2 := by
+  decide
+
+@[simp] theorem findIdx_balances_ledger :
+    List.findIdx? (fun x : Field => x.name == "balances")
+      ([{ name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) }] : List Field) = some 0 := by
+  decide
+
+@[simp] theorem findIdx_balances_ledger_decide :
+    List.findIdx? (fun x : Field => decide (x.name = "balances"))
+      ([{ name := "balances", ty := FieldType.mappingTyped (MappingType.simple MappingKeyType.address) }] : List Field) = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_newOwner :
+    List.findIdx? (fun x => x == "newOwner") ["newOwner"] = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_newOwner_decide :
+    List.findIdx? (fun x => decide (x = "newOwner")) ["newOwner"] = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_initialOwner :
+    List.findIdx? (fun x => x == "initialOwner") ["initialOwner"] = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_initialOwner_decide :
+    List.findIdx? (fun x => decide (x = "initialOwner")) ["initialOwner"] = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_to_to_amount :
+    List.findIdx? (fun x => x == "to") ["to", "amount"] = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_to_to_amount_decide :
+    List.findIdx? (fun x => decide (x = "to")) ["to", "amount"] = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_amount_to_amount :
+    List.findIdx? (fun x => x == "amount") ["to", "amount"] = some 1 := by
+  decide
+
+@[simp] theorem findIdx_param_amount_to_amount_decide :
+    List.findIdx? (fun x => decide (x = "amount")) ["to", "amount"] = some 1 := by
+  decide
+
+@[simp] theorem findIdx_param_addr :
+    List.findIdx? (fun x => x == "addr") ["addr"] = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_addr_decide :
+    List.findIdx? (fun x => decide (x = "addr")) ["addr"] = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_amount_single :
+    List.findIdx? (fun x => x == "amount") ["amount"] = some 0 := by
+  decide
+
+@[simp] theorem findIdx_param_amount_single_decide :
+    List.findIdx? (fun x => decide (x = "amount")) ["amount"] = some 0 := by
+  decide
 
 /-!
 ## Contract Result Lemmas
@@ -383,24 +525,18 @@ theorem uint256_add_val (a : Verity.Core.Uint256) (amount : Nat) :
       (a.val + amount) % Verity.Core.Uint256.modulus := by
   cases a with
   | mk aval hlt =>
-      let m := Verity.Core.Uint256.modulus
-      have h1 :
-          (Verity.EVM.Uint256.add (Verity.Core.Uint256.mk aval hlt)
-                (Verity.Core.Uint256.ofNat amount)).val =
-            (aval + amount % m) % m := by
-        simp [Verity.EVM.Uint256.add, Verity.Core.Uint256.add,
-          Verity.Core.Uint256.val_ofNat, -Verity.Core.Uint256.ofNat_add]
+      have haval : aval % Verity.Core.Uint256.modulus = aval := Nat.mod_eq_of_lt hlt
       calc
         (Verity.EVM.Uint256.add (Verity.Core.Uint256.mk aval hlt)
               (Verity.Core.Uint256.ofNat amount)).val
-            = (aval + amount % m) % m := h1
-        _ = (aval + amount) % m := by
-            calc
-              (aval + amount % m) % m
-                  = ((aval % m) + (amount % m)) % m := by
-                      simp [Nat.mod_eq_of_lt hlt]
-              _ = (aval + amount) % m := by
-                      exact (Nat.add_mod _ _ _).symm
+            = (aval + amount % Verity.Core.Uint256.modulus) % Verity.Core.Uint256.modulus := by
+                simp [Verity.EVM.Uint256.add, Verity.Core.Uint256.add,
+                  Verity.Core.Uint256.val_ofNat, -Verity.Core.Uint256.ofNat_add]
+        _ = ((aval % Verity.Core.Uint256.modulus) + (amount % Verity.Core.Uint256.modulus))
+              % Verity.Core.Uint256.modulus := by
+                simp [haval]
+        _ = (aval + amount) % Verity.Core.Uint256.modulus := by
+                exact (Nat.add_mod _ _ _).symm
 
 -- Helper: EVM sub (Uint256) matches the EDSL modular subtraction formula.
 theorem uint256_sub_val (a : Verity.Core.Uint256) (amount : Nat) :
@@ -410,25 +546,28 @@ theorem uint256_sub_val (a : Verity.Core.Uint256) (amount : Nat) :
       else
         Verity.Core.Uint256.modulus -
           (amount % Verity.Core.Uint256.modulus - a.val)) := by
-  let m := Verity.Core.Uint256.modulus
-  have h_amount_lt : amount % m < m := by
+  have h_amount_lt : amount % Verity.Core.Uint256.modulus < Verity.Core.Uint256.modulus := by
     exact Nat.mod_lt _ Verity.Core.Uint256.modulus_pos
-  by_cases h_le : amount % m ≤ a.val
-  · have h_lt : a.val - amount % m < m := by
+  by_cases h_le : amount % Verity.Core.Uint256.modulus ≤ a.val
+  · have h_lt : a.val - amount % Verity.Core.Uint256.modulus < Verity.Core.Uint256.modulus := by
       exact Nat.lt_of_le_of_lt (Nat.sub_le _ _) a.isLt
     simp [Verity.EVM.Uint256.sub, Verity.Core.Uint256.sub, h_le,
-      Verity.Core.Uint256.val_ofNat, Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_lt]
-  · have h_not_le : ¬ amount % m ≤ a.val := h_le
-    have h_pos : 0 < amount % m - a.val := by
+      Verity.Core.Uint256.val_ofNat, Nat.mod_eq_of_lt h_lt]
+  · have h_not_le : ¬ amount % Verity.Core.Uint256.modulus ≤ a.val := h_le
+    have h_pos : 0 < amount % Verity.Core.Uint256.modulus - a.val := by
       exact Nat.sub_pos_of_lt (Nat.lt_of_not_ge h_not_le)
-    have h_le_x : amount % m - a.val ≤ m := by
+    have h_le_x : amount % Verity.Core.Uint256.modulus - a.val ≤ Verity.Core.Uint256.modulus := by
       exact Nat.le_of_lt (Nat.lt_of_le_of_lt (Nat.sub_le _ _) h_amount_lt)
-    have h_lt_add : m < (amount % m - a.val) + m := by
+    have h_lt_add :
+        Verity.Core.Uint256.modulus <
+          (amount % Verity.Core.Uint256.modulus - a.val) + Verity.Core.Uint256.modulus := by
       exact Nat.lt_add_of_pos_left h_pos
-    have h_lt : m - (amount % m - a.val) < m := by
+    have h_lt :
+        Verity.Core.Uint256.modulus - (amount % Verity.Core.Uint256.modulus - a.val) <
+          Verity.Core.Uint256.modulus := by
       exact Nat.sub_lt_left_of_lt_add h_le_x h_lt_add
     simp [Verity.EVM.Uint256.sub, Verity.Core.Uint256.sub, h_not_le,
-      Verity.Core.Uint256.val_ofNat, Nat.mod_eq_of_lt h_amount_lt, Nat.mod_eq_of_lt h_lt]
+      Verity.Core.Uint256.val_ofNat, Nat.mod_eq_of_lt h_lt]
 
 -- Helper: EVM sub (Uint256) matches Nat subtraction when no underflow.
 theorem uint256_sub_val_of_le (a : Verity.Core.Uint256) (amount : Nat)

--- a/Verity/Specs/Common/Sum.lean
+++ b/Verity/Specs/Common/Sum.lean
@@ -32,7 +32,7 @@ private theorem foldl_add_zero_acc (l : List α) (f : α → Uint256)
   | nil => rfl
   | cons a t ih =>
     simp only [List.foldl]
-    have ha : f a = 0 := h a (List.mem_cons_self a t)
+    have ha : f a = 0 := h a (by simp)
     rw [ha, Uint256.add_zero]
     exact ih (fun x hx => h x (List.mem_cons_of_mem a hx)) acc
 
@@ -59,7 +59,7 @@ private theorem foldl_congr (l : List α) (f g : α → Uint256) (acc : Uint256)
   | nil => rfl
   | cons a t ih =>
     simp only [List.foldl]
-    have ha : f a = g a := h a (List.mem_cons_self a t)
+    have ha : f a = g a := h a (by simp)
     rw [ha]
     exact ih (acc + g a) (fun x hx => h x (List.mem_cons_of_mem a hx))
 
@@ -130,7 +130,7 @@ private theorem foldl_replace_one (l : List α) [DecidableEq α]
     l.foldl (fun acc x => acc + g x) 0 =
     (l.foldl (fun acc x => acc + f x) 0) - (f target) + new_val := by
   induction l with
-  | nil => exact absurd h_mem (List.not_mem_nil _)
+  | nil => cases h_mem
   | cons a t ih =>
     simp only [List.foldl, Uint256.zero_add]
     have h_nodup_t := (List.nodup_cons.mp h_nodup).2
@@ -163,7 +163,7 @@ private theorem foldl_replace_one (l : List α) [DecidableEq α]
       have h_ne : a ≠ target := by
         intro heq
         exact (List.nodup_cons.mp h_nodup).1 (heq ▸ hmem)
-      rw [h_other a (List.mem_cons_self a t) h_ne]
+      rw [h_other a (by simp) h_ne]
       rw [foldl_acc_comm t g (f a)]
       rw [foldl_acc_comm t f (f a)]
       rw [ih hmem h_nodup_t (fun x hx hne => h_other x (List.mem_cons_of_mem a hx) hne)]

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.15.0
+leanprover/lean4:v4.22.0


### PR DESCRIPTION
## Summary
- upgrade `lean-toolchain` from `leanprover/lean4:v4.15.0` to `leanprover/lean4:v4.22.0`
- fix Lean 4.22 proof breakages in Uint256 and spec-correctness modules
- add deterministic `[simp]` index-normalization lemmas for `List.findIdx?` (including `decide`-predicate forms) to keep interpreter proofs stable
- replace proof-local `native_decide` with `decide` to satisfy hygiene policy

## Why
`#294` integration work depends on aligning Verity with upstream Lean versions. This lands the toolchain bump and compatibility fixes without changing runtime semantics.

## Validation
- `~/.elan/bin/lake build`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_mapping_slot_boundary.py`

Refs #294

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the Lean toolchain bump and proof/automation updates; no runtime semantics or contract logic is modified.
> 
> **Overview**
> Upgrades the project to `leanprover/lean4:v4.22.0` and adjusts proof code to compile under Lean 4.22.
> 
> To stabilize spec-correctness proofs, it adds a set of deterministic `[simp]` lemmas in `Verity/Proofs/Stdlib/Automation.lean` that normalize `List.findIdx?` field/parameter indices (including `decide`-predicate variants), and updates affected proofs in `Counter.lean`, `SafeCounter.lean`, and `SimpleToken.lean` to rely on `decide`/explicit transitivity instead of reductions that no longer fire.
> 
> It also refactors a few arithmetic/list proofs to satisfy the new elaborator behavior, including small rewrites in `Verity/Core/Uint256.lean` (proof of `sub_add_cancel_of_lt`) and `Verity/Specs/Common/Sum.lean` (membership/empty-case handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49655bac8a38b244061f96d8344c0a62781456f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->