### PR TITLE
Issue #586: support indexed bytes event topic hashing

### DIFF
--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -284,7 +284,7 @@ Current diagnostic coverage in compiler:
 - `fallback` and `receive` are now modeled as first-class entrypoints in dispatch (empty-calldata routing to `receive`, unmatched selector routing to `fallback`) with compile-time shape checks (`receive` must be payable, both must be parameterless and non-returning).
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
-- Indexed dynamic/tuple event params now fail with explicit migration guidance (`use unindexed field + off-chain hash`) instead of a generic unsupported error.
+- Indexed `bytes` event params now emit ABI-style hashed topics (`keccak256(payload)`); indexed tuple/array forms still fail with explicit migration guidance (`use unindexed field + off-chain hash`).
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 


### PR DESCRIPTION
## Summary
This PR advances Issue #586 interop parity for event handling by implementing ABI-style topic hashing for `indexed bytes` event params.

### What changed
- `Compiler/ContractSpec.lean`
  - `Stmt.emit` now supports `indexed bytes` by:
    - copying calldata payload into scratch memory (`calldatacopy`)
    - hashing it (`keccak256`) into a derived indexed topic
  - keeps existing validation for unsupported indexed tuple/array payloads.
- `Compiler/ContractSpecFeatureTest.lean`
  - replaces the prior "indexed bytes must fail" regression with a success regression asserting:
    - calldata copy for payload bytes
    - topic hash materialization
    - expected `log2` shape with `topic0 + hashed bytes topic`
  - adds an explicit tuple-indexed regression to keep unsupported diagnostics locked.
- `docs/VERIFICATION_STATUS.md`
  - updates compiler diagnostics coverage notes to reflect:
    - indexed `bytes` is now supported via hashed topic
    - tuple/array indexed dynamic payloads remain unsupported with migration guidance.

## Why this matters
Issue #586 tracks migration-critical Solidity interop gaps. Supporting indexed bytes event topics removes a concrete mismatch with common Solidity logging semantics while preserving explicit diagnostics for still-unsupported shapes.

## Validation
- `lake build Compiler.ContractSpec`
- `lake build Compiler.ContractSpecFeatureTest`
- `python3 scripts/check_doc_counts.py`

Refs #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event emission codegen and introduces memory/calldata operations (`calldatacopy`/`keccak256`) that affect runtime logs; scope is limited and guarded by targeted feature tests, with other indexed dynamic forms still rejected.
> 
> **Overview**
> **Adds support for `indexed bytes` in event emission.** `Stmt.emit` now hashes indexed `bytes` payloads into LOG topics by copying calldata into scratch memory and computing `keccak256`, while preserving existing limits (max 3 indexed params) and continuing to reject indexed tuple/array/fixed-array params with the same migration guidance.
> 
> **Updates regression coverage and docs.** Feature tests switch from expecting indexed-bytes compilation failure to asserting the generated Yul includes the calldata copy, topic materialization, and correct `log2` usage, and add/retain an explicit failing case for indexed tuples. Documentation is updated to reflect that indexed `bytes` topics are now ABI-hashed while tuple/array remain unsupported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6b5a62e3d60dfd6ac59193c78c1d444fce856ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->