### PR TITLE
ContractSpec: explicit diagnostics for unsupported #586 interop constructs

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -570,6 +570,12 @@ private def validateInteropExternalSpec (spec : ExternalFunction) : Except Strin
   if isLowLevelCallName spec.name then
     lowLevelCallUnsupportedError s!"external declaration '{spec.name}'" spec.name
 
+private def validateInteropConstructorSpec (ctor : Option ConstructorSpec) : Except String Unit := do
+  match ctor with
+  | none => pure ()
+  | some spec =>
+      spec.body.forM (validateInteropStmt "constructor")
+
 private def compileMappingSlotWrite (fields : List Field) (field : String)
     (keyExpr valueExpr : YulExpr) (label : String) : Except String (List YulStmt) :=
   if !isMapping fields field then
@@ -1025,6 +1031,7 @@ def compile (spec : ContractSpec) (selectors : List Nat) : Except String IRContr
   for fn in spec.functions do
     validateFunctionSpec fn
     validateInteropFunctionSpec fn
+  validateInteropConstructorSpec spec.constructor
   for ext in spec.externals do
     let _ ← externalFunctionReturns ext
     validateInteropExternalSpec ext

--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -235,4 +235,52 @@ private def featureSpec : ContractSpec := {
   | .ok _ =>
       throw (IO.userError "✗ expected low-level call usage to fail compilation")
 
+#eval! do
+  let ctorMsgValueSpec : ContractSpec := {
+    name := "CtorMsgValueUnsupported"
+    fields := []
+    constructor := some {
+      params := []
+      body := [Stmt.letVar "v" Expr.msgValue, Stmt.stop]
+    }
+    functions := [
+      { name := "noop"
+        params := []
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile ctorMsgValueSpec [1] with
+  | .error err =>
+      if !(contains err "Expr.msgValue" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ constructor msgValue diagnostic mismatch: {err}")
+      IO.println "✓ constructor msgValue unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected constructor msgValue usage to fail compilation")
+
+#eval! do
+  let ctorLowLevelCallSpec : ContractSpec := {
+    name := "CtorLowLevelCallUnsupported"
+    fields := []
+    constructor := some {
+      params := []
+      body := [Stmt.letVar "v" (Expr.externalCall "call" []), Stmt.stop]
+    }
+    functions := [
+      { name := "noop"
+        params := []
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile ctorLowLevelCallSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported low-level call 'call'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ constructor low-level call diagnostic mismatch: {err}")
+      IO.println "✓ constructor low-level call unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected constructor low-level call usage to fail compilation")
+
 end Compiler.ContractSpecFeatureTest

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -281,6 +281,7 @@ Diagnostics policy for unsupported constructs:
 Current diagnostic coverage in compiler:
 - `Expr.msgValue` now fails with an explicit payable/fallback/receive unsupported message and migration guidance.
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
+- The same unsupported checks are enforced in constructor bodies (not only regular function bodies).
 - Both diagnostics include an `Issue #586` reference for scope tracking.
 
 ### Short Term (1-2 months)


### PR DESCRIPTION
## Summary
Implements the highest-leverage missing part of issue #586: deterministic, actionable compiler diagnostics for unsupported Solidity interop constructs that currently appear ambiguous during migration attempts.

## What changed
- Added a compile-time interop validation pass in `Compiler/ContractSpec.lean`:
  - Rejects `Expr.msgValue` with explicit payable/fallback/receive unsupported guidance.
  - Rejects low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) in:
    - function expressions (`Expr.externalCall`)
    - external declarations (`spec.externals`)
  - Error messages include explicit migration guidance and `Issue #586` reference.
- Added regressions in `Compiler/ContractSpecFeatureTest.lean`:
  - `msgValue` unsupported diagnostic test.
  - low-level call unsupported diagnostic test.
- Updated `docs/VERIFICATION_STATUS.md` with current diagnostic coverage details.

## Why
Issue #586 requires unsupported features to fail with explicit, actionable diagnostics. This patch enforces that policy in the compiler core, preventing silent or misleading migration paths.

## Validation
- `lake build Compiler.ContractSpec Compiler.Codegen Compiler.ContractSpecFeatureTest`
- `lake env lean Compiler/ContractSpecFeatureTest.lean`

## Remaining scope for #586
- End-to-end implementation of at least two high-impact interop features (beyond diagnostics).
- Additional unsupported diagnostics for custom errors / ABI JSON generation paths once those entry points are exposed.

Refs #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler behavior by turning previously accepted constructs (`Expr.msgValue` and low-level call names) into hard compile-time errors across functions, externals, and constructors. Risk is limited to validation/diagnostics but may break existing specs relying on these patterns.
> 
> **Overview**
> Adds a dedicated interop validation pass in `Compiler/ContractSpec.lean` that **fails compilation** when a spec uses unsupported Solidity interop constructs: `Expr.msgValue` (payable/fallback/receive) and low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) in `Expr.externalCall` and `spec.externals`, with messages linking to *Issue #586* and suggesting safer migration patterns.
> 
> Validation is now enforced during `compile` for all function bodies and constructor bodies, and `Compiler/ContractSpecFeatureTest.lean` adds regression tests asserting these diagnostics; `docs/VERIFICATION_STATUS.md` is updated to document the new diagnostic coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9ec8e3f51e5cefd2bc7d0ad4961d01e8d1b3593. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->