### PR TITLE
chore: remove unused simp args in owned proofs

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -56,7 +56,7 @@ theorem owned_constructor_correct (state : ContractState) (initialOwner : Addres
     specResult.success = true ∧
     specResult.finalStorage.getSlot 0 = Verity.Core.Address.val (edslResult.getState.storageAddr 0) := by
   simp [Verity.Examples.Owned.constructor, Contract.run, ownedSpec, interpretSpec,
-    setStorageAddr, Verity.Examples.Owned.owner, Verity.bind, Verity.pure,
+    setStorageAddr, Verity.Examples.Owned.owner,
     execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
 
 /-- The `transferOwnership` function correctly transfers ownership when called by owner -/
@@ -105,7 +105,7 @@ theorem owned_transferOwnership_reverts_as_nonowner (state : ContractState) (new
     simp [h_revert, ContractResult.isSuccess]
   · -- Spec reverts when sender is not owner
     simp [ownedSpec, requireOwner, interpretSpec, ownedEdslToSpecStorage, execFunction, execStmts, execStmt,
-      evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
+      evalExpr, SpecStorage.getSlot,
       addressToNat_beq_false_of_ne sender (state.storageAddr 0) (Ne.symm h)]
 
 /-- The `getOwner` function correctly retrieves the owner address -/
@@ -154,7 +154,7 @@ theorem owned_only_owner_can_transfer (state : ContractState) (newOwner : Addres
 theorem owned_constructor_sets_owner (state : ContractState) (initialOwner : Address) (sender : Address) :
     let finalState := (constructor initialOwner).runState { state with sender := sender }
     finalState.storageAddr 0 = initialOwner := by
-  simp [Verity.Examples.Owned.constructor, Contract.runState, setStorageAddr, Verity.Examples.Owned.owner, Verity.bind]
+  simp [Verity.Examples.Owned.constructor, Contract.runState, setStorageAddr, Verity.Examples.Owned.owner]
 
 /-- TransferOwnership updates owner when authorized -/
 theorem owned_transferOwnership_updates_owner (state : ContractState) (newOwner : Address) (sender : Address)

--- a/Verity/Proofs/Owned/Basic.lean
+++ b/Verity/Proofs/Owned/Basic.lean
@@ -27,38 +27,38 @@ theorem setStorageAddr_updates_owner (s : ContractState) (addr : Address) :
   let slot : StorageSlot Address := owner
   let s' := ((setStorageAddr slot addr).run s).snd
   s'.storageAddr 0 = addr := by
-  simp [setStorageAddr, owner]
+  simp [owner]
 
 theorem getStorageAddr_reads_owner (s : ContractState) :
   let slot : StorageSlot Address := owner
   let result := ((getStorageAddr slot).run s).fst
   result = s.storageAddr 0 := by
-  simp [getStorageAddr, owner]
+  simp [owner]
 
 theorem setStorageAddr_preserves_other_slots (s : ContractState) (addr : Address) (slot_num : Nat)
   (h : slot_num ≠ 0) :
   let slot : StorageSlot Address := owner
   let s' := ((setStorageAddr slot addr).run s).snd
   s'.storageAddr slot_num = s.storageAddr slot_num := by
-  simp [setStorageAddr, owner, h]
+  simp [owner, h]
 
 theorem setStorageAddr_preserves_uint_storage (s : ContractState) (addr : Address) :
   let slot : StorageSlot Address := owner
   let s' := ((setStorageAddr slot addr).run s).snd
   s'.storage = s.storage := by
-  simp [setStorageAddr, owner]
+  simp [owner]
 
 theorem setStorageAddr_preserves_map_storage (s : ContractState) (addr : Address) :
   let slot : StorageSlot Address := owner
   let s' := ((setStorageAddr slot addr).run s).snd
   s'.storageMap = s.storageMap := by
-  simp [setStorageAddr, owner]
+  simp [owner]
 
 theorem setStorageAddr_preserves_context (s : ContractState) (addr : Address) :
   let slot : StorageSlot Address := owner
   let s' := ((setStorageAddr slot addr).run s).snd
   s'.sender = s.sender ∧ s'.thisAddress = s.thisAddress := by
-  simp [setStorageAddr, owner]
+  simp [owner]
 
 /-! ## constructor Correctness -/
 
@@ -68,7 +68,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   simp [constructor, constructor_spec, owner, Specs.sameStorageMapContext,
     Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
   intro slot h_neq
-  simp [setStorageAddr, owner, h_neq]
+  simp [h_neq]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((constructor initialOwner).run s).snd
@@ -90,14 +90,14 @@ theorem getOwner_returns_owner (s : ContractState) :
 theorem getOwner_preserves_state (s : ContractState) :
   let s' := ((getOwner).run s).snd
   s' = s := by
-  simp [getOwner, getStorageAddr, owner]
+  simp [getOwner, owner]
 
 /-! ## isOwner Correctness -/
 
 theorem isOwner_meets_spec (s : ContractState) :
   let result := ((isOwner).run s).fst
   isOwner_spec result s := by
-  simp only [isOwner, isOwner_spec, msgSender, getStorageAddr, owner, bind, Bind.bind, Contract.run, pure, ContractResult.fst]
+  simp only [isOwner, isOwner_spec, msgSender, getStorageAddr, owner, bind, Bind.bind, Contract.run, ContractResult.fst]
   rfl
 
 theorem isOwner_returns_correct_value (s : ContractState) :
@@ -131,7 +131,7 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
   simp [transferOwnership, onlyOwner, isOwner, owner,
     msgSender, getStorageAddr, setStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst, h_owner]
+    Contract.run, h_owner]
 
 theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
   (h_is_owner : s.sender = s.storageAddr 0) :
@@ -141,7 +141,7 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   simp [transferOwnership_spec, ContractResult.snd, Specs.sameStorageMapContext,
     Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
   intro slot h_neq
-  simp [beq_iff_eq, h_neq]
+  simp [h_neq]
 
 theorem transferOwnership_changes_owner_when_allowed (s : ContractState) (newOwner : Address)
   (h_is_owner : s.sender = s.storageAddr 0) :

--- a/Verity/Proofs/Owned/Correctness.lean
+++ b/Verity/Proofs/Owned/Correctness.lean
@@ -28,9 +28,9 @@ theorem transferOwnership_reverts_when_not_owner (s : ContractState) (newOwner :
   (h_not_owner : s.sender ≠ s.storageAddr 0) :
   ∃ msg, (transferOwnership newOwner).run s = ContractResult.revert msg s := by
   simp [transferOwnership, onlyOwner, isOwner, owner,
-    msgSender, getStorageAddr, setStorageAddr,
+    msgSender, getStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst,
+    Contract.run,
     address_beq_false_of_ne s.sender (s.storageAddr 0) h_not_owner]
 
 /-! ## Invariant Preservation -/


### PR DESCRIPTION
## Summary
- remove unused `simp` arguments in the Owned proof stack
- keep theorem behavior unchanged while reducing warning noise in:
  - `Verity/Proofs/Owned/Basic.lean`
  - `Verity/Proofs/Owned/Correctness.lean`
  - `Compiler/Proofs/SpecCorrectness/Owned.lean`

## Validation
- `~/.elan/bin/lake build Verity.Proofs.Owned.Basic Verity.Proofs.Owned.Correctness Compiler.Proofs.SpecCorrectness.Owned`
- `~/.elan/bin/lake build`
- `python3 scripts/extract_property_manifest.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only cleanup (unused `simp` args removed) with no changes to contract logic, specs, or theorem statements.
> 
> **Overview**
> Simplifies `simp` invocations across the Owned proof stack by removing unused rewrite arguments in `Verity/Proofs/Owned/Basic.lean`, `Verity/Proofs/Owned/Correctness.lean`, and `Compiler/Proofs/SpecCorrectness/Owned.lean`.
> 
> Theorems and proof intent remain the same; the change is purely proof-hygiene to reduce warning noise and tighten proof scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beeee717b72e2be2724de32ffea79d4394b1a01b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->