### PR TITLE
feat(issue-586): model payable entrypoints in ContractSpec/codegen

### DIFF
--- a/Compiler/IR.lean
+++ b/Compiler/IR.lean
@@ -21,12 +21,14 @@ structure IRFunction where
   selector : Nat
   params : List IRParam
   ret : IRType
+  payable : Bool := false
   body : List IRStmt
   deriving Repr
 
 structure IRContract where
   name : String
   deploy : List IRStmt
+  constructorPayable : Bool := false
   functions : List IRFunction
   usesMapping : Bool
   internalFunctions : List IRStmt := []  -- Yul function definitions for internal calls (#181)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,7 +52,7 @@ Status legend:
 |---|---|---|---|---|---|---|
 | 1 | Custom errors + typed revert payloads | unsupported | unsupported | n/a | n/a | unsupported |
 | 2 | Low-level calls (`call`/`staticcall`/`delegatecall`) + returndata handling | unsupported | unsupported | n/a | n/a | unsupported |
-| 3 | `fallback` / `receive` / payable entrypoint modeling | unsupported | unsupported | n/a | n/a | unsupported |
+| 3 | `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
 | 4 | Full event ABI parity (indexed dynamic + tuple hashing) | partial | partial | partial | partial | partial |
 | 5 | Storage layout controls (packed fields + explicit slot mapping) | partial | partial | partial | partial | partial |
 | 6 | ABI JSON artifact generation | unsupported | unsupported | n/a | n/a | unsupported |

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -269,7 +269,7 @@ Status legend:
 |---|---|---|---|---|---|
 | Custom errors + typed revert payloads | unsupported | unsupported | n/a | n/a | unsupported |
 | Low-level calls (`call` / `staticcall` / `delegatecall`) with returndata | unsupported | unsupported | n/a | n/a | unsupported |
-| `fallback` / `receive` / payable entrypoint modeling | unsupported | unsupported | n/a | n/a | unsupported |
+| `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
 | Event ABI parity for indexed dynamic/tuple payloads | partial | partial | partial | partial | partial |
 | Storage layout controls (packing + explicit slots) | partial | partial | partial | partial | partial |
 | ABI JSON artifact generation | unsupported | unsupported | n/a | n/a | unsupported |
@@ -280,10 +280,10 @@ Diagnostics policy for unsupported constructs:
 3. Link to the owning tracking issue.
 
 Current diagnostic coverage in compiler:
-- `Expr.msgValue` now fails with an explicit payable/fallback/receive unsupported message and migration guidance.
+- Non-payable external functions and constructors now emit a runtime `msg.value == 0` guard, while explicit `isPayable := true` enables `Expr.msgValue` usage.
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
-- The same unsupported checks are enforced in constructor bodies (not only regular function bodies).
+- Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - Both diagnostics include an `Issue #586` reference for scope tracking.
 
 ### Short Term (1-2 months)


### PR DESCRIPTION
## Summary
This PR delivers a focused `#586` slice: first-class payable modeling for ContractSpec functions and constructors.

### What changed
- Added `isPayable : Bool := false` to:
  - `FunctionSpec`
  - `ConstructorSpec`
- Added payable metadata in IR/codegen:
  - `IRFunction.payable`
  - `IRContract.constructorPayable`
- Updated codegen guards:
  - Runtime callvalue guard is now conditional per function (`fn.payable`)
  - Deploy-time callvalue guard is now conditional per constructor (`constructorPayable`)
- Removed blanket compile-time rejection of `Expr.msgValue`
  - `Expr.msgValue` is now allowed when modeling payable entrypoints explicitly.
- Extended ContractSpec feature coverage with regressions for:
  - payable function using `Expr.msgValue`
  - non-payable function callvalue guard
  - payable constructor using `Expr.msgValue`
  - non-payable constructor callvalue guard
- Updated interop status docs to mark payable entrypoint modeling as `partial`.

## Why
Issue `#586` tracks Solidity interop priorities. Prior behavior rejected `msg.value` usage entirely and treated payable modeling as unsupported. This patch enables controlled payable behavior while preserving fail-closed defaults for non-payable entrypoints.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `lake build`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/generate_verification_status.py --check`

## Scope
Refs `#586` (partial delivery; fallback/receive remain out of scope).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes entrypoint value-handling semantics by making `msg.value` acceptance configurable per function/constructor and altering when runtime/deploy guards are emitted; mistakes here could allow unintended ETH transfers or unexpected reverts.
> 
> **Overview**
> Adds *explicit payable modeling* to `ContractSpec` and the IR via `FunctionSpec.isPayable`/`ConstructorSpec.isPayable`, `IRFunction.payable`, and `IRContract.constructorPayable`.
> 
> Updates Yul codegen so the `callvalue` revert guard is emitted **only for non-payable** runtime entrypoints and constructors, and relaxes interop validation to allow `Expr.msgValue` (still rejecting low-level/interop builtin calls). Tests are extended to assert guard presence/absence for payable vs non-payable cases, and docs mark payable entrypoint modeling as `partial`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea89b70fb4039f71a662b8ab9c2537c2fd730838. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->