### PR TITLE
chore: clean unused simp args in SimpleToken correctness proofs

### DIFF
--- a/Verity/Proofs/SimpleToken/Correctness.lean
+++ b/Verity/Proofs/SimpleToken/Correctness.lean
@@ -34,9 +34,9 @@ theorem mint_reverts_when_not_owner (s : ContractState) (to : Address) (amount :
   ∃ msg, (mint to amount).run s = ContractResult.revert msg s := by
   simp only [mint, Verity.Examples.SimpleToken.onlyOwner, isOwner,
     Examples.SimpleToken.owner, Examples.SimpleToken.balances, Examples.SimpleToken.totalSupply,
-    msgSender, getStorageAddr, setStorageAddr, getStorage, setStorage, getMapping, setMapping,
+    msgSender, getStorageAddr, getStorage, setStorage, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
+    Contract.run]
   simp [address_beq_false_of_ne s.sender (s.storageAddr 0) h_not_owner]
 
 /-- Transfer reverts when sender has insufficient balance.
@@ -45,9 +45,9 @@ theorem transfer_reverts_insufficient_balance (s : ContractState) (to : Address)
   (h_insufficient : s.storageMap 1 s.sender < amount) :
   ∃ msg, (transfer to amount).run s = ContractResult.revert msg s := by
   simp only [transfer, Examples.SimpleToken.balances,
-    msgSender, getMapping, setMapping,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst]
+    msgSender, getMapping,
+    Verity.require, Verity.bind, Bind.bind,
+    Contract.run]
   simp [show ¬(s.storageMap 1 s.sender ≥ amount) from Nat.not_le.mpr h_insufficient]
 
 /-! ## Invariant Preservation


### PR DESCRIPTION
## Summary
- remove 8 Lean-linter-flagged unused `simp` arguments in `Verity/Proofs/SimpleToken/Correctness.lean`
- keep proof behavior unchanged (proof hygiene only)
- eliminate all warning emissions from `Correctness.lean`

## Validation
- `~/.elan/bin/lake build Verity.Proofs.SimpleToken.Correctness`
- `~/.elan/bin/lake build`
- `python3 scripts/extract_property_manifest.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_contract_structure.py`
- `python3 scripts/check_lean_hygiene.py`
- `python3 scripts/check_doc_counts.py`

## Warning delta
- full build warnings: `220 -> 212` (net `-8`)
- by file:
  - `Verity/Proofs/SimpleToken/Correctness.lean`: `8 -> 0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts proof simplification hints; no contract logic, specs, or theorem statements change, so functional risk is minimal.
> 
> **Overview**
> Removes Lean-linter-flagged unused entries from the `simp only` lists in `mint_reverts_when_not_owner` and `transfer_reverts_insufficient_balance` within `Verity/Proofs/SimpleToken/Correctness.lean` (e.g., dropping unused `setStorageAddr`, `setMapping`, `ContractResult.fst/snd`, and some monad lemmas).
> 
> This is proof-hygiene only, intended to keep the proofs identical while eliminating warning noise from the file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 516e333be2346f2775e6615078442a826e40abc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->