### PR TITLE
feat: unindexed dynamic arrays with dynamic element types

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a step-by-step guide and [`docs-site/content/guides/linking-libraries.mdx`](docs-site/content/guides/linking-libraries.mdx) for the full documentation.
 
-431 theorems across 11 categories, all fully proven. 402 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+431 theorems across 11 categories, all fully proven. 403 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axioms. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
@@ -174,7 +174,7 @@ FOUNDRY_PROFILE=difftest forge test
 <details>
 <summary><strong>Testing</strong></summary>
 
-**Foundry tests** (402 tests) validate EDSL = Yul = EVM execution:
+**Foundry tests** (403 tests) validate EDSL = Yul = EVM execution:
 
 ```bash
 FOUNDRY_PROFILE=difftest forge test                                          # run all

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,7 +10,7 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 70000,
-    "foundry_functions": 402,
+    "foundry_functions": 403,
     "property_functions": 197,
     "suites": 35
   },

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -561,7 +561,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 402/375 tests pass
+# Expected: 403/375 tests pass
 ```
 
 ### Add New Contract
@@ -602,7 +602,7 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 402/375 passing (100%)
+**Foundry Tests**: 403/375 passing (100%)
 ```bash
 $ FOUNDRY_PROFILE=difftest forge test
 Ran 35 test suites: 375 tests passed, 0 failed, 0 skipped (375 total tests)

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 402 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 403 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -174,7 +174,7 @@ def ownedSpec : ContractSpec := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (402 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (403 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:
@@ -188,7 +188,7 @@ def ownedSpec : ContractSpec := {
 ```bash
 lake build verity-compiler    # Build compiler
 lake exe verity-compiler      # Generate all contracts
-FOUNDRY_PROFILE=difftest forge test  # 402/375 tests pass (as of 2026-02-18)
+FOUNDRY_PROFILE=difftest forge test  # 403/375 tests pass (as of 2026-02-18)
 ```
 
 ### Differential Testing (Completed 2026-02-10)
@@ -225,7 +225,7 @@ FOUNDRY_PROFILE=difftest forge test  # 402/375 tests pass (as of 2026-02-18)
 - 10,000+ random transactions pass per contract in CI (large suite)
 - Large suite is sharded across 8 CI jobs to stay within per-test gas limits
 - Zero mismatches detected
-- All Foundry tests passing (402 as of 2026-02-18)
+- All Foundry tests passing (403 as of 2026-02-18)
 - CI: All checks passing
 
 **Usage**:

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -19,7 +19,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 431 across 11 categories (431 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256, address injectivity
-- **Tests**: 402 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
+- **Tests**: 403 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
 

--- a/test/EventAbiParity.t.sol
+++ b/test/EventAbiParity.t.sol
@@ -47,6 +47,7 @@ contract EventAbiParityEmitter {
     event UnindexedStaticFixedArray(uint256[2] payload);
     event UnindexedDynamicTuple(DynamicTupleParity payload);
     event UnindexedDynamicFixedArray(DynamicTupleParity[2] payload);
+    event UnindexedDynamicDynamicTupleArray(DynamicTupleParity[] payload);
 
     function emitCreateMarket(bytes32 id, MarketParamsParity calldata market) external {
         emit CreateMarket(id, market);
@@ -151,6 +152,10 @@ contract EventAbiParityEmitter {
 
     function emitUnindexedDynamicFixedArray(DynamicTupleParity[2] calldata payload) external {
         emit UnindexedDynamicFixedArray(payload);
+    }
+
+    function emitUnindexedDynamicDynamicTupleArray(DynamicTupleParity[] calldata payload) external {
+        emit UnindexedDynamicDynamicTupleArray(payload);
     }
 }
 
@@ -702,6 +707,25 @@ contract EventAbiParityTest is Test {
         assertEq(logs[0].topics.length, 1);
 
         bytes32 expectedTopic0 = keccak256(bytes("UnindexedDynamicFixedArray((uint256,bytes)[2])"));
+        bytes memory expectedData = abi.encode(payload);
+
+        assertEq(logs[0].topics[0], expectedTopic0);
+        assertEq(logs[0].data, expectedData);
+    }
+
+    function testUnindexedDynamicDynamicTupleArrayDataUsesAbiEncoding() public {
+        DynamicTupleParity[] memory payload = new DynamicTupleParity[](2);
+        payload[0] = DynamicTupleParity({amount: 10, payload: hex"aa"});
+        payload[1] = DynamicTupleParity({amount: 20, payload: hex"bbcc"});
+
+        vm.recordLogs();
+        emitter.emitUnindexedDynamicDynamicTupleArray(payload);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        assertEq(logs[0].topics.length, 1);
+
+        bytes32 expectedTopic0 = keccak256(bytes("UnindexedDynamicDynamicTupleArray((uint256,bytes)[])"));
         bytes memory expectedData = abi.encode(payload);
 
         assertEq(logs[0].topics[0], expectedTopic0);


### PR DESCRIPTION
## Summary

Closes the last remaining gap for **issue #624** (event ABI parity): unindexed dynamic arrays whose elements are themselves dynamic types (e.g. `(uint256, bytes)[]`).

This builds on PR #660 which added support for unindexed dynamic composite types (tuples/fixedArrays with dynamic members). The missing piece was dynamic-length arrays of such types.

### Changes

- **`compileUnindexedAbiEncode`**: Replace the `ParamType.array` error with full recursive encoding. Dynamic element arrays use offset-based head/tail layout with a Yul `for` loop; static element arrays use inline encoding
- **`validateEventArgShapesInStmt`**: Accept dynamic element arrays (with direct parameter reference requirement)
- **`compileUnindexedStores`**: Route dynamic element arrays through `compileUnindexedAbiEncode`, matching the pattern used for dynamic tuple/fixedArray
- **Lean test**: Convert negative compilation test (`(uint256, bytes)[]` expected to fail) into positive test asserting correct Yul output
- **Solidity test**: Add `UnindexedDynamicDynamicTupleArray` event + runtime parity test verifying log data matches `abi.encode`
- **Doc counts**: 402 → 403 Foundry tests

### ABI encoding layout for `T[]` where `T` is dynamic

```
[length]                          ← 32 bytes
[offset_0][offset_1]...[offset_n] ← n × 32 bytes (relative to elements area start)
[encoded_element_0]               ← variable length
[encoded_element_1]               ← variable length
...
```

Each element is recursively ABI-encoded via `compileUnindexedAbiEncode`.

## Test plan

- [ ] Lean builds with zero warnings
- [ ] All 22 CI jobs pass (including the new Foundry parity test)
- [ ] Doc count check passes (`check_doc_counts.py`)
- [ ] Verification status artifact is current

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core event ABI encoding/validation logic and adds recursive/loop-based Yul generation; mistakes could cause subtle log data mismatches, but changes are covered by new Lean and Foundry parity tests.
> 
> **Overview**
> Adds Solidity-compatible ABI encoding for **unindexed dynamic arrays whose elements are themselves dynamic** (e.g. `(uint256,bytes)[]`) when emitting events.
> 
> This extends `compileUnindexedAbiEncode` to recursively encode `ParamType.array` using head/tail offset layout for dynamic elements (and inline encoding for static elements), updates event argument validation and unindexed event store compilation to accept and route these arrays through the new encoder, and converts the prior “unsupported” Lean feature test into a positive Yul-output assertion.
> 
> Updates parity coverage by adding a new Solidity event + Foundry test that asserts emitted log data equals `abi.encode(payload)`, and bumps reported Foundry test counts (402→403) in docs/artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7c57932114baff0e5ea9f88f45a1d269ba56359. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->