### PR TITLE
test(event): expand dynamic array ABI parity vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-431 theorems across 11 categories, all fully proven. 392 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+431 theorems across 11 categories, all fully proven. 396 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
@@ -174,7 +174,7 @@ FOUNDRY_PROFILE=difftest forge test
 <details>
 <summary><strong>Testing</strong></summary>
 
-**Foundry tests** (392 tests) validate EDSL = Yul = EVM execution:
+**Foundry tests** (396 tests) validate EDSL = Yul = EVM execution:
 
 ```bash
 FOUNDRY_PROFILE=difftest forge test                                          # run all

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 70000,
-    "foundry_functions": 392,
+    "foundry_functions": 396,
     "property_functions": 197,
     "suites": 35
   },

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -561,7 +561,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 392/375 tests pass
+# Expected: 396/375 tests pass
 ```
 
 ### Add New Contract
@@ -602,7 +602,7 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 392/375 passing (100%)
+**Foundry Tests**: 396/375 passing (100%)
 ```bash
 $ FOUNDRY_PROFILE=difftest forge test
 Ran 35 test suites: 375 tests passed, 0 failed, 0 skipped (375 total tests)

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 392 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 396 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (392 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (396 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:
@@ -188,7 +188,7 @@ def ownedSpec : ContractSpec := {
 ```bash
 lake build verity-compiler    # Build compiler
 lake exe verity-compiler      # Generate all contracts
-FOUNDRY_PROFILE=difftest forge test  # 392/375 tests pass (as of 2026-02-18)
+FOUNDRY_PROFILE=difftest forge test  # 396/375 tests pass (as of 2026-02-18)
 ```
 
 ### Differential Testing (Completed 2026-02-10)
@@ -225,7 +225,7 @@ FOUNDRY_PROFILE=difftest forge test  # 392/375 tests pass (as of 2026-02-18)
 - 10,000+ random transactions pass per contract in CI (large suite)
 - Large suite is sharded across 8 CI jobs to stay within per-test gas limits
 - Zero mismatches detected
-- All Foundry tests passing (392 as of 2026-02-18)
+- All Foundry tests passing (396 as of 2026-02-18)
 - CI: All checks passing
 
 **Usage**:

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -19,7 +19,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 431 across 11 categories (431 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256, address injectivity
-- **Tests**: 392 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
+- **Tests**: 396 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
 


### PR DESCRIPTION
## Summary
Refs #624

Expands event ABI parity coverage for dynamic arrays that are already supported in `ContractSpec` lowering but were under-tested across runtime and compiler-level regressions.

### Added runtime parity vectors (`test/EventAbiParity.t.sol`)
- `uint256[] indexed`
- `bytes32[] indexed`
- `uint256[]` (unindexed data ABI encoding)
- `bytes32[]` (unindexed data ABI encoding)

### Added compiler regression coverage (`Compiler/ContractSpecFeatureTest.lean`)
- `ParamType.array ParamType.bytes32` for unindexed event data lowering
- `ParamType.array ParamType.bytes32` for indexed topic hashing lowering

### Freshness artifacts
- Regenerated `artifacts/verification_status.json`
- Updated doc count mirrors required by CI freshness gates

## Validation
- `lake env lean Compiler/ContractSpecFeatureTest.lean`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `lake build`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus documentation/status counter bumps; no production compiler or contract logic is modified.
> 
> **Overview**
> Adds new ABI parity coverage for dynamic array event parameters that were already supported but under-tested: `uint256[]` and `bytes32[]` for both **indexed** topic hashing and **unindexed** event data encoding.
> 
> This expands `test/EventAbiParity.t.sol` with new emitter events + tests that compare recorded logs against `abi.encode`/`keccak256` expectations, and extends `Compiler/ContractSpecFeatureTest.lean` with compilation/Yul-string assertions for `ParamType.array ParamType.bytes32` event lowering.
> 
> Updates freshness/count mirrors (`README.md`, docs pages, and `artifacts/verification_status.json`) to reflect the increased Foundry test count (392 → 396).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 890e6f9549129294b03603c224c33215b078c694. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->