### PR TITLE
audit: add CI sync checks for internalFunctionPrefix and special entrypoints

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -137,7 +137,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 30+ scripts enforce consistency between proofs, tests, and documentation. Key checks:
 
 - `check_yul_compiles.py`: All generated Yul compiles with solc; legacy/AST bytecode diff baseline
-- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check; Error(string) selector constant sync; address mask constant sync; selector shift constant sync)
+- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check; Error(string) selector constant sync; address mask constant sync; selector shift constant sync; internal prefix sync; special entrypoint names sync)
 - `check_doc_counts.py`: Theorem/test counts consistent across all docs
 - `check_lean_warning_regression.py`: Zero-warning policy
 - `check_axiom_locations.py`: All axioms documented in AXIOMS.md


### PR DESCRIPTION
## Summary
- Add CI check #10 `check_internal_prefix_sync()`: validates `_INTERNAL_FUNCTION_PREFIX` in check_selectors.py matches `ContractSpec.internalFunctionPrefix` in Lean
- Add CI check #11 `check_special_entrypoints_sync()`: validates `_SPECIAL_ENTRYPOINTS` matches the list in `ContractSpec.isInteropEntrypointName`
- These close the last gap in the constant sync validation chain — checks #7-9 covered numeric constants, but string constants used in collision detection and entrypoint filtering were only comment-linked

## Why this matters
If someone adds a new special entrypoint to the Lean code (e.g., for a new interop feature) without updating the Python CI script, the collision check would use stale data — silently missing real Yul namespace collisions. Same for the internal function prefix.

## What changed

| File | Change |
|------|--------|
| `scripts/check_selectors.py` | New `check_internal_prefix_sync()` and `check_special_entrypoints_sync()` |
| `AUDIT.md` | Updated CI validation description |

## Test plan
- [x] `check_selectors.py` passes locally (includes both new sync checks)
- [ ] Full CI (Lean build + Foundry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/documentation-only changes that add extra consistency checks; no production compiler logic is modified, with minimal risk aside from potential false negatives if the Lean parsing regex is too strict.
> 
> **Overview**
> Strengthens the selector CI suite by adding two new validations in `scripts/check_selectors.py` that **fail CI if the Python constants diverge from Lean**.
> 
> The script now checks that `_INTERNAL_FUNCTION_PREFIX` matches `ContractSpec.internalFunctionPrefix`, and that `_SPECIAL_ENTRYPOINTS` matches the list used by `ContractSpec.isInteropEntrypointName` (e.g., `fallback`/`receive`). `AUDIT.md` is updated to document these additional CI guarantees.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efdf8db9dae06d3af2a9ff0fc0e66b158b021f10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->