### PR TITLE
Issue #583: emit patch coverage report artifacts in CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -278,6 +278,15 @@ jobs:
             --link examples/external-libs/PoseidonT3.yul \
             --link examples/external-libs/PoseidonT4.yul
 
+      - name: Generate patched Yul + patch coverage report
+        run: |
+          ./.lake/build/bin/verity-compiler \
+            --enable-patches \
+            --patch-report compiler/patch-report.tsv \
+            --output compiler/yul-patched \
+            --link examples/external-libs/PoseidonT3.yul \
+            --link examples/external-libs/PoseidonT4.yul
+
       - name: Generate Yul (unified AST path)
         run: ./.lake/build/bin/verity-compiler --ast --output compiler/yul-ast
 
@@ -313,6 +322,32 @@ jobs:
       - name: Save static gas report snapshot
         run: lake exe gas-report > gas-report-static.tsv
 
+      - name: Summarize patch coverage report
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import csv
+          from collections import defaultdict
+          path = "compiler/patch-report.tsv"
+          rows = list(csv.DictReader(open(path), delimiter="\t"))
+          totals = defaultdict(int)
+          contracts = defaultdict(int)
+          for row in rows:
+            patch = row["patch_name"]
+            if patch == "-":
+              continue
+            match_count = int(row["match_count"])
+            totals[patch] += match_count
+            contracts[patch] += 1
+          print("### Patch Coverage")
+          if not totals:
+            print("No patch rules fired in this run.")
+          else:
+            print("| Patch | Total Matches | Contracts |")
+            print("| :-- | --: | --: |")
+            for patch, total in sorted(totals.items(), key=lambda kv: kv[1], reverse=True):
+              print(f"| `{patch}` | {total} | {contracts[patch]} |")
+          PY
+
       - name: Generate property coverage report
         run: python3 scripts/report_property_coverage.py --format=markdown >> $GITHUB_STEP_SUMMARY
 
@@ -325,6 +360,12 @@ jobs:
           name: generated-yul
           path: compiler/yul
 
+      - name: Upload patched Yul
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-yul-patched
+          path: compiler/yul-patched
+
       - name: Upload difftest interpreter
         uses: actions/upload-artifact@v4
         with:
@@ -336,6 +377,12 @@ jobs:
         with:
           name: static-gas-report
           path: gas-report-static.tsv
+
+      - name: Upload patch coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: patch-coverage-report
+          path: compiler/patch-report.tsv
 
   foundry-gas-calibration:
     runs-on: ubuntu-latest

--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -16,8 +16,29 @@ private def orThrow (r : Except String Unit) : IO Unit :=
   | .error err => throw (IO.userError err)
   | .ok () => pure ()
 
-private def writeContract (outDir : String) (contract : IRContract) (libraryPaths : List String) (verbose : Bool) : IO Unit := do
-  let yulObj := emitYul contract
+private def reportRow (contractName : String) (report : Yul.PatchPassReport) : List String :=
+  match report.manifest with
+  | [] =>
+      [s!"{contractName}\t{report.iterations}\t-\t0\t0\t-"]
+  | entries =>
+      entries.map (fun entry =>
+        s!"{contractName}\t{report.iterations}\t{entry.patchName}\t{entry.matchCount}\t{entry.changedNodes}\t{entry.proofRef}")
+
+private def renderPatchReportTsv (rows : List (String × Yul.PatchPassReport)) : String :=
+  let header := "contract\titerations\tpatch_name\tmatch_count\tchanged_nodes\tproof_ref"
+  let body := rows.foldr (fun (contractName, report) acc => reportRow contractName report ++ acc) []
+  String.intercalate "\n" (header :: body) ++ "\n"
+
+private def writePatchReport (path : String) (rows : List (String × Yul.PatchPassReport)) : IO Unit := do
+  IO.FS.writeFile path (renderPatchReportTsv rows)
+
+private def writeContract
+    (outDir : String)
+    (contract : IRContract)
+    (libraryPaths : List String)
+    (verbose : Bool)
+    (options : YulEmitOptions) : IO Yul.PatchPassReport := do
+  let (yulObj, patchReport) := emitYulWithOptionsReport contract options
 
   -- Load and link external libraries if provided
   let libraries ← libraryPaths.mapM fun path => do
