### PR TITLE
ContractSpec: support unindexed bytes event data encoding

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -580,6 +580,67 @@ private def featureSpec : ContractSpec := {
       throw (IO.userError "✗ expected invalid bytes custom error arg shape to fail compilation")
 
 #eval! do
+  let unindexedBytesEventSpec : ContractSpec := {
+    name := "UnindexedBytesEventSupported"
+    fields := []
+    constructor := none
+    events := [
+      { name := "UnindexedBytes"
+        params := [
+          { name := "payload", ty := ParamType.bytes, kind := EventParamKind.unindexed }
+        ]
+      }
+    ]
+    functions := [
+      { name := "emitBytes"
+        params := [{ name := "payload", ty := ParamType.bytes }]
+        returnType := none
+        body := [Stmt.emit "UnindexedBytes" [Expr.param "payload"], Stmt.stop]
+      }
+    ]
+  }
+  match compile unindexedBytesEventSpec [1] with
+  | .error err =>
+      throw (IO.userError s!"✗ expected unindexed bytes event support to compile, got: {err}")
+  | .ok ir =>
+      let rendered := Yul.render (emitYul ir)
+      assertContains "unindexed bytes event ABI data encoding" rendered
+        ["let __evt_data_tail := 32",
+         "mstore(add(__evt_ptr, 0), __evt_data_tail)",
+         "let __evt_arg0_len := payload_length",
+         "calldatacopy(add(__evt_arg0_dst, 32), payload_data_offset, __evt_arg0_len)",
+         "log1(__evt_ptr, __evt_data_tail, __evt_topic0)"]
+
+#eval! do
+  let unindexedTupleEventSpec : ContractSpec := {
+    name := "UnindexedTupleEventUnsupported"
+    fields := []
+    constructor := none
+    events := [
+      { name := "BadUnindexedTuple"
+        params := [
+          { name := "payload", ty := ParamType.tuple [ParamType.uint256, ParamType.uint256], kind := EventParamKind.unindexed }
+        ]
+      }
+    ]
+    functions := [
+      { name := "emitBad"
+        params := [{ name := "payload", ty := ParamType.tuple [ParamType.uint256, ParamType.uint256] }]
+        returnType := none
+        body := [Stmt.emit "BadUnindexedTuple" [Expr.param "payload"], Stmt.stop]
+      }
+    ]
+  }
+  match compile unindexedTupleEventSpec [1] with
+  | .error err =>
+      if !(contains err "unindexed param 'payload' has composite type" &&
+          contains err "Issue #586") then
+        throw (IO.userError s!"✗ unindexed tuple event diagnostic mismatch: {err}")
+      IO.println "✓ unindexed tuple event diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected unindexed tuple event param usage to fail compilation")
+
+#eval! do
   let indexedBytesEventSpec : ContractSpec := {
     name := "IndexedBytesEventSupported"
     fields := []

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -311,8 +311,8 @@ Current diagnostic coverage in compiler:
 - `fallback` and `receive` are now modeled as first-class entrypoints in dispatch (empty-calldata routing to `receive`, unmatched selector routing to `fallback`) with compile-time shape checks (`receive` must be payable, both must be parameterless and non-returning).
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
-- Indexed `bytes` event params now emit ABI-style hashed topics (`keccak256(payload)`); indexed tuple/array forms still fail with explicit migration guidance (`use unindexed field + off-chain hash`).
-- Event emission now fails fast on `Expr.param` type mismatches against declared event parameter types (including indexed-bytes arg-shape checks) to prevent invalid Yul from unresolved dynamic calldata helpers.
+- Indexed `bytes` event params now emit ABI-style hashed topics (`keccak256(payload)`), and unindexed `bytes` params now emit ABI head/tail event data encoding when sourced from direct bytes parameters. Indexed tuple/array forms still fail with explicit migration guidance (`use unindexed field + off-chain hash`).
+- Event emission now fails fast on `Expr.param` type mismatches against declared event parameter types (including indexed/unindexed bytes arg-shape checks) and rejects unsupported unindexed composite event payloads (tuple/array/fixed-array) to prevent malformed Yul.
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - Constructor argument decoding now reuses ABI head/tail decoding for constructor params (including tuple/array/bytes forms) and exposes both named param bindings plus `constructorArg` index aliases.
 - `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec.


### PR DESCRIPTION
## Summary
This PR delivers a focused event-interop slice for #624:

- Adds ABI-style unindexed `bytes` event data encoding in `Stmt.emit`.
- Adds fail-fast diagnostics for unsupported unindexed composite event params (`tuple`, `array`, `fixedArray`) instead of generating malformed Yul.
- Adds arg-shape validation for unindexed `bytes` params (must be sourced from a direct bytes parameter).
- Extends `ContractSpecFeatureTest` coverage for both positive and negative paths.
- Updates interop diagnostics notes in `docs/VERIFICATION_STATUS.md`.

## Why
`Stmt.emit` previously only wrote one 32-byte word per unindexed arg. That was incorrect for dynamic payloads (`bytes`) and could silently generate invalid Yul for unsupported composite types.

## Behavior changes
- `event E(bytes)` with `Stmt.emit "E" [Expr.param "payload"]` now emits ABI head/tail log data and `log1(__evt_ptr, __evt_data_tail, __evt_topic0)`.
- Unsupported unindexed composite event payloads now fail with explicit guidance (`Issue #586` diagnostic).

## Validation
- `lake build Compiler.ContractSpecFeatureTest`

Refs #624
Refs #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event Yul codegen and memory layout for log data, so mistakes could change emitted event payloads or corrupt memory in generated contracts; changes are scoped and covered by new compiler feature tests.
> 
> **Overview**
> `Stmt.emit` now supports **unindexed `bytes` event params** by emitting ABI-style head/tail log data encoding (writing offsets/length/padded payload) and using the computed tail size for the `log*` data length.
> 
> The compiler now **fails fast** for unsupported unindexed composite event payloads (`tuple`/`array`/`fixedArray`) and adds arg-shape checks requiring unindexed `bytes` event args to be sourced from a direct `bytes` parameter, preventing malformed Yul generation.
> 
> Adds ContractSpec feature tests for the new unindexed-bytes happy path and the unindexed-tuple rejection, and updates `docs/VERIFICATION_STATUS.md` to reflect the expanded event diagnostics/interop support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61eda1110e333c1f5d5f30f5238e77c7e2ede03c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->