### PR TITLE
audit: add duplicate function name check to ContractSpec.compile

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -47,7 +47,7 @@ All three ContractSpec layers are fully verified in Lean 4. Zero `sorry` placeho
 
 ### Where external input enters
 
-1. **Contract specifications** (`Compiler/Specs.lean`): All specs are Lean source — no runtime input parsing. The `compile` function validates specs exhaustively (7+ validators for functions, 5 for constructors) before emitting code.
+1. **Contract specifications** (`Compiler/Specs.lean`): All specs are Lean source — no runtime input parsing. The `compile` function validates specs exhaustively (7+ validators for functions, 5 for constructors, duplicate function/error name rejection) before emitting code.
 
 2. **Calldata**: Generated decoder reads ABI-encoded calldata. `calldatasizeGuard` enforces minimum size for fixed params. Dynamic param bounds rely on EVM semantics (out-of-bounds calldataload returns zero), matching solc behavior.
 
@@ -137,7 +137,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 30+ scripts enforce consistency between proofs, tests, and documentation. Key checks:
 
 - `check_yul_compiles.py`: All generated Yul compiles with solc; legacy/AST bytecode diff baseline
-- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check; Error(string) selector constant sync; address mask constant sync; selector shift constant sync; internal prefix sync; special entrypoint names sync)
+- `check_selectors.py` / `check_selector_fixtures.py`: Selector cross-validation (both ContractSpec and ASTSpecs; cross-checks signature equivalence; reserved prefix collision check; duplicate function name check; Error(string) selector constant sync; address mask constant sync; selector shift constant sync; internal prefix sync; special entrypoint names sync; compile duplicate-name guard presence)
 - `check_doc_counts.py`: Theorem/test counts consistent across all docs
 - `check_lean_warning_regression.py`: Zero-warning policy
 - `check_axiom_locations.py`: All axioms documented in AXIOMS.md

--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -2496,6 +2496,11 @@ def compile (spec : ContractSpec) (selectors : List Nat) : Except String IRContr
   for ext in spec.externals do
     let _ ← externalFunctionReturns ext
     validateInteropExternalSpec ext
+  match firstDuplicateName (spec.functions.map (·.name)) with
+  | some dup =>
+      throw s!"Compilation error: duplicate function name '{dup}' in {spec.name}"
+  | none =>
+      pure ()
   match firstDuplicateName (spec.errors.map (·.name)) with
   | some dup =>
       throw s!"Compilation error: duplicate custom error declaration '{dup}'"


### PR DESCRIPTION
## Summary

- **Closes validation gap**: `ContractSpec.compile` checked for duplicate selectors (`firstDuplicateSelector`) and duplicate error names (`firstDuplicateName` on `spec.errors`) but **not** duplicate function names — inconsistent with `ASTDriver.validateSpec` which does check
- **Fix**: Added `firstDuplicateName (spec.functions.map (·.name))` guard in `compile`, using the existing private helper
- **CI check #12**: Added `check_unique_function_names()` (per-contract duplicate function name validation for both ContractSpec and ASTSpecs) and `check_compile_duplicate_name_guard()` (structural regex verifying the guard exists in `compile`)

## Changes

| File | What |
|------|------|
| `Compiler/ContractSpec.lean` | Added duplicate function name check in `compile` (5 lines) |
| `scripts/check_selectors.py` | Added `check_unique_function_names`, `check_compile_duplicate_name_guard`, wired into `main()` |
| `AUDIT.md` | Updated trust boundary and CI suite descriptions |

## Test plan

- [ ] `lake build` passes (verified locally)
- [ ] `check_selectors.py` passes all 12 checks (verified locally)
- [ ] `check_doc_counts.py` passes (verified locally)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive validation and CI/documentation updates; main risk is false positives/regex brittleness in the CI guard check rather than runtime behavior.
> 
> **Overview**
> `ContractSpec.compile` now explicitly rejects contracts with duplicate function names (mirroring existing duplicate custom error name checks), closing a validation gap before selector/IR generation.
> 
> CI selector validation is extended to (1) fail if any spec has duplicate function names (for both `Specs.lean` and `ASTSpecs.lean`) and (2) assert via a structural regex that `ContractSpec.compile` still contains the duplicate-name guard. `AUDIT.md` is updated to reflect the new validation and CI coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d0f03eb1b3456485aa125d2896a9ddce6ded069. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->