### PR TITLE
audit: consolidate ABI special entry, add AST selector validation

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -94,7 +94,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 | `partial def` in compiler | ~25 functions recurse on `ParamType` (finite depth); termination proofs would add complexity without security value |
 | `allowUnsafeReducibility` | One use in `Semantics.lean:247` for `execYulFuel`; fuel-bounded, provably terminating. See TRUST_ASSUMPTIONS.md §7 |
 | Raw text linker injection | Libraries are inherently outside the proof boundary; semantic validation would require a Yul verifier |
-| Shared `isInteropEntrypointName` | Single definition filters fallback/receive consistently across Selector, ABI, and ContractSpec.compile |
+| Shared `isInteropEntrypointName` | Single definition filters fallback/receive consistently across Selector, ABI (`renderSpecialEntry` uses it as guard + derives ABI type from `fn.name`), and ContractSpec.compile |
 | Shared `isDynamicParamType`/`paramHeadSize` | Single definitions used by both event encoding and calldata parameter loading; eliminates divergence risk |
 | Shared `fieldTypeToParamType` | ABI.lean reuses ContractSpec's canonical definition instead of maintaining a private copy; eliminates FieldType→ParamType divergence |
 | Non-short-circuit `logicalAnd`/`logicalOr` | Compiled to EVM bitwise `and`/`or` — both operands always evaluated. Simpler codegen; no side-effecting expressions in current DSL |
@@ -133,7 +133,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 30+ scripts enforce consistency between proofs, tests, and documentation. Key checks:
 
 - `check_yul_compiles.py`: All generated Yul compiles with solc; legacy/AST bytecode diff baseline
-- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation
+- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence)
 - `check_doc_counts.py`: Theorem/test counts consistent across all docs
 - `check_lean_warning_regression.py`: Zero-warning policy
 - `check_axiom_locations.py`: All axioms documented in AXIOMS.md

--- a/Compiler/ABI.lean
+++ b/Compiler/ABI.lean
@@ -107,21 +107,18 @@ private def renderConstructorEntry (ctor : ConstructorSpec) : String :=
     s!"\"stateMutability\": {jsonString stateMutability}"
   ] ++ "}"
 
+/-- Render an ABI entry for a special entrypoint (fallback/receive).
+    Uses `isInteropEntrypointName` so this stays in sync with selector filtering.
+    The caller (`emitContractABIJson`) already filters to `isInteropEntrypointName`
+    entries, so this always returns `some` for valid input. -/
 private def renderSpecialEntry (fn : FunctionSpec) : Option String :=
-  if fn.isInternal then
+  if !isInteropEntrypointName fn.name then
     none
-  else if fn.name == "fallback" then
-    some ("{" ++ joinJsonFields [
-      "\"type\": \"fallback\"",
-      s!"\"stateMutability\": {jsonString (if fn.isPayable then "payable" else "nonpayable")}"
-    ] ++ "}")
-  else if fn.name == "receive" then
-    some ("{" ++ joinJsonFields [
-      "\"type\": \"receive\"",
-      s!"\"stateMutability\": {jsonString (if fn.isPayable then "payable" else "nonpayable")}"
-    ] ++ "}")
   else
-    none
+    some ("{" ++ joinJsonFields [
+      s!"\"type\": {jsonString fn.name}",
+      s!"\"stateMutability\": {jsonString (if fn.isPayable then "payable" else "nonpayable")}"
+    ] ++ "}")
 
 def emitContractABIJson (spec : ContractSpec) : String :=
   let ctorEntries :=


### PR DESCRIPTION
## Summary

- **ABI.lean `renderSpecialEntry`**: Replaced hardcoded `"fallback"`/`"receive"` string comparisons with `isInteropEntrypointName` guard. Derives the ABI type from `fn.name` directly, eliminating code duplication between fallback/receive branches and the silent-miss risk if `isInteropEntrypointName` is extended.
- **check_selectors.py**: Now extracts ASTSpecs separately from ContractSpec and validates `yul-ast/` output against AST-derived signatures. Adds a cross-check that shared contracts have identical function signatures in both spec sets, preventing silent divergence.
- **AUDIT.md**: Updated design decision table and CI validation suite description.

### Why

The ABI renderer used inline strings that could drift from `isInteropEntrypointName`. The selector CI script validated `yul-ast/` files against ContractSpec specs, which happened to work because both spec sets define the same 7 contracts — but would silently break if they diverged.

## Test plan

- [x] `python3 scripts/check_selectors.py` passes (exercises both ContractSpec and AST extraction + cross-check)
- [x] `python3 scripts/check_selector_fixtures.py` passes
- [x] `python3 scripts/check_builtin_list_sync.py` passes
- [ ] CI `lake build` (ABI.lean change is a safe refactor: replaces inline strings with already-imported `isInteropEntrypointName`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to ABI JSON emission for special entrypoints and CI validation scripts, with no impact on on-chain semantics beyond how ABI metadata is rendered.
> 
> **Overview**
> Refactors ABI JSON generation for special entrypoints so `fallback`/`receive` rendering is gated by `isInteropEntrypointName` and the ABI `type` is derived directly from `fn.name`, reducing drift/duplication.
> 
> Expands `scripts/check_selectors.py` to parse `Compiler/ASTSpecs.lean` and validate `compiler/yul-ast` selector case labels against AST-derived signatures (with fallback to ContractSpec), plus a cross-check that contracts shared between the two spec sets have identical signatures. Updates `AUDIT.md` to document the shared guard and the strengthened selector CI checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6815218c6d3559bcef6ee9dbaaa6b0c69a42b18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->