### PR TITLE
Issue #582: replace deprecated actions/cache save-always in verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -168,15 +168,15 @@ jobs:
       - name: Add elan to PATH
         run: echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
-      - name: Cache Lake packages
-        uses: actions/cache@v4
+      - name: Restore Lake packages cache
+        id: cache-lake
+        uses: actions/cache/restore@v4
         with:
           path: .lake
           key: lake-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-${{ github.sha }}
           restore-keys: |
             lake-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-
             lake-${{ hashFiles('lean-toolchain') }}-
-          save-always: true
 
       - name: Build and verify all proofs
         env:
@@ -367,6 +367,13 @@ jobs:
 
       - name: Generate storage layout report
         run: python3 scripts/check_storage_layout.py --format=markdown >> $GITHUB_STEP_SUMMARY
+
+      - name: Save Lake packages cache
+        if: always() && steps.cache-lake.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .lake
+          key: lake-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-${{ github.sha }}
 
       - name: Upload generated Yul
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
This updates CI caching in `verify.yml` to remove deprecated `actions/cache` usage that currently emits warnings on every run.

## What changed
- Replaced `.lake` cache step from `actions/cache@v4` with deprecated `save-always: true`
- Added explicit restore/save split:
  - `actions/cache/restore@v4` before build (`id: cache-lake`)
  - `actions/cache/save@v4` after build/report generation
- Save step is guarded with:
  - `if: always() && steps.cache-lake.outputs.cache-hit != 'true'`
  - avoids redundant save attempts on exact cache hits

## Why this matters
- Removes recurring deprecation annotations from `Verify proofs`
- Aligns workflow with current GitHub Actions cache guidance
- Preserves existing cache key/restore-key strategy and behavior

## Validation
- Local workflow diff review confirms deprecation input removed and restore/save pattern correctly wired.
- Full CI validation will run on this PR.

Refs: #582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates caching behavior for `.lake` packages; main risk is potential cache miss/save behavior differences affecting build time, not correctness.
> 
> **Overview**
> Updates the `verify.yml` workflow to remove deprecated `actions/cache` usage for `.lake` by splitting it into an explicit **restore** step (`actions/cache/restore@v4`) before the Lean build and a conditional **save** step (`actions/cache/save@v4`) after reports are generated.
> 
> The new save step runs on `always()` but only when the restore step did not hit an exact cache key, preserving the existing key/restore-key strategy while avoiding redundant saves and CI deprecation warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4df8f9af4bac8463c212babb4892b8ed6f543849. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->