### PR TITLE
fix(ci): cache Foundry binaries and harden download fallback

### DIFF
--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -20,7 +20,15 @@ runs:
       shell: bash
       run: chmod +x .lake/build/bin/difftest-interpreter
 
+    - name: Cache Foundry binaries
+      id: cache-foundry
+      uses: actions/cache@v4
+      with:
+        path: ~/.foundry/bin
+        key: foundry-v1.5.0-linux-amd64
+
     - name: Install Foundry
+      if: steps.cache-foundry.outputs.cache-hit != 'true'
       id: install_foundry_primary
       continue-on-error: true
       uses: foundry-rs/foundry-toolchain@v1
@@ -28,28 +36,42 @@ runs:
         version: v1.5.0
 
     - name: Install Foundry fallback (retry on transient download errors)
-      if: steps.install_foundry_primary.outcome != 'success'
+      if: steps.cache-foundry.outputs.cache-hit != 'true' && steps.install_foundry_primary.outcome != 'success'
       shell: bash
       run: |
         set -euo pipefail
 
-        curl -fsSL https://foundry.paradigm.xyz | bash
         FOUNDRY_BIN="$HOME/.foundry/bin"
-        export PATH="${FOUNDRY_BIN}:$PATH"
-        echo "${FOUNDRY_BIN}" >> "$GITHUB_PATH"
+        mkdir -p "$FOUNDRY_BIN"
+        RELEASE_TAG="v1.5.0"
+        TARBALL_URL="https://github.com/foundry-rs/foundry/releases/download/${RELEASE_TAG}/foundry_${RELEASE_TAG}_linux_amd64.tar.gz"
 
         max_attempts=3
         attempt=1
-        until "${FOUNDRY_BIN}/foundryup" --install 1.5.0; do
+        while true; do
+          echo "Attempt ${attempt}: downloading Foundry ${RELEASE_TAG} from GitHub Releases..."
+          tmp_dir="$(mktemp -d)"
+          if curl -fsSL --retry 3 --retry-delay 5 "$TARBALL_URL" -o "${tmp_dir}/foundry.tar.gz" && \
+             tar -tf "${tmp_dir}/foundry.tar.gz" > /dev/null 2>&1; then
+            tar -xzf "${tmp_dir}/foundry.tar.gz" -C "$FOUNDRY_BIN"
+            rm -rf "$tmp_dir"
+            echo "Foundry ${RELEASE_TAG} installed successfully"
+            break
+          fi
+          rm -rf "$tmp_dir"
           if [ "$attempt" -ge "$max_attempts" ]; then
-            echo "foundryup failed after ${max_attempts} attempts"
+            echo "::error::Foundry download failed after ${max_attempts} attempts"
             exit 1
           fi
-          sleep_seconds=$((attempt * 5))
-          echo "foundryup attempt ${attempt} failed, retrying in ${sleep_seconds}s"
+          sleep_seconds=$((attempt * 10))
+          echo "::warning::Foundry download attempt ${attempt} failed, retrying in ${sleep_seconds}s"
           sleep "$sleep_seconds"
           attempt=$((attempt + 1))
         done
+
+    - name: Add Foundry to PATH
+      shell: bash
+      run: echo "$HOME/.foundry/bin" >> "$GITHUB_PATH"
 
     - name: Verify Foundry tools
       shell: bash


### PR DESCRIPTION
## Summary
- **Cache Foundry binaries** (`~/.foundry/bin/`) with `actions/cache@v4` keyed by version, so ~17 parallel foundry jobs skip the download entirely after the first successful run
- **Replace the `foundryup`-based fallback** with a direct GitHub Releases tarball download using `curl --retry`, with tarball integrity validation (`tar -tf`) before extraction
- **Clean up temp directories** between retry attempts to prevent reusing corrupted downloads

## Problem
The Foundry installation step fails intermittently due to GitHub CDN issues:
- `curl: (3) URL rejected: Malformed input to a URL function` — foundryup receives an HTML error page instead of the attestation JSON, then tries to use the HTML content as a URL
- `gzip: stdin: not in gzip format` — corrupted/truncated tarball downloads

With 17+ parallel foundry jobs hitting GitHub Releases simultaneously, rate limiting amplifies the issue. The last 2 pushes to `main` both failed CI due to this (runs [22254044440](https://github.com/Th0rgal/verity/actions/runs/22254044440), [22253814161](https://github.com/Th0rgal/verity/actions/runs/22253814161)).

## Test plan
- [ ] CI passes on this PR (the workflow itself exercises the new caching/fallback logic)
- [ ] Verify cache hit on re-run: check that "Cache Foundry binaries" shows `cache-hit: true` on repeated runs
- [ ] Verify fallback works: if `foundry-rs/foundry-toolchain@v1` fails, the direct download with retries should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes that affect tool installation/caching; main risk is breaking Foundry availability in workflows if the cache key/path or tarball URL is wrong.
> 
> **Overview**
> Adds CI caching for Foundry (`~/.foundry/bin`) keyed to `v1.5.0` so repeated/parallel jobs can skip reinstalling.
> 
> Hardens the install fallback path by replacing `foundryup` with a direct GitHub Releases tarball download that retries, validates the archive before extraction, cleans up temp dirs between attempts, and always appends Foundry’s bin directory to `GITHUB_PATH`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9f49783d5e79b988ee63384e024f8daf4183230. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->