### PR TITLE
Docs: add Solidity interop support matrix for issue #586

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,6 +35,29 @@ Execution policy:
 4. Treat `#585` docs generation as authoritative source for public metrics before broader docs expansion.
 5. Keep issue bodies and this section synchronized when scope/order changes.
 
+### Solidity Interop Profile (Issue #586)
+
+Interop priority is based on migration friction observed in the Morpho integration path.
+
+Status legend:
+- `supported`: available end-to-end for migration use
+- `partial`: usable with limits or missing proof/diagnostics coverage
+- `unsupported`: no first-class support yet
+
+| Priority | Feature | Spec support | Codegen support | Proof status | Test status | Current status |
+|---|---|---|---|---|---|---|
+| 1 | Custom errors + typed revert payloads | unsupported | unsupported | n/a | n/a | unsupported |
+| 2 | Low-level calls (`call`/`staticcall`/`delegatecall`) + returndata handling | unsupported | unsupported | n/a | n/a | unsupported |
+| 3 | `fallback` / `receive` / payable entrypoint modeling | unsupported | unsupported | n/a | n/a | unsupported |
+| 4 | Full event ABI parity (indexed dynamic + tuple hashing) | partial | partial | partial | partial | partial |
+| 5 | Storage layout controls (packed fields + explicit slot mapping) | partial | partial | partial | partial | partial |
+| 6 | ABI JSON artifact generation | unsupported | unsupported | n/a | n/a | unsupported |
+
+Delivery policy for unsupported features:
+1. Compiler diagnostics must identify the exact unsupported construct.
+2. Error text must suggest the nearest currently-supported pattern.
+3. Error text must include the tracking issue reference.
+
 ---
 
 ## Lessons from UnlinkPool (#185)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -255,6 +255,29 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 - [x] Function selector axiom with CI validation (PR #43, #46)
 - [x] External function linking for cryptographic libraries (PR #49)
 
+## Solidity Interop Support Matrix (Issue #586)
+
+This matrix tracks migration-critical Solidity interoperability features and current implementation status.
+
+Status legend:
+- `supported`: usable end-to-end
+- `partial`: implemented with functional limits or incomplete proof/test coverage
+- `unsupported`: not implemented as a first-class feature
+
+| Feature | Spec support | Codegen support | Proof status | Test status | Current status |
+|---|---|---|---|---|---|
+| Custom errors + typed revert payloads | unsupported | unsupported | n/a | n/a | unsupported |
+| Low-level calls (`call` / `staticcall` / `delegatecall`) with returndata | unsupported | unsupported | n/a | n/a | unsupported |
+| `fallback` / `receive` / payable entrypoint modeling | unsupported | unsupported | n/a | n/a | unsupported |
+| Event ABI parity for indexed dynamic/tuple payloads | partial | partial | partial | partial | partial |
+| Storage layout controls (packing + explicit slots) | partial | partial | partial | partial | partial |
+| ABI JSON artifact generation | unsupported | unsupported | n/a | n/a | unsupported |
+
+Diagnostics policy for unsupported constructs:
+1. Report the exact unsupported construct at compile time.
+2. Suggest the nearest supported migration pattern.
+3. Link to the owning tracking issue.
+
 ### Short Term (1-2 months)
 
 - [x] Add finite address set modeling for Ledger sum properties (Issue #39, closed)


### PR DESCRIPTION
## Summary
Adds the public Solidity interop support profile requested in #586 to make migration-critical gaps explicit and actionable.

## What changed
- Added a dedicated **Solidity Interop Profile** section in `docs/ROADMAP.md`:
  - migration-priority ordering
  - support matrix columns (`spec`, `codegen`, `proof`, `test`, `current status`)
  - explicit delivery policy for unsupported features (diagnostic quality requirements)
- Added matching **Solidity Interop Support Matrix** section in `docs/VERIFICATION_STATUS.md`.

## Why this helps
- Establishes a single, explicit source of truth for feature support during incremental Solidity migration.
- Gives implementers a concrete target table to update as features land.
- Makes unsupported paths actionable by setting minimum diagnostic requirements.

## Validation
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

Part of #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that don’t affect runtime behavior, proofs, or compiler logic.
> 
> **Overview**
> Adds a new **Solidity interop support profile/matrix** for Issue `#586` to `docs/ROADMAP.md` and `docs/VERIFICATION_STATUS.md`, making migration-critical Solidity features explicitly tracked across *spec*, *codegen*, *proof*, and *test* support.
> 
> Also documents a delivery/diagnostics policy for currently-unsupported constructs (precise compile-time identification, suggested workaround, and link back to the tracking issue).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e776c4e6206fe97fda19f6fe71448bffb1e8159e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->