### PR TITLE
chore: clean unused simp arg in SafeCounter correctness

### DIFF
--- a/Verity/Proofs/SafeCounter/Correctness.lean
+++ b/Verity/Proofs/SafeCounter/Correctness.lean
@@ -62,7 +62,7 @@ theorem decrement_preserves_storage_isolated (s : ContractState)
 theorem getCount_preserves_context (s : ContractState) :
   let s' := ((getCount).run s).snd
   context_preserved s s' := by
-  simp [getCount_preserves_state s, Specs.sameContext]
+  simp [getCount_preserves_state s]
 
 /-- getCount preserves well-formedness. -/
 theorem getCount_preserves_wellformedness (s : ContractState) (h : WellFormedState s) :


### PR DESCRIPTION
## Summary
- remove one unused `simp` argument in `Verity/Proofs/SafeCounter/Correctness.lean`
- keep theorem semantics unchanged
- reduce Lean linter noise in SafeCounter correctness proofs

## Validation
- `~/.elan/bin/lake build Verity.Proofs.SafeCounter.Correctness`
- `~/.elan/bin/lake build`
- `python3 scripts/extract_property_manifest.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof-script cleanup with no behavioral or spec changes; risk limited to potential proof breakage if simplification behavior changes.
> 
> **Overview**
> Removes an unused simp lemma (`Specs.sameContext`) from the proof of `getCount_preserves_context` in `Verity/Proofs/SafeCounter/Correctness.lean`, relying solely on `getCount_preserves_state`.
> 
> No proof intent or theorem statement changes; this is a small hygiene tweak to reduce Lean/linter noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 454db31d83b11e8bfe0a2f08953b8fb0de262193. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->