### PR TITLE
feat: add explicit ContractSpec field slots with conflict checks

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,6 +69,10 @@ Status legend:
 | 5 | Storage layout controls (packed fields + explicit slot mapping) | partial | partial | partial | partial | partial |
 | 6 | ABI JSON artifact generation | partial | partial | n/a | partial | partial |
 
+Recent progress for storage layout controls (`#623`):
+- `ContractSpec.Field` now supports optional explicit slot assignment (`slot := some <n>`), with backward-compatible positional slots when omitted.
+- Compiler now fails fast on conflicting effective slot assignments with an issue-linked diagnostic.
+
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.
 2. Error text must suggest the nearest currently-supported pattern.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -315,6 +315,7 @@ Current diagnostic coverage in compiler:
 - Event emission now fails fast on `Expr.param` type mismatches against declared event parameter types (including indexed/unindexed bytes arg-shape checks), supports unindexed static and dynamic composite tuple/fixed-array payload encoding from direct parameters with recursive ABI head/tail encoding.
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - Constructor argument decoding now reuses ABI head/tail decoding for constructor params (including tuple/array/bytes forms) and exposes both named param bindings plus `constructorArg` index aliases.
+- Storage fields now support optional explicit slot overrides (`Field.slot := some n`) with compile-time conflict detection against effective slot assignments (Issue #623).
 - `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 


### PR DESCRIPTION
## Summary
This PR lands a focused storage-layout slice for #623 by adding optional explicit field slot assignments in `ContractSpec` with fail-fast conflict diagnostics.

### What changed
- Added optional `slot : Option Nat := none` to `ContractSpec.Field`.
- Updated `findFieldSlot` to resolve effective slot as:
  - explicit slot when provided (`slot := some n`)
  - declaration-order slot fallback when omitted (legacy behavior)
- Added compile-time validation to reject conflicting effective slot assignments across fields, with an issue-linked diagnostic (`Issue #623`).
- Added `ContractSpecFeatureTest` coverage for:
  - explicit-slot lowering for direct storage and mapping writes
  - conflict diagnostic when two fields resolve to the same slot
- Updated interop/status docs to reflect this new partial #623 capability.

## Why
Issue #623 requests first-class storage layout controls in `ContractSpec`. This slice adds the core primitive for per-field explicit slots and safety checks, while preserving backward compatibility for existing specs.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/check_doc_counts.py`
- `lake build`

Progress on #623

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes storage slot resolution and adds new validation that can alter generated `sstore`/mapping slot addresses or fail compilation for specs that previously relied on implicit layout; impact is limited and covered by targeted feature tests.
> 
> **Overview**
> Adds an optional `slot : Option Nat` to `ContractSpec.Field` so specs can pin fields (including mappings) to explicit EVM storage slots while preserving the legacy declaration-order slot fallback.
> 
> Updates slot resolution (`findFieldSlot`) and adds a new compile-time validation that rejects conflicting *effective* slot assignments across fields with an `Issue #623`-linked diagnostic, plus feature tests that assert correct Yul lowering and the new failure mode. Docs (`ROADMAP.md`, `VERIFICATION_STATUS.md`) are updated to reflect this incremental storage-layout control support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d822cb8fc248aebee1bf97c9f8b5ec72ddcab0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->