### PR TITLE
chore(lean): trim unused simp args in example and proofs

### DIFF
--- a/Verity/Examples/ReentrancyExample.lean
+++ b/Verity/Examples/ReentrancyExample.lean
@@ -118,9 +118,7 @@ theorem vulnerable_attack_exists :
       simp
     have h_neq : (1 : Uint256) ≠ (0 : Uint256) := by decide
     -- After simplification, the invariant reduces to `1 = 0`, which is false.
-    simp [withdraw, setStorageSlot, setMappingSlot, supplyInvariant, balances, totalSupply,
-      Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run, ContractResult.snd,
-      ContractResult.fst, h_cond, s, modulus_sub_max]
+    simp [supplyInvariant, balances, totalSupply, s]
     exact h_neq
 
 /-
@@ -194,11 +192,11 @@ theorem withdraw_maintains_supply (amount : Uint256) :
   have h_left :
       ((withdraw amount).runState s).storage totalSupply.slot =
         sub (s.storage totalSupply.slot) amount := by
-    simp [Contract.runState, withdraw, setStorageSlot, setMappingSlot, balances, totalSupply, h_cond, h_cond'']
+    simp [Contract.runState, withdraw, setStorageSlot, setMappingSlot, balances, totalSupply, h_cond'']
   have h_right :
       ((withdraw amount).runState s).storageMap balances.slot s.sender =
         sub (s.storageMap balances.slot s.sender) amount := by
-    simp [Contract.runState, withdraw, setStorageSlot, setMappingSlot, balances, totalSupply, h_cond, h_cond'']
+    simp [Contract.runState, withdraw, setStorageSlot, setMappingSlot, balances, totalSupply, h_cond'']
   -- Reduce to the same subtraction on both sides.
   have h_mid : sub (s.storage totalSupply.slot) amount =
       sub (s.storageMap balances.slot s.sender) amount := by

--- a/Verity/Proofs/Ledger/Correctness.lean
+++ b/Verity/Proofs/Ledger/Correctness.lean
@@ -92,7 +92,7 @@ theorem deposit_withdraw_cancel (s : ContractState) (amount : Uint256)
   have h_inc := deposit_increases_balance s amount
   have h_sender : s1.sender = s.sender := by
     simp [s1, deposit, msgSender, getMapping, setMapping, balances,
-      Verity.bind, Bind.bind, Verity.pure, Pure.pure,
+      Verity.bind, Bind.bind,
       Contract.run, ContractResult.snd]
   have h_balance' : s1.storageMap 0 s.sender ≥ amount := by
     simpa [s1, h_inc] using h_balance

--- a/Verity/Proofs/Stdlib/ListSum.lean
+++ b/Verity/Proofs/Stdlib/ListSum.lean
@@ -48,7 +48,7 @@ private theorem mul_one_add (x n : Uint256) : x * (1 + n) = x + x * n := by
     _ = x + n * x := by
             have := Verity.Core.Uint256.add_mul (1 : Uint256) n x
             calc (1 + n) * x = 1 * x + n * x := this
-              _ = x + n * x := by simp [Verity.Core.Uint256.one_mul]
+              _ = x + n * x := by simp
     _ = x + x * n := by simp [Verity.Core.Uint256.mul_comm]
 
 /-! ## Generic List Sum Lemma: Point Update -/
@@ -76,7 +76,7 @@ theorem map_sum_point_update
       rw [← Verity.Core.Uint256.add_assoc delta (List.map f rest).sum _]
       rw [Verity.Core.Uint256.add_comm delta (List.map f rest).sum]
       rw [Verity.Core.Uint256.add_assoc (List.map f rest).sum delta _]
-    · simp [h, h_other a h, countOccU_cons_ne a target rest h]
+    · simp [h_other a h, countOccU_cons_ne a target rest h]
 
 /-! ## Generic List Sum Lemma: Point Decrease -/
 
@@ -104,7 +104,7 @@ theorem map_sum_point_decrease
       rw [h_cancel]
       simpa [Verity.Core.Uint256.mul_comm,
         Verity.Core.Uint256.add_assoc] using congrArg (fun x => f target + x) ih
-    · simp [h, h_other a h, countOccU_cons_ne a target rest h]
+    · simp [h_other a h, countOccU_cons_ne a target rest h]
       simpa [Verity.Core.Uint256.mul_comm,
         Verity.Core.Uint256.add_assoc,
         Verity.Core.Uint256.add_left_comm,


### PR DESCRIPTION
## Summary
- remove linter-flagged unused `simp` arguments in:
  - `Verity/Examples/ReentrancyExample.lean`
  - `Verity/Proofs/Stdlib/ListSum.lean`
  - `Verity/Proofs/Ledger/Correctness.lean`
- keep theorem and example behavior unchanged (proof-hygiene cleanup only)

## Why
- reduces Lean warning noise in active modules with a scoped, low-risk cleanup
- warning count from full build log drops from 311 to 292

## Validation
- `~/.elan/bin/lake build Verity.Examples.ReentrancyExample`
- `~/.elan/bin/lake build Verity.Proofs.Stdlib.ListSum`
- `~/.elan/bin/lake build Verity.Proofs.Ledger.Correctness`
- `~/.elan/bin/lake build`
- `python3 scripts/extract_property_manifest.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit df6b1e5ee733a712234accf5b69a854a00315f81. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->