### PR TITLE
feat(event): support indexed bytes[] topic hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-431 theorems across 11 categories, all fully proven. 396 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+431 theorems across 11 categories, all fully proven. 397 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
@@ -174,7 +174,7 @@ FOUNDRY_PROFILE=difftest forge test
 <details>
 <summary><strong>Testing</strong></summary>
 
-**Foundry tests** (396 tests) validate EDSL = Yul = EVM execution:
+**Foundry tests** (397 tests) validate EDSL = Yul = EVM execution:
 
 ```bash
 FOUNDRY_PROFILE=difftest forge test                                          # run all

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 70000,
-    "foundry_functions": 396,
+    "foundry_functions": 397,
     "property_functions": 197,
     "suites": 35
   },

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -561,7 +561,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 396/375 tests pass
+# Expected: 397/375 tests pass
 ```
 
 ### Add New Contract
@@ -602,7 +602,7 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 396/375 passing (100%)
+**Foundry Tests**: 397/375 passing (100%)
 ```bash
 $ FOUNDRY_PROFILE=difftest forge test
 Ran 35 test suites: 375 tests passed, 0 failed, 0 skipped (375 total tests)

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 396 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 397 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (396 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (397 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:
@@ -188,7 +188,7 @@ def ownedSpec : ContractSpec := {
 ```bash
 lake build verity-compiler    # Build compiler
 lake exe verity-compiler      # Generate all contracts
-FOUNDRY_PROFILE=difftest forge test  # 396/375 tests pass (as of 2026-02-18)
+FOUNDRY_PROFILE=difftest forge test  # 397/375 tests pass (as of 2026-02-18)
 ```
 
 ### Differential Testing (Completed 2026-02-10)
@@ -225,7 +225,7 @@ FOUNDRY_PROFILE=difftest forge test  # 396/375 tests pass (as of 2026-02-18)
 - 10,000+ random transactions pass per contract in CI (large suite)
 - Large suite is sharded across 8 CI jobs to stay within per-test gas limits
 - Zero mismatches detected
-- All Foundry tests passing (396 as of 2026-02-18)
+- All Foundry tests passing (397 as of 2026-02-18)
 - CI: All checks passing
 
 **Usage**:

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -19,7 +19,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 431 across 11 categories (431 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256, address injectivity
-- **Tests**: 396 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
+- **Tests**: 397 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
 


### PR DESCRIPTION
## Summary
- add `ContractSpec` support for indexed event params of type `bytes[]`
- lower `bytes[] indexed` topics using Solidity-compatible in-place encoding:
  - concatenate each element's raw bytes payload padded to 32-byte words
  - hash the concatenated bytes with `keccak256`
- keep existing direct-parameter arg-shape requirements for deterministic lowering

## Tests
- added Lean regression coverage in `Compiler/ContractSpecFeatureTest.lean` for `ParamType.array ParamType.bytes` indexed event lowering
- added runtime parity vector in `test/EventAbiParity.t.sol` for:
  - `event IndexedDynamicBytesArray(bytes[] indexed payload)`
  - includes elements with >32-byte length to validate multiword per-element padding

## Freshness
- refreshed verification/docs count artifacts required by CI freshness checks

Refs #624

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event topic hashing/codegen and ABI-interop logic, where subtle encoding mistakes would break downstream log indexing and parity with Solidity. Scope is limited to indexed `bytes[]` handling with added regression and runtime parity tests.
> 
> **Overview**
> Adds `ContractSpec` support for `bytes[]` when used as an **indexed** event parameter, lowering the topic hash using Solidity-compatible *in-place* encoding (concatenate each element’s raw bytes padded to 32-byte words, then `keccak256`).
> 
> Updates event argument-shape validation to allow `ParamType.array ParamType.bytes` for indexed params while keeping the existing “direct parameter reference” restriction, and extends the Yul emitter to generate the per-element offset/length loop and copy logic needed for hashing.
> 
> Adds Lean feature coverage for the new lowering and a Foundry ABI parity test vector for `IndexedDynamicBytesArray(bytes[] indexed)`, plus bumps test/metrics counts in docs and `artifacts/verification_status.json` for CI freshness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b13b0aa8b5a3ff741f31ec2350848631482719e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->