### PR TITLE
feat(event): support unindexed dynamic arrays in event data

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-431 theorems across 11 categories, all fully proven. 386 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+431 theorems across 11 categories, all fully proven. 387 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
@@ -174,7 +174,7 @@ FOUNDRY_PROFILE=difftest forge test
 <details>
 <summary><strong>Testing</strong></summary>
 
-**Foundry tests** (386 tests) validate EDSL = Yul = EVM execution:
+**Foundry tests** (387 tests) validate EDSL = Yul = EVM execution:
 
 ```bash
 FOUNDRY_PROFILE=difftest forge test                                          # run all

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 70000,
-    "foundry_functions": 386,
+    "foundry_functions": 387,
     "property_functions": 197,
     "suites": 35
   },

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -561,7 +561,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 386/375 tests pass
+# Expected: 387/375 tests pass
 ```
 
 ### Add New Contract
@@ -602,7 +602,7 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 386/375 passing (100%)
+**Foundry Tests**: 387/375 passing (100%)
 ```bash
 $ FOUNDRY_PROFILE=difftest forge test
 Ran 35 test suites: 375 tests passed, 0 failed, 0 skipped (375 total tests)

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 386 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 387 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (386 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (387 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:
@@ -188,7 +188,7 @@ def ownedSpec : ContractSpec := {
 ```bash
 lake build verity-compiler    # Build compiler
 lake exe verity-compiler      # Generate all contracts
-FOUNDRY_PROFILE=difftest forge test  # 386/375 tests pass (as of 2026-02-18)
+FOUNDRY_PROFILE=difftest forge test  # 387/375 tests pass (as of 2026-02-18)
 ```
 
 ### Differential Testing (Completed 2026-02-10)
@@ -225,7 +225,7 @@ FOUNDRY_PROFILE=difftest forge test  # 386/375 tests pass (as of 2026-02-18)
 - 10,000+ random transactions pass per contract in CI (large suite)
 - Large suite is sharded across 8 CI jobs to stay within per-test gas limits
 - Zero mismatches detected
-- All Foundry tests passing (386 as of 2026-02-18)
+- All Foundry tests passing (387 as of 2026-02-18)
 - CI: All checks passing
 
 **Usage**:

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -19,7 +19,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 431 across 11 categories (431 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256, address injectivity
-- **Tests**: 386 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
+- **Tests**: 387 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
 


### PR DESCRIPTION
## Summary
- add unindexed event support for dynamic arrays with static element types (`T[]` where `T` is scalar/static tuple/static fixed array)
- lower unindexed dynamic array payloads to canonical ABI event data tail encoding (head offset + length + normalized in-place element words)
- keep explicit fail-fast diagnostics for unindexed dynamic arrays with unsupported dynamic element types
- add Lean regression coverage and Solidity runtime parity coverage for unindexed dynamic static-tuple array encoding
- refresh generated verification artifact and test-count docs after adding parity tests

## Why
Issue #624 still had a parity gap for unindexed dynamic arrays in event data; these were blanket-rejected even for static element types that are ABI-encodable and already supported on indexed hashing paths.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `lake build`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

Refs #624

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event ABI encoding/codegen for dynamic data, which can cause subtle interoperability bugs if offsets/normalization are wrong. Scope is limited and backed by new compiler-level and Solidity parity tests.
> 
> **Overview**
> Enables emitting events with **unindexed dynamic array** parameters when the element type is ABI-static (scalar / static tuple / static fixed array), lowering them to canonical ABI event data tail encoding (head offset + length + normalized in-place element words) in `Compiler/ContractSpec.lean`.
> 
> Adds validation/diagnostics to reject unindexed arrays with dynamic element types and to require direct parameter references for these new dynamic encodings. Expands Lean feature tests and Foundry runtime parity tests (adds `UnindexedDynamicStaticTupleArray`) and updates generated metrics/docs to reflect the additional test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e7f115169158c8cbcdaf66397eb049fdce1ce68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->