### PR TITLE
ContractSpec: packed subfield layout controls in codegen

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,6 +74,7 @@ Recent progress for storage layout controls (`#623`):
 - Compiler now fails fast on conflicting effective slot assignments with an issue-linked diagnostic.
 - `ContractSpec.Field` now supports compatibility mirror-write slots (`aliasSlots := [...]`), so `setStorage`/`setMapping`/`setMapping2` write to canonical and alias slots in one declarative policy.
 - `ContractSpec` now supports declarative reserved storage slot ranges (`reservedSlotRanges := [{ start := a, end_ := b }, ...]`) with compile-time overlap checks and fail-fast diagnostics when field canonical/alias write slots intersect reserved intervals.
+- `ContractSpec.Field` now supports packed subfield placement (`packedBits := some { offset := o, width := w }`) so multiple fields can share a slot with disjoint bit ranges; codegen performs masked read-modify-write updates and masked reads directly from layout metadata.
 
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -318,6 +318,7 @@ Current diagnostic coverage in compiler:
 - Storage fields now support optional explicit slot overrides (`Field.slot := some n`) with compile-time conflict detection against effective slot assignments (Issue #623).
 - Storage fields now also support compatibility mirror-write aliases (`Field.aliasSlots := [...]`) with compile-time conflict detection across canonical and alias write slots (Issue #623).
 - Contract specs now support declarative reserved slot intervals (`reservedSlotRanges`) with compile-time diagnostics for invalid/overlapping ranges and for field canonical/alias write slots that overlap reserved intervals (Issue #623).
+- Storage fields now support packed subfield metadata (`Field.packedBits`) with masked read and read-modify-write lowering, compile-time bit-range validation, and overlap diagnostics that permit shared slots only when packed ranges are disjoint (Issue #623).
 - `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 


### PR DESCRIPTION
## Summary
Adds a high-leverage `#623` storage-layout slice: packed subfield layout metadata in `ContractSpec` with first-class codegen and diagnostics.

### What landed
- `Compiler/ContractSpec.lean`
  - Added `PackedBits` and `Field.packedBits : Option PackedBits := none`.
  - `Expr.storage` now lowers packed fields to masked+shifted reads.
  - `Stmt.setStorage` now lowers packed fields to masked read-modify-write (`sload` + clear mask + shifted insert), including alias mirror writes.
  - Added compile-time validation for packed bit ranges (`0 < width <= 256`, `offset < 256`, `offset + width <= 256`).
  - Added compile-time rejection for `packedBits` on mapping fields.
  - Upgraded write-slot conflict detection to permit slot sharing only when packed bit ranges are disjoint.
- `Compiler/ContractSpecFeatureTest.lean`
  - Added regression coverage for packed RMW lowering and packed reads.
  - Added diagnostics coverage for overlapping packed ranges, invalid packed ranges, and packed mapping rejection.
  - Updated existing conflict diagnostic expectations to match the new overlap wording.
- Docs
  - `docs/ROADMAP.md`
  - `docs/VERIFICATION_STATUS.md`
  - Added progress note for packed field support in `#623`.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/check_doc_counts.py`
- `lake build`

## Issue linkage
- Progress on: #623

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core storage read/write lowering and slot-conflict validation, so incorrect masking/overlap checks could silently corrupt storage values across packed fields or alias slots.
> 
> **Overview**
> Adds `Field.packedBits` layout metadata to allow multiple value fields to share a storage slot using disjoint bit ranges.
> 
> Updates codegen so `Expr.storage` emits masked/shifted reads and `Stmt.setStorage` emits masked read-modify-write `sstore` sequences (including mirror writes via `aliasSlots`). Adds compile-time validation for packed ranges, rejects `packedBits` on mappings, and relaxes slot conflict detection to permit shared slots only when packed ranges don’t overlap; tests and docs are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 029ffc4be34fe7c4de304d28fcbe760a218408b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->