### PR TITLE
audit: extract errorStringSelectorWord constant, add CI sync check

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -100,6 +100,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 | Non-short-circuit `logicalAnd`/`logicalOr` | Compiled to EVM bitwise `and`/`or` — both operands always evaluated. Simpler codegen; no side-effecting expressions in current DSL |
 | Shared `Selector.runKeccak` | Single keccak subprocess helper shared between ContractSpec and AST compilation paths; eliminates duplicated subprocess handling |
 | Shared `internalFunctionPrefix` | `"internal_"` prefix for generated Yul internal function names defined once; CI validates no user function name collides with this prefix |
+| Shared `errorStringSelectorWord` | `Error(string)` selector (`0x08c379a0 << 224`) defined once in ContractSpec; reused in revert codegen and proof terms. Interpreter keeps a private copy (decimal) to avoid importing ContractSpec; CI validates both values match |
 
 ## Known risks
 
@@ -134,7 +135,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 30+ scripts enforce consistency between proofs, tests, and documentation. Key checks:
 
 - `check_yul_compiles.py`: All generated Yul compiles with solc; legacy/AST bytecode diff baseline
-- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check)
+- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check; Error(string) selector constant sync)
 - `check_doc_counts.py`: Theorem/test counts consistent across all docs
 - `check_lean_warning_regression.py`: Zero-warning policy
 - `check_axiom_locations.py`: All axioms documented in AXIOMS.md

--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -436,13 +436,17 @@ def wordFromBytes (bs : List UInt8) : Nat :=
   let padded := bs ++ List.replicate (32 - bs.length) (0 : UInt8)
   padded.foldl (fun acc b => acc * 256 + b.toNat) 0
 
+/-- The 4-byte selector for `Error(string)` (keccak256("Error(string)")[0:4]),
+    left-shifted to fill a 32-byte EVM word.  This is 0x08c379a0 << 224.
+    Used in `revertWithMessage` (compiler) and concrete IR proofs. -/
+def errorStringSelectorWord : Nat := 0x08c379a0 * (2 ^ 224)
+
 def revertWithMessage (message : String) : List YulStmt :=
   let bytes := bytesFromString message
   let len := bytes.length
   let paddedLen := ((len + 31) / 32) * 32
-  let selectorShifted : Nat := 0x08c379a0 * (2 ^ 224)
   let header := [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex selectorShifted]),
+    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len])
   ]

--- a/Compiler/Interpreter.lean
+++ b/Compiler/Interpreter.lean
@@ -77,6 +77,8 @@ def extractMappingChanges (before after : ContractState) (keys : List (Nat × Ad
     if oldVal ≠ newVal then some (slot, key, newVal) else none
 
 -- EVM revert data for Error(string) uses selector 0x08c379a0 in the first 32 bytes.
+-- Canonical definition: Compiler.ContractSpec.errorStringSelectorWord
+-- Duplicated here to avoid importing ContractSpec into the interpreter.
 private def revertSelectorWord : Nat :=
   3963877391197344453575983046348115674221700746820753546331534351508065746944
 

--- a/Compiler/Proofs/IRGeneration/Expr.lean
+++ b/Compiler/Proofs/IRGeneration/Expr.lean
@@ -272,7 +272,7 @@ def safeCounterOverflowRevert : List YulStmt :=
   [
     YulStmt.expr (YulExpr.call "mstore" [
       YulExpr.lit 0,
-      YulExpr.hex 0x08c379a000000000000000000000000000000000000000000000000000000000
+      YulExpr.hex errorStringSelectorWord
     ]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 21]),
@@ -287,7 +287,7 @@ def safeCounterUnderflowRevert : List YulStmt :=
   [
     YulStmt.expr (YulExpr.call "mstore" [
       YulExpr.lit 0,
-      YulExpr.hex 0x08c379a000000000000000000000000000000000000000000000000000000000
+      YulExpr.hex errorStringSelectorWord
     ]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 22]),
@@ -302,7 +302,7 @@ def insufficientBalanceRevert : List YulStmt :=
   [
     YulStmt.expr (YulExpr.call "mstore" [
       YulExpr.lit 0,
-      YulExpr.hex 0x08c379a000000000000000000000000000000000000000000000000000000000
+      YulExpr.hex errorStringSelectorWord
     ]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 20]),
@@ -529,7 +529,7 @@ def ownedNotOwnerRevert : List YulStmt :=
   [
     YulStmt.expr (YulExpr.call "mstore" [
       YulExpr.lit 0,
-      YulExpr.hex 0x08c379a000000000000000000000000000000000000000000000000000000000
+      YulExpr.hex errorStringSelectorWord
     ]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
     YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit 9]),


### PR DESCRIPTION
## Summary
- Extract `errorStringSelectorWord` (`0x08c379a0 << 224`) as a public constant in `ContractSpec.lean`, replacing 5 inline magic hex literals across compiler and proof files
- `Interpreter.lean` keeps a private decimal copy (avoiding ContractSpec import); CI now validates both values stay in sync
- New check #7 in `check_selectors.py`: `check_error_selector_sync()` validates the constant in both ContractSpec and Interpreter

## What changed

| File | Change |
|------|--------|
| `Compiler/ContractSpec.lean` | New public `errorStringSelectorWord`; `revertWithMessage` uses it |
| `Compiler/Proofs/IRGeneration/Expr.lean` | 4 concrete IR revert defs use the constant instead of inline hex |
| `Compiler/Interpreter.lean` | Added comments linking private copy to canonical constant |
| `scripts/check_selectors.py` | New `check_error_selector_sync()` validates constant consistency |
| `AUDIT.md` | Documented design decision and CI check |

## Test plan
- [x] `check_selectors.py` passes locally (includes new sync check)
- [x] `check_doc_counts.py` passes locally
- [ ] Full CI (Lean build + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly constant deduplication plus an additional CI consistency check; behavior should remain identical aside from preventing accidental selector drift.
> 
> **Overview**
> Extracts a shared `errorStringSelectorWord` constant for the `Error(string)` ABI selector (shifted into a 32-byte word) and replaces multiple inline magic literals in `ContractSpec.revertWithMessage` and concrete IR proof revert snippets.
> 
> Keeps the interpreter’s private copy but documents it as a duplicate of the canonical value, and extends `scripts/check_selectors.py` to CI-validate that the `ContractSpec` and `Interpreter` constants remain in sync; `AUDIT.md` is updated to record this design decision and the new check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0fef29900c0e6d0b8868ff273b206df0c1da3d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->