### PR TITLE
Issue #582: expand foundation Yul patch rules with algebraic identities

### DIFF
--- a/Compiler/Proofs/YulGeneration/PatchRulesProofs.lean
+++ b/Compiler/Proofs/YulGeneration/PatchRulesProofs.lean
@@ -13,13 +13,20 @@ def ExprPatchPreservesUnder (eval : EvalExpr) (rule : ExprPatchRule) : Prop :=
     rule.applyExpr expr = some rewritten →
     eval expr = eval rewritten
 
-/-- Minimal evaluator laws needed to discharge the foundation bitwise patch pack. -/
+/-- Minimal evaluator laws needed to discharge the foundation patch pack. -/
 structure FoundationEvaluatorLaws (eval : EvalExpr) : Prop where
   or_zero_right : ∀ lhs, eval (.call "or" [lhs, .lit 0]) = eval lhs
   or_zero_left : ∀ rhs, eval (.call "or" [.lit 0, rhs]) = eval rhs
   xor_zero_right : ∀ lhs, eval (.call "xor" [lhs, .lit 0]) = eval lhs
   xor_zero_left : ∀ rhs, eval (.call "xor" [.lit 0, rhs]) = eval rhs
   and_zero_right : ∀ lhs, eval (.call "and" [lhs, .lit 0]) = eval (.lit 0)
+  add_zero_right : ∀ lhs, eval (.call "add" [lhs, .lit 0]) = eval lhs
+  add_zero_left : ∀ rhs, eval (.call "add" [.lit 0, rhs]) = eval rhs
+  sub_zero_right : ∀ lhs, eval (.call "sub" [lhs, .lit 0]) = eval lhs
+  mul_one_right : ∀ lhs, eval (.call "mul" [lhs, .lit 1]) = eval lhs
+  mul_one_left : ∀ rhs, eval (.call "mul" [.lit 1, rhs]) = eval rhs
+  div_one_right : ∀ lhs, eval (.call "div" [lhs, .lit 1]) = eval lhs
+  mod_one_right : ∀ lhs, eval (.call "mod" [lhs, .lit 1]) = eval (.lit 0)
 
 /-- Obligation for `or(x, 0) -> x`. -/
 def or_zero_right_preserves (eval : EvalExpr) : Prop :=
@@ -41,12 +48,47 @@ def xor_zero_left_preserves (eval : EvalExpr) : Prop :=
 def and_zero_right_preserves (eval : EvalExpr) : Prop :=
   FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.andZeroRightRule
 
+/-- Obligation for `add(x, 0) -> x`. -/
+def add_zero_right_preserves (eval : EvalExpr) : Prop :=
+  FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.addZeroRightRule
+
+/-- Obligation for `add(0, x) -> x`. -/
+def add_zero_left_preserves (eval : EvalExpr) : Prop :=
+  FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.addZeroLeftRule
+
+/-- Obligation for `sub(x, 0) -> x`. -/
+def sub_zero_right_preserves (eval : EvalExpr) : Prop :=
+  FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.subZeroRightRule
+
+/-- Obligation for `mul(x, 1) -> x`. -/
+def mul_one_right_preserves (eval : EvalExpr) : Prop :=
+  FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.mulOneRightRule
+
+/-- Obligation for `mul(1, x) -> x`. -/
+def mul_one_left_preserves (eval : EvalExpr) : Prop :=
+  FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.mulOneLeftRule
+
+/-- Obligation for `div(x, 1) -> x`. -/
+def div_one_right_preserves (eval : EvalExpr) : Prop :=
+  FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.divOneRightRule
+
+/-- Obligation for `mod(x, 1) -> 0`. -/
+def mod_one_right_preserves (eval : EvalExpr) : Prop :=
+  FoundationEvaluatorLaws eval → ExprPatchPreservesUnder eval Compiler.Yul.modOneRightRule
+
 /-- Registry hook: each shipped foundation patch has an explicit proof obligation. -/
 def foundation_patch_pack_obligations (eval : EvalExpr) : Prop :=
   or_zero_right_preserves eval ∧
   or_zero_left_preserves eval ∧
   xor_zero_right_preserves eval ∧
   xor_zero_left_preserves eval ∧
