### PR TITLE
ContractSpec: declarative slot alias ranges for compatibility layout

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -73,6 +73,7 @@ Recent progress for storage layout controls (`#623`):
 - `ContractSpec.Field` now supports optional explicit slot assignment (`slot := some <n>`), with backward-compatible positional slots when omitted.
 - Compiler now fails fast on conflicting effective slot assignments with an issue-linked diagnostic.
 - `ContractSpec.Field` now supports compatibility mirror-write slots (`aliasSlots := [...]`), so `setStorage`/`setMapping`/`setMapping2` write to canonical and alias slots in one declarative policy.
+- `ContractSpec` now supports slot remap policies (`slotAliasRanges := [{ sourceStart := a, sourceEnd := b, targetStart := c }, ...]`) so compatibility windows like `8..11 -> 20..23` can be declared once and applied automatically to canonical field writes.
 - `ContractSpec` now supports declarative reserved storage slot ranges (`reservedSlotRanges := [{ start := a, end_ := b }, ...]`) with compile-time overlap checks and fail-fast diagnostics when field canonical/alias write slots intersect reserved intervals.
 - `ContractSpec.Field` now supports packed subfield placement (`packedBits := some { offset := o, width := w }`) so multiple fields can share a slot with disjoint bit ranges; codegen performs masked read-modify-write updates and masked reads directly from layout metadata.
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -317,6 +317,7 @@ Current diagnostic coverage in compiler:
 - Constructor argument decoding now reuses ABI head/tail decoding for constructor params (including tuple/array/bytes forms) and exposes both named param bindings plus `constructorArg` index aliases.
 - Storage fields now support optional explicit slot overrides (`Field.slot := some n`) with compile-time conflict detection against effective slot assignments (Issue #623).
 - Storage fields now also support compatibility mirror-write aliases (`Field.aliasSlots := [...]`) with compile-time conflict detection across canonical and alias write slots (Issue #623).
+- Contract specs now support declarative slot remap policies (`slotAliasRanges`) so canonical slot windows can auto-derive compatibility mirror slots (for example `8..11 -> 20..23`), with compile-time diagnostics for invalid/overlapping source intervals (Issue #623).
 - Contract specs now support declarative reserved slot intervals (`reservedSlotRanges`) with compile-time diagnostics for invalid/overlapping ranges and for field canonical/alias write slots that overlap reserved intervals (Issue #623).
 - Storage fields now support packed subfield metadata (`Field.packedBits`) with masked read and read-modify-write lowering, compile-time bit-range validation, and overlap diagnostics that permit shared slots only when packed ranges are disjoint (Issue #623).
 - `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec.


### PR DESCRIPTION
## Summary
Adds declarative slot remap policy support to `ContractSpec` so compatibility windows like `8..11 -> 20..23` can be encoded once and applied automatically to storage/mapping writes.

### What changed
- Added `SlotAliasRange` and `ContractSpec.slotAliasRanges` in `Compiler/ContractSpec.lean`.
- Added slot-alias policy normalization that augments field write aliases from canonical slots.
- Added compile-time diagnostics for:
  - invalid source intervals (`sourceStart > sourceEnd`)
  - overlapping source intervals across `slotAliasRanges`
- Reused existing write-slot conflict checks on normalized fields so target collisions are still fail-fast.
- Added regression coverage in `Compiler/ContractSpecFeatureTest.lean` for:
  - mirror writes derived from `slotAliasRanges`
  - invalid `slotAliasRanges` diagnostics
  - overlapping-source diagnostics
  - target collision diagnostics
- Updated docs:
  - `docs/ROADMAP.md`
  - `docs/VERIFICATION_STATUS.md`

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/check_doc_counts.py`
- `lake build`

Closes #623.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes storage layout/mirror-write behavior by implicitly adding alias write slots during compilation, which could affect generated Yul and conflict detection; new validation and regression tests reduce but don’t eliminate the risk of unexpected slot remaps.
> 
> **Overview**
> Adds declarative slot remap policies via `SlotAliasRange` and `ContractSpec.slotAliasRanges`, letting a source slot window (e.g. `8..11`) automatically derive per-field mirror-write `aliasSlots` (e.g. `20..23`).
> 
> `compile` now normalizes fields by merging derived aliases (deduped) before running existing write-slot conflict and reserved-range checks, and introduces new fail-fast diagnostics for invalid `slotAliasRanges` intervals and overlapping source ranges. Feature tests cover derived mirror writes plus the new error cases, and docs are updated to reflect the new storage layout control capability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0725a75a0df50683576ebd106b5445577953cada. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->