### PR TITLE
chore: clean SafeCounter unused simp warnings

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
@@ -73,14 +73,14 @@ private theorem increment_spec_success_iff (state : ContractState) (sender : Add
         ¬((state.storage 0).val + 1) % Verity.Core.Uint256.modulus > (state.storage 0).val :=
       Nat.not_lt_of_ge h_le
     simp [interpretSpec, safeCounterSpec, safeCounterEdslToSpecStorage,
-      execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
-      lookup_count_newcount, lookup_newcount, List.lookup, one_mod_modulus, h_le, h_not_gt]
+      execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot,
+      List.lookup, one_mod_modulus, h_not_gt]
   · have h_gt :
         ((state.storage 0).val + 1) % Verity.Core.Uint256.modulus > (state.storage 0).val :=
       Nat.lt_of_not_ge h_le
     simp [interpretSpec, safeCounterSpec, safeCounterEdslToSpecStorage,
       execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
-      lookup_count_newcount, lookup_newcount, List.lookup, one_mod_modulus, h_le, h_gt]
+      List.lookup, one_mod_modulus, h_gt]
 
 private theorem increment_spec_storage (state : ContractState) (sender : Address)
     (h_gt : ((state.storage 0).val + 1) % Verity.Core.Uint256.modulus > (state.storage 0).val) :
