### PR TITLE
ContractSpec ABI: support view/pure stateMutability (closes #686)

### DIFF
--- a/Compiler/ABI.lean
+++ b/Compiler/ABI.lean
@@ -72,7 +72,7 @@ end
 private def renderFunctionEntry (fn : FunctionSpec) : String :=
   let inputs := fn.params.map (fun p => renderParam p.name p.ty none)
   let outputs := (functionOutputs fn).map (fun ty => renderParam "" ty none)
-  let stateMutability := if fn.isPayable then "payable" else "nonpayable"
+  let stateMutability := functionStateMutability fn
   "{" ++ joinJsonFields [
     "\"type\": \"function\"",
     s!"\"name\": {jsonString fn.name}",
@@ -117,7 +117,7 @@ private def renderSpecialEntry (fn : FunctionSpec) : Option String :=
   else
     some ("{" ++ joinJsonFields [
       s!"\"type\": {jsonString fn.name}",
-      s!"\"stateMutability\": {jsonString (if fn.isPayable then "payable" else "nonpayable")}"
+      s!"\"stateMutability\": {jsonString (functionStateMutability fn)}"
     ] ++ "}")
 
 def emitContractABIJson (spec : ContractSpec) : String :=

--- a/Compiler/ABITest.lean
+++ b/Compiler/ABITest.lean
@@ -42,6 +42,18 @@ private def abiSpec : ContractSpec := {
       returns := [ParamType.array (ParamType.tuple [ParamType.uint256, ParamType.bool])]
       body := [Stmt.stop]
     },
+    { name := "totalSupply"
+      params := []
+      returnType := some FieldType.uint256
+      isView := true
+      body := [Stmt.return (Expr.literal 1)]
+    },
+    { name := "version"
+      params := []
+      returnType := some FieldType.uint256
+      isPure := true
+      body := [Stmt.return (Expr.literal 1)]
+    },
     { name := "fallback"
       params := []
       returnType := none
@@ -82,6 +94,7 @@ private def abiSpec : ContractSpec := {
   assertContains "function entry" rendered ["\"type\": \"function\"", "\"name\": \"setTuple\""]
   assertContains "tuple components" rendered ["\"type\": \"tuple\"", "\"components\": [{\"name\": \"\", \"type\": \"address\"}, {\"name\": \"\", \"type\": \"uint256\"}]"]
   assertContains "tuple array components" rendered ["\"type\": \"tuple[]\"", "\"outputs\": [{\"name\": \"\", \"type\": \"tuple[]\", \"components\": [{\"name\": \"\", \"type\": \"uint256\"}, {\"name\": \"\", \"type\": \"bool\"}]}]"]
+  assertContains "state mutability view/pure" rendered ["\"name\": \"totalSupply\"", "\"stateMutability\": \"view\"", "\"name\": \"version\"", "\"stateMutability\": \"pure\""]
   assertContains "event indexed metadata" rendered ["\"type\": \"event\"", "\"indexed\": true", "\"indexed\": false"]
   assertContains "error entry" rendered ["\"type\": \"error\"", "\"name\": \"BadThing\""]
   assertContains "special entrypoints" rendered ["\"type\": \"fallback\"", "\"type\": \"receive\""]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -82,6 +82,7 @@ Recent progress for low-level calls + returndata handling (`#622`):
 - `ContractSpec.Expr.returndataSize`, `Stmt.returndataCopy`, and `Stmt.revertReturndata` now provide first-class returndata access and revert-data forwarding without raw Yul builtin injection.
 - `ContractSpec.Expr.returndataOptionalBoolAt(outOffset)` now provides a first-class ERC20 compatibility helper for optional return-data bool decoding (`returndatasize()==0 || (returndatasize()==32 && mload(outOffset)==1)`), so low-level token call acceptance paths can be expressed without raw Yul builtins.
 - Raw `Expr.externalCall` interop names for low-level/builtin opcodes remain fail-fast rejected, preserving explicit migration diagnostics while the first-class surface continues to expand.
+- ABI artifact emission now reflects explicit function mutability markers (`isView`, `isPure`) as `stateMutability: "view" | "pure"` in generated JSON.
 
 Recent progress for custom errors (`#586`):
 - `Stmt.requireError` / `Stmt.revertError` now support ABI encoding for tuple/fixed-array/array/bytes payloads (including nested dynamic composites) when arguments are direct `Expr.param` references.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -323,7 +323,7 @@ Current diagnostic coverage in compiler:
 - Contract specs now support declarative slot remap policies (`slotAliasRanges`) so canonical slot windows can auto-derive compatibility mirror slots (for example `8..11 -> 20..23`), with compile-time diagnostics for invalid/overlapping source intervals (Issue #623).
 - Contract specs now support declarative reserved slot intervals (`reservedSlotRanges`) with compile-time diagnostics for invalid/overlapping ranges and for field canonical/alias write slots that overlap reserved intervals (Issue #623).
 - Storage fields now support packed subfield metadata (`Field.packedBits`) with masked read and read-modify-write lowering, compile-time bit-range validation, and overlap diagnostics that permit shared slots only when packed ranges are disjoint (Issue #623).
-- `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec.
+- `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec, including `view`/`pure` `stateMutability` metadata when declared in `ContractSpec.FunctionSpec`.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 
 ### Short Term (1-2 months)


### PR DESCRIPTION
## Summary
This PR fixes ABI artifact mutability metadata so ContractSpec functions can emit Solidity-accurate `stateMutability` for `view` and `pure` functions.

## Changes
- Add `FunctionSpec.isView` and `FunctionSpec.isPure` flags.
- Add canonical mutability resolver `functionStateMutability`.
- Emit ABI mutability from canonical resolver in `Compiler/ABI.lean`.
- Add compile-time validation for invalid mutability combinations:
  - `payable` with `view`/`pure`
  - `view` with `pure`
  - `fallback`/`receive` marked as `view`/`pure`
- Extend tests:
  - `Compiler/ABITest.lean`: verifies emitted `view`/`pure` ABI entries.
  - `Compiler/ContractSpecFeatureTest.lean`: verifies mutability diagnostics.
- Sync docs notes in roadmap/status.

## Validation
- `lake build Compiler.ABITest`
- `lake build Compiler.ContractSpecFeatureTest`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`
- `FOUNDRY_PROFILE=difftest forge test --match-path test/EventAbiParity.t.sol`
- `lake build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new metadata flags plus straightforward validation and ABI JSON emission changes; limited surface area and covered by targeted tests.
> 
> **Overview**
> Generated ABI JSON now emits Solidity-accurate `stateMutability` for `ContractSpec.FunctionSpec` by adding `isView`/`isPure` flags and routing ABI rendering through a shared `functionStateMutability` resolver (including `fallback`/`receive`).
> 
> Compilation now validates mutability combinations, rejecting `payable`+`view/pure`, `view`+`pure`, and `fallback`/`receive` marked `view/pure`; tests and docs were updated to cover the new metadata and diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed8566c40cddb7a25a62c7a4df9fe878ec1bd0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->