### PR TITLE
audit: add builtin list sync CI, close constructor validation gap

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Check Yul builtin abstraction boundary
         run: python3 scripts/check_yul_builtin_boundary.py
 
+      - name: Check builtin list sync (Linker ↔ ContractSpec)
+        run: python3 scripts/check_builtin_list_sync.py
+
       - name: Check EVMYulLean capability boundary
         run: python3 scripts/check_evmyullean_capability_boundary.py
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -34,7 +34,7 @@ All three layers are fully verified in Lean 4. Zero `sorry` placeholders. One ax
 
 ### Where external input enters
 
-1. **Contract specifications** (`Compiler/Specs.lean`): All specs are Lean source — no runtime input parsing. The `compile` function validates specs exhaustively (7+ validators) before emitting code.
+1. **Contract specifications** (`Compiler/Specs.lean`): All specs are Lean source — no runtime input parsing. The `compile` function validates specs exhaustively (7+ validators for functions, 5 for constructors) before emitting code.
 
 2. **Calldata**: Generated decoder reads ABI-encoded calldata. `calldatasizeGuard` enforces minimum size for fixed params. Dynamic param bounds rely on EVM semantics (out-of-bounds calldataload returns zero), matching solc behavior.
 
@@ -120,3 +120,4 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 - `check_axiom_locations.py`: All axioms documented in AXIOMS.md
 - `check_storage_layout.py`: Storage layout validation
 - `check_solc_pin.py`: solc version pinned
+- `check_builtin_list_sync.py`: Linker/ContractSpec opcode list sync

--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -2464,6 +2464,12 @@ def compile (spec : ContractSpec) (selectors : List Nat) : Except String IRContr
     validateInternalCallShapesInFunction spec.functions fn
   validateConstructorSpec spec.constructor
   validateInteropConstructorSpec spec.constructor
+  match spec.constructor with
+  | none => pure ()
+  | some ctor => do
+      ctor.body.forM (validateEventArgShapesInStmt "constructor" ctor.params spec.events)
+      ctor.body.forM (validateCustomErrorArgShapesInStmt "constructor" ctor.params spec.errors)
+      ctor.body.forM (validateInternalCallShapesInStmt spec.functions "constructor")
   for ext in spec.externals do
     let _ ← externalFunctionReturns ext
     validateInteropExternalSpec ext

