### PR TITLE
audit: extract selectorShift constant, add CI sync check

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -102,6 +102,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 | Shared `internalFunctionPrefix` | `"internal_"` prefix for generated Yul internal function names defined once; CI validates no user function name collides with this prefix |
 | Shared `errorStringSelectorWord` | `Error(string)` selector (`0x08c379a0 << 224`) defined once in ContractSpec; reused in revert codegen and proof terms. Interpreter keeps a private copy (decimal) to avoid importing ContractSpec; CI validates both values match |
 | Shared `addressMask` | 160-bit address mask `(2^160)-1` defined once in ContractSpec; used across codegen (ContractSpec, ASTDriver) and proof terms (Expr.lean). Interpreter keeps private `addressModulus` (`2^160`); CI validates both |
+| Shared `selectorShift` | Selector shift amount (`224` bits) defined in ContractSpec; Codegen and proof Builtins keep private copies to avoid cross-module imports. CI validates all three definitions match |
 
 ## Known risks
 
@@ -136,7 +137,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 30+ scripts enforce consistency between proofs, tests, and documentation. Key checks:
 
 - `check_yul_compiles.py`: All generated Yul compiles with solc; legacy/AST bytecode diff baseline
-- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check; Error(string) selector constant sync; address mask constant sync)
+- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check; Error(string) selector constant sync; address mask constant sync; selector shift constant sync)
 - `check_doc_counts.py`: Theorem/test counts consistent across all docs
 - `check_lean_warning_regression.py`: Zero-warning policy
 - `check_axiom_locations.py`: All axioms documented in AXIOMS.md

--- a/Compiler/Codegen.lean
+++ b/Compiler/Codegen.lean
@@ -76,11 +76,16 @@ private def defaultDispatchCase
           (dispatchBody fb.payable "fallback()" fb.body)
       ]]
 
+-- Selector shift amount (224 = 256 - 32).
+-- Canonical definition: Compiler.ContractSpec.selectorShift
+-- Duplicated here to avoid importing ContractSpec into the lightweight Codegen module.
+private def selectorShift : Nat := 224
+
 def buildSwitch
     (funcs : List IRFunction)
     (fallback : Option IREntrypoint := none)
     (receive : Option IREntrypoint := none) : YulStmt :=
-  let selectorExpr := YulExpr.call "shr" [YulExpr.lit 224, YulExpr.call "calldataload" [YulExpr.lit 0]]
+  let selectorExpr := YulExpr.call "shr" [YulExpr.lit selectorShift, YulExpr.call "calldataload" [YulExpr.lit 0]]
   let cases := funcs.map (fun fn =>
     let body := dispatchBody fn.payable s!"{fn.name}()" ([calldatasizeGuard fn.params.length] ++ fn.body)
     (fn.selector, body)

--- a/Compiler/Proofs/YulGeneration/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/Builtins.lean
@@ -9,6 +9,8 @@ abbrev evmModulus : Nat := Compiler.Proofs.evmModulus
 
 def selectorModulus : Nat := 2 ^ 32
 
+-- Canonical definition: Compiler.ContractSpec.selectorShift
+-- Duplicated here to avoid importing ContractSpec into the proof module.
 def selectorShift : Nat := 224
 
 def selectorWord (selector : Nat) : Nat :=


### PR DESCRIPTION
## Summary
- Extract `selectorShift` (224) as a named constant across ContractSpec, Codegen, and proof Builtins — replaces bare `224` literals in dispatcher codegen and custom error encoding
- New CI check #9 in `check_selectors.py`: `check_selector_shift_sync()` validates all three definitions match
- Completes the constant-extraction audit trail (errorStringSelectorWord #671, addressMask #672, selectorShift this PR)

## What changed

| File | Change |
|------|--------|
| `Compiler/ContractSpec.lean` | New public `selectorShift`; used in `revertWithCustomError` |
| `Compiler/Codegen.lean` | New private `selectorShift`; used in `buildSwitch` |
| `Compiler/Proofs/YulGeneration/Builtins.lean` | Comment linking to canonical definition |
| `scripts/check_selectors.py` | New `check_selector_shift_sync()` validates 3-way consistency |
| `AUDIT.md` | Documented design decision and CI check |

## Test plan
- [x] `check_selectors.py` passes locally (includes new sync check)
- [x] `check_doc_counts.py` passes locally
- [x] `check_builtin_list_sync.py` passes locally
- [ ] Full CI (Lean build + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constant extraction + CI check only; behavior should be unchanged aside from reducing risk of future constant drift in selector/custom-error encoding.
> 
> **Overview**
> Extracts `selectorShift` (=224) into a named constant in `ContractSpec`, and mirrors it in `Codegen` and proof `Builtins`, replacing hard-coded `224` literals in selector extraction and custom error selector packing.
> 
> Extends `scripts/check_selectors.py` with a new CI validation to ensure `selectorShift` stays consistent across those three modules, and updates `AUDIT.md` to document the shared-constant decision and the new check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 416aa90c0ada20c4f9603253f2623643ec86bdfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->