### PR TITLE
interop: fail-fast reject blobbasefee/blobhash builtins

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -823,7 +823,7 @@ private def isInteropBuiltinCallName (name : String) : Bool :=
   (isLowLevelCallName name) ||
     ["create", "create2", "balance", "selfbalance", "origin", "caller", "callvalue",
      "gasprice", "blockhash", "coinbase", "timestamp", "number", "difficulty",
-     "prevrandao", "gaslimit", "chainid", "basefee", "gas",
+     "prevrandao", "gaslimit", "chainid", "basefee", "blobbasefee", "blobhash", "gas",
      "extcodesize", "extcodecopy", "extcodehash", "returndatasize", "returndatacopy",
      "selfdestruct", "invalid"].contains name
 

--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -562,6 +562,48 @@ private def featureSpec : ContractSpec := {
       throw (IO.userError "✗ expected gasprice usage to fail compilation")
 
 #eval! do
+  let blobBaseFeeSpec : ContractSpec := {
+    name := "BlobBaseFeeUnsupported"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "probe"
+        params := []
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.externalCall "blobbasefee" [])]
+      }
+    ]
+  }
+  match compile blobBaseFeeSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'blobbasefee'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ blobbasefee diagnostic mismatch: {err}")
+      IO.println "✓ blobbasefee unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected blobbasefee usage to fail compilation")
+
+#eval! do
+  let blobHashSpec : ContractSpec := {
+    name := "BlobHashUnsupported"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "probe"
+        params := [{ name := "index", ty := ParamType.uint256 }]
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.externalCall "blobhash" [Expr.param "index"])]
+      }
+    ]
+  }
+  match compile blobHashSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'blobhash'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ blobhash diagnostic mismatch: {err}")
+      IO.println "✓ blobhash unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected blobhash usage to fail compilation")
+
+#eval! do
   let extCodeSizeSpec : ContractSpec := {
     name := "ExtCodeSizeUnsupported"
     fields := []
@@ -763,6 +805,62 @@ private def featureSpec : ContractSpec := {
       IO.println "✓ external gasprice unsupported diagnostic"
   | .ok _ =>
       throw (IO.userError "✗ expected external gasprice declaration to fail compilation")
+
+#eval! do
+  let externalBlobBaseFeeSpec : ContractSpec := {
+    name := "ExternalBlobBaseFeeUnsupported"
+    fields := []
+    constructor := none
+    externals := [
+      { name := "blobbasefee"
+        params := []
+        returnType := some ParamType.uint256
+        axiomNames := []
+      }
+    ]
+    functions := [
+      { name := "noop"
+        params := []
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile externalBlobBaseFeeSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'blobbasefee'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ external blobbasefee diagnostic mismatch: {err}")
+      IO.println "✓ external blobbasefee unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected external blobbasefee declaration to fail compilation")
+
+#eval! do
+  let externalBlobHashSpec : ContractSpec := {
+    name := "ExternalBlobHashUnsupported"
+    fields := []
+    constructor := none
+    externals := [
+      { name := "blobhash"
+        params := [ParamType.uint256]
+        returnType := some ParamType.uint256
+        axiomNames := []
+      }
+    ]
+    functions := [
+      { name := "noop"
+        params := []
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile externalBlobHashSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'blobhash'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ external blobhash diagnostic mismatch: {err}")
+      IO.println "✓ external blobhash unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected external blobhash declaration to fail compilation")
 
 #eval! do
   let externalCreate2Spec : ContractSpec := {


### PR DESCRIPTION
## Summary
- add `blobbasefee` and `blobhash` to the interop builtin denylist in `ContractSpec`
- keep fail-fast diagnostics consistent for unsupported low-level/env builtin call paths
- add regression coverage for both function-body `Expr.externalCall` and external declaration validation

## Why
`#622` keeps the interop profile explicit and safe until first-class low-level call/returndata primitives land. These Cancun-era builtins were a gap in the denylist and could otherwise silently compile as raw builtins.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`
- `lake build`

Refs #622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized validation change plus tests; main risk is breaking any specs that previously (incorrectly) relied on these builtins compiling.
> 
> **Overview**
> Adds Cancun-era env builtins `blobbasefee` and `blobhash` to the `ContractSpec` interop builtin denylist so they are rejected during compilation like other unsupported EVM builtins.
> 
> Extends `ContractSpecFeatureTest` with regression checks that both `Expr.externalCall` usage and `externals` declarations of these names fail compilation and emit the expected *Issue #586* diagnostic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57d19035d6f9e01d1cfbf114ec252cba4f08f763. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->