### PR TITLE
audit: deduplicate runKeccak, fix ASTDriver bool normalization

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -84,6 +84,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 | Shared `isDynamicParamType`/`paramHeadSize` | Single definitions used by both event encoding and calldata parameter loading; eliminates divergence risk |
 | Shared `fieldTypeToParamType` | ABI.lean reuses ContractSpec's canonical definition instead of maintaining a private copy; eliminates FieldType→ParamType divergence |
 | Non-short-circuit `logicalAnd`/`logicalOr` | Compiled to EVM bitwise `and`/`or` — both operands always evaluated. Simpler codegen; no side-effecting expressions in current DSL |
+| Shared `Selector.runKeccak` | Single keccak subprocess helper shared between ContractSpec and AST compilation paths; eliminates duplicated subprocess handling |
 
 ## Known risks
 

--- a/Compiler/Selector.lean
+++ b/Compiler/Selector.lean
@@ -16,7 +16,7 @@ private def parseSelectorLine (line : String) : Option Nat :=
   let trimmed := line.trim
   parseHexNat? trimmed
 
-private def runKeccak (sigs : List String) : IO (List Nat) := do
+def runKeccak (sigs : List String) : IO (List Nat) := do
   if sigs.isEmpty then
     return []
   let args := #["scripts/keccak256.py"] ++ sigs.toArray


### PR DESCRIPTION
## Summary

- **Deduplicate `runKeccak`**: `ASTDriver.lean` had a private copy of `Selector.runKeccak` (identical 15-line keccak subprocess handler). Made `Selector.runKeccak` public; ASTDriver now imports and reuses it. Eliminates drift risk between the two compilation paths.

- **Fix missing `bool` normalization in ASTDriver constructor loading**: `genConstructorArgLoads` handled `address` (160-bit mask) but used a raw `mload` catch-all for all other types, including `bool`. Added `iszero(iszero(...))` clamping for `ParamType.bool` to match ContractSpec's `genScalarLoad`. Currently latent (no AST specs use bool constructor params), but prevents silent data corruption if one is added.

- **Document ASTDriver selector filtering gap**: Added forward-looking comment noting that `ASTFunctionSpec` doesn't model `isInternal` or fallback/receive, so `computeSelectors` treats all functions as external. If these semantics are added to the AST path, filtering must be added to match `Selector.computeSelectors`.

## Test plan

- [ ] Lean build passes (ASTDriver correctly imports `Selector.runKeccak`)
- [ ] All Foundry tests pass (AST-compiled contracts produce identical bytecode)
- [ ] All CI check scripts pass
- [ ] `python3 scripts/check_selectors.py` passes
- [ ] `python3 scripts/check_builtin_list_sync.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to selector computation plumbing and constructor arg decoding; primary risk is behavioral change only for AST constructors with `bool` params and relies on the existing external `keccak256.py` script.
> 
> **Overview**
> Deduplicates selector hashing by making `Compiler.Selector.runKeccak` public and reusing it from `ASTDriver.computeSelectors`, removing the ASTDriver-local keccak subprocess implementation and documenting the AST path’s lack of internal/fallback/receive filtering.
> 
> Fixes AST constructor argument loading by normalizing `ParamType.bool` via `iszero(iszero(mload))` (and minor refactor to reuse the loaded word), preventing non-canonical boolean values from being passed into AST-compiled constructors. Updates `AUDIT.md` to record the shared `Selector.runKeccak` design decision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 442562bd58f8f17369114a9b2e157c268877fb93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->