### PR TITLE
Compiler: guard constructor param decoding to supported static types (#586 slice)

### DIFF
--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -313,6 +313,7 @@ Current diagnostic coverage in compiler:
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
 - Indexed `bytes` event params now emit ABI-style hashed topics (`keccak256(payload)`); indexed tuple/array forms still fail with explicit migration guidance (`use unindexed field + off-chain hash`).
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
+- Constructor argument decoding is currently constrained to static ABI words (`uint256`/`address`/`bool`/`bytes32`); unsupported constructor parameter types now fail fast with explicit diagnostics.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 
 ### Short Term (1-2 months)


### PR DESCRIPTION
## Summary
This PR fixes a constructor decoding reliability gap by preventing unsupported constructor parameter shapes from compiling into incorrect 32-byte word loads.

### What changed
- Added constructor parameter validation in `Compiler/ContractSpec.lean`:
  - constructor params are now restricted to currently-supported static ABI word types: `uint256`, `address`, `bool`, `bytes32`.
  - unsupported constructor param types now fail fast with an actionable `Issue #586` diagnostic.
- Normalized constructor `bool` parameter decoding to canonical `0/1` in generated Yul (matching function param behavior).
- Added regressions in `Compiler/ContractSpecFeatureTest.lean`:
  - positive: constructor `bool` parameter normalization codegen
  - negative: dynamic constructor parameter (`bytes`) emits explicit diagnostic
- Updated `docs/VERIFICATION_STATUS.md` diagnostic coverage text.

## Why
`genConstructorArgLoads` decodes constructor arguments from bytecode as fixed 32-byte words. Accepting dynamic/complex constructor param types without decode support can silently produce invalid Yul assumptions. This change makes the boundary explicit and fail-closed until dynamic constructor decoding is implemented.

## Validation
- `lake build Compiler.ContractSpec Compiler.ContractSpecFeatureTest` ✅

## Scope
Focused `#586` diagnostics/reliability slice. Dynamic constructor ABI decoding remains out of scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect constructor compilation/codegen and introduce new compile-time rejections for previously accepted specs; risk is mainly behavior/compatibility for contracts using unsupported constructor param types.
> 
> **Overview**
> Constructor compilation now **fails fast** when constructor parameters use unsupported ABI shapes, restricting params to static word types (`uint256`, `address`, `bool`, `bytes32`) and emitting an `Issue #586` diagnostic instead of generating incorrect `mload`-based decoding.
> 
> Constructor argument codegen now normalizes `bool` params to canonical `0/1` (via `iszero(iszero(...))`), aligning with function-param behavior. Feature tests add coverage for the new bool normalization and the unsupported-dynamic-param diagnostic, and verification docs note the constructor-decoding constraint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 319d6ae35a7f27cb0c2e29dee4700ae97b5a33d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->