### PR TITLE
Issue #581: unify EVMYulLean capability boundary source

### DIFF
--- a/scripts/check_evmyullean_capability_boundary.py
+++ b/scripts/check_evmyullean_capability_boundary.py
@@ -9,50 +9,16 @@ operations.
 
 from __future__ import annotations
 
-import re
 import sys
-from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-BUILTINS_FILE = ROOT / "Compiler" / "Proofs" / "YulGeneration" / "Builtins.lean"
-
-BUILTIN_NAME_RE = re.compile(r'func\s*=\s*"([^"]+)"')
-
-# Builtins currently modeled as part of the overlap subset for planned
-# EVMYulLean-backed semantics.
-EVMYULLEAN_OVERLAP_BUILTINS = {
-    "add",
-    "and",
-    "calldataload",
-    "caller",
-    "div",
-    "eq",
-    "gt",
-    "iszero",
-    "lt",
-    "mod",
-    "mul",
-    "not",
-    "or",
-    "shl",
-    "shr",
-    "sload",
-    "sub",
-    "xor",
-}
-
-# Verity-level helper kept outside upstream Yul builtin set.
-VERITY_HELPER_BUILTINS = {"mappingSlot"}
-
-# Explicitly unsupported in the planned EVMYulLean-backed path (per #294
-# research notes). Presence here in Builtins.lean should block CI.
-EVMYULLEAN_UNSUPPORTED_BUILTINS = {
-    "create",
-    "create2",
-    "extcodecopy",
-    "extcodehash",
-    "extcodesize",
-}
+from evmyullean_capability import (
+    BUILTINS_FILE,
+    EVMYULLEAN_OVERLAP_BUILTINS,
+    EVMYULLEAN_UNSUPPORTED_BUILTINS,
+    VERITY_HELPER_BUILTINS,
+    extract_found_builtins,
+)
+from property_utils import ROOT
 
 
 def main() -> int:
@@ -63,8 +29,7 @@ def main() -> int:
         )
         return 1
 
-    text = BUILTINS_FILE.read_text(encoding="utf-8")
-    found = set(BUILTIN_NAME_RE.findall(text))
+    found = extract_found_builtins(BUILTINS_FILE)
 
     allowed = EVMYULLEAN_OVERLAP_BUILTINS | VERITY_HELPER_BUILTINS
 

