### PR TITLE
chore: clean unused simp args in ownedcounter proofs

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
@@ -65,7 +65,7 @@ theorem ownedCounter_constructor_correct (state : ContractState) (initialOwner :
     specResult.success = true ∧
     specResult.finalStorage.getSlot 0 = (edslResult.getState.storageAddr 0).val := by
   simp [Verity.Examples.OwnedCounter.constructor, Contract.run, ownedCounterSpec, interpretSpec,
-    setStorageAddr, Verity.Examples.OwnedCounter.owner, Verity.bind, Verity.pure,
+    setStorageAddr, Verity.Examples.OwnedCounter.owner,
     execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
 
 /-- The `increment` function correctly increments when called by owner -/
@@ -119,7 +119,7 @@ theorem ownedCounter_increment_reverts_as_nonowner (state : ContractState) (send
     simp [h_revert, ContractResult.isSuccess]
   · -- Spec reverts when sender is not owner
     simp [ownedCounterSpec, requireOwner, interpretSpec, ownedCounterEdslToSpecStorage, execFunction, execStmts,
-      execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
+      execStmt, evalExpr, SpecStorage.getSlot,
       addressToNat_beq_false_of_ne sender (state.storageAddr 0) (Ne.symm h)]
 
 /-- The `decrement` function correctly decrements when called by owner -/
@@ -177,7 +177,7 @@ theorem ownedCounter_decrement_reverts_as_nonowner (state : ContractState) (send
     simp [h_revert, ContractResult.isSuccess]
   · -- Spec reverts when sender is not owner
     simp [ownedCounterSpec, requireOwner, interpretSpec, ownedCounterEdslToSpecStorage, execFunction, execStmts,
-      execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
+      execStmt, evalExpr, SpecStorage.getSlot,
       addressToNat_beq_false_of_ne sender (state.storageAddr 0) (Ne.symm h)]
 
 /-- The `getCount` function correctly retrieves the counter value -/
@@ -255,7 +255,7 @@ theorem ownedCounter_transferOwnership_reverts_as_nonowner (state : ContractStat
     simp [h_revert, ContractResult.isSuccess]
   · -- Spec reverts when sender is not owner
     simp [ownedCounterSpec, requireOwner, interpretSpec, ownedCounterEdslToSpecStorage, execFunction, execStmts,
-      execStmt, evalExpr, SpecStorage.getSlot, SpecStorage.setSlot,
+      execStmt, evalExpr, SpecStorage.getSlot,
       addressToNat_beq_false_of_ne sender (state.storageAddr 0) (Ne.symm h)]
 
 /- Helper Properties -/

--- a/Verity/Proofs/OwnedCounter/Basic.lean
+++ b/Verity/Proofs/OwnedCounter/Basic.lean
@@ -26,7 +26,6 @@ private theorem onlyOwner_reverts (s : ContractState) (h : s.sender ≠ s.storag
     onlyOwner s = ContractResult.revert "Caller is not the owner" s := by
   simp [onlyOwner, isOwner, owner, msgSender, getStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    ContractResult.snd, ContractResult.fst,
     address_beq_false_of_ne s.sender (s.storageAddr 0) h]
 
 private theorem guarded_reverts (f : Unit → Contract α) (s : ContractState)
@@ -42,7 +41,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   simp [constructor, setStorageAddr, owner, constructor_spec, Contract.run, ContractResult.snd,
     Specs.sameStorageMapContext, Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
   intro slot h_neq
-  simp [setStorageAddr, owner, h_neq]
+  simp [h_neq]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((constructor initialOwner).run s).snd
@@ -110,7 +109,7 @@ theorem increment_unfold (s : ContractState)
   simp [increment, onlyOwner, isOwner, owner, count,
     msgSender, getStorageAddr, getStorage, setStorage,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst, h_owner]
+    Contract.run, h_owner]
 
 theorem increment_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -120,7 +119,7 @@ theorem increment_meets_spec_when_owner (s : ContractState)
   simp [increment_spec, ContractResult.snd, Specs.sameAddrMapContext,
     Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap]
   intro slot h_neq
-  simp [beq_iff_eq, h_neq]
+  simp [h_neq]
 
 theorem increment_adds_one_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -154,7 +153,7 @@ theorem decrement_unfold (s : ContractState)
   simp [decrement, onlyOwner, isOwner, owner, count,
     msgSender, getStorageAddr, getStorage, setStorage,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst, h_owner]
+    Contract.run, h_owner]
 
 theorem decrement_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -164,7 +163,7 @@ theorem decrement_meets_spec_when_owner (s : ContractState)
   simp [decrement_spec, ContractResult.snd, Specs.sameAddrMapContext,
     Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap]
   intro slot h_neq
-  simp [beq_iff_eq, h_neq]
+  simp [h_neq]
 
 theorem decrement_subtracts_one_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -197,7 +196,7 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
   simp [transferOwnership, onlyOwner, isOwner, owner,
     msgSender, getStorageAddr, setStorageAddr,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst, h_owner]
+    Contract.run, h_owner]
 
 theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -207,7 +206,7 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   simp [transferOwnership_spec, ContractResult.snd, Specs.sameStorageMapContext,
     Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
   intro slot h_neq
-  simp [beq_iff_eq, h_neq]
+  simp [h_neq]
 
 theorem transferOwnership_changes_owner (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :


### PR DESCRIPTION
## Summary
- remove unused simp arguments in Verity/Proofs/OwnedCounter/Basic.lean
- remove unused simp arguments in Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
- keep theorem behavior unchanged while reducing warning noise in OwnedCounter proof path

## Validation
- ~/.elan/bin/lake build Verity.Proofs.OwnedCounter.Basic Compiler.Proofs.SpecCorrectness.OwnedCounter
- ~/.elan/bin/lake build
- python3 scripts/extract_property_manifest.py
- python3 scripts/check_property_manifest_sync.py
- python3 scripts/check_property_manifest.py
- python3 scripts/check_property_coverage.py
- python3 scripts/check_contract_structure.py
- python3 scripts/check_lean_hygiene.py
- python3 scripts/check_doc_counts.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that just narrows `simp` hints; it should not affect executable code, with risk limited to potential proof fragility if `simp` no longer closes goals.
> 
> **Overview**
> Removes unused/over-specified `simp` arguments across OwnedCounter proof files to reduce Lean warning noise and make proof scripts more robust.
> 
> In `Compiler/Proofs/SpecCorrectness/OwnedCounter.lean`, trims `simp` sets in constructor and revert-correctness theorems (e.g., dropping unused `SpecStorage.setSlot`/`Verity.bind`/`Verity.pure` entries). In `Verity/Proofs/OwnedCounter/Basic.lean`, simplifies `simp` calls and per-slot proof obligations by removing unnecessary rewrites (e.g., `ContractResult.fst`/`snd`, `beq_iff_eq`, and redundant definitions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e4e50cde0de0f3525380446827b4fc5182eba4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->