### PR TITLE
feat(issue-586): explicit diagnostics for unsupported interop builtins

### DIFF
--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -282,6 +282,7 @@ Diagnostics policy for unsupported constructs:
 Current diagnostic coverage in compiler:
 - `Expr.msgValue` now fails with an explicit payable/fallback/receive unsupported message and migration guidance.
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
+- Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
 - The same unsupported checks are enforced in constructor bodies (not only regular function bodies).
 - Both diagnostics include an `Issue #586` reference for scope tracking.
 


### PR DESCRIPTION
## Summary
Adds a focused interoperability diagnostics slice for #586 by extending compile-time validation of unsupported Solidity-style interop builtins.

### What changed
- Extended `ContractSpec` interop validation to reject additional unsupported EVM interop builtin names:
  - `create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`
- Kept existing low-level call diagnostics (`call`, `staticcall`, `delegatecall`, `callcode`) and routed all unsupported interop names through explicit issue-linked error messages.
- Added regression tests in `Compiler/ContractSpecFeatureTest.lean` for:
  - function-body `extcodesize` usage
  - `externals` declaration named `create2`
- Updated diagnostics coverage note in `docs/VERIFICATION_STATUS.md`.

## Why
Issue #586 requires actionable diagnostics for unsupported migration constructs. Before this change, these builtin names could fall into generic external-call handling instead of producing explicit migration guidance.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `python3 scripts/check_doc_counts.py`

Refs #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only changes that affect compile-time error reporting for a small set of interop names; no runtime/codegen behavior is altered aside from earlier failures.
> 
> **Overview**
> Tightens `ContractSpec` compile-time interop validation to treat additional Solidity/EVM-style builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) as **explicitly unsupported**, producing clearer, Issue-586-linked diagnostics with migration guidance (and routing low-level calls through the same path).
> 
> Adds feature tests covering a function-body `extcodesize` call and an `externals` declaration named `create2`, and updates `docs/VERIFICATION_STATUS.md` to reflect the expanded diagnostic coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba5061fcdb8c2994911d70eb44dd00a3d4b51620. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->