### PR TITLE
refactor: consolidate duplicated filters, unify type helpers, sync builtin lists

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -80,6 +80,8 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 | `partial def` in compiler | ~25 functions recurse on `ParamType` (finite depth); termination proofs would add complexity without security value |
 | `allowUnsafeReducibility` | One use in `Semantics.lean:247` for `execYulFuel`; fuel-bounded, provably terminating. See TRUST_ASSUMPTIONS.md §7 |
 | Raw text linker injection | Libraries are inherently outside the proof boundary; semantic validation would require a Yul verifier |
+| Shared `isInteropEntrypointName` | Single definition filters fallback/receive consistently across Selector, ABI, and ContractSpec.compile |
+| Shared `isDynamicParamType`/`paramHeadSize` | Single definitions used by both event encoding and calldata parameter loading; eliminates divergence risk |
 
 ## Known risks
 

--- a/Compiler/ABI.lean
+++ b/Compiler/ABI.lean
@@ -38,8 +38,7 @@ private def fieldTypeToOutputType : FieldType → ParamType
   | .address => .address
   | .mappingTyped _ => .uint256
 
-private def isSpecialEntrypoint (name : String) : Bool :=
-  name == "fallback" || name == "receive"
+-- Uses `isInteropEntrypointName` from ContractSpec for consistent filtering.
 
 private def functionOutputs (fn : FunctionSpec) : List ParamType :=
   if !fn.returns.isEmpty then
@@ -133,8 +132,8 @@ def emitContractABIJson (spec : ContractSpec) : String :=
     match spec.constructor with
     | some ctor => [renderConstructorEntry ctor]
     | none => []
-  let functionEntries := spec.functions.filter (fun fn => !fn.isInternal && !isSpecialEntrypoint fn.name) |>.map renderFunctionEntry
-  let specialEntries := (spec.functions.filter (fun fn => !fn.isInternal && isSpecialEntrypoint fn.name)).filterMap renderSpecialEntry
+  let functionEntries := spec.functions.filter (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name) |>.map renderFunctionEntry
+  let specialEntries := (spec.functions.filter (fun fn => !fn.isInternal && isInteropEntrypointName fn.name)).filterMap renderSpecialEntry
   let eventEntries := spec.events.map renderEventEntry
   let errorEntries := spec.errors.map renderErrorEntry
   let entries := ctorEntries ++ functionEntries ++ eventEntries ++ errorEntries ++ specialEntries

--- a/Compiler/Linker.lean
+++ b/Compiler/Linker.lean
@@ -179,7 +179,10 @@ def renderWithLibraries (obj : YulObject) (libraries : List LibraryFunction) : E
 ## Validation
 -/
 
--- EVM/Yul built-in opcodes (not user-defined functions)
+-- EVM/Yul built-in opcodes (not user-defined functions).
+-- This list must include all opcodes that linked libraries may call,
+-- otherwise `validateExternalReferences` will reject valid library code.
+-- Keep in sync with `interopBuiltinCallNames` in ContractSpec.lean.
 private def yulBuiltins : List String :=
   ["add", "sub", "mul", "div", "sdiv", "mod", "smod", "exp",
    "not", "lt", "gt", "slt", "sgt", "eq", "iszero", "and", "or", "xor",
@@ -189,9 +192,9 @@ private def yulBuiltins : List String :=
    "calldataload", "calldatasize", "calldatacopy", "codesize", "codecopy",
    "gasprice", "extcodesize", "extcodecopy", "returndatasize", "returndatacopy",
    "extcodehash", "blockhash", "coinbase", "timestamp", "number", "difficulty",
-   "prevrandao", "gaslimit", "chainid", "basefee",
-   "pop", "mload", "mstore", "mstore8", "sload", "sstore",
-   "msize", "gas",
+   "prevrandao", "gaslimit", "chainid", "basefee", "blobbasefee", "blobhash",
+   "pop", "mload", "mstore", "mstore8", "sload", "sstore", "tload", "tstore",
+   "mcopy", "msize", "gas", "pc",
    "log0", "log1", "log2", "log3", "log4",
    "create", "create2", "call", "callcode", "delegatecall", "staticcall",
    "return", "revert", "selfdestruct", "invalid", "stop",

--- a/Compiler/Selector.lean
+++ b/Compiler/Selector.lean
@@ -33,11 +33,11 @@ private def runKeccak (sigs : List String) : IO (List Nat) := do
 
 /-- Compute Solidity-compatible selectors for external functions in a spec.
     Internal functions and special entrypoints (fallback/receive) are excluded
-    since they are not dispatched via selector. This filter must match the one
-    in `ContractSpec.compile` to avoid a selector count mismatch. -/
+    since they are not dispatched via selector. Uses `isInteropEntrypointName`
+    so this filter stays in sync with `ContractSpec.compile`. -/
 def computeSelectors (spec : ContractSpec) : IO (List Nat) := do
   let externalFns := spec.functions.filter (fun fn =>
-    !fn.isInternal && !["fallback", "receive"].contains fn.name)
+    !fn.isInternal && !isInteropEntrypointName fn.name)
   let sigs := externalFns.map functionSignature
   runKeccak sigs
 


### PR DESCRIPTION
## Summary

Three audit-hardening improvements that eliminate code duplication and divergence risks across the compiler:

- **Consolidate `isInteropEntrypointName`**: Made the definition in `ContractSpec.lean` public and replaced the independent copies in `Selector.lean` (inline string list) and `ABI.lean` (`isSpecialEntrypoint`) with calls to it. All three sites now share a single source of truth for the fallback/receive filter.

- **Unify `isDynamicParamType`/`eventIsDynamicType` and `paramHeadSize`/`eventHeadWordSize`**: These pairs were structurally identical but defined ~1600 lines apart. Moved the canonical definitions (`isDynamicParamType`, `paramHeadSize`) to the top of the file alongside event encoding, then replaced the duplicates with `private def` aliases. Eliminates the risk of a `ParamType` constructor being added to one but not the other.

- **Sync Linker `yulBuiltins` with ContractSpec `interopBuiltinCallNames`**: Added 6 missing EVM opcodes (`tload`, `tstore`, `blobbasefee`, `blobhash`, `mcopy`, `pc`) that were in the ContractSpec denylist but absent from the Linker's built-in list. Without this fix, linked libraries using these opcodes would be incorrectly rejected by `validateExternalReferences`.

Net: -5 lines. No behavioral changes for existing code paths.

## Test plan

- [ ] Lean builds with zero warnings
- [ ] All Foundry CI jobs pass
- [ ] `check_doc_counts.py` passes
- [ ] `check_yul_builtin_boundary.py` passes
- [ ] `check_lean_hygiene.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly consolidation/DRY changes with small allowlist expansion in the linker; risk is limited to potential mismatches in filtering or built-in validation if a helper’s semantics changed.
> 
> **Overview**
> Refactors the compiler to **use shared helpers instead of duplicated logic**: `ABI.emitContractABIJson` and `Selector.computeSelectors` now call the public `ContractSpec.isInteropEntrypointName` for consistent fallback/receive filtering.
> 
> Unifies ABI sizing/dynamic-type helpers by moving canonical `isDynamicParamType` and `paramHeadSize` to a single definition used for both event encoding and calldata loading (keeping legacy event names as aliases), and updates the linker’s `yulBuiltins` allowlist to include additional opcodes (`tload`, `tstore`, `blobbasefee`, `blobhash`, `mcopy`, `pc`) so valid linked libraries aren’t rejected. Documentation in `AUDIT.md` is updated to record these consolidation decisions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2849079a6574fdcade34fa506290403d4f44f064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->