### PR TITLE
ci: enforce EVMYulLean capability boundary for builtins

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Check Yul builtin abstraction boundary
         run: python3 scripts/check_yul_builtin_boundary.py
 
+      - name: Check EVMYulLean capability boundary
+        run: python3 scripts/check_evmyullean_capability_boundary.py
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,6 +80,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, Compiler, and AST layers; strips Lean comments/docstrings with a shared string-aware parser (so `--` and `/- -/` inside string literals are preserved), detects intra-contract slot collisions, derives Spec slot usage from `Verity/Specs/*/Spec.lean` literal state accesses, enforces Spec↔EDSL slot/type parity for compiled non-external contracts, enforces ASTSpec coverage for non-external compiler specs, and checks AST-vs-Compiler slot/type drift
 - **`check_mapping_slot_boundary.py`** - Enforces the mapping-slot abstraction boundary for proof interpreters: only `Compiler/Proofs/MappingSlot.lean` may import `MappingEncoding`; builtin dispatch in `Compiler/Proofs/YulGeneration/Builtins.lean` must route through `abstractMappingSlot`/`abstractLoadStorageOrMapping`; runtime interpreters must import `MappingSlot`, use `abstractStoreStorageOrMapping`/`abstractStoreMappingEntry`, and avoid legacy mapping internals (`mappingTag`/`encodeMappingSlot`/`decodeMappingSlot`) including local aliases
 - **`check_yul_builtin_boundary.py`** - Enforces a centralized Yul builtin semantics boundary: runtime interpreters must import `Compiler/Proofs/YulGeneration/Builtins.lean`, call `evalBuiltinCall`, and avoid inline builtin dispatch branches (`func = "add"`, `func = "sload"`, etc.)
+- **`check_evmyullean_capability_boundary.py`** - Enforces the current `#294` EVMYulLean overlap capability matrix in `Compiler/Proofs/YulGeneration/Builtins.lean`: allows only the explicit overlap builtin set plus Verity helper `mappingSlot`, and blocks known unsupported builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) from silently entering the migration seam
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
@@ -166,8 +167,9 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 7. Storage layout consistency (`check_storage_layout.py`)
 8. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
 9. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-10. Lean hygiene (`check_lean_hygiene.py`)
-11. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+10. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+11. Lean hygiene (`check_lean_hygiene.py`)
+12. Static gas model builtin coverage (`check_gas_model_coverage.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/check_evmyullean_capability_boundary.py
+++ b/scripts/check_evmyullean_capability_boundary.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Enforce EVMYulLean capability boundary for centralized Yul builtins.
+
+Issue #294 tracks replacing hand-rolled semantics with EVMYulLean. This check
+keeps `Compiler/Proofs/YulGeneration/Builtins.lean` within an explicitly
+supported builtin surface so migration cannot silently expand into unsupported
+operations.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILTINS_FILE = ROOT / "Compiler" / "Proofs" / "YulGeneration" / "Builtins.lean"
+
+BUILTIN_NAME_RE = re.compile(r'func\s*=\s*"([^"]+)"')
+
+# Builtins currently modeled as part of the overlap subset for planned
+# EVMYulLean-backed semantics.
+EVMYULLEAN_OVERLAP_BUILTINS = {
+    "add",
+    "and",
+    "calldataload",
+    "caller",
+    "div",
+    "eq",
+    "gt",
+    "iszero",
+    "lt",
+    "mod",
+    "mul",
+    "not",
+    "or",
+    "shl",
+    "shr",
+    "sload",
+    "sub",
+    "xor",
+}
+
+# Verity-level helper kept outside upstream Yul builtin set.
+VERITY_HELPER_BUILTINS = {"mappingSlot"}
+
+# Explicitly unsupported in the planned EVMYulLean-backed path (per #294
+# research notes). Presence here in Builtins.lean should block CI.
+EVMYULLEAN_UNSUPPORTED_BUILTINS = {
+    "create",
+    "create2",
+    "extcodecopy",
+    "extcodehash",
+    "extcodesize",
+}
+
+
+def main() -> int:
+    if not BUILTINS_FILE.exists():
+        print(
+            f"EVMYulLean capability boundary check failed: missing {BUILTINS_FILE.relative_to(ROOT)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    text = BUILTINS_FILE.read_text(encoding="utf-8")
+    found = set(BUILTIN_NAME_RE.findall(text))
+
+    allowed = EVMYULLEAN_OVERLAP_BUILTINS | VERITY_HELPER_BUILTINS
+
+    errors: list[str] = []
+
+    unsupported_present = sorted(found & EVMYULLEAN_UNSUPPORTED_BUILTINS)
+    if unsupported_present:
+        errors.append(
+            "contains EVMYulLean-unsupported builtins: " + ", ".join(unsupported_present)
+        )
+
+    unknown = sorted(found - allowed)
+    if unknown:
+        errors.append(
+            "introduces builtins outside capability boundary: " + ", ".join(unknown)
+        )
+
+    if errors:
+        print("EVMYulLean capability boundary check failed:", file=sys.stderr)
+        print(f"  - file: {BUILTINS_FILE.relative_to(ROOT)}", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(
+            "  - action: keep unsupported builtins in legacy fallback semantics, "
+            "or update #294 capability matrix with proof/test justification",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("✓ EVMYulLean capability boundary is enforced")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_evmyullean_capability_boundary.py` to enforce an explicit `#294` overlap capability matrix on `Compiler/Proofs/YulGeneration/Builtins.lean`
- fail CI if known unsupported EVMYulLean builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) enter the centralized builtin seam
- wire the new check into `.github/workflows/verify.yml` and document it in `scripts/README.md`

## Why
`#294` migration safety depends on an explicit boundary between overlap builtins and unsupported operations. This makes capability drift fail fast in CI instead of surfacing later during backend swap/proof migration.

## Validation
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `python3 scripts/check_yul_builtin_boundary.py`
- `python3 scripts/check_mapping_slot_boundary.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_lean_hygiene.py`
- `~/.elan/bin/lake build`

Refs #294

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 56317799824e011688a4bf508c2ea6f17ed8eea9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->