### PR TITLE
fix(contractspec): block transient storage builtins tload/tstore

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -989,7 +989,7 @@ private def interopBuiltinCallNames : List String :=
    "lt", "gt", "slt", "sgt", "eq", "iszero", "and", "or", "xor", "byte", "shl", "shr", "sar",
    "addmod", "mulmod", "signextend",
    "keccak256", "pop",
-   "mload", "mstore", "mstore8", "sload", "sstore", "msize", "gas", "pc",
+   "mload", "mstore", "mstore8", "sload", "sstore", "tload", "tstore", "msize", "gas", "pc",
    "address", "balance", "selfbalance", "origin", "caller", "callvalue", "gasprice",
    "blockhash", "coinbase", "timestamp", "number", "difficulty", "prevrandao", "gaslimit",
    "chainid", "basefee", "blobbasefee", "blobhash",

--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -796,6 +796,51 @@ private def featureSpec : ContractSpec := {
       throw (IO.userError "✗ expected sstore builtin usage to fail compilation")
 
 #eval! do
+  let tloadBuiltinSpec : ContractSpec := {
+    name := "TloadBuiltinUnsupported"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "probe"
+        params := [{ name := "slot", ty := ParamType.uint256 }]
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.externalCall "tload" [Expr.param "slot"])]
+      }
+    ]
+  }
+  match compile tloadBuiltinSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'tload'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ tload builtin diagnostic mismatch: {err}")
+      IO.println "✓ tload builtin unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected tload builtin usage to fail compilation")
+
+#eval! do
+  let tstoreBuiltinSpec : ContractSpec := {
+    name := "TstoreBuiltinUnsupported"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "probe"
+        params := [
+          { name := "slot", ty := ParamType.uint256 },
+          { name := "value", ty := ParamType.uint256 }
+        ]
+        returnType := none
+        body := [Stmt.letVar "_ignored" (Expr.externalCall "tstore" [Expr.param "slot", Expr.param "value"]), Stmt.stop]
+      }
+    ]
+  }
+  match compile tstoreBuiltinSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'tstore'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ tstore builtin diagnostic mismatch: {err}")
+      IO.println "✓ tstore builtin unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected tstore builtin usage to fail compilation")
+
+#eval! do
   let externalBalanceSpec : ContractSpec := {
     name := "ExternalBalanceUnsupported"
     fields := []
@@ -1018,6 +1063,62 @@ private def featureSpec : ContractSpec := {
       IO.println "✓ external sstore unsupported diagnostic"
   | .ok _ =>
       throw (IO.userError "✗ expected external sstore declaration to fail compilation")
+
+#eval! do
+  let externalTloadSpec : ContractSpec := {
+    name := "ExternalTloadUnsupported"
+    fields := []
+    constructor := none
+    externals := [
+      { name := "tload"
+        params := [ParamType.uint256]
+        returnType := some ParamType.uint256
+        axiomNames := []
+      }
+    ]
+    functions := [
+      { name := "noop"
+        params := []
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile externalTloadSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'tload'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ external tload diagnostic mismatch: {err}")
+      IO.println "✓ external tload unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected external tload declaration to fail compilation")
+
+#eval! do
+  let externalTstoreSpec : ContractSpec := {
+    name := "ExternalTstoreUnsupported"
+    fields := []
+    constructor := none
+    externals := [
+      { name := "tstore"
+        params := [ParamType.uint256, ParamType.uint256]
+        returnType := none
+        axiomNames := []
+      }
+    ]
+    functions := [
+      { name := "noop"
+        params := []
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile externalTstoreSpec [1] with
+  | .error err =>
+      if !(contains err "unsupported interop builtin call 'tstore'" && contains err "Issue #586") then
+        throw (IO.userError s!"✗ external tstore diagnostic mismatch: {err}")
+      IO.println "✓ external tstore unsupported diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected external tstore declaration to fail compilation")
 
 #eval! do
   let unknownCustomErrorSpec : ContractSpec := {


### PR DESCRIPTION
## Summary
Fixes a post-merge Bugbot finding on #653: the interop builtin denylist blocked `sload`/`sstore` and Cancun blob opcodes, but omitted Cancun transient storage opcodes `tload`/`tstore`.

This patch:
- adds `tload` and `tstore` to `interopBuiltinCallNames`
- adds regression tests for both unsupported paths:
  - direct `Expr.externalCall` usage
  - external declaration names

Refs #622

## Why
Transient storage builtins create the same unsafe raw-opcode escape hatch as `sload`/`sstore`. They should be blocked consistently by the interop validation layer.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `lake build`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens compiler validation in the Solidity interop profile, which may newly reject specs that previously compiled when using `tload`/`tstore`. The change is small and well-covered by targeted regression tests.
> 
> **Overview**
> The interop validation denylist is updated to treat Cancun transient storage opcodes `tload` and `tstore` as unsupported builtins, matching the existing restrictions for other raw opcode escape hatches.
> 
> `ContractSpecFeatureTest` adds regression cases asserting compilation fails (with the Issue #586 diagnostic) for both direct `Expr.externalCall` usage and `externals` declarations named `tload`/`tstore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22699b75d88f00e679f1f77ac859b5d01ed1b3ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->