### PR TITLE
fix(contractspec): block raw Yul builtin names in interop call paths

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -819,13 +819,23 @@ private partial def staticCompositeLeafTypeOffsets
 private def isLowLevelCallName (name : String) : Bool :=
   ["call", "staticcall", "delegatecall", "callcode"].contains name
 
+private def interopBuiltinCallNames : List String :=
+  ["stop", "add", "sub", "mul", "div", "sdiv", "mod", "smod", "exp", "not",
+   "lt", "gt", "slt", "sgt", "eq", "iszero", "and", "or", "xor", "byte", "shl", "shr", "sar",
+   "addmod", "mulmod", "signextend",
+   "keccak256", "pop",
+   "mload", "mstore", "mstore8", "sload", "sstore", "msize", "gas", "pc",
+   "address", "balance", "selfbalance", "origin", "caller", "callvalue", "gasprice",
+   "blockhash", "coinbase", "timestamp", "number", "difficulty", "prevrandao", "gaslimit",
+   "chainid", "basefee", "blobbasefee", "blobhash",
+   "calldataload", "calldatasize", "calldatacopy", "codesize", "codecopy",
+   "extcodesize", "extcodecopy", "extcodehash",
+   "returndatasize", "returndatacopy", "mcopy",
+   "create", "create2", "return", "revert", "selfdestruct", "invalid",
+   "log0", "log1", "log2", "log3", "log4"]
+
 private def isInteropBuiltinCallName (name : String) : Bool :=
-  (isLowLevelCallName name) ||
-    ["create", "create2", "balance", "selfbalance", "origin", "caller", "callvalue",
-     "gasprice", "blockhash", "coinbase", "timestamp", "number", "difficulty",
-     "prevrandao", "gaslimit", "chainid", "basefee", "blobbasefee", "blobhash", "gas",
-     "extcodesize", "extcodecopy", "extcodehash", "returndatasize", "returndatacopy",
-     "selfdestruct", "invalid"].contains name
+  (isLowLevelCallName name) || interopBuiltinCallNames.contains name
 
 private def isInteropEntrypointName (name : String) : Bool :=
   ["fallback", "receive"].contains name


### PR DESCRIPTION
## Summary
- broadened `ContractSpec` interop-call validation from a narrow low-level/env subset to a broad raw-Yul builtin denylist
- reject direct `Expr.externalCall`/external declaration names for raw opcode/memory/storage/control/log/system builtins (e.g. `mload`, `sstore`, `calldataload`, `log*`, `return`, `revert`, etc.)
- retained existing low-level-call specific diagnostics for `call`/`staticcall`/`delegatecall`/`callcode`

## Why
Issue #622 is still blocked on first-class low-level call primitives. Until those primitives exist, allowing raw builtin names through interop call paths is an unsafe escape hatch and can silently bypass intended DSL restrictions.

This PR makes that gap explicit and fail-fast.

## Tests
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`
- `lake build`

## New regression coverage
- function-body unsupported builtin diagnostics:
  - `mload`
  - `sstore`
- external declaration unsupported builtin diagnostics:
  - `mload`
  - `sstore`

Refs #622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens a compiler validation denylist, which may break existing specs that relied on calling raw Yul builtins via interop; behavior is fail-fast but impacts compilation gating.
> 
> **Overview**
> Tightens `ContractSpec` interop-call validation by expanding the set of forbidden callee names from a small low-level/env subset to a comprehensive denylist of raw Yul/EVM builtins (arithmetic/bitwise, memory/storage, environment, calldata/code, logs, create/return/revert, etc.). Calls to these names via `Expr.externalCall` or via `externals` declarations now fail compilation with the existing Issue #586 diagnostics (retaining the specialized low-level-call error message for `call`/`staticcall`/`delegatecall`/`callcode`).
> 
> Adds feature tests that assert compilation fails (with the expected diagnostics) when using or declaring `mload` and `sstore` through these interop call paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18e6e05554bfb31dbec079b705f6770abfac5a61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->