### PR TITLE
Infra: add deterministic EVMYulLean capability report artifact

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Check EVMYulLean capability boundary
         run: python3 scripts/check_evmyullean_capability_boundary.py
 
+      - name: Check EVMYulLean capability report freshness
+        run: python3 scripts/generate_evmyullean_capability_report.py --check
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/artifacts/evmyullean_capability_report.json
+++ b/artifacts/evmyullean_capability_report.json
@@ -1,0 +1,58 @@
+{
+  "allowed_overlap_builtins": [
+    "add",
+    "and",
+    "calldataload",
+    "caller",
+    "div",
+    "eq",
+    "gt",
+    "iszero",
+    "lt",
+    "mod",
+    "mul",
+    "not",
+    "or",
+    "shl",
+    "shr",
+    "sload",
+    "sub",
+    "xor"
+  ],
+  "allowed_verity_helpers": [
+    "mappingSlot"
+  ],
+  "builtins_file": "Compiler/Proofs/YulGeneration/Builtins.lean",
+  "found_builtins": [
+    "add",
+    "and",
+    "calldataload",
+    "caller",
+    "div",
+    "eq",
+    "gt",
+    "iszero",
+    "lt",
+    "mappingSlot",
+    "mod",
+    "mul",
+    "not",
+    "or",
+    "shl",
+    "shr",
+    "sload",
+    "sub",
+    "xor"
+  ],
+  "schema_version": 1,
+  "status": "ok",
+  "unknown_builtins_present": [],
+  "unsupported_builtins": [
+    "create",
+    "create2",
+    "extcodecopy",
+    "extcodehash",
+    "extcodesize"
+  ],
+  "unsupported_builtins_present": []
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -81,6 +81,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_mapping_slot_boundary.py`** - Enforces the mapping-slot abstraction boundary for proof interpreters: only `Compiler/Proofs/MappingSlot.lean` may import `MappingEncoding`; builtin dispatch in `Compiler/Proofs/YulGeneration/Builtins.lean` must route through `abstractMappingSlot`/`abstractLoadStorageOrMapping`; runtime interpreters must import `MappingSlot`, use `abstractStoreStorageOrMapping`/`abstractStoreMappingEntry`, and avoid legacy mapping internals (`mappingTag`/`encodeMappingSlot`/`decodeMappingSlot`) including local aliases
 - **`check_yul_builtin_boundary.py`** - Enforces a centralized Yul builtin semantics boundary: runtime interpreters must import `Compiler/Proofs/YulGeneration/Builtins.lean`, call `evalBuiltinCall`, and avoid inline builtin dispatch branches (`func = "add"`, `func = "sload"`, etc.)
 - **`check_evmyullean_capability_boundary.py`** - Enforces the current `#294` EVMYulLean overlap capability matrix in `Compiler/Proofs/YulGeneration/Builtins.lean`: allows only the explicit overlap builtin set plus Verity helper `mappingSlot`, and blocks known unsupported builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) from silently entering the migration seam
+- **`generate_evmyullean_capability_report.py`** - Deterministically generates `artifacts/evmyullean_capability_report.json` from `Compiler/Proofs/YulGeneration/Builtins.lean` and supports `--check` mode for CI freshness gating
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
@@ -108,6 +109,9 @@ python3 scripts/check_property_manifest_sync.py
 
 # Run locally after adding a new contract
 python3 scripts/check_contract_structure.py
+
+# Regenerate capability artifact after builtin-boundary updates
+python3 scripts/generate_evmyullean_capability_report.py
 ```
 
 ## Selector & Yul Scripts
@@ -180,8 +184,9 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 9. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
 10. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
 11. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-12. Lean hygiene (`check_lean_hygiene.py`)
-13. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+12. EVMYulLean capability report freshness (`generate_evmyullean_capability_report.py --check`)
+13. Lean hygiene (`check_lean_hygiene.py`)
+14. Static gas model builtin coverage (`check_gas_model_coverage.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/generate_evmyullean_capability_report.py
+++ b/scripts/generate_evmyullean_capability_report.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Generate/check deterministic EVMYulLean capability report artifact.
+
+Usage:
+    python3 scripts/generate_evmyullean_capability_report.py
+    python3 scripts/generate_evmyullean_capability_report.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from property_utils import ROOT
+
+BUILTINS_FILE = ROOT / "Compiler" / "Proofs" / "YulGeneration" / "Builtins.lean"
+DEFAULT_OUTPUT = ROOT / "artifacts" / "evmyullean_capability_report.json"
+
+BUILTIN_NAME_RE = re.compile(r'func\s*=\s*"([^"]+)"')
+
+EVMYULLEAN_OVERLAP_BUILTINS = {
+    "add",
+    "and",
+    "calldataload",
+    "caller",
+    "div",
+    "eq",
+    "gt",
+    "iszero",
+    "lt",
+    "mod",
+    "mul",
+    "not",
+    "or",
+    "shl",
+    "shr",
+    "sload",
+    "sub",
+    "xor",
+}
+
+VERITY_HELPER_BUILTINS = {"mappingSlot"}
+
+EVMYULLEAN_UNSUPPORTED_BUILTINS = {
+    "create",
+    "create2",
+    "extcodecopy",
+    "extcodehash",
+    "extcodesize",
+}
+
+
+def build_report() -> dict[str, object]:
+    if not BUILTINS_FILE.exists():
+        raise FileNotFoundError(f"Missing builtins file: {BUILTINS_FILE.relative_to(ROOT)}")
+
+    text = BUILTINS_FILE.read_text(encoding="utf-8")
+    found = sorted(set(BUILTIN_NAME_RE.findall(text)))
+    found_set = set(found)
+    allowed_set = EVMYULLEAN_OVERLAP_BUILTINS | VERITY_HELPER_BUILTINS
+
+    unknown = sorted(found_set - allowed_set)
+    unsupported_present = sorted(found_set & EVMYULLEAN_UNSUPPORTED_BUILTINS)
+
+    return {
+        "schema_version": 1,
+        "builtins_file": str(BUILTINS_FILE.relative_to(ROOT)),
+        "status": "ok" if not unknown and not unsupported_present else "error",
+        "found_builtins": found,
+        "allowed_overlap_builtins": sorted(EVMYULLEAN_OVERLAP_BUILTINS),
+        "allowed_verity_helpers": sorted(VERITY_HELPER_BUILTINS),
+        "unsupported_builtins": sorted(EVMYULLEAN_UNSUPPORTED_BUILTINS),
+        "unknown_builtins_present": unknown,
+        "unsupported_builtins_present": unsupported_present,
+    }
+
+
+def write_report(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Output artifact path (default: artifacts/evmyullean_capability_report.json)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if output artifact is missing or stale",
+    )
+    args = parser.parse_args()
+
+    payload = build_report()
+    rendered = json.dumps(payload, sort_keys=True, indent=2) + "\n"
+
+    if args.check:
+        if not args.output.exists():
+            print(f"Missing capability artifact: {args.output}", file=sys.stderr)
+            return 1
+        existing = args.output.read_text(encoding="utf-8")
+        if existing != rendered:
+            print(
+                "EVMYulLean capability report is stale. Regenerate with:\n"
+                "  python3 scripts/generate_evmyullean_capability_report.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"EVMYulLean capability report is up to date: {args.output}")
+        return 0
+
+    write_report(args.output, payload)
+    print(f"Wrote EVMYulLean capability report: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds deterministic, machine-readable EVMYulLean capability reporting as groundwork for issue #581's canonical equivalence pipeline.

## Changes
- Added `scripts/generate_evmyullean_capability_report.py`
  - Generates `artifacts/evmyullean_capability_report.json`
  - Supports `--check` mode to enforce artifact freshness in CI
- Added committed artifact: `artifacts/evmyullean_capability_report.json`
- Wired CI check in `verify.yml`:
  - `python3 scripts/generate_evmyullean_capability_report.py --check`
- Updated `scripts/README.md` with usage and CI integration details.

## Why this matters for #581
This creates a deterministic report contract over the current Yul builtin overlap surface, which is required for auditable ingestion/canonicalization scope tracking before full equivalence checking lands.

## Validation
- `python3 scripts/generate_evmyullean_capability_report.py --check`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `python3 scripts/check_doc_counts.py`

Part of #581

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/tooling-only change that adds an additional freshness gate; primary risk is increased CI failures if the committed artifact isn’t regenerated alongside builtin updates.
> 
> **Overview**
> Adds a deterministic, machine-readable EVMYulLean capability report generated from `Compiler/Proofs/YulGeneration/Builtins.lean`, committing the initial `artifacts/evmyullean_capability_report.json` output.
> 
> Introduces `scripts/generate_evmyullean_capability_report.py` (with `--check` mode) and wires it into the `verify.yml` `checks` job to fail CI if the artifact is missing/stale; updates `scripts/README.md` with regeneration and CI-order details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd452a721e148216da1f816b941a52f837a347af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->