### PR TITLE
[Compiler Enhancement] Strengthen ContractSpec event parity regression tests

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -873,7 +873,8 @@ private def featureSpec : ContractSpec := {
   }
   match compile indexedDynamicArrayEventSpec [1] with
   | .error err =>
-      if !(contains err "indexed dynamic event param 'payload' in event 'BadIndexedDynamicArray' is not supported yet" &&
+      if !(contains err "indexed param 'payload' has dynamic composite type" &&
+          contains err "BadIndexedDynamicArray" &&
           contains err "Issue #586") then
         throw (IO.userError s!"✗ indexed dynamic array event diagnostic mismatch: {err}")
       IO.println "✓ indexed dynamic array event diagnostic"


### PR DESCRIPTION
## Summary
Adds a focused Issue #624 reliability slice by expanding machine-checked regression coverage for event ABI behavior in `ContractSpec`.

## What changed
- Added support-path regression tests for unindexed static fixed-array event payload encoding.
- Added support-path regression tests for indexed static fixed-array event topic hashing.
- Added explicit unsupported-path regression test for indexed dynamic array event params, ensuring actionable `Issue #586` diagnostics remain stable.

## Why
Event ABI parity work is landing in slices. This PR tightens confidence around array/composite paths already implemented and guards diagnostics for unsupported dynamic indexed composites.

## Validation
- `lake build`
- `forge test --match-path test/SelectorSanity.t.sol`

Refs #624

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only add regression tests around event ABI codegen and diagnostics without modifying compiler logic.
> 
> **Overview**
> Strengthens `ContractSpecFeatureTest.lean` event parity regression coverage by adding **support-path** checks for fixed-size array event params.
> 
> Specifically adds assertions for *unindexed* fixed-array event data `mstore` layout and *indexed* fixed-array topic hashing (`keccak256` + `log2`), and introduces an explicit **unsupported-path** test ensuring indexed *dynamic array* event params fail with stable `Issue #586` diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f1e2af2236414d2f169e90318003a86dbc3eff4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->