-  and_zero_right_preserves eval
+  and_zero_right_preserves eval ∧
+  add_zero_right_preserves eval ∧
+  add_zero_left_preserves eval ∧
+  sub_zero_right_preserves eval ∧
+  mul_one_right_preserves eval ∧
+  mul_one_left_preserves eval ∧
+  div_one_right_preserves eval ∧
+  mod_one_right_preserves eval
 
 end Compiler.Proofs.YulGeneration.PatchRulesProofs

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -289,7 +289,7 @@ Implemented:
   - deterministic ordering (`priority` + stable tie-break by declaration order)
   - bounded fixpoint execution (`maxIterations`) with patch manifest output
 - `Compiler/Yul/PatchRules.lean`
-  - expanded expression patch pack: `or(x,0) -> x`, `or(0,x) -> x`, `xor(x,0) -> x`, `xor(0,x) -> x`, `and(x,0) -> 0`
+  - expanded expression patch pack: `or(x,0) -> x`, `or(0,x) -> x`, `xor(x,0) -> x`, `xor(0,x) -> x`, `and(x,0) -> 0`, `add(x,0) -> x`, `add(0,x) -> x`, `sub(x,0) -> x`, `mul(x,1) -> x`, `mul(1,x) -> x`, `div(x,1) -> x`, `mod(x,1) -> 0`
 - `Compiler/Proofs/YulGeneration/PatchRulesProofs.lean`
   - backend-agnostic preservation contract `ExprPatchPreservesUnder`
   - explicit evaluator-law proof obligations for each shipped patch rule


### PR DESCRIPTION
## Summary
Expands the Issue #582 deterministic Yul foundation patch pack with a set of algebraic identity rewrites that are semantics-preserving under explicit evaluator-law obligations.

Added patch rules in `Compiler/Yul/PatchRules.lean`:
- `add(x, 0) -> x`
- `add(0, x) -> x`
- `sub(x, 0) -> x`
- `mul(x, 1) -> x`
- `mul(1, x) -> x`
- `div(x, 1) -> x`
- `mod(x, 1) -> 0`

Also updates:
- `FoundationEvaluatorLaws` + patch obligation registry in `Compiler/Proofs/YulGeneration/PatchRulesProofs.lean`
- smoke tests in `Compiler/Yul/PatchRules.lean` for deterministic ordering and rule behavior
- `docs/VERIFICATION_STATUS.md` patch-pack status list

## Why this improves #582
- Keeps the patch framework deterministic/fail-closed while increasing optimization coverage.
- Preserves auditable proof linkage per rule (`proofId`) and explicit side conditions.
- Improves leverage for downstream issue #583 (patch impact tuning) without changing framework invariants.

## Validation
- `lake build Compiler.Yul.PatchRules Compiler.Proofs.YulGeneration.PatchRulesProofs`
- `lake build`

Closes #582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alter post-codegen Yul rewriting behavior across all patched builds; while the rules are simple identities guarded by literal side conditions and proof hooks, any mismatch with real backend semantics (e.g., `div`/`mod`) could affect generated code.
> 
> **Overview**
> Expands the deterministic Yul *foundation expression patch pack* with new algebraic identity rewrites: `add(x,0)`, `add(0,x)`, `sub(x,0)`, `mul(x,1)`, `mul(1,x)`, `div(x,1)`, and `mod(x,1)`.
> 
> Updates the proof/verification surface by extending `FoundationEvaluatorLaws` and the `foundation_patch_pack_obligations` registry so each new rule has an explicit preservation obligation, and adds/updates smoke tests to validate rule ordering and basic rewrite behavior. Documentation is updated to reflect the larger patch pack.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73315a05ed0659b7873a6ccc80e6196327144630. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->