### PR TITLE
fix(contractspec): reject env builtin names in interop calls

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -821,7 +821,11 @@ private def isLowLevelCallName (name : String) : Bool :=
 
 private def isInteropBuiltinCallName (name : String) : Bool :=
   (isLowLevelCallName name) ||
-    ["create", "create2", "gasprice", "extcodesize", "extcodecopy", "extcodehash", "returndatasize", "returndatacopy", "selfdestruct", "invalid"].contains name
+    ["create", "create2", "balance", "selfbalance", "origin", "caller", "callvalue",
+     "gasprice", "blockhash", "coinbase", "timestamp", "number", "difficulty",
+     "prevrandao", "gaslimit", "chainid", "basefee", "gas",
+     "extcodesize", "extcodecopy", "extcodehash", "returndatasize", "returndatacopy",
+     "selfdestruct", "invalid"].contains name
 
 private def isInteropEntrypointName (name : String) : Bool :=
   ["fallback", "receive"].contains name


### PR DESCRIPTION
## Summary
- extend `ContractSpec` interop builtin validation to reject environment/opcode-style Yul builtins in `externalCall` and external declarations (`balance`, `selfbalance`, `origin`, `caller`, `callvalue`, `gasprice`, block metadata/gas builtins)
- add focused regression coverage for `balance` in both call sites:
  - `Expr.externalCall "balance" [Expr.param "target"]`
  - external declaration named `balance`

## Why
Builtin opcode names were being accepted and lowered as raw Yul builtins instead of linked external calls. This is a silent semantic footgun for migration specs. Failing fast with explicit diagnostics is safer and keeps unsupported interop patterns actionable.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `lake build`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

Refs #622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change plus tests; risk is limited to stricter compile-time rejection of previously-accepted specs that used builtin opcode names.
> 
> **Overview**
> Tightens `ContractSpec` interop validation to **reject a broader set of EVM “environment/opcode” builtin names** (e.g., `balance`, `origin`, `caller`, block metadata, `gas`, etc.) when used via `Expr.externalCall` or declared in `externals`, preventing them from being lowered as raw Yul builtins.
> 
> Adds regression tests ensuring `balance` fails compilation with the expected *unsupported interop builtin call* diagnostic in both call-site and external-declaration scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8b0b00c0e8511850def3bb43504815f7894e828. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->