### PR TITLE
audit: extract internalFunctionPrefix, add reserved-name CI check

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -99,6 +99,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 | Shared `fieldTypeToParamType` | ABI.lean reuses ContractSpec's canonical definition instead of maintaining a private copy; eliminates FieldType→ParamType divergence |
 | Non-short-circuit `logicalAnd`/`logicalOr` | Compiled to EVM bitwise `and`/`or` — both operands always evaluated. Simpler codegen; no side-effecting expressions in current DSL |
 | Shared `Selector.runKeccak` | Single keccak subprocess helper shared between ContractSpec and AST compilation paths; eliminates duplicated subprocess handling |
+| Shared `internalFunctionPrefix` | `"internal_"` prefix for generated Yul internal function names defined once; CI validates no user function name collides with this prefix |
 
 ## Known risks
 
@@ -133,7 +134,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 30+ scripts enforce consistency between proofs, tests, and documentation. Key checks:
 
 - `check_yul_compiles.py`: All generated Yul compiles with solc; legacy/AST bytecode diff baseline
-- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence)
+- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check)
 - `check_doc_counts.py`: Theorem/test counts consistent across all docs
 - `check_lean_warning_regression.py`: Zero-warning policy
 - `check_axiom_locations.py`: All axioms documented in AXIOMS.md


### PR DESCRIPTION
## Summary

- **ContractSpec.lean**: Extracted shared `internalFunctionPrefix` constant (`"internal_"`) and `internalFunctionYulName` helper, replacing 4 scattered `s!"internal_{…}"` string interpolations that could diverge silently.
- **check_selectors.py**: Added `check_reserved_prefix_collisions` validation — ensures no user function name starts with `internal_`, which would collide with compiler-generated internal function names in the Yul namespace.
- **AUDIT.md**: Documented the shared prefix constant and CI collision check.

### Why

Internal functions are compiled to Yul with a `internal_` prefix (e.g. `internal_pair`). This prefix was hardcoded as a string literal in 4 separate locations in ContractSpec.lean. If any of them drifted, generated Yul would have broken call references. There was also no CI validation preventing users from naming a function `internal_foo`, which would create a Yul namespace collision with a generated internal function.

## Test plan

- [x] `python3 scripts/check_selectors.py` passes (exercises new reserved prefix check + all existing checks)
- [x] `python3 scripts/check_selector_fixtures.py` passes
- [x] `python3 scripts/check_builtin_list_sync.py` passes
- [ ] CI `lake build` (Lean change is a pure refactor: 4 identical `s!"internal_{name}"` → `internalFunctionYulName name`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a refactor of internal-function name construction plus a new CI validation; runtime output should be unchanged except for earlier detection of reserved-name collisions.
> 
> **Overview**
> Centralizes generation of Yul internal function names in `ContractSpec.lean` via a shared `internalFunctionPrefix` and `internalFunctionYulName`, replacing scattered `"internal_{...}"` string interpolation at internal call sites and internal function definition emission.
> 
> Extends `scripts/check_selectors.py` to collect all function names from both `Specs.lean` and `ASTSpecs.lean` and fail CI if any function name starts with the reserved `internal_` prefix, preventing Yul namespace collisions. Updates `AUDIT.md` to document the shared prefix and the new CI check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83c2dfbe1772e79cf147782d720b589654f838e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->