### PR TITLE
ContractSpec: fail fast on selfdestruct/invalid interop builtins

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -809,7 +809,7 @@ private def isLowLevelCallName (name : String) : Bool :=
 
 private def isInteropBuiltinCallName (name : String) : Bool :=
   (isLowLevelCallName name) ||
-    ["create", "create2", "extcodesize", "extcodecopy", "extcodehash", "returndatasize", "returndatacopy"].contains name
+    ["create", "create2", "extcodesize", "extcodecopy", "extcodehash", "returndatasize", "returndatacopy", "selfdestruct", "invalid"].contains name
 
 private def isInteropEntrypointName (name : String) : Bool :=
   ["fallback", "receive"].contains name


### PR DESCRIPTION
## Summary
- reject `selfdestruct` and `invalid` in ContractSpec interop validation (`Expr.externalCall` path)
- surface explicit compile-time diagnostics with Issue #586 guidance
- add regression coverage for both unsupported builtin calls

## Why
Issue #622 tracks first-class low-level interop/returndata support. Until those primitives are modeled, allowing raw `selfdestruct`/`invalid` through the DSL creates unsafe escape hatches and weakens deterministic verification assumptions.

This PR keeps behavior fail-fast and explicit.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `lake build`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

Refs #622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, compile-time-only validation change that expands the unsupported builtin list; risk is limited to potentially breaking specs that previously (incorrectly) relied on these escape-hatch calls.
> 
> **Overview**
> **ContractSpec interop validation is tightened** to fail compilation when `Expr.externalCall` targets the EVM builtins `selfdestruct` or `invalid`, treating them as unsupported interop builtins and emitting the existing Issue #586-guided diagnostic.
> 
> **Regression tests** are added to `ContractSpecFeatureTest` to assert these two calls now reliably produce the expected compile-time errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89c04fe2f8f28850a1d9b30b81928f8b0b2a0fc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->