### PR TITLE
Compiler: support bytes custom error payload encoding (Issue #586 slice)

### DIFF
--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -307,7 +307,7 @@ Implemented:
 
 Current diagnostic coverage in compiler:
 - Non-payable external functions and constructors now emit a runtime `msg.value == 0` guard, while explicit `isPayable := true` enables `Expr.msgValue` usage.
-- Custom errors are now first-class declarations (`errors`) with `Stmt.requireError`/`Stmt.revertError` emission for static payload types (`uint256`, `address`, `bool`, `bytes32`). Dynamic custom error payloads still fail with explicit guidance.
+- Custom errors are now first-class declarations (`errors`) with `Stmt.requireError`/`Stmt.revertError` emission for static payload types (`uint256`, `address`, `bool`, `bytes32`) plus `bytes` payloads when sourced from direct bytes parameters. Other dynamic custom error payloads still fail with explicit guidance.
 - `fallback` and `receive` are now modeled as first-class entrypoints in dispatch (empty-calldata routing to `receive`, unmatched selector routing to `fallback`) with compile-time shape checks (`receive` must be payable, both must be parameterless and non-returning).
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.


### PR DESCRIPTION
## Summary
This PR ships another focused `#586` interop slice by extending custom-error support from static-only payloads to include `bytes` payloads sourced from direct bytes parameters.

### What changed
- Compiler: allow `ParamType.bytes` in `ErrorDef` declarations.
- Compiler: ABI-encode `bytes` custom error args in `Stmt.requireError` / `Stmt.revertError`:
  - head offset emission
  - dynamic tail length/data encoding
  - padded tail accounting and revert size calculation
- Diagnostics: fail fast with actionable messages when a `bytes` error arg is not a direct `bytes` parameter reference.
- Tests:
  - added positive regression for bytes custom error encoding
  - added negative regression for invalid bytes-arg shape
  - updated existing static custom error assertion for the new shared tail-size path
- Docs: updated interop diagnostic status text in `docs/VERIFICATION_STATUS.md`.

## Validation
- `lake build Compiler.ContractSpec Compiler.ContractSpecFeatureTest` ✅

## Scope
- Partial progress for `#586`.
- Still out of scope: broader dynamic custom error payload shapes (arrays/tuples) and low-level call interop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler codegen for `Stmt.requireError`/`Stmt.revertError` revert payload emission, so mistakes could produce incorrect revert data or memory writes. Scope is constrained to `bytes` custom-error args sourced directly from parameters with added validation and tests.
> 
> **Overview**
> Adds `bytes` as an allowed `ErrorDef` parameter type and updates custom error revert emission to ABI-encode dynamic `bytes` payloads (head offset + length/data tail, padded tail tracking, and revert size derived from `__err_tail`).
> 
> Introduces compile-time validation that `bytes` custom-error args must be *direct* references to `bytes` parameters, failing early with Issue #586 diagnostics when shapes/types don’t match.
> 
> Updates feature tests to cover the new bytes encoding path (plus a negative arg-shape case) and adjusts the existing static custom error assertion for the shared tail-size-based revert path; docs are updated to reflect `bytes` custom error support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad9de68b3b95cff1c551617d2d0b07bc3b1b797e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->