### PR TITLE
feat(issue-586): diagnose unsupported fallback/receive entrypoint modeling

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -389,4 +389,51 @@ private def featureSpec : ContractSpec := {
   | .ok _ =>
       throw (IO.userError "✗ expected external create2 declaration to fail compilation")
 
+#eval! do
+  let fallbackSpec : ContractSpec := {
+    name := "FallbackUnsupported"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "fallback"
+        params := []
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile fallbackSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported Solidity interop entrypoint modeling" &&
+          contains err "function 'fallback'" &&
+          contains err "Issue #586") then
+        throw (IO.userError s!"✗ fallback diagnostic mismatch: {err}")
+      IO.println "✓ fallback entrypoint diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected fallback entrypoint modeling to fail compilation")
+
+#eval! do
+  let receiveSpec : ContractSpec := {
+    name := "ReceiveUnsupported"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "receive"
+        params := []
+        returnType := none
+        isPayable := true
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile receiveSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported Solidity interop entrypoint modeling" &&
+          contains err "function 'receive'" &&
+          contains err "Issue #586") then
+        throw (IO.userError s!"✗ receive diagnostic mismatch: {err}")
+      IO.println "✓ receive entrypoint diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected receive entrypoint modeling to fail compilation")
+
 end Compiler.ContractSpecFeatureTest

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -283,8 +283,9 @@ Current diagnostic coverage in compiler:
 - Non-payable external functions and constructors now emit a runtime `msg.value == 0` guard, while explicit `isPayable := true` enables `Expr.msgValue` usage.
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
+- Reserved Solidity entrypoint names (`fallback`, `receive`) now fail with explicit guidance when modeled as regular ContractSpec functions.
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
-- Both diagnostics include an `Issue #586` reference for scope tracking.
+- All interop diagnostics include an `Issue #586` reference for scope tracking.
 
 ### Short Term (1-2 months)
 


### PR DESCRIPTION
## Summary
This PR adds explicit, issue-linked compiler diagnostics for unsupported Solidity interop entrypoints in ContractSpec:
- `fallback`
- `receive`

Without this check, these names could be modeled as normal selector-dispatched functions, which is semantically misleading for migration work.

## What changed
- Added reserved entrypoint validation in ContractSpec interop checks:
  - Rejects function names `fallback` and `receive` with actionable migration guidance and `Issue #586` reference.
- Added regression coverage for both diagnostics in `Compiler.ContractSpecFeatureTest`.
- Updated interop status documentation to include the new diagnostic coverage.

## Why this is high leverage
Issue #586 is about practical migration safety. Failing fast on unsupported `fallback`/`receive` modeling prevents subtle miscompilation assumptions and gives users a clear supported workaround path.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `python3 scripts/check_doc_counts.py`

Refs #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a narrow name-based validation with matching tests/docs; the only behavior change is earlier compilation failure for specs using `fallback`/`receive`.
> 
> **Overview**
> Adds a new compile-time interop validation that **rejects modeling Solidity reserved entrypoints** `fallback` and `receive` as normal `ContractSpec` functions, emitting an actionable error message that references `Issue #586`.
> 
> Extends `ContractSpecFeatureTest` with regression cases asserting the new diagnostics for both names, and updates `docs/VERIFICATION_STATUS.md` to list this diagnostic coverage under the interop policy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27e669d5c203cd3d395b8c757701e40e8e715cf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->