### PR TITLE
audit: dedup fieldType helper, fix selector script filtering, correct logicalAnd/Or docs

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -82,6 +82,8 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 | Raw text linker injection | Libraries are inherently outside the proof boundary; semantic validation would require a Yul verifier |
 | Shared `isInteropEntrypointName` | Single definition filters fallback/receive consistently across Selector, ABI, and ContractSpec.compile |
 | Shared `isDynamicParamType`/`paramHeadSize` | Single definitions used by both event encoding and calldata parameter loading; eliminates divergence risk |
+| Shared `fieldTypeToParamType` | ABI.lean reuses ContractSpec's canonical definition instead of maintaining a private copy; eliminates FieldType→ParamType divergence |
+| Non-short-circuit `logicalAnd`/`logicalOr` | Compiled to EVM bitwise `and`/`or` — both operands always evaluated. Simpler codegen; no side-effecting expressions in current DSL |
 
 ## Known risks
 
@@ -89,6 +91,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 2. **Linked library correctness**: No semantic validation. Mitigation: name/arity checks, explicit trust boundary documentation.
 3. **No gas bounds**: Unbounded loops could exhaust gas. Mitigation: gas calibration tests, manual review.
 4. **Wrapping overflow**: No automatic overflow protection. Mitigation: explicit `require` guards per contract.
+5. **Non-short-circuit logic ops**: `Expr.logicalAnd`/`logicalOr` always evaluate both operands. Safe today (no side-effecting sub-expressions), but must be revisited if low-level calls (#622) are added to `Expr`.
 
 ## External dependencies
 

--- a/Compiler/ABI.lean
+++ b/Compiler/ABI.lean
@@ -33,11 +33,7 @@ private partial def abiTypeString : ParamType → String
   | .array t => abiTypeString t ++ "[]"
   | .fixedArray t n => abiTypeString t ++ "[" ++ toString n ++ "]"
 
-private def fieldTypeToOutputType : FieldType → ParamType
-  | .uint256 => .uint256
-  | .address => .address
-  | .mappingTyped _ => .uint256
-
+-- Uses `fieldTypeToParamType` from ContractSpec (shared, not duplicated).
 -- Uses `isInteropEntrypointName` from ContractSpec for consistent filtering.
 
 private def functionOutputs (fn : FunctionSpec) : List ParamType :=
@@ -45,7 +41,7 @@ private def functionOutputs (fn : FunctionSpec) : List ParamType :=
     fn.returns
   else
     match fn.returnType with
-    | some ty => [fieldTypeToOutputType ty]
+    | some ty => [fieldTypeToParamType ty]
     | none => []
 
 mutual

--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -193,8 +193,8 @@ inductive Expr
   | gt (a b : Expr)  -- Greater than (strict)
   | lt (a b : Expr)
   | le (a b : Expr)  -- Less than or equal
-  | logicalAnd (a b : Expr)  -- Short-circuit logical AND
-  | logicalOr (a b : Expr)   -- Short-circuit logical OR
+  | logicalAnd (a b : Expr)  -- Logical AND (both operands always evaluated)
+  | logicalOr (a b : Expr)   -- Logical OR  (both operands always evaluated)
   | logicalNot (a : Expr)    -- Logical NOT
   deriving Repr
 


### PR DESCRIPTION
## Summary

- **Deduplicate `fieldTypeToOutputType`**: ABI.lean had a private copy of `fieldTypeToParamType` (identical logic: `FieldType → ParamType`). Removed the duplicate; ABI.lean now reuses the public definition from ContractSpec. This eliminates a drift risk — if a new `FieldType` variant is added, only one function needs updating.

- **Fix `check_selectors.py` filtering**: The CI selector validation script extracted ALL functions from spec blocks, including internal functions (`isInternal := true`) and special entrypoints (`fallback`/`receive`). This doesn't match the Lean compiler's filtering (`Selector.computeSelectors` and `ContractSpec.compile` both skip these). Currently latent (no existing specs use internal functions or fallback/receive), but would cause CI false-positives as soon as these features are used in specs.

- **Correct misleading `logicalAnd`/`logicalOr` comments**: The `Expr` constructor comments claimed "Short-circuit logical AND/OR" but the implementation compiles to EVM bitwise `and`/`or` which always evaluate both operands. Fixed the comments to say "both operands always evaluated" and documented this as Known Risk #5 in AUDIT.md (safe today — no side-effecting sub-expressions in the DSL — but must be revisited when low-level calls from #622 are added to `Expr`).

## Test plan

- [ ] `python3 scripts/check_selectors.py` passes
- [ ] Lean build succeeds (ABI.lean uses `fieldTypeToParamType` from ContractSpec)
- [ ] All existing CI checks pass (no regressions)
- [ ] AUDIT.md reflects new design decisions and known risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly deduplication and CI/script filtering plus comment/doc clarifications; no runtime semantics change beyond making selector checks reflect existing compiler behavior.
> 
> **Overview**
> Removes ABI’s private `FieldType → ParamType` mapping and reuses `ContractSpec.fieldTypeToParamType` to avoid drift in return-type rendering.
> 
> Fixes `scripts/check_selectors.py` to skip `isInternal := true` functions and special `fallback`/`receive` entrypoints so CI selector validation matches compiler/selector filtering.
> 
> Updates documentation: clarifies `Expr.logicalAnd`/`logicalOr` are *non-short-circuit* (both operands evaluated) and records this as a known risk/design decision in `AUDIT.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb122177f8cd352c2e4a95d9e4e173b61a0915c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->