--- a/scripts/check_builtin_list_sync.py
+++ b/scripts/check_builtin_list_sync.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Ensure Linker.yulBuiltins and ContractSpec.interopBuiltinCallNames stay in sync.
+
+Both lists enumerate EVM/Yul opcodes. yulBuiltins is the Linker allowlist for
+linked library validation; interopBuiltinCallNames is the ContractSpec denylist
+for user-function body validation. They must agree on the opcode universe, with
+known exceptions documented below.
+
+Expected differences:
+  - yulBuiltins includes low-level call opcodes (call, staticcall, delegatecall,
+    callcode) that ContractSpec tracks separately in `isLowLevelCallName`.
+  - yulBuiltins includes Yul-object builtins (datasize, dataoffset, datacopy)
+    that are not EVM opcodes and not relevant to interop validation.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LINKER = ROOT / "Compiler" / "Linker.lean"
+CONTRACT_SPEC = ROOT / "Compiler" / "ContractSpec.lean"
+
+# Items in yulBuiltins but intentionally absent from interopBuiltinCallNames
+# AND isLowLevelCallName. These are Yul-object builtins, not EVM opcodes.
+EXPECTED_LINKER_ONLY = {
+    "datasize", "dataoffset", "datacopy",
+}
+
+
+def extract_string_list(text: str, name: str) -> set[str]:
+    """Extract a Lean string list definition by name."""
+    # Match: (private )?(def|abbrev) <name> ... := \n  [...]
+    pattern = rf'(?:private\s+)?def\s+{re.escape(name)}\b[^:]*:\s*List\s+String\s*:=\s*\n((?:\s*\[.*?\](?:\s*\+\+\s*\[.*?\])*)+)'
+    # Simpler: just find all quoted strings after the definition start
+    # First find the definition
+    def_pattern = rf'(?:private\s+)?def\s+{re.escape(name)}\b'
+    m = re.search(def_pattern, text)
+    if not m:
+        print(f"  Could not find definition of '{name}'", file=sys.stderr)
+        return set()
+
+    # From the definition start, collect all quoted strings until next definition or end
+    rest = text[m.start():]
+    # Find end: next `private def`, `def`, `end`, or blank line after content
+    lines = rest.split('\n')
+    strings: set[str] = set()
+    started = False
+    for line in lines:
+        if '"' in line:
+            started = True
+            strings.update(re.findall(r'"([^"]+)"', line))
+        elif started and line.strip() and not line.strip().startswith('--'):
+            # Non-empty line without strings after we started = end of list
+            break
+    return strings
+
+
+def extract_low_level_calls(text: str) -> set[str]:
+    """Extract the isLowLevelCallName string list (single-line definition)."""
+    m = re.search(r'def\s+isLowLevelCallName[^\n]*\n\s*\[([^\]]+)\]', text)
+    if not m:
+        return set()
+    return set(re.findall(r'"([^"]+)"', m.group(1)))
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    if not LINKER.exists():
+        errors.append(f"Missing: {LINKER.relative_to(ROOT)}")
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+
+    if not CONTRACT_SPEC.exists():
+        errors.append(f"Missing: {CONTRACT_SPEC.relative_to(ROOT)}")
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+
+    linker_text = LINKER.read_text(encoding="utf-8")
+    spec_text = CONTRACT_SPEC.read_text(encoding="utf-8")
+
+    yul_builtins = extract_string_list(linker_text, "yulBuiltins")
+    interop_builtins = extract_string_list(spec_text, "interopBuiltinCallNames")
+    low_level_calls = extract_low_level_calls(spec_text)
+
+    if not yul_builtins:
+        errors.append("Failed to extract yulBuiltins from Linker.lean")
+    if not interop_builtins:
+        errors.append("Failed to extract interopBuiltinCallNames from ContractSpec.lean")
+
+    if errors:
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    # ContractSpec's full opcode set = interopBuiltinCallNames ∪ isLowLevelCallName
+    spec_full = interop_builtins | low_level_calls
+
+    # yulBuiltins without the expected Linker-only entries should equal spec_full
+    linker_comparable = yul_builtins - EXPECTED_LINKER_ONLY
+
+    in_linker_not_spec = linker_comparable - spec_full
+    in_spec_not_linker = spec_full - linker_comparable
+
+    if in_linker_not_spec:
+        sorted_names = sorted(in_linker_not_spec)
+        errors.append(
+            f"In Linker.yulBuiltins but not in ContractSpec "
+            f"(interopBuiltinCallNames ∪ isLowLevelCallName): {sorted_names}"
+        )
+    if in_spec_not_linker:
+        sorted_names = sorted(in_spec_not_linker)
+        errors.append(
+            f"In ContractSpec (interopBuiltinCallNames ∪ isLowLevelCallName) "
+            f"but not in Linker.yulBuiltins: {sorted_names}"
+        )
+
+    if errors:
+        print("Builtin list sync check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(
+            "\nKeep Linker.yulBuiltins and ContractSpec.interopBuiltinCallNames "
+            "in sync. See scripts/check_builtin_list_sync.py for expected differences.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✓ Builtin lists in sync ({len(yul_builtins)} Linker, "
+          f"{len(interop_builtins)}+{len(low_level_calls)} ContractSpec)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **New CI script `check_builtin_list_sync.py`**: Extracts opcode lists from both `Linker.yulBuiltins` and `ContractSpec.interopBuiltinCallNames` (plus `isLowLevelCallName`), then asserts they agree — with documented exceptions for Yul-object builtins (`datasize`/`dataoffset`/`datacopy`). Catches opcode drift that PR #663's manual sync could miss in the future.

- **Constructor validation parity**: Previously, `compile` ran 7+ validators on function bodies but only 2 on constructors (param references + interop checks). Constructors that emit events, revert with custom errors, or call internal functions now get the same `validateEventArgShapesInStmt`, `validateCustomErrorArgShapesInStmt`, and `validateInternalCallShapesInStmt` checks that functions receive.

- **AUDIT.md updates**: Reflects constructor validation coverage ("5 for constructors"), adds `check_builtin_list_sync.py` to the CI validation suite list.

## Test plan

- [ ] `python3 scripts/check_builtin_list_sync.py` passes (85 Linker, 78+4 ContractSpec)
- [ ] All existing CI checks pass (no regressions in Lean build or Foundry tests)
- [ ] Verify: removing an opcode from either list causes the new script to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it tightens constructor-body validation and may cause previously-compiling contracts to fail compilation; the added CI/doc changes are low risk.
> 
> **Overview**
> Adds a new CI check `scripts/check_builtin_list_sync.py` (wired into `verify.yml`) to assert `Linker.yulBuiltins` stays in sync with `ContractSpec.interopBuiltinCallNames` plus `isLowLevelCallName`, allowing documented exceptions for Yul-object builtins.
> 
> Closes a validation gap in `Compiler/ContractSpec.lean` by running event arg-shape, custom error arg-shape, and internal-call shape validators over constructor bodies (when present), and updates `AUDIT.md` to reflect the expanded constructor validation and the new CI script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f3ccf06d25035607140f8c4dbfb6df8d2682bd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->