### PR TITLE
ContractSpec: support indexed dynamic arrays with dynamic elements

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -1807,7 +1807,7 @@ private def featureSpec : ContractSpec := {
 
 #eval! do
   let indexedDynamicCompositeArrayEventSpec : ContractSpec := {
-    name := "IndexedDynamicCompositeArrayEventUnsupported"
+    name := "IndexedDynamicCompositeArrayEventSupported"
     fields := []
     constructor := none
     events := [
@@ -1827,14 +1827,16 @@ private def featureSpec : ContractSpec := {
   }
   match compile indexedDynamicCompositeArrayEventSpec [1] with
   | .error err =>
-      if !(contains err "indexed array param 'payload' has unsupported element type" &&
-          contains err "ParamType.tuple" &&
-          contains err "ParamType.bytes" &&
-          contains err "Issue #586") then
-        throw (IO.userError s!"✗ indexed dynamic composite array event diagnostic mismatch: {err}")
-      IO.println "✓ indexed dynamic composite array event diagnostic"
-  | .ok _ =>
-      throw (IO.userError "✗ expected indexed dynamic composite array event param usage to fail compilation")
+      throw (IO.userError s!"✗ expected indexed dynamic composite array event support to compile, got: {err}")
+  | .ok ir =>
+      let rendered := Yul.render (emitYul ir)
+      assertContains "indexed dynamic composite array event topic hashing" rendered
+        ["let __evt_arg0_indexed_arr_len := calldataload(add(4, payload_offset))",
+         "let __evt_arg0_indexed_arr_elem_rel := calldataload(add(__evt_arg0_indexed_arr_data, mul(__evt_arg0_indexed_arr_i, 32)))",
+         "let __evt_arg0_indexed_arr_elem_tuple_elem_rel_1 := calldataload(add(__evt_arg0_indexed_arr_elem_src, 32))",
+         "calldatacopy(__evt_arg0_indexed_arr_elem_tuple_elem_dst_1, add(__evt_arg0_indexed_arr_elem_tuple_elem_src_1, 32), __evt_arg0_indexed_arr_elem_tuple_elem_1_len)",
+         "let __evt_topic1 := keccak256(__evt_ptr, __evt_arg0_indexed_arr_out_len)",
+         "log2(__evt_ptr, 0, __evt_topic0, __evt_topic1)"]
 
 #eval! do
   let internalVoidReturnSpec : ContractSpec := {

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-431 theorems across 11 categories, all fully proven. 399 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+431 theorems across 11 categories, all fully proven. 400 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
@@ -174,7 +174,7 @@ FOUNDRY_PROFILE=difftest forge test
 <details>
 <summary><strong>Testing</strong></summary>
 
-**Foundry tests** (399 tests) validate EDSL = Yul = EVM execution:
+**Foundry tests** (400 tests) validate EDSL = Yul = EVM execution:
 
 ```bash
 FOUNDRY_PROFILE=difftest forge test                                          # run all

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 70000,
-    "foundry_functions": 399,
+    "foundry_functions": 400,
     "property_functions": 197,
     "suites": 35
   },

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -561,7 +561,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 399/375 tests pass
+# Expected: 400/375 tests pass
 ```
 
 ### Add New Contract
@@ -602,7 +602,7 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 399/375 passing (100%)
+**Foundry Tests**: 400/375 passing (100%)
 ```bash
 $ FOUNDRY_PROFILE=difftest forge test
 Ran 35 test suites: 375 tests passed, 0 failed, 0 skipped (375 total tests)

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 399 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 400 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (399 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (400 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:
@@ -188,7 +188,7 @@ def ownedSpec : ContractSpec := {
 ```bash
 lake build verity-compiler    # Build compiler
 lake exe verity-compiler      # Generate all contracts
-FOUNDRY_PROFILE=difftest forge test  # 399/375 tests pass (as of 2026-02-18)
+FOUNDRY_PROFILE=difftest forge test  # 400/375 tests pass (as of 2026-02-18)
 ```
 
 ### Differential Testing (Completed 2026-02-10)
@@ -225,7 +225,7 @@ FOUNDRY_PROFILE=difftest forge test  # 399/375 tests pass (as of 2026-02-18)
 - 10,000+ random transactions pass per contract in CI (large suite)
 - Large suite is sharded across 8 CI jobs to stay within per-test gas limits
 - Zero mismatches detected
-- All Foundry tests passing (399 as of 2026-02-18)
+- All Foundry tests passing (400 as of 2026-02-18)
 - CI: All checks passing
 
 **Usage**:

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -19,7 +19,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 431 across 11 categories (431 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256, address injectivity
-- **Tests**: 399 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
+- **Tests**: 400 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
 


### PR DESCRIPTION
Refs #624

## Summary
- enable indexed dynamic-array event params whose element type is dynamic composite (e.g. `(uint256,bytes)[] indexed`)
- route indexed topic hashing for these arrays through recursive in-place ABI preimage encoding
- keep direct-parameter arg-shape validation and existing fail-fast behavior for non-direct expressions

## Changes
- `Compiler/ContractSpec.lean`
  - relax indexed array arg-shape validation to accept dynamic element arrays (still direct parameter references only)
  - add indexed array codegen path for dynamic element types via `compileIndexedInPlaceEncoding` over the full array payload
- `Compiler/ContractSpecFeatureTest.lean`
  - convert indexed dynamic composite-array case from unsupported diagnostic to positive codegen regression
- `test/EventAbiParity.t.sol`
  - add runtime parity test for `IndexedDynamicDynamicTupleArray((uint256,bytes)[] indexed)`
  - add helper for expected in-place preimage generation
- refresh verification/doc freshness artifacts

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `lake build`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event topic hashing codegen for a new class of ABI types; incorrect encoding would silently break log/topic interoperability even though the surface change is localized and covered by new regression/parity tests.
> 
> **Overview**
> Adds support in `Compiler/ContractSpec.lean` for `indexed` dynamic-array event params whose element types are *dynamic* (e.g. tuples containing `bytes`), generating the topic hash by recursively in-place ABI-encoding the full array payload before `keccak256`.
> 
> Updates `ContractSpecFeatureTest.lean` to turn the previously-failing “indexed dynamic composite array” case into a positive regression that asserts the expected Yul topic-hashing sequence, and extends `test/EventAbiParity.t.sol` with a new parity event/test for `IndexedDynamicDynamicTupleArray((uint256,bytes)[] indexed)`.
> 
> Refreshes docs/metrics artifacts to reflect the new Foundry test count (399 → 400).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ca88e2fbd56520a73a99b586845fdda96044e06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->