### PR TITLE
Expand custom-error ABI payload support for composite types

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,6 +83,10 @@ Recent progress for low-level calls + returndata handling (`#622`):
 - `ContractSpec.Expr.returndataOptionalBoolAt(outOffset)` now provides a first-class ERC20 compatibility helper for optional return-data bool decoding (`returndatasize()==0 || (returndatasize()==32 && mload(outOffset)==1)`), so low-level token call acceptance paths can be expressed without raw Yul builtins.
 - Raw `Expr.externalCall` interop names for low-level/builtin opcodes remain fail-fast rejected, preserving explicit migration diagnostics while the first-class surface continues to expand.
 
+Recent progress for custom errors (`#586`):
+- `Stmt.requireError` / `Stmt.revertError` now support ABI encoding for tuple/fixed-array/array/bytes payloads (including nested dynamic composites) when arguments are direct `Expr.param` references.
+- Static scalar payload args remain expression-friendly (`uint256`, `address`, `bool`, `bytes32`), while composite/dynamic payload args fail fast with issue-linked diagnostics when not provided as direct parameter references.
+
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.
 2. Error text must suggest the nearest currently-supported pattern.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -307,7 +307,7 @@ Implemented:
 
 Current diagnostic coverage in compiler:
 - Non-payable external functions and constructors now emit a runtime `msg.value == 0` guard, while explicit `isPayable := true` enables `Expr.msgValue` usage.
-- Custom errors are now first-class declarations (`errors`) with `Stmt.requireError`/`Stmt.revertError` emission for static payload types (`uint256`, `address`, `bool`, `bytes32`) plus `bytes` payloads when sourced from direct bytes parameters. Other dynamic custom error payloads still fail with explicit guidance.
+- Custom errors are now first-class declarations (`errors`) with `Stmt.requireError`/`Stmt.revertError` ABI payload emission for scalar payloads (`uint256`, `address`, `bool`, `bytes32`) and direct-parameter composite/dynamic payloads (`bytes`, tuple, fixed-array, array; including nested dynamic composites). Composite/dynamic args still fail fast with explicit guidance when not sourced from direct `Expr.param` references.
 - `fallback` and `receive` are now modeled as first-class entrypoints in dispatch (empty-calldata routing to `receive`, unmatched selector routing to `fallback`) with compile-time shape checks (`receive` must be payable, both must be parameterless and non-returning).
 - `ContractSpec` now provides first-class low-level call expressions (`Expr.call`, `Expr.staticcall`, `Expr.delegatecall`) with explicit gas/target/value/input/output operands and deterministic direct lowering to Yul call opcodes.
 - `ContractSpec` now provides first-class returndata primitives (`Expr.returndataSize`, `Stmt.returndataCopy`, `Stmt.revertReturndata`) so revert-data bubbling can be expressed without raw interop builtin calls.


### PR DESCRIPTION
## Summary
- extend custom-error ABI payload lowering to support direct-parameter composite/dynamic shapes (`tuple`, `fixedArray`, `array`, `bytes`), including nested dynamic composites
- preserve expression-based scalar custom-error args (`uint256`, `address`, `bool`, `bytes32`) and normalize scalar encoding
- add fail-fast arg-shape diagnostics for non-scalar custom-error args that are not direct `Expr.param` references
- add regression coverage for tuple and dynamic-array custom-error payload encoding plus updated bytes-path expectations
- update interop status docs with the new custom-error capability slice

## Validation
- `lake build Compiler.ContractSpecFeatureTest`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`
- `lake build`

Closes #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ABI encoding and revert payload generation for custom errors, which can affect runtime revert data shape across contracts; changes are scoped and covered by new regression tests.
> 
> **Overview**
> Extends `Stmt.requireError`/`Stmt.revertError` lowering to ABI-encode **composite/dynamic** custom error payloads (`tuple`, `fixedArray`, `array`, `bytes`, including nested dynamic composites) when the argument is a direct `Expr.param` reference, while keeping scalar args (`uint256`, `address`, `bool`, `bytes32`) expression-based with normalized encoding.
> 
> Adds stricter shape validation and clearer diagnostics for custom error args that must be direct parameter references, updates the bytes custom-error encoding expectations, and adds new feature tests for tuple and dynamic-array custom error payloads. Documentation is updated to reflect the expanded custom-error support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c391bd17c0c8f28496a87d743b83a1ae4bb9f037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->