### PR TITLE
proofs(simpletoken): remove unused simp args in isolation proofs

### DIFF
--- a/Verity/Proofs/SimpleToken/Isolation.lean
+++ b/Verity/Proofs/SimpleToken/Isolation.lean
@@ -64,17 +64,15 @@ private theorem mint_isolation (s : ContractState) (to : Address) (amount : Uint
   (slot ≠ 0 → ((mint to amount).run s).snd.storageAddr slot = s.storageAddr slot) := by
   simp only [mint, Verity.Examples.SimpleToken.onlyOwner, isOwner,
     Examples.SimpleToken.owner, Examples.SimpleToken.balances, Examples.SimpleToken.totalSupply,
-    msgSender, getStorageAddr, setStorageAddr, getStorage, setStorage, getMapping, setMapping,
+    msgSender, getStorageAddr, getStorage, setStorage, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst,
+    Contract.run, ContractResult.snd,
     h_owner, beq_self_eq_true, ite_true]
   unfold Stdlib.Math.requireSomeUint
   cases safeAdd (s.storageMap 1 to) amount <;>
-    simp_all [Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-      Contract.run, ContractResult.snd, ContractResult.fst, beq_iff_eq]
+    simp_all [Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure, beq_iff_eq]
   cases safeAdd (s.storage 2) amount <;>
-    simp_all [Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-      Contract.run, ContractResult.snd, ContractResult.fst, beq_iff_eq]
+    simp_all [Verity.require, Verity.pure, Verity.bind]
 
 /-- Mint only writes Uint256 slot 2. -/
 theorem mint_supply_storage_isolated (s : ContractState) (to : Address) (amount : Uint256)
@@ -106,19 +104,17 @@ private theorem transfer_isolation (s : ContractState) (to : Address) (amount : 
   by_cases h_eq : s.sender = to
   · have h_balance' := uint256_ge_val_le (h_eq ▸ h_balance)
     simp [transfer, Examples.SimpleToken.balances,
-      msgSender, getMapping, setMapping,
-      Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-      Contract.run, ContractResult.snd, ContractResult.fst,
-      h_balance', h_eq, beq_iff_eq]
+      msgSender, getMapping,
+      Verity.require, Verity.pure, Verity.bind, Bind.bind,
+      Contract.run, ContractResult.snd, h_balance', h_eq]
   · refine ⟨?_, fun h_ne_slot addr => ?_, ?_⟩
     all_goals simp [transfer, Examples.SimpleToken.balances,
         msgSender, getMapping, setMapping, requireSomeUint,
-        Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-        Contract.run, ContractResult.snd, ContractResult.fst,
+        Verity.require, Verity.bind, Bind.bind, Pure.pure,
+        Contract.run, ContractResult.snd,
         h_balance, h_eq, beq_iff_eq]
     all_goals cases safeAdd (s.storageMap 1 to) amount <;>
-        simp_all [Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-          Contract.run, ContractResult.snd, ContractResult.fst, beq_iff_eq]
+        simp_all [Verity.require, Verity.pure, Verity.bind]
 
 /-- Transfer doesn't write any Uint256 slot (supply unchanged). -/
 theorem transfer_supply_storage_isolated (s : ContractState) (to : Address) (amount : Uint256)


### PR DESCRIPTION
## Summary
- remove Lean-linter-flagged unused `simp` arguments in `Verity/Proofs/SimpleToken/Isolation.lean`
- keep theorem behavior unchanged; this is a proof-maintenance cleanup only
- reduce warning noise in a core SimpleToken proof module

## Validation
- `~/.elan/bin/lake build Verity.Proofs.SimpleToken.Isolation`
- `~/.elan/bin/lake build`
- `python3 scripts/extract_property_manifest.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1c6e758d814902373130eb368213b225d3ef3918. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->