@@ -45,8 +66,14 @@ private def writeContract (outDir : String) (contract : IRContract) (libraryPath
 
   let path := s!"{outDir}/{contract.name}.yul"
   IO.FS.writeFile path text
+  pure patchReport
 
-def compileAll (outDir : String) (verbose : Bool := false) (libraryPaths : List String := []) : IO Unit := do
+def compileAllWithOptions
+    (outDir : String)
+    (verbose : Bool := false)
+    (libraryPaths : List String := [])
+    (options : YulEmitOptions := {})
+    (patchReportPath : Option String := none) : IO Unit := do
   IO.FS.createDirAll outDir
 
   -- Load libraries once for validation messages
@@ -61,18 +88,29 @@ def compileAll (outDir : String) (verbose : Bool := false) (libraryPaths : List 
     if libraryPaths.isEmpty then Specs.allSpecs
     else Specs.allSpecs ++ [Specs.cryptoHashSpec]
 
+  let mut patchRows : List (String × Yul.PatchPassReport) := []
   for spec in specs do
     let selectors ← computeSelectors spec
     match compile spec selectors with
     | .ok contract =>
       -- Only pass libraries to contracts that declare external functions
       let contractLibs := if spec.externals.isEmpty then [] else libraryPaths
-      writeContract outDir contract contractLibs verbose
+      let patchReport ← writeContract outDir contract contractLibs verbose options
+      patchRows := (contract.name, patchReport) :: patchRows
       if verbose then
         IO.println s!"✓ Compiled {contract.name}"
     | .error err =>
       throw (IO.userError err)
+  match patchReportPath with
+  | some path =>
+      writePatchReport path patchRows.reverse
+      if verbose then
+        IO.println s!"✓ Wrote patch report: {path}"
+  | none => pure ()
   if verbose then
     IO.println ""
     IO.println "Compilation complete!"
     IO.println s!"Generated {specs.length} contracts in {outDir}"
+
+def compileAll (outDir : String) (verbose : Bool := false) (libraryPaths : List String := []) : IO Unit := do
+  compileAllWithOptions outDir verbose libraryPaths {} none

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ lake exe verity-compiler                      # Output in compiler/yul/
 lake exe verity-compiler --link examples/external-libs/MyLib.yul -o compiler/yul
 ```
 
+**With deterministic Yul patch pass + coverage report:**
+```bash
+lake exe verity-compiler \
+  --enable-patches \
+  --patch-max-iterations 2 \
+  --patch-report compiler/patch-report.tsv \
+  -o compiler/yul-patched
+```
+
 **Run tests:**
 ```bash
 FOUNDRY_PROFILE=difftest forge test           # 375 tests across 32 suites

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,6 +39,7 @@ Current P1 foundation coverage (Issue #582):
 - Proof hooks + preservation theorems in `Compiler/Proofs/YulGeneration/PatchRulesProofs.lean`
 - Opt-in compiler path via `Compiler.emitYulWithOptions` (`YulEmitOptions.patchConfig`)
 - Report-capable compiler path via `Compiler.emitYulWithOptionsReport` to surface patch manifest/iteration metadata to CI and tooling
+- `verity-compiler` patch coverage emission (`--patch-report`) now writes per-contract/rule TSV output and CI uploads it as an artifact for Issue #583 tuning
 
 Execution policy:
 1. Do not start patch-pack expansion in `#583` before `#582` proof hooks are merged.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -297,6 +297,10 @@ Implemented:
   - opt-in patch execution via `YulEmitOptions.patchConfig`
 - `Compiler.emitYulWithOptionsReport`
   - emits `(YulObject × PatchPassReport)` so manifest + iteration metadata are available for CI/tooling
+- `verity-compiler` (`Compiler/Main.lean`, `Compiler/CompileDriver.lean`, `Compiler/ASTDriver.lean`)
+  - supports `--enable-patches`, `--patch-max-iterations`, and `--patch-report <path>` to export TSV patch coverage per contract/rule
+- CI (`.github/workflows/verify.yml`)
+  - produces and uploads `patch-coverage-report` artifact; summary table is included in workflow step summary
 
 Current diagnostic coverage in compiler:
 - Non-payable external functions and constructors now emit a runtime `msg.value == 0` guard, while explicit `isPayable := true` enables `Expr.msgValue` usage.


### PR DESCRIPTION
## Summary
Adds compiler and CI support for patch-pass coverage reporting so optimization tuning work in #583 has concrete per-rule usage data.

## What changed
- `verity-compiler` now supports:
  - `--enable-patches`
  - `--patch-max-iterations <n>`
  - `--patch-report <path>`
- Legacy and AST drivers now emit a TSV patch report (`contract`, `iterations`, `patch_name`, `match_count`, `changed_nodes`, `proof_ref`) when requested.
- CI (`verify.yml`) now:
  - Generates a patched Yul output directory (`compiler/yul-patched`)
  - Produces `compiler/patch-report.tsv`
  - Publishes a patch coverage summary table in the job summary
  - Uploads `generated-yul-patched` and `patch-coverage-report` artifacts
- Docs updated with new compiler/reporting path and usage snippet.

## Validation
- `lake build Compiler.CompileDriver Compiler.ASTDriver Compiler.Main` ✅

## Notes
- Full `lake build verity-compiler` is blocked in this local environment due missing `cc` for `evmyul` FFI C compilation, but CI already covers full executable + workflow execution.

Refs #583

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds reporting/CLI plumbing and CI steps; patch execution is explicitly opt-in, so risk is limited to new flag handling and report generation paths.
> 
> **Overview**
> Adds an opt-in *deterministic Yul patch pass* execution path to `verity-compiler` via new CLI flags `--enable-patches`, `--patch-max-iterations`, and `--patch-report`, threading `YulEmitOptions` through both legacy (`CompileDriver`) and AST (`ASTDriver`) compilation.
> 
> When `--patch-report` is provided, both drivers now capture `emitYulWithOptionsReport` results and write a per-contract/per-rule TSV report (`contract`, `iterations`, `patch_name`, `match_count`, `changed_nodes`, `proof_ref`). CI is updated to generate a patched Yul output dir, upload patched Yul + the TSV as artifacts, and append a small patch-coverage summary table to the job summary; docs add usage examples and note the new artifact/reporting capability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e4a95ef101aaeb41de87d5b29a27df1b551bd27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->