### PR TITLE
Add solc pin consistency guard in CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Check documentation counts
         run: python3 scripts/check_doc_counts.py
 
+      - name: Check solc pin consistency
+        run: python3 scripts/check_solc_pin.py
+
       - name: Check property manifest sync
         run: python3 scripts/check_property_manifest_sync.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,6 +82,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_yul_builtin_boundary.py`** - Enforces a centralized Yul builtin semantics boundary: runtime interpreters must import `Compiler/Proofs/YulGeneration/Builtins.lean`, call `evalBuiltinCall`, and avoid inline builtin dispatch branches (`func = "add"`, `func = "sload"`, etc.)
 - **`check_evmyullean_capability_boundary.py`** - Enforces the current `#294` EVMYulLean overlap capability matrix in `Compiler/Proofs/YulGeneration/Builtins.lean`: allows only the explicit overlap builtin set plus Verity helper `mappingSlot`, and blocks known unsupported builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) from silently entering the migration seam
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
+- **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
 - **`check_lean_hygiene.py`** - Validates proof hygiene (`#eval/#check/#print/#reduce`, `native_decide`, `sorry`) and exactly 1 `allowUnsafeReducibility`; parsing is comment/string-aware (including Lean raw strings) via shared Lean lexer utilities
@@ -163,13 +164,14 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 3. Contract file structure validation (`check_contract_structure.py`)
 4. Axiom location validation (`check_axiom_locations.py`)
 5. Documentation count validation (`check_doc_counts.py`)
