### PR TITLE
ERC20: bridge constructor/getTotalSupply spec correctness

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/ERC20.lean
+++ b/Compiler/Proofs/SpecCorrectness/ERC20.lean
@@ -15,6 +15,11 @@ open Verity
 open Verity.Specs.ERC20
 open Verity.Examples.ERC20
 
+/-- Spec/EDSL agreement for `constructor`. -/
+theorem erc20_constructor_spec_correct (s : ContractState) (initialOwner : Address) :
+    constructor_spec initialOwner s ((constructor initialOwner).runState s) := by
+  simpa using Verity.Proofs.ERC20.constructor_meets_spec s initialOwner
+
 /-- Spec/EDSL agreement for read-only `balanceOf`. -/
 theorem erc20_balanceOf_spec_correct (s : ContractState) (addr : Address) :
     balanceOf_spec addr ((balanceOf addr).runValue s) s := by
@@ -29,6 +34,11 @@ theorem erc20_allowanceOf_spec_correct (s : ContractState) (ownerAddr spender : 
 theorem erc20_getOwner_spec_correct (s : ContractState) :
     getOwner_spec ((getOwner).runValue s) s := by
   simp [getOwner_spec, getOwner, getStorageAddr, Contract.runValue, owner]
+
+/-- Spec/EDSL agreement for read-only `getTotalSupply`. -/
+theorem erc20_totalSupply_spec_correct (s : ContractState) :
+    totalSupply_spec ((getTotalSupply).runValue s) s := by
+  simpa using Verity.Proofs.ERC20.totalSupply_meets_spec s
 
 /-- Spec/EDSL agreement for `approve` with sender-bound owner. -/
 theorem erc20_approve_spec_correct (s : ContractState) (spender : Address) (amount : Uint256) :


### PR DESCRIPTION
## Summary
- add compiler bridge theorem for ERC20 `constructor` spec agreement
- add compiler bridge theorem for ERC20 `getTotalSupply` spec agreement
- reuse existing proven ERC20 basic lemmas for both bridges

## Why
This is a low-risk, high-signal `#69` increment that tightens compiler/spec alignment for ERC20 while keeping the proof surface merge-safe.

## Validation
- `~/.elan/bin/lake build`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

Refs #69

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions that reuse existing established lemmas; no runtime logic or spec definitions are modified.
> 
> **Overview**
> Adds new spec-correctness bridge theorems in `Compiler/Proofs/SpecCorrectness/ERC20.lean` for ERC20 `constructor` and read-only `getTotalSupply`.
> 
> Both theorems are thin wrappers that `simpa` against existing proofs (`Verity.Proofs.ERC20.constructor_meets_spec` and `totalSupply_meets_spec`), expanding the compiler/spec agreement surface without changing contract logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02e558fff0387e399bc88d26565f43270afe17c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->