### PR TITLE
Issue #586: add first-class fallback/receive entrypoint modeling

### DIFF
--- a/Compiler/Codegen.lean
+++ b/Compiler/Codegen.lean
@@ -37,22 +37,50 @@ def calldatasizeGuard (numParams : Nat) : YulStmt :=
     YulExpr.lit (4 + numParams * 32)])
     [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
 
-def buildSwitch (funcs : List IRFunction) : YulStmt :=
+private def dispatchBody (payable : Bool) (label : String) (body : List YulStmt) : List YulStmt :=
+  let valueGuard := if payable then [] else [callvalueGuard]
+  [YulStmt.comment label] ++ valueGuard ++ body
+
+private def defaultDispatchCase
+    (fallback : Option IREntrypoint)
+    (receive : Option IREntrypoint) : List YulStmt :=
+  match receive, fallback with
+  | none, none =>
+      [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+  | none, some fb =>
+      dispatchBody fb.payable "fallback()" fb.body
+  | some rc, none =>
+      [YulStmt.block [
+        YulStmt.let_ "__is_empty_calldata" (YulExpr.call "eq" [YulExpr.call "calldatasize" [], YulExpr.lit 0]),
+        YulStmt.if_ (YulExpr.ident "__is_empty_calldata")
+          (dispatchBody rc.payable "receive()" rc.body),
+        YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__is_empty_calldata"])
+          [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])]
+      ]]
+  | some rc, some fb =>
+      [YulStmt.block [
+        YulStmt.let_ "__is_empty_calldata" (YulExpr.call "eq" [YulExpr.call "calldatasize" [], YulExpr.lit 0]),
+        YulStmt.if_ (YulExpr.ident "__is_empty_calldata")
+          (dispatchBody rc.payable "receive()" rc.body),
+        YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__is_empty_calldata"])
+          (dispatchBody fb.payable "fallback()" fb.body)
+      ]]
+
+def buildSwitch
+    (funcs : List IRFunction)
+    (fallback : Option IREntrypoint := none)
+    (receive : Option IREntrypoint := none) : YulStmt :=
   let selectorExpr := YulExpr.call "shr" [YulExpr.lit 224, YulExpr.call "calldataload" [YulExpr.lit 0]]
   let cases := funcs.map (fun fn =>
-    let valueGuard := if fn.payable then [] else [callvalueGuard]
-    let body := [YulStmt.comment s!"{fn.name}()"] ++
-      valueGuard ++ [calldatasizeGuard fn.params.length] ++ fn.body
+    let body := dispatchBody fn.payable s!"{fn.name}()" ([calldatasizeGuard fn.params.length] ++ fn.body)
     (fn.selector, body)
   )
-  YulStmt.switch selectorExpr cases (some [
-    YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
-  ])
+  YulStmt.switch selectorExpr cases (some (defaultDispatchCase fallback receive))
 
 def runtimeCode (contract : IRContract) : List YulStmt :=
   let mapping := if contract.usesMapping then [mappingSlotFunc] else []
   let internals := contract.internalFunctions
-  mapping ++ internals ++ [buildSwitch contract.functions]
+  mapping ++ internals ++ [buildSwitch contract.functions contract.fallbackEntrypoint contract.receiveEntrypoint]
 
 private def deployCode (contract : IRContract) : List YulStmt :=
   let valueGuard := if contract.constructorPayable then [] else [callvalueGuard]

--- a/Compiler/IR.lean
+++ b/Compiler/IR.lean
@@ -25,11 +25,20 @@ structure IRFunction where
   body : List IRStmt
   deriving Repr
 
+structure IREntrypoint where
+  payable : Bool := false
+  body : List IRStmt
+  deriving Repr
+
 structure IRContract where
   name : String
   deploy : List IRStmt
   constructorPayable : Bool := false
   functions : List IRFunction
+  /-- Optional Solidity-style fallback entrypoint for unmatched selectors. -/
+  fallbackEntrypoint : Option IREntrypoint := none
+  /-- Optional Solidity-style receive entrypoint for empty calldata. -/
+  receiveEntrypoint : Option IREntrypoint := none
   usesMapping : Bool
   internalFunctions : List IRStmt := []  -- Yul function definitions for internal calls (#181)
   deriving Repr

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -281,9 +281,9 @@ Diagnostics policy for unsupported constructs:
 
 Current diagnostic coverage in compiler:
 - Non-payable external functions and constructors now emit a runtime `msg.value == 0` guard, while explicit `isPayable := true` enables `Expr.msgValue` usage.
+- `fallback` and `receive` are now modeled as first-class entrypoints in dispatch (empty-calldata routing to `receive`, unmatched selector routing to `fallback`) with compile-time shape checks (`receive` must be payable, both must be parameterless and non-returning).
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
-- Reserved Solidity entrypoint names (`fallback`, `receive`) now fail with explicit guidance when modeled as regular ContractSpec functions.
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 


### PR DESCRIPTION
## Summary
This PR implements a focused interop slice for #586 by adding first-class `fallback` / `receive` entrypoint support in the ContractSpec -> IR -> Yul pipeline.

### What changed
- Added dedicated IR entrypoint support for selectorless entrypoints:
  - `IRContract.fallbackEntrypoint`
  - `IRContract.receiveEntrypoint`
- Updated codegen dispatch default branch behavior:
  - empty calldata routes to `receive` (when present)
  - unmatched selectors route to `fallback` (when present)
  - no special entrypoints keeps revert behavior
- Updated ContractSpec compilation pipeline:
  - `fallback` / `receive` are no longer treated as unsupported names
  - they are excluded from selector mapping (no selector required)
  - compile-time shape checks now enforce:
    - no params
    - no return values
    - cannot be internal
    - `receive` must be payable
- Added/updated regression coverage in `Compiler/ContractSpecFeatureTest.lean`:
  - fallback-only default branch
  - receive-only empty-calldata routing + non-empty revert
  - receive+fallback split dispatch behavior
  - receive non-payable validation failure
- Updated interop status notes in `docs/VERIFICATION_STATUS.md`

## Validation
- `lake build Compiler.IR Compiler.Codegen Compiler.ContractSpec`
- `lake env lean Compiler/ContractSpecFeatureTest.lean`
- `python3 scripts/check_doc_counts.py`

## Issue
Progress on #586.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core runtime dispatch and selector mapping rules, which can affect how contracts handle unknown selectors/empty calldata and could introduce behavioral regressions if routing/guards are incorrect.
> 
> **Overview**
> Adds first-class modeling of Solidity-style `fallback` and `receive` entrypoints in the `ContractSpec → IR → Yul` pipeline, so selectorless calls can be handled without manual selector/guard work.
> 
> IR now carries optional `IRContract.fallbackEntrypoint`/`receiveEntrypoint` (`IREntrypoint`), `ContractSpec.compile` extracts and validates these functions (uniqueness + shape checks; `receive` must be payable) and excludes them from selector assignment/collision checks, and codegen updates the `switch` default branch to route empty calldata to `receive`, unmatched selectors to `fallback`, otherwise revert. Feature tests are updated/added to assert the emitted Yul dispatch behavior and the new validation error for non-payable `receive`, and docs reflect the new support status/diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c00ae5ed63184f5d669a0b8b129a6d553d8b381. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->