### PR TITLE
chore(simple-storage): clean unused simp args in proofs

### DIFF
--- a/Verity/Proofs/SimpleStorage/Basic.lean
+++ b/Verity/Proofs/SimpleStorage/Basic.lean
@@ -22,14 +22,14 @@ theorem setStorage_updates_slot (s : ContractState) (value : Uint256) :
   let s' := ((setStorage slot value).run s).snd
   s'.storage 0 = value := by
   -- Unfold definitions
-  simp [setStorage]
+  simp
 
 -- Lemma: getStorage reads from the correct slot
 theorem getStorage_reads_slot (s : ContractState) :
   let slot : StorageSlot Uint256 := ⟨0⟩
   let result := ((getStorage slot).run s).fst
   result = s.storage 0 := by
-  simp [getStorage]
+  simp
 
 -- Lemma: setStorage preserves other slots
 theorem setStorage_preserves_other_slots (s : ContractState) (value : Uint256) (n : Nat)
@@ -37,34 +37,34 @@ theorem setStorage_preserves_other_slots (s : ContractState) (value : Uint256) (
   let slot : StorageSlot Uint256 := ⟨0⟩
   let s' := ((setStorage slot value).run s).snd
   s'.storage n = s.storage n := by
-  simp [setStorage, h]
+  simp [h]
 
 -- Lemma: setStorage preserves context (sender, thisAddress)
 theorem setStorage_preserves_sender (s : ContractState) (value : Uint256) :
   let slot : StorageSlot Uint256 := ⟨0⟩
   let s' := ((setStorage slot value).run s).snd
   s'.sender = s.sender := by
-  simp [setStorage]
+  simp
 
 theorem setStorage_preserves_address (s : ContractState) (value : Uint256) :
   let slot : StorageSlot Uint256 := ⟨0⟩
   let s' := ((setStorage slot value).run s).snd
   s'.thisAddress = s.thisAddress := by
-  simp [setStorage]
+  simp
 
 -- Lemma: setStorage preserves address storage
 theorem setStorage_preserves_addr_storage (s : ContractState) (value : Uint256) :
   let slot : StorageSlot Uint256 := ⟨0⟩
   let s' := ((setStorage slot value).run s).snd
   s'.storageAddr = s.storageAddr := by
-  simp [setStorage]
+  simp
 
 -- Lemma: setStorage preserves mapping storage
 theorem setStorage_preserves_map_storage (s : ContractState) (value : Uint256) :
   let slot : StorageSlot Uint256 := ⟨0⟩
   let s' := ((setStorage slot value).run s).snd
   s'.storageMap = s.storageMap := by
-  simp [setStorage]
+  simp
 
 -- Main theorem: store meets its specification
 theorem store_meets_spec (s : ContractState) (value : Uint256) :
@@ -73,7 +73,7 @@ theorem store_meets_spec (s : ContractState) (value : Uint256) :
   simp [store, storedData, store_spec, Specs.sameAddrMapContext,
     Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap]
   intro slot h_neq
-  simp [setStorage, storedData, h_neq]
+  simp [h_neq]
 
 -- Main theorem: retrieve meets its specification
 theorem retrieve_meets_spec (s : ContractState) :
@@ -109,7 +109,7 @@ theorem store_preserves_wellformedness (s : ContractState) (value : Uint256)
 theorem retrieve_preserves_state (s : ContractState) :
   let s' := ((retrieve).run s).snd
   s' = s := by
-  simp [retrieve, storedData, getStorage]
+  simp [retrieve, storedData]
 
 -- Theorem: retrieve is idempotent (running twice is the same as once)
 theorem retrieve_twice_idempotent (s : ContractState) :

--- a/Verity/Proofs/SimpleStorage/Correctness.lean
+++ b/Verity/Proofs/SimpleStorage/Correctness.lean
@@ -71,7 +71,7 @@ theorem store_preserves_context (s : ContractState) (value : Uint256) :
 theorem retrieve_preserves_context (s : ContractState) :
   let s' := ((retrieve).run s).snd
   context_preserved s s' := by
-  simp [retrieve_preserves_state s, Specs.sameContext]
+  simp [retrieve_preserves_state s]
 
 /-- retrieve preserves well-formedness. -/
 theorem retrieve_preserves_wellformedness (s : ContractState) (h : WellFormedState s) :


### PR DESCRIPTION
## Summary
- remove unused `simp` arguments in `SimpleStorage` proof modules
- keep theorem behavior unchanged while reducing Lean warning noise
- clean both `Basic` and `Correctness` files for this contract slice

## Why
No open issues/PRs were available, so this pass targets a high-leverage maintenance cleanup that improves signal in CI logs and keeps proof code aligned with Lean linter expectations.

## Validation
- `~/.elan/bin/lake build Verity.Proofs.SimpleStorage.Basic`
- `~/.elan/bin/lake build Verity.Proofs.SimpleStorage.Correctness`
- `~/.elan/bin/lake build`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that adjusts tactic invocations (`simp`) without changing specs, implementations, or theorem statements; risk is limited to potential proof brittleness if simp sets change.
> 
> **Overview**
> Simplifies the `SimpleStorage` proof scripts by removing redundant `simp` arguments/unfold hints in `Basic.lean` and `Correctness.lean`, relying on default simp behavior and keeping only needed hypotheses (e.g., `[h]`).
> 
> Also trims the `retrieve_preserves_state`/`retrieve_preserves_context` proofs to avoid explicitly rewriting with definitions that `simp` can already resolve, reducing linter/warning noise without changing any proven properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35ffbd081f1e93b056d7912f8afd180ef687d311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->