### PR TITLE
chore(lean): clean unused simp args in Uint256

### DIFF
--- a/Verity/Core/Uint256.lean
+++ b/Verity/Core/Uint256.lean
@@ -347,7 +347,7 @@ theorem sub_val_of_gt {a b : Uint256} (h : b.val > a.val) :
             -- drop the inner mod on the left factor
             simp [m]
     _ = (a.val * c.val + b.val * c.val) % m := by
-            simp [Nat.add_mul, Nat.add_assoc]
+            simp [Nat.add_mul]
     _ = (((a.val * c.val) % m) + ((b.val * c.val) % m)) % m := by
             -- expand with add_mod
             exact (Nat.add_mod (a.val * c.val) (b.val * c.val) m)
@@ -390,20 +390,20 @@ theorem sub_val_of_gt {a b : Uint256} (h : b.val > a.val) :
         m - d + b.val
             = m - d + (a.val + d) := by simp [hba_eq]
         _ = (m - d + d) + a.val := by
-            simp [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+            simp [Nat.add_assoc, Nat.add_comm]
         _ = m + a.val := by
             have hle : d ≤ m := Nat.le_of_lt hba
-            simp [Nat.sub_add_cancel hle, Nat.add_assoc]
+            simp [Nat.sub_add_cancel hle]
     calc
       ((a - b) + b).val
           = (((m - d) % m) + b.val) % m := by
               simp [HAdd.hAdd, HSub.hSub, sub, add, ofNat, m, h, d]
       _ = ((m - d) + b.val) % m := by
-              simp [Nat.mod_eq_of_lt hba]
+              simp
       _ = (m + a.val) % m := by
               simp [hsum]
       _ = a.val % m := by
-              simp [Nat.add_mod_left, Nat.add_comm]
+              simp [Nat.add_mod_left]
       _ = a.val := by
               exact Nat.mod_eq_of_lt (by
                 simp [m]
@@ -474,7 +474,7 @@ theorem sub_add_cancel_of_lt {a b : Uint256} (ha : a.val < modulus) (hb : b.val 
           calc
             a + b < m + b := h'
             _ = b + m := by
-              simp [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc]
+              simp [Nat.add_comm]
         have hbgt : b > a + b - m := by
           exact Nat.sub_lt_right_of_lt_add h_ge hlt'
         have hbnot : ¬ b ≤ a + b - m := Nat.not_le_of_gt hbgt
@@ -489,7 +489,7 @@ theorem sub_add_cancel_of_lt {a b : Uint256} (ha : a.val < modulus) (hb : b.val 
             _ = ((m - a) + a) + b - m := by
                     simp [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
             _ = m + b - m := by
-                    simp [Nat.sub_add_cancel hma, Nat.add_assoc]
+                    simp [Nat.sub_add_cancel hma]
             _ = b := by
                     exact Nat.add_sub_cancel_left m b
         have hdiff : b - (a + b - m) = m - a := by
@@ -511,7 +511,7 @@ theorem sub_add_cancel_of_lt {a b : Uint256} (ha : a.val < modulus) (hb : b.val 
             calc
               m = m - a + a := h1.symm
               _ = a + (m - a) := by
-                simp [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc])
+                simp [Nat.add_comm])
         have hval' : (aU + bU - bU).val = (m - (b - (a + b) % m)) % m := by
           have hgt : b > (a + b) % m := by
             exact Nat.lt_of_not_ge hbnot'


### PR DESCRIPTION
## Summary
- remove 8 unused `simp` arguments in `Verity/Core/Uint256.lean`
- keep theorem behavior unchanged while reducing linter noise in a foundational module
- keep scope intentionally narrow (single-file maintenance cleanup)

## Validation
- `~/.elan/bin/lake build Verity.Core.Uint256`
- `~/.elan/bin/lake build`
- `python3 scripts/extract_property_manifest.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that primarily tweaks `simp` invocation hints; risk is limited to potential proof breakage if simp behavior changes, with no runtime semantics affected.
> 
> **Overview**
> Cleans up `Verity/Core/Uint256.lean` by removing several unused or redundant arguments passed to `simp` in modular-arithmetic proofs (notably around `add_mul`, `sub_add_cancel_left`, and an overflow-cancellation lemma), relying on Lean's default simp set instead.
> 
> No functional or semantic changes are intended; this is a narrow proof-maintenance refactor to keep the file building cleanly with fewer superfluous simp hints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8e097bd035b0671aa8a96cb5498f7b05d5d26b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->