### PR TITLE
AST: preserve mutability metadata in ABI and runtime dispatch

### DIFF
--- a/Compiler/ASTSpecs.lean
+++ b/Compiler/ASTSpecs.lean
@@ -48,6 +48,12 @@ structure ASTFunctionSpec where
   params : List Param
   /-- Return type. -/
   returnType : ASTReturnType
+  /-- Whether ETH value is accepted for this function. -/
+  isPayable : Bool := false
+  /-- ABI mutability marker (`view`). -/
+  isView : Bool := false
+  /-- ABI mutability marker (`pure`). -/
+  isPure : Bool := false
   /-- Function body as a unified AST statement. -/
   body : Stmt
   deriving Repr
@@ -55,6 +61,8 @@ structure ASTFunctionSpec where
 structure ASTConstructorSpec where
   /-- Constructor parameters (loaded from end of bytecode). -/
   params : List Param
+  /-- Whether ETH value is accepted during deployment. -/
+  isPayable : Bool := false
   /-- Constructor body as a unified AST statement. -/
   body : Stmt
   deriving Repr

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -91,6 +91,7 @@ Recent progress for custom errors (`#586`):
 Recent progress for ABI JSON artifact generation (`#688`):
 - `verity-compiler --ast --abi-output <dir>` now emits one `<Contract>.abi.json` file per unified AST spec, using an AST→ABI bridge that reuses the shared ABI renderer.
 - The previous AST-mode CLI rejection for `--abi-output` has been removed, so ContractSpec and AST compilation paths now have parity for ABI artifact emission.
+- AST specs now support explicit mutability metadata (`isPayable`, `isView`, `isPure`) that propagates to both runtime payability guards and ABI JSON `stateMutability`, with compile-time validation for invalid combinations.
 
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -325,6 +325,7 @@ Current diagnostic coverage in compiler:
 - Storage fields now support packed subfield metadata (`Field.packedBits`) with masked read and read-modify-write lowering, compile-time bit-range validation, and overlap diagnostics that permit shared slots only when packed ranges are disjoint (Issue #623).
 - `verity-compiler` now supports deterministic ABI artifact emission in ContractSpec mode via `--abi-output <dir>` and writes one `<Contract>.abi.json` per compiled spec, including `view`/`pure` `stateMutability` metadata when declared in `ContractSpec.FunctionSpec`.
 - `verity-compiler` now supports deterministic ABI artifact emission in unified AST mode via `--ast --abi-output <dir>`, using an AST→ABI bridge that emits one `<Contract>.abi.json` per AST spec with constructor/function signatures and typed outputs.
+- AST specs now support explicit mutability metadata (`isPayable`, `isView`, `isPure`) that drives runtime payability guards and ABI `stateMutability` emission, with compile-time diagnostics for invalid mutability combinations.
 - All interop diagnostics include an `Issue #586` reference for scope tracking.
 
 ### Short Term (1-2 months)


### PR DESCRIPTION
## Summary
- add explicit mutability metadata to AST specs:
  - `ASTFunctionSpec.isPayable`, `ASTFunctionSpec.isView`, `ASTFunctionSpec.isPure`
  - `ASTConstructorSpec.isPayable`
- plumb mutability through AST compilation so runtime deploy/dispatch preserves payable semantics:
  - `IRContract.constructorPayable`
  - `IRFunction.payable`
- plumb mutability through AST ABI bridge so generated ABI has correct `stateMutability`
- add AST compile-time diagnostics for invalid mutability combinations
  - payable + view/pure
  - view + pure
- add regression coverage in `Compiler/ASTDriverTest.lean`

## Validation
- `lake build Compiler.ASTDriverTest`
- `lake build Compiler.ABITest`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_doc_counts.py`
- `lake build`

Closes #690

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ABI output and runtime payability enforcement, so incorrect propagation could change generated interfaces or revert behavior for value-sending calls; scope is contained to the AST pipeline with added tests and validation.
> 
> **Overview**
> AST specs now carry explicit mutability metadata: `ASTFunctionSpec` adds `isPayable`/`isView`/`isPure`, and `ASTConstructorSpec` adds `isPayable`.
> 
> The AST compilation path propagates this into generated artifacts: ABI JSON emission now includes correct `stateMutability` for constructors/functions, and AST→IR lowering sets `IRFunction.payable` plus `IRContract.constructorPayable` so deploy/runtime `callvalue` guards match the declared payability.
> 
> `compileSpec` now rejects invalid mutability combinations (payable with view/pure, or view with pure), and `ASTDriverTest` adds regression coverage for default non-payable constructors, payable lowering, ABI mutability markers, and the new validation errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca9a9cc5a4644f95819d53a18100ef890231c851. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->