### PR TITLE
test(contractspec): complete low-level call diagnostic coverage

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -781,7 +781,7 @@ private def isInteropEntrypointName (name : String) : Bool :=
   ["fallback", "receive"].contains name
 
 private def lowLevelCallUnsupportedError (context : String) (name : String) : Except String Unit :=
-  throw s!"Compilation error: {context} uses unsupported low-level call '{name}' ({issue586Ref}). Use a verified linked external function wrapper instead of raw call/staticcall/delegatecall."
+  throw s!"Compilation error: {context} uses unsupported low-level call '{name}' ({issue586Ref}). Use a verified linked external function wrapper instead of raw call/staticcall/delegatecall/callcode."
 
 private def interopBuiltinCallUnsupportedError (context : String) (name : String) : Except String Unit :=
   throw s!"Compilation error: {context} uses unsupported interop builtin call '{name}' ({issue586Ref}). Use a verified linked external wrapper or pass the required value through explicit function parameters."


### PR DESCRIPTION
## Summary
- harden unsupported low-level call guidance to explicitly include `callcode`
- add regression coverage for unsupported `staticcall` usage in function bodies
- add regression coverage for unsupported `callcode` usage in constructors

## Why
Issue #622 requests explicit, actionable low-level call behavior. This PR keeps the current fail-closed policy and makes diagnostics/tests complete across all blocked low-level call names.

## Scope
This is a diagnostics + test coverage increment only. It does not add low-level call support yet.

Refs #622
Refs #586

## Validation
- `lake env lean Compiler/ContractSpecFeatureTest.lean`
- `lake build`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates an error message string and adds regression tests around existing fail-closed validation for low-level calls.
> 
> **Overview**
> Tightens the unsupported low-level call diagnostic in `ContractSpec` to explicitly recommend avoiding `callcode` in addition to `call`/`staticcall`/`delegatecall`.
> 
> Extends `ContractSpecFeatureTest` with new regression cases ensuring compilation fails with the expected `Issue #586` error for `staticcall` used in a function body and `callcode` used in a constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9af96912cd08896ee7cd186bc6fee94ba394d43e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->