### PR TITLE
feat(#627): emit ABI JSON artifacts from ContractSpec

### DIFF
--- a/Compiler/ABITest.lean
+++ b/Compiler/ABITest.lean
@@ -1,0 +1,92 @@
+import Compiler.ABI
+
+namespace Compiler.ABITest
+
+open Compiler.ContractSpec
+
+private def contains (haystack needle : String) : Bool :=
+  let h := haystack.toList
+  let n := needle.toList
+  if n.isEmpty then true
+  else
+    let rec go : List Char → Bool
+      | [] => false
+      | c :: cs =>
+        if (c :: cs).take n.length == n then true
+        else go cs
+    go h
+
+private def assertContains (label rendered : String) (needles : List String) : IO Unit := do
+  for needle in needles do
+    if !contains rendered needle then
+      throw (IO.userError s!"✗ {label}: missing '{needle}' in:\n{rendered}")
+  IO.println s!"✓ {label}"
+
+private def abiSpec : ContractSpec := {
+  name := "ABIEmitterFixture"
+  fields := []
+  constructor := some {
+    params := [{ name := "owner", ty := ParamType.address }]
+    isPayable := true
+    body := [Stmt.stop]
+  }
+  functions := [
+    { name := "setTuple"
+      params := [{ name := "cfg", ty := ParamType.tuple [ParamType.address, ParamType.uint256] }]
+      returnType := none
+      body := [Stmt.stop]
+    },
+    { name := "echoTupleArray"
+      params := [{ name := "items", ty := ParamType.array (ParamType.tuple [ParamType.uint256, ParamType.bool]) }]
+      returnType := none
+      returns := [ParamType.array (ParamType.tuple [ParamType.uint256, ParamType.bool])]
+      body := [Stmt.stop]
+    },
+    { name := "fallback"
+      params := []
+      returnType := none
+      isPayable := false
+      body := [Stmt.stop]
+    },
+    { name := "receive"
+      params := []
+      returnType := none
+      isPayable := true
+      body := [Stmt.stop]
+    },
+    { name := "internalHelper"
+      params := [{ name := "x", ty := ParamType.uint256 }]
+      returnType := some FieldType.uint256
+      body := [Stmt.return (Expr.param "x")]
+      isInternal := true
+    }
+  ]
+  events := [
+    { name := "Data"
+      params := [
+        { name := "id", ty := ParamType.uint256, kind := EventParamKind.indexed },
+        { name := "payload", ty := ParamType.bytes, kind := EventParamKind.unindexed }
+      ]
+    }
+  ]
+  errors := [
+    { name := "BadThing"
+      params := [ParamType.address, ParamType.bytes]
+    }
+  ]
+}
+
+#eval! do
+  let rendered := Compiler.ABI.emitContractABIJson abiSpec
+  assertContains "constructor entry" rendered ["\"type\": \"constructor\"", "\"stateMutability\": \"payable\""]
+  assertContains "function entry" rendered ["\"type\": \"function\"", "\"name\": \"setTuple\""]
+  assertContains "tuple components" rendered ["\"type\": \"tuple\"", "\"components\": [{\"name\": \"\", \"type\": \"address\"}, {\"name\": \"\", \"type\": \"uint256\"}]"]
+  assertContains "tuple array components" rendered ["\"type\": \"tuple[]\"", "\"outputs\": [{\"name\": \"\", \"type\": \"tuple[]\", \"components\": [{\"name\": \"\", \"type\": \"uint256\"}, {\"name\": \"\", \"type\": \"bool\"}]}]"]
+  assertContains "event indexed metadata" rendered ["\"type\": \"event\"", "\"indexed\": true", "\"indexed\": false"]
+  assertContains "error entry" rendered ["\"type\": \"error\"", "\"name\": \"BadThing\""]
+  assertContains "special entrypoints" rendered ["\"type\": \"fallback\"", "\"type\": \"receive\""]
+  if contains rendered "internalHelper" then
+    throw (IO.userError s!"✗ internal functions must not appear in ABI: {rendered}")
+  IO.println "✓ internal function filtering"
+
+end Compiler.ABITest

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,7 +67,7 @@ Status legend:
 | 3 | `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
 | 4 | Full event ABI parity (indexed dynamic + tuple hashing) | partial | partial | partial | partial | partial |
 | 5 | Storage layout controls (packed fields + explicit slot mapping) | partial | partial | partial | partial | partial |
-| 6 | ABI JSON artifact generation | unsupported | unsupported | n/a | n/a | unsupported |
+| 6 | ABI JSON artifact generation | partial | partial | n/a | partial | partial |
 
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -272,7 +272,7 @@ Status legend:
 | `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
 | Event ABI parity for indexed dynamic/tuple payloads | partial | partial | partial | partial | partial |
 | Storage layout controls (packing + explicit slots) | partial | partial | partial | partial | partial |
-| ABI JSON artifact generation | unsupported | unsupported | n/a | n/a | unsupported |
+| ABI JSON artifact generation | partial | partial | n/a | partial | partial |
 
 Diagnostics policy for unsupported constructs:
 1. Report the exact unsupported construct at compile time.
@@ -315,6 +315,7 @@ Current diagnostic coverage in compiler:
 - Event emission now fails fast on `Expr.param` type mismatches against declared event parameter types (including indexed-bytes arg-shape checks) to prevent invalid Yul from unresolved dynamic calldata helpers.
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - Constructor argument decoding is currently constrained to static ABI words (`uint256`/`address`/`bool`/`bytes32`); unsupported constructor parameter types now fail fast with explicit diagnostics.
+- `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 
 ### Short Term (1-2 months)


### PR DESCRIPTION
## Summary
- add deterministic ABI JSON emission for ContractSpec contracts
- wire `verity-compiler --abi-output <dir>` to write one `<Contract>.abi.json` per compiled spec
- add a focused Lean regression test for tuple/components, events, errors, and fallback/receive ABI entries
- update interop status docs for issue #627 progress

## Details
- New module: `Compiler/ABI.lean`
  - emits standard ABI entries for constructor/function/event/error/fallback/receive
  - handles tuple/array/fixed-array `components` rendering recursively
  - filters internal-only functions from ABI artifacts
- CLI + driver integration:
  - `Compiler/Main.lean`: add `--abi-output <dir>`
  - `Compiler/CompileDriver.lean`: emit ABI artifacts during ContractSpec compilation
  - guardrail: `--abi-output` is rejected in `--ast` mode for now
- Tests:
  - `Compiler/ABITest.lean`

## Validation
- `lake build Compiler.ABI Compiler.CompileDriver Compiler.Main`
- `lake env lean Compiler/ABITest.lean`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_property_manifest_sync.py`

## Notes
- Full `lake exe verity-compiler` execution in this container still fails due missing `cc` (existing environment limitation in `evmyul` build dependency).

Refs #586
Closes #627

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new artifact-emission path and CLI flag integrated into the compile loop; risk is mainly ABI format correctness/compatibility and ensuring it doesn’t interfere with normal compilation output.
> 
> **Overview**
> Adds deterministic ABI JSON artifact generation for `ContractSpec` contracts via new `Compiler/ABI.lean`, emitting constructor/function/event/error entries (including tuple/array `components`) while filtering `isInternal` functions and handling `fallback`/`receive`.
> 
> Wires this into `verity-compiler` with a new `--abi-output <dir>` flag and a `compileAllWithOptions` `abiOutDir` parameter to write one `<Contract>.abi.json` per compiled spec; `--abi-output` is explicitly rejected in `--ast` mode. Includes a Lean regression test (`Compiler/ABITest.lean`) covering tuple components, events indexed metadata, errors, special entrypoints, and internal-function exclusion, and updates interop status docs to mark ABI generation as *partial*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 488564e57f75b28123ae5f971ee2cbcc6a0672f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->