### PR TITLE
audit: complete duplicate name checks for fields, events, externals

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -103,6 +103,7 @@ EDSL uses **wrapping** `mod 2^256` arithmetic. Solidity uses **checked** arithme
 | Shared `errorStringSelectorWord` | `Error(string)` selector (`0x08c379a0 << 224`) defined once in ContractSpec; reused in revert codegen and proof terms. Interpreter keeps a private copy (decimal) to avoid importing ContractSpec; CI validates both values match |
 | Shared `addressMask` | 160-bit address mask `(2^160)-1` defined once in ContractSpec; used across codegen (ContractSpec, ASTDriver) and proof terms (Expr.lean). Interpreter keeps private `addressModulus` (`2^160`); CI validates both |
 | Shared `selectorShift` | Selector shift amount (`224` bits) defined in ContractSpec; Codegen and proof Builtins keep private copies to avoid cross-module imports. CI validates all three definitions match |
+| Named `freeMemoryPointer` | Solidity free memory pointer address (`0x40`) extracted as named constant; used in custom error emission and event encoding. CI validates the value matches the Solidity convention |
 
 ## Known risks
 


### PR DESCRIPTION
## Summary

**Commit 1: Complete duplicate name checks**
- **Closes validation gap**: `ContractSpec.compile` checked for duplicate function names and error names, but **not** field names, event names, or external declaration names
  - Duplicate fields → silent storage slot shadowing (first match wins via `find?`) → potential fund lock
  - Duplicate events → ABI-misencoded event data → off-chain indexer failures
  - Duplicate externals → wrong function arity used in linked calls
- Added three `firstDuplicateName` guards for `spec.fields`, `spec.events`, `spec.externals`
- Expanded `check_compile_duplicate_name_guard` to verify all 5 collections
- Fixed misleading comment referencing nonexistent `#guard` directives in Specs.lean

**Commit 2: Extract freeMemoryPointer constant**
- The Solidity free memory pointer address (`0x40`) was hardcoded in two codegen locations
- Extracted as named constant `freeMemoryPointer` with docstring explaining the convention
- Added CI check #13 validating the value matches `0x40`

## Changes

| File | What |
|------|------|
| `Compiler/ContractSpec.lean` | +15 lines: 3 duplicate-name guards; +5 lines: `freeMemoryPointer` constant; comment fix |
| `scripts/check_selectors.py` | Expanded structural check to 5 collections; added check #13 for free memory pointer |
| `AUDIT.md` | Updated trust boundary, CI suite descriptions, design decisions table |

## Test plan

- [x] `lake build` passes (verified locally, both commits)
- [x] `check_selectors.py` passes all 13 checks (verified locally)
- [x] `check_doc_counts.py` passes (verified locally)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)