-6. Property manifest sync (`check_property_manifest_sync.py`)
-7. Storage layout consistency (`check_storage_layout.py`)
-8. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-9. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-10. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-11. Lean hygiene (`check_lean_hygiene.py`)
-12. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+6. Solc pin consistency (`check_solc_pin.py`)
+7. Property manifest sync (`check_property_manifest_sync.py`)
+8. Storage layout consistency (`check_storage_layout.py`)
+9. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+10. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+11. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+12. Lean hygiene (`check_lean_hygiene.py`)
+13. Static gas model builtin coverage (`check_gas_model_coverage.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/check_solc_pin.py
+++ b/scripts/check_solc_pin.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Enforce pinned solc version consistency across CI, tooling, and docs.
+
+Issue #76 depends on stable Yul->bytecode semantics. This script prevents
+silent compiler-version drift by requiring one canonical solc version across:
+  - GitHub Actions verify workflow env vars
+  - foundry.toml profile config
+  - trust assumptions documentation
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+SETUP_SOLC_ACTION = ROOT / ".github" / "actions" / "setup-solc" / "action.yml"
+FOUNDRY_TOML = ROOT / "foundry.toml"
+TRUST_ASSUMPTIONS = ROOT / "TRUST_ASSUMPTIONS.md"
+
+SOLC_VERSION_RE = re.compile(r'^\s*SOLC_VERSION:\s*"([^"]+)"\s*$', re.MULTILINE)
+SOLC_URL_RE = re.compile(r'^\s*SOLC_URL:\s*"([^"]+)"\s*$', re.MULTILINE)
+SOLC_SHA256_RE = re.compile(r'^\s*SOLC_SHA256:\s*"([0-9a-fA-F]{64})"\s*$', re.MULTILINE)
+
+URL_VERSION_RE = re.compile(r"solc-linux-amd64-v(\d+\.\d+\.\d+)\+commit\.([0-9a-fA-F]{8})$")
+FOUNDRY_SOLC_RE = re.compile(r'^\s*solc_version\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
+TRUST_PIN_RE = re.compile(r"\*\*Version\*\*:\s*([0-9]+\.[0-9]+\.[0-9]+\+commit\.[0-9a-fA-F]{8})\s+\(pinned\)")
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"missing file: {path.relative_to(ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def _match(pattern: re.Pattern[str], text: str, label: str) -> str:
+    m = pattern.search(text)
+    if m is None:
+        raise ValueError(f"could not parse {label}")
+    return m.group(1)
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    try:
+        verify_text = _read(VERIFY_YML)
+        action_text = _read(SETUP_SOLC_ACTION)
+        foundry_text = _read(FOUNDRY_TOML)
+        trust_text = _read(TRUST_ASSUMPTIONS)
+    except (FileNotFoundError, OSError) as err:
+        print(f"solc pin check failed: {err}", file=sys.stderr)
+        return 1
+
+    try:
+        solc_version = _match(SOLC_VERSION_RE, verify_text, "SOLC_VERSION")
+        solc_url = _match(SOLC_URL_RE, verify_text, "SOLC_URL")
+        _match(SOLC_SHA256_RE, verify_text, "SOLC_SHA256")
+    except ValueError as err:
+        print(f"solc pin check failed: {err}", file=sys.stderr)
+        return 1
+
+    url_match = URL_VERSION_RE.search(solc_url)
+    if url_match is None:
+        errors.append(
+            ".github/workflows/verify.yml: SOLC_URL does not match expected solidity binary form"
+        )
+        url_version = None
+        url_commit = None
+    else:
+        url_version, url_commit = url_match.group(1), url_match.group(2)
+        if url_version != solc_version:
+            errors.append(
+                ".github/workflows/verify.yml: SOLC_VERSION does not match SOLC_URL embedded version"
+            )
+
+    foundry_solc = FOUNDRY_SOLC_RE.search(foundry_text)
+    if foundry_solc is None:
+        errors.append("foundry.toml: missing solc_version")
+    elif foundry_solc.group(1) != solc_version:
+        errors.append("foundry.toml: solc_version must match verify.yml SOLC_VERSION")
+
+    trust_pin = TRUST_PIN_RE.search(trust_text)
+    if trust_pin is None:
+        errors.append(
+            "TRUST_ASSUMPTIONS.md: missing pinned solc version line ('**Version**: <semver+commit> (pinned)')"
+        )
+    elif url_commit is not None and trust_pin.group(1) != f"{solc_version}+commit.{url_commit}":
+        errors.append(
+            "TRUST_ASSUMPTIONS.md: pinned solc version must match verify.yml SOLC_VERSION/SOLC_URL"
+        )
+
+    if 'curl -sSfL "$SOLC_URL" -o solc' not in action_text:
+        errors.append(".github/actions/setup-solc/action.yml: install step must download from $SOLC_URL")
+    if 'echo "${SOLC_SHA256}  solc" | sha256sum -c -' not in action_text:
+        errors.append(".github/actions/setup-solc/action.yml: install step must verify $SOLC_SHA256")
+
+    if errors:
+        print("solc pin check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(
+        "✓ solc pin is consistent "
+        f"({solc_version}{'' if url_commit is None else f'+commit.{url_commit}'})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_solc_pin.py` to enforce pinned solc consistency across CI/tooling/docs
- validate `SOLC_VERSION`/`SOLC_URL`/`SOLC_SHA256` coherence in `.github/workflows/verify.yml`
- enforce `foundry.toml` `solc_version` matches CI pin
- enforce `setup-solc` action still uses env URL+SHA verification
- enforce `TRUST_ASSUMPTIONS.md` pinned solc line matches CI pin
- wire the new check into the fast `checks` CI job and document it in `scripts/README.md`

## Why
Issue #76 tracks reducing trust around Yul->bytecode semantics. This adds a hard guard against accidental solc version drift, keeping semantics assumptions stable and explicit.

## Validation
- `python3 scripts/check_solc_pin.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `python3 scripts/check_yul_builtin_boundary.py`
- `python3 scripts/check_mapping_slot_boundary.py`
- `~/.elan/bin/lake build`

Refs #76

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new validation step and does not change runtime/proof logic; primary risk is CI false-failures if the expected pin formats change.
> 
> **Overview**
> Adds a new CI-critical script, `scripts/check_solc_pin.py`, that fails the build if the pinned `solc` version drifts between `.github/workflows/verify.yml` (`SOLC_VERSION`/`SOLC_URL`/`SOLC_SHA256`), `foundry.toml` (`solc_version`), `.github/actions/setup-solc/action.yml` (must download from `$SOLC_URL` and verify `$SOLC_SHA256`), and the pinned version line in `TRUST_ASSUMPTIONS.md`.
> 
> Wires this check into the fast `checks` job in `verify.yml` and documents it in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b70f7bb48a6e183127f12240ef2991cf1fc09289. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->