@@ -97,7 +97,7 @@ private theorem increment_spec_storage (state : ContractState) (sender : Address
     Nat.not_le_of_gt h_gt
   simp [interpretSpec, safeCounterSpec, safeCounterEdslToSpecStorage,
     execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
-    lookup_count_newcount, lookup_newcount, List.lookup, one_mod_modulus, h_not_le]
+    List.lookup, one_mod_modulus, h_not_le]
 
 private theorem decrement_spec_success_iff (state : ContractState) (sender : Address) :
     let specTx : DiffTestTypes.Transaction := {
@@ -110,22 +110,16 @@ private theorem decrement_spec_success_iff (state : ContractState) (sender : Add
   by_cases h_ge : (state.storage 0).val ≥ 1
   · have h_not_lt : ¬(state.storage 0).val < 1 :=
       Nat.not_lt_of_ge h_ge
-    have h_not_lt' : ¬(state.storage 0).val < 1 % Verity.Core.Uint256.modulus := by
-      simpa [one_mod_modulus] using h_not_lt
-    have h_ne : (state.storage 0).val ≠ 0 := by
-      omega
     simp [interpretSpec, safeCounterSpec, safeCounterEdslToSpecStorage,
       execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
-      lookup_count_single, List.lookup, one_mod_modulus, h_not_lt', h_ge, h_ne]
+      List.lookup, one_mod_modulus, h_ge]
   · have h_lt : (state.storage 0).val < 1 :=
       Nat.lt_of_not_ge h_ge
-    have h_lt' : (state.storage 0).val < 1 % Verity.Core.Uint256.modulus := by
-      simpa [one_mod_modulus] using h_lt
     have h_zero : (state.storage 0).val = 0 := by
       omega
     simp [interpretSpec, safeCounterSpec, safeCounterEdslToSpecStorage,
-      execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
-      lookup_count_single, List.lookup, one_mod_modulus, h_lt', h_ge, h_zero]
+      execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot,
+      List.lookup, one_mod_modulus, h_zero]
 
 private theorem decrement_spec_storage (state : ContractState) (sender : Address)
     (h_ge : (state.storage 0).val ≥ 1) :
@@ -138,13 +132,9 @@ private theorem decrement_spec_storage (state : ContractState) (sender : Address
     specResult.finalStorage.getSlot 0 = (state.storage 0).val - 1 := by
   have h_not_lt : ¬(state.storage 0).val < 1 :=
     Nat.not_lt_of_ge h_ge
-  have h_not_lt' : ¬(state.storage 0).val < 1 % Verity.Core.Uint256.modulus := by
-    simpa [one_mod_modulus] using h_not_lt
-  have h_ne : (state.storage 0).val ≠ 0 := by
-    omega
   simp [interpretSpec, safeCounterSpec, safeCounterEdslToSpecStorage,
     execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
-    lookup_count_single, List.lookup, one_mod_modulus, h_not_lt', h_ge, h_ne]
+    List.lookup, one_mod_modulus, h_ge]
 
 /-- Increment reverts when counter is at MAX_UINT256 -/
 theorem safeIncrement_reverts_at_max (state : ContractState) (sender : Address)
@@ -169,7 +159,7 @@ theorem safeIncrement_succeeds_below_max (state : ContractState) (sender : Addre
   -- When count < MAX_UINT256, count + 1 ≤ MAX_UINT256, so safeAdd succeeds
   -- Unfold increment and show that safeAdd succeeds (returns Some), thus no revert
   unfold increment getStorage setStorage count requireSomeUint Contract.run ContractResult.isSuccess
-  simp only [Verity.bind, Bind.bind, Verity.pure, Pure.pure]
+  simp only [Verity.bind, Bind.bind, Pure.pure]
   -- Show safeAdd returns Some when no overflow
   have h_no_overflow : ((state.storage 0) : Nat) + 1 ≤ Verity.Core.MAX_UINT256 := by
     omega
@@ -308,7 +298,7 @@ theorem safeDecrement_succeeds_above_zero (state : ContractState) (sender : Addr
     result.isSuccess = true := by
   -- When count > 0, count ≥ 1, so safeSub succeeds
   unfold decrement getStorage setStorage count requireSomeUint Contract.run ContractResult.isSuccess
-  simp only [Verity.bind, Bind.bind, Verity.pure, Pure.pure]
+  simp only [Verity.bind, Bind.bind, Pure.pure]
   -- Show safeSub returns Some when no underflow
   have h_no_underflow : ((state.storage 0) : Nat) ≥ 1 := by
     omega

--- a/Verity/Proofs/SafeCounter/Basic.lean
+++ b/Verity/Proofs/SafeCounter/Basic.lean
@@ -59,7 +59,7 @@ private theorem increment_unfold (s : ContractState)
       events := s.events } := by
   simp only [increment, getStorage, setStorage, count, requireSomeUint,
     Verity.bind, Bind.bind, Verity.pure, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst,
+    Contract.run,
     safeAdd_some (s.storage 0) 1 h_no_overflow]
 
 theorem increment_meets_spec (s : ContractState)
@@ -93,9 +93,9 @@ theorem increment_preserves_other_slots (s : ContractState)
 theorem increment_reverts_overflow (s : ContractState)
   (h_overflow : (s.storage 0 : Nat) + 1 > MAX_UINT256) :
   ∃ msg, (increment).run s = ContractResult.revert msg s := by
-  simp [increment, getStorage, setStorage, count, requireSomeUint,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure,
-    Verity.require, Contract.run, ContractResult.snd, ContractResult.fst,
+  simp [increment, getStorage, count, requireSomeUint,
+    Verity.bind, Bind.bind,
+    Verity.require, Contract.run,
     safeAdd_none (s.storage 0) 1 h_overflow]
 
 /-! ## Decrement Correctness -/
@@ -117,7 +117,7 @@ private theorem decrement_unfold (s : ContractState)
       events := s.events } := by
   simp only [decrement, getStorage, setStorage, count, requireSomeUint,
     Verity.bind, Bind.bind, Verity.pure, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst,
+    Contract.run,
     safeSub_some (s.storage 0) 1 h_no_underflow]
 
 theorem decrement_meets_spec (s : ContractState)
@@ -151,9 +151,9 @@ theorem decrement_preserves_other_slots (s : ContractState)
 theorem decrement_reverts_underflow (s : ContractState)
   (h_underflow : s.storage 0 = 0) :
   ∃ msg, (decrement).run s = ContractResult.revert msg s := by
-  simp [decrement, getStorage, setStorage, count, requireSomeUint,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure,
-    Verity.require, Contract.run, ContractResult.snd, ContractResult.fst,
+  simp [decrement, getStorage, count, requireSomeUint,
+    Verity.bind, Bind.bind,
+    Verity.require, Contract.run,
     safeSub_none (s.storage 0) 1 (show (1 : Nat) > (s.storage 0 : Nat) by rw [h_underflow]; decide)]
 
 /-! ## State Preservation -/


### PR DESCRIPTION
## Summary
- remove unused `simp` arguments in `SafeCounter` proof modules
- keep theorem behavior unchanged while reducing warning noise in a core proof path
- simplify local proof context by dropping no-longer-needed helper facts where applicable

## Files
- `Verity/Proofs/SafeCounter/Basic.lean`
- `Compiler/Proofs/SpecCorrectness/SafeCounter.lean`

## Validation
- `~/.elan/bin/lake build Verity.Proofs.SafeCounter.Basic`
- `~/.elan/bin/lake build Compiler.Proofs.SpecCorrectness.SafeCounter`
- `~/.elan/bin/lake build`
- `python3 scripts/extract_property_manifest.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 114e5c059801cbf04857075759107ed5ec58e3cd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->