### PR TITLE
test: cover cross-kind selector signature reuse across contracts

### DIFF
--- a/scripts/fixtures/SelectorFixtures.sol
+++ b/scripts/fixtures/SelectorFixtures.sol
@@ -133,3 +133,19 @@ contract SelectorFixtures {
         return amount + 2;
     }
 }
+
+contract SelectorFixturesCollisionEvent {
+    // Cross-contract function/event signature reuse is legal and should remain
+    // unambiguous in the checker keyspace (`function` vs `event`).
+    event MirrorMarket(bytes32 indexed id, MarketParams market);
+}
+
+contract SelectorFixturesCollisionFunction {
+    function MirrorMarket(bytes32 id, MarketParams calldata market)
+        external
+        pure
+        returns (uint256)
+    {
+        return uint256(id) + market.lltv;
+    }
+}


### PR DESCRIPTION
## Summary
Adds fixture coverage for cross-contract reuse of the same textual signature across ABI item kinds (event vs function).

## What changed
- Extended `scripts/fixtures/SelectorFixtures.sol` with:
  - `SelectorFixturesCollisionEvent` containing `event MirrorMarket(bytes32 indexed id, MarketParams market)`
  - `SelectorFixturesCollisionFunction` containing `function MirrorMarket(bytes32 id, MarketParams calldata market) external pure returns (uint256)`

## Why
The selector/event checker now keys hashes by `(kind, signature)`. This fixture locks in that behavior with a concrete parity case where textual signatures intentionally overlap across kinds.

## Validation
- `python3 scripts/check_selector_fixtures.py`
- `forge test --match-path test/SelectorSanity.t.sol`
- `lake build`

Refs #624

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture additions; no runtime or security-sensitive logic changes.
> 
> **Overview**
> Adds two new Solidity fixture contracts that intentionally reuse the same textual signature `MirrorMarket(bytes32,MarketParams)` across an `event` and a `function`, ensuring the selector/hash checker treats `(kind, signature)` as the unique key and doesn’t flag cross-kind collisions.
> 
> This expands `scripts/fixtures/SelectorFixtures.sol` test coverage for cross-contract, cross-ABI-item signature reuse without changing production logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a4c1de612095068291f851b6935113a5180956a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->