### PR TITLE
fix(contractspec): fail fast on gasprice interop builtin usage

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -821,7 +821,7 @@ private def isLowLevelCallName (name : String) : Bool :=
 
 private def isInteropBuiltinCallName (name : String) : Bool :=
   (isLowLevelCallName name) ||
-    ["create", "create2", "extcodesize", "extcodecopy", "extcodehash", "returndatasize", "returndatacopy", "selfdestruct", "invalid"].contains name
+    ["create", "create2", "gasprice", "extcodesize", "extcodecopy", "extcodehash", "returndatasize", "returndatacopy", "selfdestruct", "invalid"].contains name
 
 private def isInteropEntrypointName (name : String) : Bool :=
   ["fallback", "receive"].contains name


### PR DESCRIPTION
## Summary
- reject `gasprice` as an unsupported interop builtin call in `ContractSpec` validation
- add regression coverage for both unsupported paths:
  - direct `Expr.externalCall "gasprice" []` in function bodies
  - external declaration named `gasprice`

## Why
`gasprice` is a Yul builtin. Allowing it through `externalCall`/external declarations can silently compile to unintended builtin semantics instead of a real linked external function call. This change makes that failure mode explicit and actionable.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `lake build`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

Refs #622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation tightening plus tests; behavior change is limited to rejecting a previously-allowed (but unsafe/ambiguous) builtin name during compilation.
> 
> **Overview**
> `ContractSpec` validation now treats `gasprice` as an unsupported interop builtin (like other Yul/EVM builtins), causing compilation to fail fast instead of potentially compiling to unintended builtin semantics.
> 
> Adds feature-test coverage that asserts the expected `Issue #586` diagnostic is produced for both direct `Expr.externalCall "gasprice" []` usage and for an external declaration named `gasprice`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3d5456480dfc942a9542c5b2fe3543344c72925. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->