### PR TITLE
ContractSpec: reserved slot ranges with conflict diagnostics

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -73,6 +73,7 @@ Recent progress for storage layout controls (`#623`):
 - `ContractSpec.Field` now supports optional explicit slot assignment (`slot := some <n>`), with backward-compatible positional slots when omitted.
 - Compiler now fails fast on conflicting effective slot assignments with an issue-linked diagnostic.
 - `ContractSpec.Field` now supports compatibility mirror-write slots (`aliasSlots := [...]`), so `setStorage`/`setMapping`/`setMapping2` write to canonical and alias slots in one declarative policy.
+- `ContractSpec` now supports declarative reserved storage slot ranges (`reservedSlotRanges := [{ start := a, end_ := b }, ...]`) with compile-time overlap checks and fail-fast diagnostics when field canonical/alias write slots intersect reserved intervals.
 
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -317,6 +317,7 @@ Current diagnostic coverage in compiler:
 - Constructor argument decoding now reuses ABI head/tail decoding for constructor params (including tuple/array/bytes forms) and exposes both named param bindings plus `constructorArg` index aliases.
 - Storage fields now support optional explicit slot overrides (`Field.slot := some n`) with compile-time conflict detection against effective slot assignments (Issue #623).
 - Storage fields now also support compatibility mirror-write aliases (`Field.aliasSlots := [...]`) with compile-time conflict detection across canonical and alias write slots (Issue #623).
+- Contract specs now support declarative reserved slot intervals (`reservedSlotRanges`) with compile-time diagnostics for invalid/overlapping ranges and for field canonical/alias write slots that overlap reserved intervals (Issue #623).
 - `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 


### PR DESCRIPTION
## Summary
Adds a focused storage-layout control slice for #623 by introducing declarative reserved slot ranges in `ContractSpec`, with compile-time validation.

## What landed
- Added `ReservedSlotRange` and `ContractSpec.reservedSlotRanges`.
- Added compile-time diagnostics for:
  - invalid reserved ranges (`start > end`),
  - overlapping reserved ranges,
  - conflicts where field write slots (canonical `slot` and `aliasSlots`) overlap reserved ranges.
- Added feature regression coverage for:
  - disjoint reserved ranges (accepted),
  - reserved range conflict with field write slot,
  - overlapping reserved ranges.
- Updated storage-layout status notes in roadmap/verification docs.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/check_doc_counts.py`
- `lake build`

Progress for #623 (does not fully close: packed subfields and broader ergonomics remain).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds validation-only checks and diagnostics around storage slot assignment; behavior changes are limited to earlier compile-time failures for newly-invalid specs.
> 
> **Overview**
> Adds `ContractSpec.reservedSlotRanges` (via new `ReservedSlotRange`) to let specs declare storage slot intervals that must not be written for compatibility.
> 
> The compiler now validates reserved ranges (start/end ordering, disjointness) and fails fast when any field canonical slot or `aliasSlots` intersects a reserved interval, with Issue #623-linked diagnostics. Feature tests and roadmap/verification docs are updated to cover/describe the new reserved-slot behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c2acbce087323c0da3e7085ecac245fa91ebd18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->