### PR TITLE
Compiler: enable --abi-output in unified AST mode

### DIFF
--- a/Compiler/ASTDriverTest.lean
+++ b/Compiler/ASTDriverTest.lean
@@ -201,4 +201,17 @@ private def badContractIdentifierSpec : ASTContractSpec := {
   | .ok _ =>
     throw (IO.userError "✗ expected invalid contract identifier to be rejected")
 
+#eval! do
+  let rendered := emitASTContractABIJson simpleTokenSpec
+  assertContains "AST ABI includes constructor and function entries" rendered
+    ["\"type\": \"constructor\"",
+     "\"name\": \"mint\"",
+     "\"name\": \"transfer\"",
+     "\"name\": \"balanceOf\""]
+  assertContains "AST ABI includes typed returns" rendered
+    ["\"name\": \"owner\"",
+     "\"outputs\": [{\"name\": \"\", \"type\": \"address\"}]",
+     "\"name\": \"totalSupply\"",
+     "\"outputs\": [{\"name\": \"\", \"type\": \"uint256\"}]"]
+
 end Compiler.ASTDriverTest

--- a/Compiler/Main.lean
+++ b/Compiler/Main.lean
@@ -99,9 +99,7 @@ def main (args : List String) : IO Unit := do
       }
     }
     if cfg.useAST then
-      if cfg.abiOutDir.isSome then
-        throw (IO.userError "--abi-output is currently supported only for ContractSpec mode (omit --ast).")
-      Compiler.ASTDriver.compileAllASTWithOptions cfg.outDir cfg.verbose cfg.libs options cfg.patchReportPath
+      Compiler.ASTDriver.compileAllASTWithOptions cfg.outDir cfg.verbose cfg.libs options cfg.patchReportPath cfg.abiOutDir
     else
       compileAllWithOptions cfg.outDir cfg.verbose cfg.libs options cfg.patchReportPath cfg.abiOutDir
   catch e =>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,6 +88,10 @@ Recent progress for custom errors (`#586`):
 - `Stmt.requireError` / `Stmt.revertError` now support ABI encoding for tuple/fixed-array/array/bytes payloads (including nested dynamic composites) when arguments are direct `Expr.param` references.
 - Static scalar payload args remain expression-friendly (`uint256`, `address`, `bool`, `bytes32`), while composite/dynamic payload args fail fast with issue-linked diagnostics when not provided as direct parameter references.
 
+Recent progress for ABI JSON artifact generation (`#688`):
+- `verity-compiler --ast --abi-output <dir>` now emits one `<Contract>.abi.json` file per unified AST spec, using an AST→ABI bridge that reuses the shared ABI renderer.
+- The previous AST-mode CLI rejection for `--abi-output` has been removed, so ContractSpec and AST compilation paths now have parity for ABI artifact emission.
+
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.
 2. Error text must suggest the nearest currently-supported pattern.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -324,6 +324,7 @@ Current diagnostic coverage in compiler:
 - Contract specs now support declarative reserved slot intervals (`reservedSlotRanges`) with compile-time diagnostics for invalid/overlapping ranges and for field canonical/alias write slots that overlap reserved intervals (Issue #623).
 - Storage fields now support packed subfield metadata (`Field.packedBits`) with masked read and read-modify-write lowering, compile-time bit-range validation, and overlap diagnostics that permit shared slots only when packed ranges are disjoint (Issue #623).
 - `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec, including `view`/`pure` `stateMutability` metadata when declared in `ContractSpec.FunctionSpec`.
+- `verity-compiler` now supports deterministic ABI artifact emission in unified AST mode via `--ast --abi-output <dir>`, using an AST→ABI bridge that emits one `<Contract>.abi.json` per AST spec with constructor/function signatures and typed outputs.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 
 ### Short Term (1-2 months)


### PR DESCRIPTION
Summary
- Enable ABI artifact emission for unified AST compilation path.
- Remove CLI guard that rejected abi-output when ast mode was enabled.
- Add AST ABI bridge and regression coverage.

Changes
- Compiler/ASTDriver.lean
  - added astSpecToContractSpecForABI and emitASTContractABIJson
  - extended compileAllASTWithOptions with abiOutDir and per-spec ABI file emission
  - replaced deprecated List.enum usage with zipIdx
- Compiler/Main.lean
  - pass abiOutDir through AST mode instead of failing fast
- Compiler/ASTDriverTest.lean
  - added regression assertions for AST ABI JSON entries and typed returns
- docs/ROADMAP.md and docs/VERIFICATION_STATUS.md
  - documented AST ABI artifact emission progress

Validation
- lake build Compiler.ASTDriverTest Compiler.ABITest Compiler.ContractSpecFeatureTest
- python3 scripts/generate_verification_status.py --check
- python3 scripts/check_doc_counts.py

Notes
- Full CLI smoke of lake exe verity-compiler in this environment is blocked by missing system C compiler (cc) required by transitive evmyul FFI build steps.

Closes #688

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds optional ABI file emission and a simple AST→ABI mapping without changing codegen or runtime semantics; risk is mainly incorrect ABI signatures/return typing for AST specs.
> 
> **Overview**
> Unified AST compilation now supports `--abi-output` by bridging `ASTContractSpec` into a minimal `ContractSpec` shape and reusing the shared ABI JSON renderer, emitting one `<Contract>.abi.json` per AST spec during `compileAllASTWithOptions`.
> 
> The CLI no longer rejects `--abi-output` when `--ast` is enabled, and AST driver tests add coverage that rendered ABI includes constructor/function entries and typed outputs. Minor cleanup switches constructor arg loading from deprecated `enum` to `zipIdx`, and docs are updated to reflect AST-mode ABI parity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a9f45649d30b1b00a676960ea69b9431ed8d86f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->