### PR TITLE
docs: sync event ABI parity status and close #624

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -65,7 +65,7 @@ Status legend:
 | 1 | Custom errors + typed revert payloads | partial | partial | n/a | partial | partial |
 | 2 | Low-level calls (`call`/`staticcall`/`delegatecall`) + returndata handling | unsupported | unsupported | n/a | n/a | unsupported |
 | 3 | `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
-| 4 | Full event ABI parity (indexed dynamic + tuple hashing) | partial | partial | partial | partial | partial |
+| 4 | Full event ABI parity (indexed dynamic + tuple hashing) | supported | supported | supported | supported | supported |
 | 5 | Storage layout controls (packed fields + explicit slot mapping) | partial | partial | partial | partial | partial |
 | 6 | ABI JSON artifact generation | partial | partial | n/a | partial | partial |
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -270,7 +270,7 @@ Status legend:
 | Custom errors + typed revert payloads | partial | partial | n/a | partial | partial |
 | Low-level calls (`call` / `staticcall` / `delegatecall`) with returndata | unsupported | unsupported | n/a | n/a | unsupported |
 | `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
-| Event ABI parity for indexed dynamic/tuple payloads | partial | partial | partial | partial | partial |
+| Event ABI parity for indexed dynamic/tuple payloads | supported | supported | supported | supported | supported |
 | Storage layout controls (packing + explicit slots) | partial | partial | partial | partial | partial |
 | ABI JSON artifact generation | partial | partial | n/a | partial | partial |
 
@@ -311,7 +311,7 @@ Current diagnostic coverage in compiler:
 - `fallback` and `receive` are now modeled as first-class entrypoints in dispatch (empty-calldata routing to `receive`, unmatched selector routing to `fallback`) with compile-time shape checks (`receive` must be payable, both must be parameterless and non-returning).
 - Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
-- Indexed `bytes` event params now emit ABI-style hashed topics (`keccak256(payload)`), indexed static tuple/fixed-array params emit ABI-style hashed topics over canonical static in-place encoding, indexed dynamic arrays whose element type is static (including scalar, static tuple, and static fixed-array elements) now hash canonical in-place element words, and indexed dynamic tuple/fixed-array composite params now hash recursive in-place ABI encodings. Indexed dynamic arrays whose element type contains dynamic members still fail with explicit migration guidance.
+- Indexed `bytes` event params emit ABI-style hashed topics (`keccak256(payload)`), indexed static tuple/fixed-array params emit ABI-style hashed topics over canonical static in-place encoding, indexed dynamic arrays (including arrays with dynamic element payloads) hash canonical in-place ABI preimages, and indexed dynamic tuple/fixed-array composite params hash recursive in-place ABI encodings.
 - Event emission now fails fast on `Expr.param` type mismatches against declared event parameter types (including indexed/unindexed bytes arg-shape checks), supports unindexed static and dynamic composite tuple/fixed-array payload encoding from direct parameters with recursive ABI head/tail encoding.
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - Constructor argument decoding now reuses ABI head/tail decoding for constructor params (including tuple/array/bytes forms) and exposes both named param bindings plus `constructorArg` index aliases.


### PR DESCRIPTION
## Summary
- mark Solidity interop matrix row for full event ABI parity as `supported` in `docs/ROADMAP.md`
- mark the matching row as `supported` in `docs/VERIFICATION_STATUS.md`
- update the diagnostics note to remove stale text claiming indexed dynamic arrays with dynamic members are unsupported

This aligns docs with the already-landed implementation slices through PR #661 and keeps issue tracking consistent.

Closes #624.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update status/wording; no runtime, compiler, or proof logic is modified.
> 
> **Overview**
> Updates the Solidity interop status tables in `docs/ROADMAP.md` and `docs/VERIFICATION_STATUS.md` to mark **full event ABI parity (indexed dynamic + tuple hashing)** as `supported` across spec/codegen/proofs/tests.
> 
> Refreshes the verification-status diagnostics note to remove stale wording about unsupported indexed dynamic arrays with dynamic members, aligning the docs with current behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2255f41460ca6ec4b6b1fc4f71a5e42439e02789. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->