### PR TITLE
Issue #586: add ContractSpec custom error revert payloads

### DIFF
--- a/Verity/Proofs/Stdlib/SpecInterpreter.lean
+++ b/Verity/Proofs/Stdlib/SpecInterpreter.lean
@@ -317,6 +317,13 @@ def execStmt (ctx : EvalContext) (fields : List Field) (paramNames : List String
       let cond := evalExpr ctx state.storage fields paramNames externalFns condExpr
       if cond ≠ 0 then some (ctx, state) else none
 
+  | Stmt.requireError condExpr _errorName _args =>
+      let cond := evalExpr ctx state.storage fields paramNames externalFns condExpr
+      if cond ≠ 0 then some (ctx, state) else none
+
+  | Stmt.revertError _errorName _args =>
+      none
+
   | Stmt.return expr =>
       let value := evalExpr ctx state.storage fields paramNames externalFns expr
       some (ctx, { state with returnValue := some value, halted := true })

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,7 +50,7 @@ Status legend:
 
 | Priority | Feature | Spec support | Codegen support | Proof status | Test status | Current status |
 |---|---|---|---|---|---|---|
-| 1 | Custom errors + typed revert payloads | unsupported | unsupported | n/a | n/a | unsupported |
+| 1 | Custom errors + typed revert payloads | partial | partial | n/a | partial | partial |
 | 2 | Low-level calls (`call`/`staticcall`/`delegatecall`) + returndata handling | unsupported | unsupported | n/a | n/a | unsupported |
 | 3 | `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
 | 4 | Full event ABI parity (indexed dynamic + tuple hashing) | partial | partial | partial | partial | partial |

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -267,7 +267,7 @@ Status legend:
 
 | Feature | Spec support | Codegen support | Proof status | Test status | Current status |
 |---|---|---|---|---|---|
-| Custom errors + typed revert payloads | unsupported | unsupported | n/a | n/a | unsupported |
+| Custom errors + typed revert payloads | partial | partial | n/a | partial | partial |
 | Low-level calls (`call` / `staticcall` / `delegatecall`) with returndata | unsupported | unsupported | n/a | n/a | unsupported |
 | `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
 | Event ABI parity for indexed dynamic/tuple payloads | partial | partial | partial | partial | partial |
@@ -281,6 +281,7 @@ Diagnostics policy for unsupported constructs:
 
 Current diagnostic coverage in compiler:
 - Non-payable external functions and constructors now emit a runtime `msg.value == 0` guard, while explicit `isPayable := true` enables `Expr.msgValue` usage.
+- Custom errors are now first-class declarations (`errors`) with `Stmt.requireError`/`Stmt.revertError` emission for static payload types (`uint256`, `address`, `bool`, `bytes32`). Dynamic custom error payloads still fail with explicit guidance.
 - `fallback` and `receive` are now modeled as first-class entrypoints in dispatch (empty-calldata routing to `receive`, unmatched selector routing to `fallback`) with compile-time shape checks (`receive` must be payable, both must be parameterless and non-returning).
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.


### PR DESCRIPTION
## Summary
Adds a focused Solidity-interop slice for issue #586: first-class custom error emission in ContractSpec with typed ABI payloads for static parameter shapes.

### What changed
- Added custom error declarations to ContractSpec:
  - `ErrorDef`
  - `ContractSpec.errors`
- Added new statement forms:
  - `Stmt.requireError cond errorName args`
  - `Stmt.revertError errorName args`
- Added custom-error codegen path in `Compiler/ContractSpec.lean`:
  - ABI payload emission (`selector + args`) with runtime signature hashing via `keccak256`
  - static arg normalization for `address`/`bool`
  - diagnostics for unknown custom errors, arg-count mismatch, duplicate declarations, and unsupported dynamic error param types
- Updated spec interpreter pattern matching for the new `Stmt` constructors.
- Added regression coverage in `Compiler/ContractSpecFeatureTest.lean` for:
  - positive custom-error payload emission
  - unknown custom error diagnostic
  - dynamic custom-error param diagnostic
- Updated interop matrix/docs status from `unsupported` to `partial` for custom errors.

## Scope/limits
- Supported custom error param types (for now): `uint256`, `address`, `bool`, `bytes32`
- Dynamic custom error payload types remain unsupported with explicit diagnostics.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `lake build`

Progress on #586.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core statement compilation and introduces new revert encoding logic; mistakes could change runtime revert behavior or diagnostics, though scope is limited to the new custom-error paths and static types.
> 
> **Overview**
> Adds **first-class Solidity custom errors** to `ContractSpec`: new `ErrorDef` declarations stored in `ContractSpec.errors`, and new statements `Stmt.requireError` / `Stmt.revertError`.
> 
> Extends Yul codegen to emit typed custom-error revert payloads (selector + static args) with address/bool normalization, plus validation/diagnostics for unknown errors, duplicate error names, arg-count mismatches, and rejecting dynamic error parameter types.
> 
> Updates the spec interpreter to handle the new statements, adds feature/negative tests covering payload emission and diagnostics, and marks custom-error support as *partial* in the interop docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4723a294a4114fdf7e65a46c47cd72a95caaf1ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->