--- a/scripts/evmyullean_capability.py
+++ b/scripts/evmyullean_capability.py
@@ -1,0 +1,55 @@
+"""Shared EVMYulLean capability boundary definitions for CI checks/artifacts."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from property_utils import ROOT
+
+BUILTINS_FILE = ROOT / "Compiler" / "Proofs" / "YulGeneration" / "Builtins.lean"
+
+BUILTIN_NAME_RE = re.compile(r'func\s*=\s*"([^"]+)"')
+
+# Builtins currently modeled as part of the overlap subset for planned
+# EVMYulLean-backed semantics.
+EVMYULLEAN_OVERLAP_BUILTINS = {
+    "add",
+    "and",
+    "calldataload",
+    "caller",
+    "div",
+    "eq",
+    "gt",
+    "iszero",
+    "lt",
+    "mod",
+    "mul",
+    "not",
+    "or",
+    "shl",
+    "shr",
+    "sload",
+    "sub",
+    "xor",
+}
+
+# Verity-level helper kept outside upstream Yul builtin set.
+VERITY_HELPER_BUILTINS = {"mappingSlot"}
+
+# Explicitly unsupported in the planned EVMYulLean-backed path (per #294
+# research notes). Presence here in Builtins.lean should block CI.
+EVMYULLEAN_UNSUPPORTED_BUILTINS = {
+    "create",
+    "create2",
+    "extcodecopy",
+    "extcodehash",
+    "extcodesize",
+}
+
+
+def extract_found_builtins(builtins_file: Path = BUILTINS_FILE) -> set[str]:
+    """Extract builtin names from Builtins.lean."""
+    text = builtins_file.read_text(encoding="utf-8")
+    return set(BUILTIN_NAME_RE.findall(text))
+

--- a/scripts/generate_evmyullean_capability_report.py
+++ b/scripts/generate_evmyullean_capability_report.py
@@ -14,45 +14,18 @@ import re
 import sys
 from pathlib import Path
 
+from evmyullean_capability import (
+    BUILTINS_FILE,
+    EVMYULLEAN_OVERLAP_BUILTINS,
+    EVMYULLEAN_UNSUPPORTED_BUILTINS,
+    VERITY_HELPER_BUILTINS,
+    extract_found_builtins,
+)
 from property_utils import ROOT
 
-BUILTINS_FILE = ROOT / "Compiler" / "Proofs" / "YulGeneration" / "Builtins.lean"
 ADAPTER_FILE = ROOT / "Compiler" / "Proofs" / "YulGeneration" / "Backends" / "EvmYulLeanAdapter.lean"
 DEFAULT_OUTPUT = ROOT / "artifacts" / "evmyullean_capability_report.json"
 DEFAULT_UNSUPPORTED_OUTPUT = ROOT / "artifacts" / "evmyullean_unsupported_nodes.json"
-
-BUILTIN_NAME_RE = re.compile(r'func\s*=\s*"([^"]+)"')
-
-EVMYULLEAN_OVERLAP_BUILTINS = {
-    "add",
-    "and",
-    "calldataload",
-    "caller",
-    "div",
-    "eq",
-    "gt",
-    "iszero",
-    "lt",
-    "mod",
-    "mul",
-    "not",
-    "or",
-    "shl",
-    "shr",
-    "sload",
-    "sub",
-    "xor",
-}
-
-VERITY_HELPER_BUILTINS = {"mappingSlot"}
-
-EVMYULLEAN_UNSUPPORTED_BUILTINS = {
-    "create",
-    "create2",
-    "extcodecopy",
-    "extcodehash",
-    "extcodesize",
-}
 
 
 def extract_adapter_gaps() -> list[dict[str, str]]:
@@ -82,8 +55,7 @@ def build_report() -> dict[str, object]:
     if not BUILTINS_FILE.exists():
         raise FileNotFoundError(f"Missing builtins file: {BUILTINS_FILE.relative_to(ROOT)}")
 
-    text = BUILTINS_FILE.read_text(encoding="utf-8")
-    found = sorted(set(BUILTIN_NAME_RE.findall(text)))
+    found = sorted(extract_found_builtins(BUILTINS_FILE))
     found_set = set(found)
     allowed_set = EVMYULLEAN_OVERLAP_BUILTINS | VERITY_HELPER_BUILTINS
 


### PR DESCRIPTION
## Summary
Issue #581 follow-up reliability slice.

This change removes duplicated EVMYulLean capability boundary definitions across scripts by introducing a shared module used by both:
- `scripts/check_evmyullean_capability_boundary.py`
- `scripts/generate_evmyullean_capability_report.py`

## Why
The same overlap/unsupported builtin sets were duplicated in two places, which can drift and produce inconsistent CI vs artifact results.

With this PR, boundary definitions live in one source of truth:
- `scripts/evmyullean_capability.py`

## Changes
- Added shared boundary module with:
  - builtin file path
  - overlap/unsupported/helper builtin sets
  - builtin extraction helper
- Refactored boundary checker to consume shared module.
- Refactored capability report generator to consume shared module.

## Validation
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `python3 scripts/generate_evmyullean_capability_report.py --check`

Both pass locally.

Closes #581 (reliability sub-slice toward deterministic equivalence-boundary tooling).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor of Python CI/report scripts that centralizes constants and parsing logic; runtime behavior should be unchanged aside from reducing drift risk.
> 
> **Overview**
> Unifies the EVMYulLean capability boundary “source of truth” by introducing `scripts/evmyullean_capability.py` and moving the builtin allow/deny sets plus builtin-name extraction into that shared module.
> 
> Both `check_evmyullean_capability_boundary.py` and `generate_evmyullean_capability_report.py` are refactored to import these shared constants/helpers instead of maintaining duplicated regexes/sets, keeping CI enforcement and generated artifacts consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 514a18e8050616cec77bc87f9a504b37a6632391. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->