### PR TITLE
audit: extract addressMask constant, fix silent fallback, correct docstring

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -101,6 +101,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 | Shared `Selector.runKeccak` | Single keccak subprocess helper shared between ContractSpec and AST compilation paths; eliminates duplicated subprocess handling |
 | Shared `internalFunctionPrefix` | `"internal_"` prefix for generated Yul internal function names defined once; CI validates no user function name collides with this prefix |
 | Shared `errorStringSelectorWord` | `Error(string)` selector (`0x08c379a0 << 224`) defined once in ContractSpec; reused in revert codegen and proof terms. Interpreter keeps a private copy (decimal) to avoid importing ContractSpec; CI validates both values match |
+| Shared `addressMask` | 160-bit address mask `(2^160)-1` defined once in ContractSpec; used across codegen (ContractSpec, ASTDriver) and proof terms (Expr.lean). Interpreter keeps private `addressModulus` (`2^160`); CI validates both |
 
 ## Known risks
 
@@ -135,7 +136,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 30+ scripts enforce consistency between proofs, tests, and documentation. Key checks:
 
 - `check_yul_compiles.py`: All generated Yul compiles with solc; legacy/AST bytecode diff baseline
-- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check; Error(string) selector constant sync)
+- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check; Error(string) selector constant sync; address mask constant sync)
 - `check_doc_counts.py`: Theorem/test counts consistent across all docs
 - `check_lean_warning_regression.py`: Zero-warning policy
 - `check_axiom_locations.py`: All axioms documented in AXIOMS.md

--- a/Compiler/ABI.lean
+++ b/Compiler/ABI.lean
@@ -109,8 +109,8 @@ private def renderConstructorEntry (ctor : ConstructorSpec) : String :=
 
 /-- Render an ABI entry for a special entrypoint (fallback/receive).
     Uses `isInteropEntrypointName` so this stays in sync with selector filtering.
-    The caller (`emitContractABIJson`) already filters to `isInteropEntrypointName`
-    entries, so this always returns `some` for valid input. -/
+    Returns `some` for special entrypoints, `none` otherwise (defensive guard
+    even though the caller pre-filters via `isInteropEntrypointName`). -/
 private def renderSpecialEntry (fn : FunctionSpec) : Option String :=
   if !isInteropEntrypointName fn.name then
     none

--- a/Compiler/ASTDriver.lean
+++ b/Compiler/ASTDriver.lean
@@ -26,7 +26,7 @@ open Compiler
 open Compiler.Yul
 open Compiler.ASTSpecs
 open Compiler.ASTCompile (compileStmt)
-open Compiler.ContractSpec (ParamType Param genParamLoads paramTypeToSolidityString)
+open Compiler.ContractSpec (ParamType Param genParamLoads paramTypeToSolidityString addressMask)
 open Compiler.Linker
 open Compiler.Hex
 open Compiler.Selector (runKeccak)
@@ -78,7 +78,7 @@ private def genConstructorArgLoads (params : List Param) : List YulStmt :=
       match param.ty with
       | ParamType.address =>
         [YulStmt.let_ param.name (YulExpr.call "and" [
-          load, YulExpr.hex ((2^160) - 1)
+          load, YulExpr.hex addressMask
         ])]
       | ParamType.bool =>
         [YulStmt.let_ param.name (YulExpr.call "iszero" [

--- a/Compiler/Interpreter.lean
+++ b/Compiler/Interpreter.lean
@@ -86,6 +86,8 @@ private def revertReturnValue (msg : String) : Nat :=
   if msg.isEmpty then 0 else revertSelectorWord
 
 -- Helper: 160-bit address modulus (EVM address size)
+-- Canonical mask: Compiler.ContractSpec.addressMask ((2^160) - 1)
+-- Duplicated here as modulus (2^160) to avoid importing ContractSpec.
 private def addressModulus : Nat :=
   2 ^ 160
 

--- a/Compiler/Proofs/IRGeneration/Expr.lean
+++ b/Compiler/Proofs/IRGeneration/Expr.lean
@@ -547,7 +547,7 @@ def ownedIRContract : IRContract :=
       YulStmt.expr (YulExpr.call "codecopy" [YulExpr.lit 0, YulExpr.ident "argsOffset", YulExpr.lit 32]),
       YulStmt.let_ "arg0" (YulExpr.call "and" [
         YulExpr.call "mload" [YulExpr.lit 0],
-        YulExpr.hex ((2^160) - 1)
+        YulExpr.hex addressMask
       ]),
       YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "arg0"])
     ]
@@ -559,7 +559,7 @@ def ownedIRContract : IRContract :=
         body := [
           YulStmt.let_ "newOwner" (YulExpr.call "and" [
             YulExpr.call "calldataload" [YulExpr.lit 4],
-            YulExpr.hex ((2^160) - 1)
+            YulExpr.hex addressMask
           ]),
           YulStmt.if_
             (YulExpr.call "iszero" [
@@ -656,7 +656,7 @@ def ownedCounterIRContract : IRContract :=
       YulStmt.expr (YulExpr.call "codecopy" [YulExpr.lit 0, YulExpr.ident "argsOffset", YulExpr.lit 32]),
       YulStmt.let_ "arg0" (YulExpr.call "and" [
         YulExpr.call "mload" [YulExpr.lit 0],
-        YulExpr.hex ((2^160) - 1)
+        YulExpr.hex addressMask
       ]),
       YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "arg0"])
     ]
