### PR TITLE
feat: add ContractSpec alias slot mirror writes

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,6 +72,7 @@ Status legend:
 Recent progress for storage layout controls (`#623`):
 - `ContractSpec.Field` now supports optional explicit slot assignment (`slot := some <n>`), with backward-compatible positional slots when omitted.
 - Compiler now fails fast on conflicting effective slot assignments with an issue-linked diagnostic.
+- `ContractSpec.Field` now supports compatibility mirror-write slots (`aliasSlots := [...]`), so `setStorage`/`setMapping`/`setMapping2` write to canonical and alias slots in one declarative policy.
 
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -316,6 +316,7 @@ Current diagnostic coverage in compiler:
 - Unsupported low-level/interop builtin checks are enforced in constructor bodies and function bodies.
 - Constructor argument decoding now reuses ABI head/tail decoding for constructor params (including tuple/array/bytes forms) and exposes both named param bindings plus `constructorArg` index aliases.
 - Storage fields now support optional explicit slot overrides (`Field.slot := some n`) with compile-time conflict detection against effective slot assignments (Issue #623).
+- Storage fields now also support compatibility mirror-write aliases (`Field.aliasSlots := [...]`) with compile-time conflict detection across canonical and alias write slots (Issue #623).
 - `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 


### PR DESCRIPTION
## Summary
This lands a focused storage-layout compatibility slice for #623 by adding declarative mirror-write aliases to `ContractSpec` fields.

### What changed
- Added `Field.aliasSlots : List Nat := []` for compatibility mirror-write targets.
- Added `findFieldWriteSlots` (canonical slot + aliases).
- Updated lowering so writes mirror to all configured write slots:
  - `Stmt.setStorage`
  - `Stmt.setMapping`
  - `Stmt.setMapping2`
- Added compile-time conflict validation across *all* write slots (canonical + aliases), including duplicate alias entries.

### Tests
- Added regression coverage for mirrored writes to canonical + alias slots.
- Added diagnostic coverage for alias slot conflicts.

### Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/check_doc_counts.py`
- `lake build`

### Docs
- Updated roadmap/status notes to reflect alias-slot support as partial #623 progress.

Refs #623

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how storage writes are emitted, potentially affecting on-chain state layout/compatibility and gas usage; mitigated by conflict checks and targeted regression tests.
> 
> **Overview**
> Adds `Field.aliasSlots` to `ContractSpec` so a storage field can *mirror-write* to additional compatibility slots.
> 
> Updates Yul lowering for `Stmt.setStorage`, `Stmt.setMapping`, and `Stmt.setMapping2` to emit `sstore` to the canonical slot plus all alias slots (with temporary bindings to avoid re-evaluating key/value expressions), and introduces `findFieldWriteSlots` to centralize this.
> 
> Tightens compile-time validation to detect conflicts across **all** write slots (canonical + aliases) with improved diagnostics, adds feature tests for mirror-write output and alias-slot conflict failures, and updates docs to reflect the new partial #623 storage-layout capability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ce366bb101a39df48b3e38a57194ce6864a5780. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->