### PR TITLE
feat(#583): expand proven Yul patch pack to 5 deterministic rules

### DIFF
--- a/Compiler/Proofs/YulGeneration/PatchRulesProofs.lean
+++ b/Compiler/Proofs/YulGeneration/PatchRulesProofs.lean
@@ -18,6 +18,8 @@ structure FoundationEvaluatorLaws (eval : EvalExpr) : Prop where
   or_zero_right : ∀ lhs, eval (.call "or" [lhs, .lit 0]) = eval lhs
   or_zero_left : ∀ rhs, eval (.call "or" [.lit 0, rhs]) = eval rhs
   xor_zero_right : ∀ lhs, eval (.call "xor" [lhs, .lit 0]) = eval lhs
+  xor_zero_left : ∀ rhs, eval (.call "xor" [.lit 0, rhs]) = eval rhs
+  and_zero_right : ∀ lhs, eval (.call "and" [lhs, .lit 0]) = eval (.lit 0)
 
 /-- Obligation for `or(x, 0) -> x`. -/
 def or_zero_right_preserves (eval : EvalExpr) : Prop :=
@@ -31,10 +33,20 @@ def or_zero_left_preserves (eval : EvalExpr) : Prop :=
 def xor_zero_right_preserves (eval : EvalExpr) : Prop :=
   FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.xorZeroRightRule
 
+/-- Obligation for `xor(0, x) -> x`. -/
+def xor_zero_left_preserves (eval : EvalExpr) : Prop :=
+  FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.xorZeroLeftRule
+
+/-- Obligation for `and(x, 0) -> 0`. -/
+def and_zero_right_preserves (eval : EvalExpr) : Prop :=
+  FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.andZeroRightRule
+
 /-- Registry hook: each shipped foundation patch has an explicit proof obligation. -/
 def foundation_patch_pack_obligations (eval : EvalExpr) : Prop :=
   or_zero_right_preserves eval ∧
   or_zero_left_preserves eval ∧
-  xor_zero_right_preserves eval
+  xor_zero_right_preserves eval ∧
+  xor_zero_left_preserves eval ∧
+  and_zero_right_preserves eval
 
 end Compiler.Proofs.YulGeneration.PatchRulesProofs

--- a/Compiler/Proofs/YulGeneration/README.md
+++ b/Compiler/Proofs/YulGeneration/README.md
@@ -33,7 +33,7 @@ This directory contains the verification proofs for Layer 3 (IR → Yul) of the 
 - **`SmokeTests.lean`** - Concrete examples demonstrating equivalence
 - **`PatchRulesProofs.lean`** - Proof hooks for deterministic Yul patch rules
   - Defines `ExprPatchPreservesUnder` backend-agnostic proof contract for patch correctness
-  - Registers evaluator-law proof obligations for the initial foundation patch pack (`or(x,0)`, `or(0,x)`, `xor(x,0)`)
+  - Registers evaluator-law proof obligations for the foundation patch pack (`or(x,0)`, `or(0,x)`, `xor(x,0)`, `xor(0,x)`, `and(x,0)`)
 
 ## Expression Equivalence Theorems
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -289,7 +289,7 @@ Implemented:
   - deterministic ordering (`priority` + stable tie-break by declaration order)
   - bounded fixpoint execution (`maxIterations`) with patch manifest output
 - `Compiler/Yul/PatchRules.lean`
-  - initial expression patch pack: `or(x,0) -> x`, `or(0,x) -> x`, `xor(x,0) -> x`
+  - expanded expression patch pack: `or(x,0) -> x`, `or(0,x) -> x`, `xor(x,0) -> x`, `xor(0,x) -> x`, `and(x,0) -> 0`
 - `Compiler/Proofs/YulGeneration/PatchRulesProofs.lean`
   - backend-agnostic preservation contract `ExprPatchPreservesUnder`
   - explicit evaluator-law proof obligations for each shipped patch rule


### PR DESCRIPTION
## Summary
This PR advances issue #583 by expanding the proven-safe deterministic Yul expression patch pack from 3 rules to 5 rules.

Added rules:
- `xor(0, x) -> x`
- `and(x, 0) -> 0`

## Changes
- `Compiler/Yul/PatchRules.lean`
  - added `xorZeroLeftRule` and `andZeroRightRule`
  - included both in `foundationExprPatchPack`
  - updated deterministic ordering smoke test
  - added smoke tests proving rewrites fire correctly
- `Compiler/Proofs/YulGeneration/PatchRulesProofs.lean`
  - extended `FoundationEvaluatorLaws` with new evaluator laws
  - added obligations `xor_zero_left_preserves` and `and_zero_right_preserves`
  - extended `foundation_patch_pack_obligations`
- `Compiler/Proofs/YulGeneration/README.md`
  - updated documented foundation patch set
- `docs/VERIFICATION_STATUS.md`
  - updated patch-pack status to include all 5 rules

## Validation
- `lake build Compiler.Yul.PatchRules Compiler.Proofs.YulGeneration.PatchRulesProofs` ✅

Note: a full `lake build Compiler` currently fails on existing upstream issues in `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean` (`unknown identifier 'lowerStmt'`, parse error), unrelated to this PR.

## Issue
Closes part of #583.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two simple, local expression rewrites plus corresponding proof obligations and smoke tests; main risk is unintended rewrite triggering, mitigated by literal-zero pattern matches and deterministic ordering.
> 
> **Overview**
> Expands the foundation deterministic Yul expression patch pack to include two additional bitwise simplifications: **`xor(0, x) -> x`** and **`and(x, 0) -> 0`**, and wires them into `foundationExprPatchPack` with defined priorities and metadata.
> 
> Extends `FoundationEvaluatorLaws` and `foundation_patch_pack_obligations` to add explicit preservation obligations for the new rules, and adds/updates smoke tests plus README/status docs to reflect the 5-rule pack.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bf46e3def78cb722f6a371bea9976f4527dd374. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->