### PR TITLE
chore: replace deprecated List.enum/List.get? usages

### DIFF
--- a/Verity/Proofs/Stdlib/SpecInterpreter.lean
+++ b/Verity/Proofs/Stdlib/SpecInterpreter.lean
@@ -151,14 +151,14 @@ def evalExpr (ctx : EvalContext) (storage : SpecStorage) (fields : List Field) (
       match paramNames.findIdx? (· == name) with
       | some idx =>
           let raw := ctx.params.getD idx 0
-          match ctx.paramTypes.get? idx with
+          match ctx.paramTypes[idx]? with
           | some ParamType.address => raw % addressModulus
           | some ParamType.bool => if raw % modulus == 0 then 0 else 1
           | _ => raw % modulus
       | none => 0
   | Expr.constructorArg idx =>
       let raw := ctx.constructorArgs.getD idx 0
-      match ctx.constructorParamTypes.get? idx with
+      match ctx.constructorParamTypes[idx]? with
       | some ParamType.address => raw % addressModulus
       | some ParamType.bool => if raw % modulus == 0 then 0 else 1
       | _ => raw % modulus


### PR DESCRIPTION
## Summary
- replace deprecated `List.enum` call sites in compiler generation with `List.zipIdx`
- replace deprecated `List.get?` usages in spec interpreter with index notation (`xs[i]?`)
- keep behavior unchanged while reducing deprecation noise in build logs

## Why
This removes active Lean deprecation warnings in core compiler/spec modules and reduces upgrade risk for future Lean versions.

## Validation
- `~/.elan/bin/lake build`
- `python3 scripts/extract_property_manifest.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors to iteration/indexing to address deprecations; risk is limited to potential off-by-one/index ordering mistakes in codegen and interpreter paths.
> 
> **Overview**
> Updates compiler Yul generation in `Compiler/ContractSpec.lean` to replace deprecated `List.enum` iteration with `List.zipIdx` (affecting `revertWithMessage`, event signature/topic storage, multi-value returns, and constructor arg loading), and simplifies a termination proof step for `chunkBytes32`.
> 
> Updates `Verity/Proofs/Stdlib/SpecInterpreter.lean` to replace deprecated `List.get?` calls with index-notation option access (`xs[i]?`) when interpreting parameter and constructor argument types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82e7ea0be87bed999ba3a718a92cdeb826b7a55e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->