### PR TITLE
Issue #582: fail closed on patched Yul filename parity

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -312,6 +312,7 @@ jobs:
             --dir compiler/yul \
             --dir compiler/yul-patched \
             --dir compiler/yul-ast \
+            --require-same-files compiler/yul compiler/yul-patched \
             --compare-dirs compiler/yul compiler/yul-ast \
             --allow-compare-diff-file scripts/fixtures/yul_ast_bytecode_diffs.allowlist
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,7 +41,7 @@ Current P1 foundation coverage (Issue #582):
 - Report-capable compiler path via `Compiler.emitYulWithOptionsReport` to surface patch manifest/iteration metadata to CI and tooling
 - `verity-compiler` patch coverage emission (`--patch-report`) now writes per-contract/rule TSV output and CI uploads it as an artifact for Issue #583 tuning
 - Static gas delta gate for patch impact (`scripts/check_patch_gas_delta.py`) now compares baseline vs patch-enabled reports in CI with median/p90 non-regression and measurable-improvement requirements
-- CI now runs `check_yul_compiles.py` + `check_gas_model_coverage.py` on `compiler/yul-patched` as part of Issue #582 fail-closed hardening for patch-enabled output
+- CI now runs `check_yul_compiles.py` + `check_gas_model_coverage.py` on `compiler/yul-patched` as part of Issue #582 fail-closed hardening for patch-enabled output, including filename-set parity checks against baseline Yul output
 
 Execution policy:
 1. Do not start patch-pack expansion in `#583` before `#582` proof hooks are merged.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -302,7 +302,7 @@ Implemented:
 - CI (`.github/workflows/verify.yml`)
   - produces and uploads `patch-coverage-report` artifact; summary table is included in workflow step summary
   - computes baseline vs patch-enabled static gas deltas, reports total/deploy/runtime median+p90 deltas in CI summary, and gates on total median/p90 non-regression with a configurable improved-contract floor (currently `0` in CI)
-  - runs `check_yul_compiles.py` and `check_gas_model_coverage.py` against `compiler/yul-patched` in addition to baseline outputs, so patch-enabled codegen is fail-closed on solc-compileability and static-gas builtin-coverage regressions
+  - runs `check_yul_compiles.py` and `check_gas_model_coverage.py` against `compiler/yul-patched` in addition to baseline outputs, including explicit filename-set parity checks vs `compiler/yul`, so patch-enabled codegen is fail-closed on contract-drop, solc-compileability, and static-gas builtin-coverage regressions
 
 Current diagnostic coverage in compiler:
 - Non-payable external functions and constructors now emit a runtime `msg.value == 0` guard, while explicit `isPayable := true` enables `Expr.msgValue` usage.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -120,7 +120,7 @@ python3 scripts/generate_evmyullean_adapter_report.py
 
 - **`check_selectors.py`** - Verifies selector hash consistency across ContractSpec, compile selector tables, and generated Yul (`compiler/yul` and `compiler/yul-ast` when present); strips Lean comments/docstrings with the same shared string-aware parser used by storage checks; parses `ParamType` expressions recursively (including `bool`, tuple, array, and fixed-array forms) when extracting Solidity signatures; enforces compile selector table coverage for all specs except those with non-empty `externals`
 - **`check_selector_fixtures.py`** - Cross-checks selectors against solc-generated hashes; fixture signature extraction is comment/string-aware so commented examples/debug strings cannot create false selector expectations, scans full function headers (so visibility can appear after modifiers like `virtual`), includes only `public`/`external` selectors (matching `solc --hashes`), canonicalizes ABI-sensitive param forms (`function(...)`, `uint/int` aliases, user-defined `contract`/`enum`/`type` aliases, and struct params into canonical tuple signatures), parses both `solc --hashes` output layouts robustly (including nested tuple signatures), and enforces reverse completeness (every `solc --hashes` signature must be present in extracted fixtures)
-- **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc, fails closed when any requested `--dir` is missing/empty, can compare bytecode parity between directories, and can enforce a checked baseline of known compare diffs via allowlist
+- **`check_yul_compiles.py`** - Ensures generated Yul code compiles with solc, fails closed when any requested `--dir` is missing/empty, can enforce filename-set parity between directories (e.g. legacy vs patched outputs), can compare bytecode parity between directories, and can enforce a checked baseline of known compare diffs via allowlist
 - **`check_gas_report.py`** - Validates `lake exe gas-report` output shape, arithmetic consistency of totals, and monotonicity under more conservative static analysis settings
 - **`check_patch_gas_delta.py`** - Compares baseline vs patch-enabled static gas reports, reports median/p90 deltas for total/deploy/runtime gas, enforces total-gas median/p90 non-regression thresholds, and supports configurable minimum improved-contract thresholds
 - **`check_gas_model_coverage.py`** - Verifies that every call emitted in generated Yul has an explicit cost branch in `Compiler/Gas/StaticAnalysis.lean` (prevents silent fallback to unknown-call costs)
@@ -133,7 +133,9 @@ python3 scripts/check_yul_compiles.py
 # Check multiple directories and enforce legacy/AST known-diff baseline
 python3 scripts/check_yul_compiles.py \
   --dir compiler/yul \
+  --dir compiler/yul-patched \
   --dir compiler/yul-ast \
+  --require-same-files compiler/yul compiler/yul-patched \
   --compare-dirs compiler/yul compiler/yul-ast \
   --allow-compare-diff-file scripts/fixtures/yul_ast_bytecode_diffs.allowlist
 


### PR DESCRIPTION
## Summary
Adds a fail-closed filename parity gate between baseline and patch-enabled Yul outputs so CI catches partial patch-output contract drops.

## Changes
- `.github/workflows/verify.yml`
  - extends `check_yul_compiles.py` invocation with:
    - `--require-same-files compiler/yul compiler/yul-patched`
- `scripts/check_yul_compiles.py`
  - adds repeatable `--require-same-files DIR_A DIR_B` option
  - validates each pair fail-closed (`dir exists`, `non-empty`, exact `.yul` filename set parity)
  - keeps existing bytecode parity behavior under `--compare-dirs` unchanged
- `scripts/README.md`
  - documents `--require-same-files` usage and updated CI example
- `docs/ROADMAP.md`, `docs/VERIFICATION_STATUS.md`
  - records contract-drop protection in #582 CI hardening notes

## Why
The previous hardening closed missing/empty directory gaps, but a partial regression where patched output drops one or more contracts while still producing some files could still pass compileability checks. This closes that gap.

## Validation
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_yul_compiles.py --dir <tmpA> --dir <tmpB> --require-same-files <tmpA> <tmpB>` (pass case)
- `python3 scripts/check_yul_compiles.py --dir <tmpA> --dir <tmpB> --require-same-files <tmpA> <tmpB>` (mismatch case, expected fail)

Refs #582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/script and documentation changes only; main risk is false failures if filename expectations or output paths change.
> 
> **Overview**
> Adds a **fail-closed contract-drop guard** for patch-enabled Yul output by requiring `.yul` filename-set parity between `compiler/yul` and `compiler/yul-patched`.
> 
> Extends `scripts/check_yul_compiles.py` with repeatable `--require-same-files DIR_A DIR_B` checks (directory exists, non-empty, identical filename sets) and wires this into the `verify.yml` solc compilation step; accompanying docs (`scripts/README.md`, `docs/ROADMAP.md`, `docs/VERIFICATION_STATUS.md`) are updated to reflect the new CI hardening.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16b25ef4753df5325f897aefd264966a5154d756. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->