### PR TITLE
Compiler: fail fast on event arg type mismatches (Issue #586 slice)

### DIFF
--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -312,6 +312,7 @@ Current diagnostic coverage in compiler:
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
 - Indexed `bytes` event params now emit ABI-style hashed topics (`keccak256(payload)`); indexed tuple/array forms still fail with explicit migration guidance (`use unindexed field + off-chain hash`).
+- Event emission now fails fast on `Expr.param` type mismatches against declared event parameter types (including indexed-bytes arg-shape checks) to prevent invalid Yul from unresolved dynamic calldata helpers.
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - Constructor argument decoding is currently constrained to static ABI words (`uint256`/`address`/`bool`/`bytes32`); unsupported constructor parameter types now fail fast with explicit diagnostics.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.


### PR DESCRIPTION
## Summary
This PR closes a reliability gap in ContractSpec event emission validation.

Previously, `Stmt.emit` accepted mismatched `Expr.param` argument types and could produce invalid Yul (notably for indexed `bytes`, which requires dynamic calldata helper symbols like `<name>_length` / `<name>_data_offset`).

## Changes
- Add pre-compilation event argument shape validation in `Compiler/ContractSpec.lean`:
  - Validate `Stmt.emit` event existence and arg count in the validator pass.
  - Validate `Expr.param` argument type matches declared event parameter type.
  - Keep explicit indexed-`bytes` arg-shape checks (must reference a direct `bytes` parameter) in validation, fail-fast.
- Wire `validateEventArgShapesInFunction` into `compile` before lowering.
- Add regression in `Compiler/ContractSpecFeatureTest.lean`:
  - `IndexedBytesEventArgTypeMismatch` now fails with explicit diagnostic + Issue #586 reference.
- Update diagnostics notes in `docs/VERIFICATION_STATUS.md`.
- Adjust indexed tuple unsupported test to use a tuple-typed parameter so it exercises the intended unsupported path.

## Why this matters
This prevents malformed generated Yul from parameter-type mismatches in event emission and improves migration diagnostics quality for the Solidity interop track.

## Validation
- `lake build Compiler.ContractSpec Compiler.ContractSpecFeatureTest`
- `lake env lean Compiler/ContractSpecFeatureTest.lean`

Refs: #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes compiler acceptance/diagnostics for event emission and may cause previously-compiling specs with mismatched event args to fail earlier, though the change is localized to validation.
> 
> **Overview**
> **Event emission is now validated earlier and more strictly.** The compiler adds a new validation pass for `Stmt.emit` that checks the event exists, argument counts match, and any `Expr.param` arguments have types matching the declared event parameter types; it also enforces the existing indexed-`bytes` “must reference a direct `bytes` parameter” constraint with clearer `Issue #586` diagnostics.
> 
> This validation is wired into `compile` before lowering to Yul, adds a regression test that expects an indexed-`bytes` arg type mismatch to fail compilation, and adjusts the indexed-tuple unsupported test to pass a tuple-typed parameter so it hits the intended diagnostic path. Docs are updated to note the new fail-fast behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76fc48a563618d0492b05a973048ee57ccccd824. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->