### PR TITLE
Issue #581: add deterministic EVMYulLean adapter coverage artifact

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Check EVMYulLean capability report freshness
         run: python3 scripts/generate_evmyullean_capability_report.py --check
 
+      - name: Check EVMYulLean adapter report freshness
+        run: python3 scripts/generate_evmyullean_adapter_report.py --check
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/artifacts/evmyullean_adapter_report.json
+++ b/artifacts/evmyullean_adapter_report.json
@@ -1,0 +1,41 @@
+{
+  "adapter_file": "Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean",
+  "eval_builtin_via_evmyullean": "stub-none",
+  "expr_supported": [
+    "call",
+    "hex",
+    "ident",
+    "lit",
+    "str"
+  ],
+  "missing_expr_cases": [],
+  "missing_stmt_cases": [],
+  "schema_version": 1,
+  "status": "partial",
+  "stmt_gap_messages": {
+    "assign": [
+      "adapter gap: assignment lowering not implemented"
+    ],
+    "for_": [
+      "adapter gap: for-loop init lowering not implemented"
+    ],
+    "funcDef": [
+      "adapter gap: function definition lowering not implemented"
+    ]
+  },
+  "stmt_gaps": [
+    "assign",
+    "funcDef"
+  ],
+  "stmt_partial": [
+    "for_"
+  ],
+  "stmt_supported": [
+    "block",
+    "comment",
+    "expr",
+    "if_",
+    "let_",
+    "switch"
+  ]
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,6 +28,10 @@ This tracker is the execution order for migration-oriented compiler work. Later 
 | P1 | Proven optimization foundation | [#582](https://github.com/Th0rgal/verity/issues/582), [#583](https://github.com/Th0rgal/verity/issues/583), [#584](https://github.com/Th0rgal/verity/issues/584) | blocked by #581 | Proven patch framework + initial patch pack + warning non-regression gate |
 | P2 | Interop + verification docs hardening | [#585](https://github.com/Th0rgal/verity/issues/585), [#586](https://github.com/Th0rgal/verity/issues/586) | blocked by P0/P1 outputs | Generated verification artifact consumed by docs + published interop support profile |
 
+Current P0 baseline artifact coverage:
+- `artifacts/evmyullean_capability_report.json` tracks builtin overlap boundaries and explicit unsupported adapter nodes.
+- `artifacts/evmyullean_adapter_report.json` tracks adapter AST-lowering coverage (`supported`/`partial`/`gap`) and runtime seam status.
+
 Execution policy:
 1. Do not start patch-pack expansion in `#583` before `#582` proof hooks are merged.
 2. Treat `#584` as a release gate for ongoing compiler work after initial warning cleanup lands.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -254,6 +254,7 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 - [x] Complete Layer 3 statement-level equivalence proofs (PR #42)
 - [x] Function selector axiom with CI validation (PR #43, #46)
 - [x] External function linking for cryptographic libraries (PR #49)
+- [x] Deterministic EVMYulLean seam artifacts in CI (`evmyullean_capability_report.json`, `evmyullean_adapter_report.json`)
 
 ## Solidity Interop Support Matrix (Issue #586)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,6 +82,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_yul_builtin_boundary.py`** - Enforces a centralized Yul builtin semantics boundary: runtime interpreters must import `Compiler/Proofs/YulGeneration/Builtins.lean`, call `evalBuiltinCall`, and avoid inline builtin dispatch branches (`func = "add"`, `func = "sload"`, etc.)
 - **`check_evmyullean_capability_boundary.py`** - Enforces the current `#294` EVMYulLean overlap capability matrix in `Compiler/Proofs/YulGeneration/Builtins.lean`: allows only the explicit overlap builtin set plus Verity helper `mappingSlot`, and blocks known unsupported builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) from silently entering the migration seam
 - **`generate_evmyullean_capability_report.py`** - Deterministically generates `artifacts/evmyullean_capability_report.json` from `Compiler/Proofs/YulGeneration/Builtins.lean` and `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean`, including explicit `unsupported_adapter_nodes` for unimplemented adapter lowering branches; supports `--check` mode for CI freshness gating
+- **`generate_evmyullean_adapter_report.py`** - Deterministically generates `artifacts/evmyullean_adapter_report.json` with constructor-level lowering coverage (`supported`/`partial`/`gap`) for `lowerExpr` and `lowerStmt` plus explicit adapter-gap reasons and runtime-seam status (`stub-none` vs `implemented`); supports `--check` mode for CI freshness gating
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
@@ -112,6 +113,7 @@ python3 scripts/check_contract_structure.py
 
 # Regenerate capability artifact after builtin-boundary updates
 python3 scripts/generate_evmyullean_capability_report.py
+python3 scripts/generate_evmyullean_adapter_report.py
 ```
 
 ## Selector & Yul Scripts
@@ -185,8 +187,9 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 10. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
 11. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
 12. EVMYulLean capability report freshness (`generate_evmyullean_capability_report.py --check`)
-13. Lean hygiene (`check_lean_hygiene.py`)
-14. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+13. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+14. Lean hygiene (`check_lean_hygiene.py`)
+15. Static gas model builtin coverage (`check_gas_model_coverage.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/generate_evmyullean_adapter_report.py
+++ b/scripts/generate_evmyullean_adapter_report.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Generate/check deterministic EVMYulLean adapter coverage report artifact.
+
+Usage:
+    python3 scripts/generate_evmyullean_adapter_report.py
+    python3 scripts/generate_evmyullean_adapter_report.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from property_utils import ROOT
+
+ADAPTER_FILE = (
+    ROOT
+    / "Compiler"
+    / "Proofs"
+    / "YulGeneration"
+    / "Backends"
+    / "EvmYulLeanAdapter.lean"
+)
+DEFAULT_OUTPUT = ROOT / "artifacts" / "evmyullean_adapter_report.json"
+
+EXPECTED_EXPR_CASES = ["lit", "hex", "str", "ident", "call"]
+EXPECTED_STMT_CASES = ["comment", "let_", "assign", "expr", "if_", "for_", "switch", "block", "funcDef"]
+
+CASE_RE = re.compile(r"^\s*\|\s*\.([A-Za-z0-9_']+)")
+GAP_RE = re.compile(r'\.error\s+"([^"]+)"')
+EVAL_STUB_RE = re.compile(r"def\s+evalBuiltinCallViaEvmYulLean[\s\S]*?:\s*Option\s+Nat\s*:=\s*none")
+
+
+def _extract_block(text: str, start_marker: str, end_marker: str) -> list[str]:
+    start = text.find(start_marker)
+    if start < 0:
+        raise ValueError(f"Could not find block start marker: {start_marker}")
+    end = text.find(end_marker, start)
+    if end < 0:
+        raise ValueError(f"Could not find block end marker: {end_marker}")
+    return text[start:end].splitlines()
+
+
+def _parse_cases(lines: list[str]) -> dict[str, str]:
+    clauses: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in lines:
+        m = CASE_RE.match(line)
+        if m:
+            current = m.group(1)
+            clauses.setdefault(current, [])
+        if current is not None:
+            clauses[current].append(line)
+
+    result: dict[str, str] = {}
+    for name, body_lines in clauses.items():
+        body = "\n".join(body_lines)
+        gaps = GAP_RE.findall(body)
+        if not gaps:
+            result[name] = "supported"
+            continue
+        if "pure (" in body and (".error" in body):
+            result[name] = "partial"
+            continue
+        result[name] = "gap"
+    return result
+
+
+def _parse_gap_messages(lines: list[str]) -> dict[str, list[str]]:
+    clauses: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in lines:
+        m = CASE_RE.match(line)
+        if m:
+            current = m.group(1)
+            clauses.setdefault(current, [])
+        if current is not None:
+            clauses[current].append(line)
+
+    messages: dict[str, list[str]] = {}
+    for name, body_lines in clauses.items():
+        body = "\n".join(body_lines)
+        gaps = sorted(set(GAP_RE.findall(body)))
+        if gaps:
+            messages[name] = gaps
+    return messages
+
+
+def build_report() -> dict[str, object]:
+    if not ADAPTER_FILE.exists():
+        raise FileNotFoundError(f"Missing adapter file: {ADAPTER_FILE.relative_to(ROOT)}")
+
+    text = ADAPTER_FILE.read_text(encoding="utf-8")
+    expr_lines = _extract_block(text, "def lowerExpr", "partial def lowerStmts")
+    stmt_lines = _extract_block(text, "partial def lowerStmt", "def lowerProgram")
+
+    expr_status = _parse_cases(expr_lines)
+    stmt_status = _parse_cases(stmt_lines)
+    stmt_gap_messages = _parse_gap_messages(stmt_lines)
+
+    missing_expr = sorted(set(EXPECTED_EXPR_CASES) - set(expr_status))
+    missing_stmt = sorted(set(EXPECTED_STMT_CASES) - set(stmt_status))
+
+    expr_supported = sorted(k for k, v in expr_status.items() if v == "supported")
+    stmt_supported = sorted(k for k, v in stmt_status.items() if v == "supported")
+    stmt_partial = sorted(k for k, v in stmt_status.items() if v == "partial")
+    stmt_gaps = sorted(k for k, v in stmt_status.items() if v == "gap")
+
+    eval_stub = EVAL_STUB_RE.search(text) is not None
+
+    status = "ok"
+    if missing_expr or missing_stmt or stmt_partial or stmt_gaps or eval_stub:
+        status = "partial"
+
+    return {
+        "schema_version": 1,
+        "adapter_file": str(ADAPTER_FILE.relative_to(ROOT)),
+        "status": status,
+        "expr_supported": expr_supported,
+        "stmt_supported": stmt_supported,
+        "stmt_partial": stmt_partial,
+        "stmt_gaps": stmt_gaps,
+        "stmt_gap_messages": stmt_gap_messages,
+        "missing_expr_cases": missing_expr,
+        "missing_stmt_cases": missing_stmt,
+        "eval_builtin_via_evmyullean": "stub-none" if eval_stub else "implemented",
+    }
+
+
+def write_report(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Output artifact path (default: artifacts/evmyullean_adapter_report.json)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if output artifact is missing or stale",
+    )
+    args = parser.parse_args()
+
+    payload = build_report()
+    rendered = json.dumps(payload, sort_keys=True, indent=2) + "\n"
+
+    if args.check:
+        if not args.output.exists():
+            print(f"Missing adapter artifact: {args.output}", file=sys.stderr)
+            return 1
+        existing = args.output.read_text(encoding="utf-8")
+        if existing != rendered:
+            print(
+                "EVMYulLean adapter report is stale. Regenerate with:\n"
+                "  python3 scripts/generate_evmyullean_adapter_report.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"EVMYulLean adapter report is up to date: {args.output}")
+        return 0
+
+    write_report(args.output, payload)
+    print(f"Wrote EVMYulLean adapter report: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a deterministic, machine-readable adapter coverage artifact for the EVMYulLean seam and gates it in CI.

## What changed
- Added `scripts/generate_evmyullean_adapter_report.py`:
  - Parses `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean`
  - Reports per-node lowering status (`supported` / `partial` / `gap`) for `lowerExpr` and `lowerStmt`
  - Exposes explicit adapter gap reasons from `.error "adapter gap: ..."` branches
  - Tracks runtime seam status (`evalBuiltinCallViaEvmYulLean`: `stub-none` vs `implemented`)
  - Supports `--check` mode for freshness gating
- Added generated artifact: `artifacts/evmyullean_adapter_report.json`
- Added CI freshness check in `.github/workflows/verify.yml`
- Updated docs:
  - `scripts/README.md`
  - `docs/ROADMAP.md`
  - `docs/VERIFICATION_STATUS.md`

## Why
Issue #581 needs a canonical-equivalence baseline that is auditable and deterministic. This does not implement the full equivalence engine, but it closes a key observability gap: adapter lowering coverage and explicit seam gaps are now first-class CI artifacts.

## Validation
- `python3 scripts/generate_evmyullean_adapter_report.py --check`
- `python3 scripts/generate_evmyullean_capability_report.py --check`
- `python3 scripts/check_doc_counts.py`

Refs #581

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily CI/tooling changes, but the new `--check` gate can break builds if the Lean adapter structure or error-message patterns drift from what the generator expects.
> 
> **Overview**
> Adds `scripts/generate_evmyullean_adapter_report.py` to deterministically generate/check `artifacts/evmyullean_adapter_report.json`, reporting `lowerExpr`/`lowerStmt` AST-lowering coverage (`supported`/`partial`/`gap`), explicit gap messages, and whether `evalBuiltinCallViaEvmYulLean` remains stubbed.
> 
> Updates CI (`verify.yml`) to run the new script in `--check` mode, commits the initial artifact, and updates docs (`scripts/README.md`, `docs/ROADMAP.md`, `docs/VERIFICATION_STATUS.md`) to reference the new seam/coverage artifact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f980cee40cd0f11eb613f6161f05121ac96f2429. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->