### PR TITLE
feat(contractspec): fail fast on unsupported returndata builtins

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -775,7 +775,7 @@ private def isLowLevelCallName (name : String) : Bool :=
 
 private def isInteropBuiltinCallName (name : String) : Bool :=
   (isLowLevelCallName name) ||
-    ["create", "create2", "extcodesize", "extcodecopy", "extcodehash"].contains name
+    ["create", "create2", "extcodesize", "extcodecopy", "extcodehash", "returndatasize", "returndatacopy"].contains name
 
 private def isInteropEntrypointName (name : String) : Bool :=
   ["fallback", "receive"].contains name

--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -583,6 +583,48 @@ private def featureSpec : ContractSpec := {
       throw (IO.userError "✗ expected extcodehash usage to fail compilation")
 
 #eval! do
+  let returnDataSizeSpec : ContractSpec := {
+    name := "ReturnDataSizeUnsupported"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "probe"
+        params := []
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.externalCall "returndatasize" [])]
+      }
+    ]
+  }
+  match compile returnDataSizeSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'returndatasize'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ returndatasize diagnostic mismatch: {err}")
+      IO.println "✓ returndatasize unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected returndatasize usage to fail compilation")
+
+#eval! do
+  let returnDataCopySpec : ContractSpec := {
+    name := "ReturnDataCopyUnsupported"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "probe"
+        params := []
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.externalCall "returndatacopy" [])]
+      }
+    ]
+  }
+  match compile returnDataCopySpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'returndatacopy'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ returndatacopy diagnostic mismatch: {err}")
+      IO.println "✓ returndatacopy unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected returndatacopy usage to fail compilation")
+
+#eval! do
   let externalCreate2Spec : ContractSpec := {
     name := "ExternalCreate2Unsupported"
     fields := []


### PR DESCRIPTION
## Summary
- reject `returndatasize` and `returndatacopy` as unsupported interop builtins during ContractSpec validation
- add regression coverage that both constructs fail fast with actionable diagnostics

## Why
Issue #622 tracks first-class low-level call + returndata support. Until those primitives are properly modeled, these builtins should not silently pass through as ordinary extern calls.

## Changes
- `Compiler/ContractSpec.lean`
  - extend `isInteropBuiltinCallName` to include:
    - `returndatasize`
    - `returndatacopy`
- `Compiler/ContractSpecFeatureTest.lean`
  - add `ReturnDataSizeUnsupported` diagnostic test
  - add `ReturnDataCopyUnsupported` diagnostic test

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `lake build`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

Refs #622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to validation allowlist plus tests; affects only compilation-time rejection of two additional builtin names.
> 
> **Overview**
> ContractSpec validation now treats `returndatasize` and `returndatacopy` as unsupported interop builtins (like `create*`/`extcode*`), causing compilation to fail fast with the existing Issue #586 diagnostic.
> 
> Adds regression tests in `ContractSpecFeatureTest.lean` asserting both calls are rejected and produce actionable error messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ae6fb4ace13e4d49f8c6f475dd2a1b4b0b9cbf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->