### PR TITLE
ContractSpec: first-class low-level call and returndata primitives (#622 slice)

### DIFF
--- a/Verity/Proofs/Stdlib/SpecInterpreter.lean
+++ b/Verity/Proofs/Stdlib/SpecInterpreter.lean
@@ -182,6 +182,18 @@ def evalExpr (ctx : EvalContext) (storage : SpecStorage) (fields : List Field) (
   | Expr.caller => ctx.sender.val
   | Expr.msgValue => ctx.msgValue % modulus
   | Expr.blockTimestamp => ctx.blockTimestamp % modulus
+  | Expr.call _gas _target _value _inOffset _inSize _outOffset _outSize =>
+      -- Low-level call semantics are not modeled in the scalar SpecInterpreter yet.
+      0
+  | Expr.staticcall _gas _target _inOffset _inSize _outOffset _outSize =>
+      -- Low-level call semantics are not modeled in the scalar SpecInterpreter yet.
+      0
+  | Expr.delegatecall _gas _target _inOffset _inSize _outOffset _outSize =>
+      -- Low-level call semantics are not modeled in the scalar SpecInterpreter yet.
+      0
+  | Expr.returndataSize =>
+      -- Returndata buffers are not modeled in the scalar SpecInterpreter yet.
+      0
   | Expr.localVar name =>
       ctx.localVars.lookup name |>.getD 0
   | Expr.externalCall name args =>
@@ -346,6 +358,13 @@ def execStmt (ctx : EvalContext) (fields : List Field) (paramNames : List String
       -- The spec interpreter models scalar returnValue only.
       -- Dynamic array return encoding/storage reads are codegen concerns.
       some (ctx, { state with returnValue := none, halted := true })
+
+  | Stmt.returndataCopy _destOffset _sourceOffset _size =>
+      -- Returndata memory effects are not modeled in the scalar SpecInterpreter.
+      some (ctx, state)
+
+  | Stmt.revertReturndata =>
+      none
 
   | Stmt.stop =>
       some (ctx, { state with halted := true })

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -63,7 +63,7 @@ Status legend:
 | Priority | Feature | Spec support | Codegen support | Proof status | Test status | Current status |
 |---|---|---|---|---|---|---|
 | 1 | Custom errors + typed revert payloads | partial | partial | n/a | partial | partial |
-| 2 | Low-level calls (`call`/`staticcall`/`delegatecall`) + returndata handling | unsupported | unsupported | n/a | n/a | unsupported |
+| 2 | Low-level calls (`call`/`staticcall`/`delegatecall`) + returndata handling | partial | partial | n/a | partial | partial |
 | 3 | `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
 | 4 | Full event ABI parity (indexed dynamic + tuple hashing) | supported | supported | supported | supported | supported |
 | 5 | Storage layout controls (packed fields + explicit slot mapping) | partial | partial | partial | partial | partial |
@@ -76,6 +76,11 @@ Recent progress for storage layout controls (`#623`):
 - `ContractSpec` now supports slot remap policies (`slotAliasRanges := [{ sourceStart := a, sourceEnd := b, targetStart := c }, ...]`) so compatibility windows like `8..11 -> 20..23` can be declared once and applied automatically to canonical field writes.
 - `ContractSpec` now supports declarative reserved storage slot ranges (`reservedSlotRanges := [{ start := a, end_ := b }, ...]`) with compile-time overlap checks and fail-fast diagnostics when field canonical/alias write slots intersect reserved intervals.
 - `ContractSpec.Field` now supports packed subfield placement (`packedBits := some { offset := o, width := w }`) so multiple fields can share a slot with disjoint bit ranges; codegen performs masked read-modify-write updates and masked reads directly from layout metadata.
+
+Recent progress for low-level calls + returndata handling (`#622`):
+- `ContractSpec.Expr` now supports first-class low-level call primitives (`call`, `staticcall`, `delegatecall`) with explicit gas/value/target/input/output operands and deterministic Yul lowering.
+- `ContractSpec.Expr.returndataSize`, `Stmt.returndataCopy`, and `Stmt.revertReturndata` now provide first-class returndata access and revert-data forwarding without raw Yul builtin injection.
+- Raw `Expr.externalCall` interop names for low-level/builtin opcodes remain fail-fast rejected, preserving explicit migration diagnostics while the first-class surface continues to expand.
 
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -268,7 +268,7 @@ Status legend:
 | Feature | Spec support | Codegen support | Proof status | Test status | Current status |
 |---|---|---|---|---|---|
 | Custom errors + typed revert payloads | partial | partial | n/a | partial | partial |
-| Low-level calls (`call` / `staticcall` / `delegatecall`) with returndata | unsupported | unsupported | n/a | n/a | unsupported |
+| Low-level calls (`call` / `staticcall` / `delegatecall`) with returndata | partial | partial | n/a | partial | partial |
 | `fallback` / `receive` / payable entrypoint modeling | partial | partial | n/a | partial | partial |
 | Event ABI parity for indexed dynamic/tuple payloads | supported | supported | supported | supported | supported |
 | Storage layout controls (packing + explicit slots) | partial | partial | partial | partial | partial |
@@ -309,7 +309,9 @@ Current diagnostic coverage in compiler:
 - Non-payable external functions and constructors now emit a runtime `msg.value == 0` guard, while explicit `isPayable := true` enables `Expr.msgValue` usage.
 - Custom errors are now first-class declarations (`errors`) with `Stmt.requireError`/`Stmt.revertError` emission for static payload types (`uint256`, `address`, `bool`, `bytes32`) plus `bytes` payloads when sourced from direct bytes parameters. Other dynamic custom error payloads still fail with explicit guidance.
 - `fallback` and `receive` are now modeled as first-class entrypoints in dispatch (empty-calldata routing to `receive`, unmatched selector routing to `fallback`) with compile-time shape checks (`receive` must be payable, both must be parameterless and non-returning).
-- Low-level call-style names (`call`, `staticcall`, `delegatecall`, `callcode`) now fail with explicit guidance to use verified linked wrappers.
+- `ContractSpec` now provides first-class low-level call expressions (`Expr.call`, `Expr.staticcall`, `Expr.delegatecall`) with explicit gas/target/value/input/output operands and deterministic direct lowering to Yul call opcodes.
+- `ContractSpec` now provides first-class returndata primitives (`Expr.returndataSize`, `Stmt.returndataCopy`, `Stmt.revertReturndata`) so revert-data bubbling can be expressed without raw interop builtin calls.
+- Raw interop builtin call names via `Expr.externalCall` (including low-level call-style names like `callcode`) remain fail-fast rejected with issue-linked diagnostics.
 - Additional interop builtins (`create`, `create2`, `extcodesize`, `extcodecopy`, `extcodehash`) now fail with explicit migration guidance instead of generic external-call handling.
 - Indexed `bytes` event params emit ABI-style hashed topics (`keccak256(payload)`), indexed static tuple/fixed-array params emit ABI-style hashed topics over canonical static in-place encoding, indexed dynamic arrays (including arrays with dynamic element payloads) hash canonical in-place ABI preimages, and indexed dynamic tuple/fixed-array composite params hash recursive in-place ABI encodings.
 - Event emission now fails fast on `Expr.param` type mismatches against declared event parameter types (including indexed/unindexed bytes arg-shape checks), supports unindexed static and dynamic composite tuple/fixed-array payload encoding from direct parameters with recursive ABI head/tail encoding.


### PR DESCRIPTION
## Summary
Adds a focused first-class low-level interop slice for #622 in `ContractSpec`:

- Add first-class low-level call expressions:
  - `Expr.call(gas, target, value, inOffset, inSize, outOffset, outSize)`
  - `Expr.staticcall(gas, target, inOffset, inSize, outOffset, outSize)`
  - `Expr.delegatecall(gas, target, inOffset, inSize, outOffset, outSize)`
- Add first-class returndata primitives:
  - `Expr.returndataSize`
  - `Stmt.returndataCopy(destOffset, sourceOffset, size)`
  - `Stmt.revertReturndata` (returndata bubble helper)
- Keep raw interop builtin names blocked in `Expr.externalCall` (fail-fast diagnostics remain).

## Why
Issue #622 asks for first-class low-level runtime calls and returndata handling in the DSL without relying on raw Yul builtin string injection. This slice adds explicit, typed AST surface and deterministic lowering while preserving existing safety diagnostics for raw interop call names.

## Scope and limits
- This is a partial #622 slice.
- `SpecInterpreter` models the new low-level/returndata operations conservatively (uninterpreted/no-op for scalar model), so proof status stays `n/a` for this row.

## Tests
- Added `ContractSpecFeatureTest` coverage for:
  - first-class lowering of `call/staticcall/delegatecall`
  - first-class `returndatasize/returndatacopy`
  - revert-data forwarding via `Stmt.revertReturndata`
- Existing tests that reject raw `Expr.externalCall "call"` / `"returndatasize"` continue to pass.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`
- `lake build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ContractSpec compilation/codegen paths and introduces new EVM call/revert primitives, so incorrect lowering could change runtime behavior. Changes are scoped and covered by feature tests, with interpreter semantics intentionally conservative.
> 
> **Overview**
> Adds first-class `ContractSpec` AST support for EVM low-level calls and returndata handling: `Expr.call`/`Expr.staticcall`/`Expr.delegatecall`, `Expr.returndataSize`, plus `Stmt.returndataCopy` and `Stmt.revertReturndata` for revert-data bubbling.
> 
> Compiler validation is extended to allow these new nodes while still rejecting raw low-level/builtin opcodes passed via `Expr.externalCall`, and codegen deterministically lowers the new constructs directly to the corresponding Yul opcodes. Tests cover the new lowering, and the scalar `SpecInterpreter` treats the new operations conservatively (unmodeled/no-op or revert), with docs updated to mark the feature as *partial* support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 599bb3a8b4fd7edcd76c2a680349e9fd2662c5b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->