@@ -720,7 +720,7 @@ def ownedCounterIRContract : IRContract :=
         body := [
           YulStmt.let_ "newOwner" (YulExpr.call "and" [
             YulExpr.call "calldataload" [YulExpr.lit 4],
-            YulExpr.hex ((2^160) - 1)
+            YulExpr.hex addressMask
           ]),
           YulStmt.if_
             (YulExpr.call "iszero" [
@@ -953,7 +953,7 @@ def ledgerIRContract : IRContract :=
         body := [
           YulStmt.let_ "to" (YulExpr.call "and" [
             YulExpr.call "calldataload" [YulExpr.lit 4],
-            YulExpr.hex ((2^160) - 1)
+            YulExpr.hex addressMask
           ]),
           YulStmt.let_ "amount" (YulExpr.call "calldataload" [YulExpr.lit 36]),
           YulStmt.let_ "senderBal" (YulExpr.call "sload" [
@@ -983,7 +983,7 @@ def ledgerIRContract : IRContract :=
         body := [
           YulStmt.let_ "addr" (YulExpr.call "and" [
             YulExpr.call "calldataload" [YulExpr.lit 4],
-            YulExpr.hex ((2^160) - 1)
+            YulExpr.hex addressMask
           ]),
           YulStmt.expr (YulExpr.call "mstore" [
             YulExpr.lit 0,
@@ -1149,7 +1149,7 @@ def simpleTokenIRContract : IRContract :=
       YulStmt.expr (YulExpr.call "codecopy" [YulExpr.lit 0, YulExpr.ident "argsOffset", YulExpr.lit 32]),
       YulStmt.let_ "arg0" (YulExpr.call "and" [
         YulExpr.call "mload" [YulExpr.lit 0],
-        YulExpr.hex ((2^160) - 1)
+        YulExpr.hex addressMask
       ]),
       YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "arg0"]),
       YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 2, YulExpr.lit 0])
@@ -1162,7 +1162,7 @@ def simpleTokenIRContract : IRContract :=
         body := [
           YulStmt.let_ "to" (YulExpr.call "and" [
             YulExpr.call "calldataload" [YulExpr.lit 4],
-            YulExpr.hex ((2^160) - 1)
+            YulExpr.hex addressMask
           ]),
           YulStmt.let_ "amount" (YulExpr.call "calldataload" [YulExpr.lit 36]),
           YulStmt.if_
@@ -1192,7 +1192,7 @@ def simpleTokenIRContract : IRContract :=
         body := [
           YulStmt.let_ "to" (YulExpr.call "and" [
             YulExpr.call "calldataload" [YulExpr.lit 4],
-            YulExpr.hex ((2^160) - 1)
+            YulExpr.hex addressMask
           ]),
           YulStmt.let_ "amount" (YulExpr.call "calldataload" [YulExpr.lit 36]),
           YulStmt.let_ "senderBal" (YulExpr.call "sload" [
@@ -1222,7 +1222,7 @@ def simpleTokenIRContract : IRContract :=
         body := [
           YulStmt.let_ "addr" (YulExpr.call "and" [
             YulExpr.call "calldataload" [YulExpr.lit 4],
-            YulExpr.hex ((2^160) - 1)
+            YulExpr.hex addressMask
           ]),
           YulStmt.expr (YulExpr.call "mstore" [
             YulExpr.lit 0,


### PR DESCRIPTION
## Summary
- Extract `addressMask` (`(2^160)-1`) as a public constant in `ContractSpec.lean`, replacing 15 inline literals across compiler codegen, AST driver, and proof terms
- Add CI check #8 in `check_selectors.py`: `check_address_mask_sync()` validates consistency between `ContractSpec.addressMask` and `Interpreter.addressModulus`
- Fix silent fallback: `check_selectors.py` now emits a stderr warning when yul-ast/ is validated against ContractSpec specs instead of ASTSpecs (was completely silent — audit transparency gap)
- Fix misleading docstring on `ABI.lean:renderSpecialEntry` (claimed "always returns `some`" but code has a defensive `none` branch)

## What changed

| File | Change |
|------|--------|
| `Compiler/ContractSpec.lean` | New public `addressMask`; 4 inline literals replaced |
| `Compiler/ASTDriver.lean` | 1 inline literal replaced; `addressMask` added to open list |
| `Compiler/Proofs/IRGeneration/Expr.lean` | 10 inline literals replaced |
| `Compiler/Interpreter.lean` | Comments linking `addressModulus` to canonical constant |
| `Compiler/ABI.lean` | Docstring corrected (code/doc contradiction) |
| `scripts/check_selectors.py` | New `check_address_mask_sync()`; silent fallback → stderr warning |
| `AUDIT.md` | Documented `addressMask` design decision and CI check |

## Test plan
- [x] `check_selectors.py` passes locally (includes new sync check)
- [x] `check_doc_counts.py` passes locally
- [x] `check_builtin_list_sync.py` passes locally
- [ ] Full CI (Lean build + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily refactors repeated address-masking literals into a shared constant and adds CI/doc updates; behavior should be unchanged aside from clearer CI warnings.
> 
> **Overview**
> Introduces a canonical `addressMask` constant in `ContractSpec.lean` and replaces multiple inline `(2^160)-1` literals across the ContractSpec codegen paths, the AST driver’s constructor arg loading, and IR proof fixtures to keep address normalization consistent.
> 
> Strengthens CI/audit transparency by extending `scripts/check_selectors.py` with an address mask/modulus sync check (ContractSpec vs Interpreter) and emitting a stderr warning when `yul-ast/` validation falls back to ContractSpec specs due to missing/empty `ASTSpecs.lean`. Also fixes a misleading docstring in `ABI.lean` about `renderSpecialEntry` and updates `AUDIT.md` to document the new shared constant and CI coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dec37ba359f688e6fcc3de331516b1ff0468a278. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->