### PR TITLE
[Infrastructure] Add Lean warning non-regression CI gate (baseline artifact)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -175,7 +175,12 @@ jobs:
       - name: Build and verify all proofs
         env:
           LEAN_NUM_THREADS: 2
-        run: lake build
+        run: |
+          set -o pipefail
+          lake build 2>&1 | tee lake-build.log
+
+      - name: Check Lean warning non-regression
+        run: python3 scripts/check_lean_warning_regression.py --log lake-build.log
 
       - name: Run AST pipeline regression modules
         env:

--- a/artifacts/lean_warning_baseline.json
+++ b/artifacts/lean_warning_baseline.json
@@ -1,0 +1,11 @@
+{
+  "by_file": {
+    "Compiler/Proofs/SpecCorrectness/SimpleToken.lean": 150,
+    "Verity/Proofs/SimpleToken/Basic.lean": 62
+  },
+  "by_message": {
+    "This simp argument is unused:": 212
+  },
+  "schema_version": 1,
+  "total_warnings": 212
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,8 +31,9 @@ This tracker is the execution order for migration-oriented compiler work. Later 
 Execution policy:
 1. Do not start patch-pack expansion in `#583` before `#582` proof hooks are merged.
 2. Treat `#584` as a release gate for ongoing compiler work after initial warning cleanup lands.
-3. Treat `#585` docs generation as authoritative source for public metrics before broader docs expansion.
-4. Keep issue bodies and this section synchronized when scope/order changes.
+3. Enforce Lean warning non-regression via `artifacts/lean_warning_baseline.json` + CI check (`scripts/check_lean_warning_regression.py`) until warning count reaches zero.
+4. Treat `#585` docs generation as authoritative source for public metrics before broader docs expansion.
+5. Keep issue bodies and this section synchronized when scope/order changes.
 
 ---
 


### PR DESCRIPTION
## Summary
Add a Lean warning non-regression gate so warning count cannot increase while `#584` warning cleanup to zero is in progress.

### What changed
- Add `scripts/check_lean_warning_regression.py` to parse `lake build` logs and compare against checked baseline by:
  - total warning count
  - per-file warning count
  - warning-message count
- Add baseline artifact: `artifacts/lean_warning_baseline.json` (current baseline: 212 warnings)
- Wire CI build job to:
  - capture `lake build` output to `lake-build.log` with `set -o pipefail`
  - run warning non-regression check against baseline artifact
- Document warning-gate workflow in `scripts/README.md`
- Update roadmap execution policy to make baseline gate explicit during cleanup phase

## Why
`#584` requires CI warning non-regression. This lands the gate now, so warning count cannot regress while remaining warning removal proceeds in follow-up PRs.

## Validation
- `python3 scripts/check_lean_warning_regression.py --log /tmp/lake_build_current.log`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_lean_hygiene.py`
- `lake build`

Partial progress for #584.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CI failure condition based on parsing `lake build` output, which can block merges if the log format or baseline drifts. Changes are confined to build tooling/docs and don’t affect runtime/compiler behavior.
> 
> **Overview**
> Adds a **Lean warning non-regression gate** to CI: `verify.yml` now logs `lake build` output to `lake-build.log` (with `pipefail`) and runs `scripts/check_lean_warning_regression.py` to fail if warnings increase.
> 
> Introduces `artifacts/lean_warning_baseline.json` as the checked baseline (total/per-file/per-message counts) and documents the workflow in `scripts/README.md` plus an execution-policy note in `docs/ROADMAP.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd7d979d634aaccb5109f8e8a4a6600665e5e455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->