### PR TITLE
Add generated verification-status artifact and enforce freshness in CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Check axiom locations in AXIOMS.md
         run: python3 scripts/check_axiom_locations.py
 
+      - name: Check verification status artifact freshness
+        run: python3 scripts/generate_verification_status.py --check
+
       - name: Check documentation counts
         run: python3 scripts/check_doc_counts.py
 

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -1,0 +1,45 @@
+{
+  "codebase": {
+    "core_lines": 351,
+    "example_contracts": 11
+  },
+  "proofs": {
+    "axioms": 1,
+    "sorry": 0
+  },
+  "schema_version": 1,
+  "tests": {
+    "differential_total": 70000,
+    "foundry_functions": 377,
+    "property_functions": 197,
+    "suites": 34
+  },
+  "theorems": {
+    "ast_equivalence": 29,
+    "categories": 11,
+    "coverage_percent": 58,
+    "covered": 250,
+    "excluded": 181,
+    "non_stdlib_total": 272,
+    "per_contract": {
+      "Counter": 28,
+      "ERC20": 19,
+      "ERC721": 11,
+      "Ledger": 33,
+      "Owned": 23,
+      "OwnedCounter": 48,
+      "ReentrancyExample": 4,
+      "SafeCounter": 25,
+      "SimpleStorage": 20,
+      "SimpleToken": 61,
+      "Stdlib": 159
+    },
+    "proven": 431,
+    "stdlib": 159,
+    "total": 431
+  },
+  "toolchain": {
+    "lean": "leanprover/lean4:v4.22.0",
+    "solc": "0.8.33"
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,6 +82,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_yul_builtin_boundary.py`** - Enforces a centralized Yul builtin semantics boundary: runtime interpreters must import `Compiler/Proofs/YulGeneration/Builtins.lean`, call `evalBuiltinCall`, and avoid inline builtin dispatch branches (`func = "add"`, `func = "sload"`, etc.)
 - **`check_evmyullean_capability_boundary.py`** - Enforces the current `#294` EVMYulLean overlap capability matrix in `Compiler/Proofs/YulGeneration/Builtins.lean`: allows only the explicit overlap builtin set plus Verity helper `mappingSlot`, and blocks known unsupported builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) from silently entering the migration seam
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
+- **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
 - **`check_contract_structure.py`** - Validates all contracts in Examples/ have complete file structure (Spec, Invariants, Basic proofs, Correctness proofs)
@@ -89,6 +90,7 @@ These CI-critical scripts validate cross-layer consistency:
 
 ```bash
 # Run locally before submitting documentation changes
+python3 scripts/generate_verification_status.py
 python3 scripts/check_doc_counts.py
 
 # Run locally after modifying storage slots or adding contracts

--- a/scripts/generate_verification_status.py
+++ b/scripts/generate_verification_status.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Generate artifacts/verification_status.json from repository metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from check_doc_counts import collect_metrics
+from property_utils import ROOT
+
+
+def _normalize(data: dict) -> str:
+    """Return deterministic JSON encoding."""
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate verification status artifact consumed by docs checks."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / "artifacts" / "verification_status.json",
+        help="Output artifact path.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if output file is missing or stale; do not write changes.",
+    )
+    args = parser.parse_args()
+
+    metrics = collect_metrics()
+    rendered = _normalize(metrics)
+    output = args.output
+
+    if args.check:
+        if not output.exists():
+            raise SystemExit(f"Missing verification artifact: {output}")
+        existing = output.read_text(encoding="utf-8")
+        if existing != rendered:
+            raise SystemExit(
+                f"Stale verification artifact: {output}\n"
+                "Run `python3 scripts/generate_verification_status.py`."
+            )
+        print(f"Verification artifact is up to date: {output}")
+        return
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+    print(f"Wrote verification artifact: {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Implements the core execution path for #585 by introducing a generated verification-status artifact and making CI enforce freshness before doc-count validation.

### What changed
- Added `scripts/generate_verification_status.py` to deterministically generate `artifacts/verification_status.json`.
- Added committed artifact: `artifacts/verification_status.json`.
- Updated `scripts/check_doc_counts.py` to:
  - read expected metrics from the artifact,
  - fail when artifact drift is detected vs live repository metrics.
- Added CI check step in `.github/workflows/verify.yml`:
  - `python3 scripts/generate_verification_status.py --check`.
- Documented local usage in `scripts/README.md`.

## Why
This removes implicit/duplicated metric sources and creates one machine-readable source of truth consumed by documentation-count validation.

## Validation
- `python3 scripts/generate_verification_status.py`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_doc_counts.py --fix`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_lean_hygiene.py`
- `lake build`

Refs #585

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a deterministic metrics artifact and CI/documentation gating without changing proof logic; primary risk is CI failures if the artifact generation/check logic drifts from repo metrics.
> 
> **Overview**
> Introduces a deterministic, committed verification metrics artifact (`artifacts/verification_status.json`) generated by a new `scripts/generate_verification_status.py` script.
> 
> Updates `scripts/check_doc_counts.py` to treat that artifact as the source of truth: it recomputes live metrics, fails fast on any drift (with an overrideable `--artifact` path), and then uses the artifact values for downstream doc-count validations.
> 
> Extends the `verify.yml` CI `checks` job to run `generate_verification_status.py --check` before doc-count validation, and documents local regeneration workflow in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dfba9db2ff3f7bec8c395098e1b78242ce3d07f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->