### PR TITLE
ContractSpec: encode unindexed static tuple/fixed-array event payloads

### DIFF
--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -312,7 +312,7 @@ Current diagnostic coverage in compiler:
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
 - Indexed `bytes` event params now emit ABI-style hashed topics (`keccak256(payload)`), and unindexed `bytes` params now emit ABI head/tail event data encoding when sourced from direct bytes parameters. Indexed tuple/array forms still fail with explicit migration guidance (`use unindexed field + off-chain hash`).
-- Event emission now fails fast on `Expr.param` type mismatches against declared event parameter types (including indexed/unindexed bytes arg-shape checks) and rejects unsupported unindexed composite event payloads (tuple/array/fixed-array) to prevent malformed Yul.
+- Event emission now fails fast on `Expr.param` type mismatches against declared event parameter types (including indexed/unindexed bytes arg-shape checks), supports unindexed static tuple/fixed-array payload encoding from direct parameters, and rejects dynamic composite unindexed payloads to prevent malformed Yul.
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - Constructor argument decoding now reuses ABI head/tail decoding for constructor params (including tuple/array/bytes forms) and exposes both named param bindings plus `constructorArg` index aliases.
 - `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec.


### PR DESCRIPTION
## Summary
This PR extends ContractSpec event interop for issue #624 by supporting ABI-correct **unindexed static composite** payloads in `Stmt.emit`.

### What changed
- Adds unindexed event data encoding for static `tuple` and static `fixedArray` params:
  - flattens static leaves into ABI head words
  - normalizes leaf `address`/`bool` values to ABI-compatible 32-byte words
  - computes unindexed head size using composite-aware word sizing (not `params * 32`)
- Keeps unsupported dynamic composite unindexed payloads explicit with fail-fast diagnostics.
- Keeps indexed tuple/array behavior unchanged (still explicitly unsupported for now).
- Updates feature tests:
  - positive path for unindexed static tuple event payload encoding
  - negative path for unindexed dynamic tuple rejection
- Updates verification status notes accordingly.

## Why
Morpho-style events include unindexed static tuples (e.g. market params). Previously the compiler rejected all unindexed tuple/fixed-array payloads, forcing downstream Yul patching. This closes that gap for static composite payloads while preserving strict diagnostics for still-unsupported dynamic composites.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `lake build`

Refs #624
Refs #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `Stmt.emit` validation and Yul event data encoding logic; incorrect sizing/flattening would produce ABI-incompatible logs, though coverage is added via feature tests and fail-fast diagnostics for unsupported dynamic composites.
> 
> **Overview**
> Adds ABI-correct support for **unindexed static composite** event params (`tuple`/static `fixedArray`) in `ContractSpec` `Stmt.emit` by flattening leaf words into the event data head and normalizing `address`/`bool` values.
> 
> Updates event arg validation to distinguish *static vs dynamic* composites (allowing only static composites from direct `Expr.param` references), computes unindexed head size using composite-aware sizing, and keeps dynamic composites explicitly rejected with clearer diagnostics. Feature tests and `VERIFICATION_STATUS.md` are updated to cover the new supported case and the dynamic-tuple rejection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 318bba4e7abb88fb1065371196e96b1e089f4375. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->