### PR TITLE
cleanup: remove unused simp args in Counter proofs

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Counter.lean
+++ b/Compiler/Proofs/SpecCorrectness/Counter.lean
@@ -76,7 +76,7 @@ private theorem evalExpr_decrement_eq (state : ContractState) (sender : Address)
         modulus - (1 - (state.storage 0).val) := by
       apply Nat.mod_eq_of_lt
       simpa [h0] using Nat.sub_lt_of_pos_le Nat.one_pos (Nat.succ_le_of_lt Verity.Core.Uint256.modulus_pos)
-    simp [evalExpr, SpecStorage.getSlot, List.lookup, hidx, h1mod, h, h0, h_sub, h_mod]
+    simp [evalExpr, SpecStorage.getSlot, List.lookup, hidx, h1mod, h0, h_sub]
 
 /- Correctness Theorems -/
 
@@ -92,8 +92,8 @@ theorem counter_increment_correct (state : ContractState) (sender : Address) :
     specResult.success = true ∧
     specResult.finalStorage.getSlot 0 = (edslFinal.storage 0).val := by
   unfold increment counterSpec interpretSpec counterEdslToSpecStorage Contract.runState
-  simp [getStorage, setStorage, add, count, execFunction, execStmts, execStmt, evalExpr,
-    SpecStorage.setSlot, SpecStorage.getSlot, modulus, val_ofNat]
+  simp [add, count, execFunction, execStmts, execStmt, evalExpr,
+    SpecStorage.setSlot, SpecStorage.getSlot, modulus]
   rfl
 
 /-- The `decrement` function correctly decrements the counter with modular arithmetic -/
@@ -145,7 +145,7 @@ theorem counter_increment_decrement_roundtrip (state : ContractState) (sender : 
     let afterInc := increment.runState { state with sender := sender }
     let afterDec := decrement.runState { afterInc with sender := sender }
     afterDec.storage 0 = state.storage 0 := by
-  simp [increment, decrement, Contract.runState, getStorage, setStorage, count, Verity.bind]
+  simp [increment, decrement, Contract.runState, count]
   -- We have: sub (add (state.storage 0) 1) 1 = state.storage 0
   -- This is exactly the sub_add_cancel theorem
   exact Verity.EVM.Uint256.sub_add_cancel (state.storage 0) 1
@@ -156,7 +156,7 @@ theorem counter_decrement_increment_roundtrip (state : ContractState) (sender : 
     let afterDec := decrement.runState { state with sender := sender }
     let afterInc := increment.runState { afterDec with sender := sender }
     afterInc.storage 0 = state.storage 0 := by
-  simp [decrement, increment, Contract.runState, getStorage, setStorage, count, Verity.bind]
+  simp [decrement, increment, Contract.runState, count]
   -- We have: add (sub (state.storage 0) 1) 1 = state.storage 0
   -- This is exactly sub_add_cancel_left in infix notation: (a - b) + b = a
   exact Verity.Core.Uint256.sub_add_cancel_left (state.storage 0) 1

--- a/Verity/Proofs/Counter/Basic.lean
+++ b/Verity/Proofs/Counter/Basic.lean
@@ -22,38 +22,38 @@ theorem setStorage_updates_count (s : ContractState) (value : Uint256) :
   let slot : StorageSlot Uint256 := count
   let s' := ((setStorage slot value).run s).snd
   s'.storage 0 = value := by
-  simp [setStorage, count]
+  simp [count]
 
 theorem getStorage_reads_count (s : ContractState) :
   let slot : StorageSlot Uint256 := count
   let result := ((getStorage slot).run s).fst
   result = s.storage 0 := by
-  simp [getStorage, count]
+  simp [count]
 
 theorem setStorage_preserves_other_slots (s : ContractState) (value : Uint256) (slot_num : Nat)
   (h : slot_num ≠ 0) :
   let slot : StorageSlot Uint256 := count
   let s' := ((setStorage slot value).run s).snd
   s'.storage slot_num = s.storage slot_num := by
-  simp [setStorage, count, h]
+  simp [count, h]
 
 theorem setStorage_preserves_context (s : ContractState) (value : Uint256) :
   let slot : StorageSlot Uint256 := count
   let s' := ((setStorage slot value).run s).snd
   s'.sender = s.sender ∧ s'.thisAddress = s.thisAddress := by
-  simp [setStorage, count]
+  simp [count]
 
 theorem setStorage_preserves_addr_storage (s : ContractState) (value : Uint256) :
   let slot : StorageSlot Uint256 := count
   let s' := ((setStorage slot value).run s).snd
   s'.storageAddr = s.storageAddr := by
-  simp [setStorage, count]
+  simp [count]
 
 theorem setStorage_preserves_map_storage (s : ContractState) (value : Uint256) :
   let slot : StorageSlot Uint256 := count
   let s' := ((setStorage slot value).run s).snd
   s'.storageMap = s.storageMap := by
-  simp [setStorage, count]
+  simp [count]
 
 /-! ## increment Correctness -/
 
@@ -170,6 +170,6 @@ theorem decrement_preserves_wellformedness (s : ContractState) (h : WellFormedSt
 theorem getCount_preserves_state (s : ContractState) :
   let s' := ((getCount).run s).snd
   s' = s := by
-  simp [getCount, getStorage]
+  simp [getCount]
 
 end Verity.Proofs.Counter

--- a/Verity/Proofs/Counter/Correctness.lean
+++ b/Verity/Proofs/Counter/Correctness.lean
@@ -48,8 +48,7 @@ theorem decrement_state_preserved_except_count (s : ContractState) :
 theorem getCount_state_preserved (s : ContractState) :
   let s' := ((getCount).run s).snd
   state_preserved_except_count s s' := by
-  simp [getCount_preserves_state s, state_preserved_except_count, storage_isolated,
-    Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameContext]
+  simp [getCount_preserves_state s, state_preserved_except_count, storage_isolated]
 
 /-! ## Combined Spec Proofs
 


### PR DESCRIPTION
## Summary
- remove unused `simp` arguments in `Verity/Proofs/Counter/Basic.lean`
- remove unused `simp` arguments in `Verity/Proofs/Counter/Correctness.lean`
- remove unused `simp` arguments in `Compiler/Proofs/SpecCorrectness/Counter.lean`

## Why
- reduces Lean warning noise in the Counter proof stack
- keeps proofs and behavior unchanged while improving maintainability

## Validation
- `~/.elan/bin/lake build Verity.Proofs.Counter.Basic`
- `~/.elan/bin/lake build Verity.Proofs.Counter.Correctness`
- `~/.elan/bin/lake build Compiler.Proofs.SpecCorrectness.Counter`
- `~/.elan/bin/lake build`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit b996a2db48a63adfc8ec02f7863ee07e717aaf6a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->