### PR TITLE
Issue #586: improve indexed dynamic event diagnostics

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -733,7 +733,7 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
       for (p, _) in indexed do
         match p.ty with
         | ParamType.array _ | ParamType.fixedArray _ _ | ParamType.bytes | ParamType.tuple _ =>
-            throw s!"Compilation error: indexed dynamic/tuple param '{p.name}' in event '{eventName}' is not supported yet"
+            throw s!"Compilation error: indexed dynamic/tuple param '{p.name}' in event '{eventName}' is not supported yet ({issue586Ref}). Use an unindexed field for now and hash payload data off-chain when topic-style filtering is required."
         | _ => pure ()
       let sig := eventSignature eventDef
       let sigBytes := bytesFromString sig

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -284,6 +284,7 @@ Current diagnostic coverage in compiler:
 - `fallback` and `receive` are now modeled as first-class entrypoints in dispatch (empty-calldata routing to `receive`, unmatched selector routing to `fallback`) with compile-time shape checks (`receive` must be payable, both must be parameterless and non-returning).
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
+- Indexed dynamic/tuple event params now fail with explicit migration guidance (`use unindexed field + off-chain hash`) instead of a generic unsupported error.
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 


### PR DESCRIPTION
## Summary
Progress on #586 by tightening unsupported interop diagnostics for one migration-critical edge case:

- `indexed` event params with dynamic/tuple ABI types now fail with an actionable compiler diagnostic that includes:
  - explicit construct identification
  - an `Issue #586` reference
  - migration guidance (`use unindexed field + off-chain hash`)
- Added a regression in `Compiler/ContractSpecFeatureTest.lean` to lock this diagnostic behavior.
- Updated interop diagnostic coverage notes in `docs/VERIFICATION_STATUS.md`.

## Why this matters
Issue #586 defines a diagnostics policy for unsupported features. This patch closes a concrete gap where an unsupported interop pattern previously returned only a generic error.

## Validation
- `lake build Compiler.ContractSpec`
- `lake build Compiler.ContractSpecFeatureTest`
- `lake env lean Compiler/ContractSpecFeatureTest.lean`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes compiler error messaging and adds a regression test/docs; no codegen or runtime behavior changes beyond diagnostics.
> 
> **Overview**
> Tightens `Stmt.emit` validation so `indexed` event params with dynamic/tuple ABI types (`bytes`, arrays, tuples) fail compilation with an **actionable diagnostic** that includes an `Issue #586` reference and a recommended workaround (use `unindexed` + off-chain hashing).
> 
> Adds a `ContractSpecFeatureTest` regression that asserts the new diagnostic contents, and updates `docs/VERIFICATION_STATUS.md` to reflect the improved coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d531dd78779a025fcc50a20b51d0a432bec02d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->