### PR TITLE
ci(docs): enforce interop matrix sync across roadmap/status docs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Check documentation counts
         run: python3 scripts/check_doc_counts.py
 
+      - name: Check Solidity interop matrix sync
+        run: python3 scripts/check_interop_matrix_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,6 +84,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`generate_evmyullean_capability_report.py`** - Deterministically generates `artifacts/evmyullean_capability_report.json` from `Compiler/Proofs/YulGeneration/Builtins.lean` and `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean`, and emits `artifacts/evmyullean_unsupported_nodes.json` as a dedicated machine-readable unsupported-node artifact for adapter lowering gaps; supports `--check` mode for CI freshness gating
 - **`generate_evmyullean_adapter_report.py`** - Deterministically generates `artifacts/evmyullean_adapter_report.json` with constructor-level lowering coverage (`supported`/`partial`/`gap`) for `lowerExpr` and `lowerStmt` plus explicit adapter-gap reasons and runtime-seam status (`stub-none` vs `implemented`); supports `--check` mode for CI freshness gating
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
+- **`check_interop_matrix_sync.py`** - Ensures the Solidity interop support matrix in `docs/ROADMAP.md` and `docs/VERIFICATION_STATUS.md` stays synchronized (row coverage + status-column parity)
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -95,6 +96,7 @@ These CI-critical scripts validate cross-layer consistency:
 # Run locally before submitting documentation changes
 python3 scripts/generate_verification_status.py
 python3 scripts/check_doc_counts.py
+python3 scripts/check_interop_matrix_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -190,16 +192,17 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 3. Contract file structure validation (`check_contract_structure.py`)
 4. Axiom location validation (`check_axiom_locations.py`)
 5. Documentation count validation (`check_doc_counts.py`)
-6. Solc pin consistency (`check_solc_pin.py`)
-7. Property manifest sync (`check_property_manifest_sync.py`)
-8. Storage layout consistency (`check_storage_layout.py`)
-9. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-10. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-11. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-12. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-13. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
-14. Lean hygiene (`check_lean_hygiene.py`)
-15. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+6. Solidity interop matrix sync (`check_interop_matrix_sync.py`)
+7. Solc pin consistency (`check_solc_pin.py`)
+8. Property manifest sync (`check_property_manifest_sync.py`)
+9. Storage layout consistency (`check_storage_layout.py`)
+10. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+11. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+12. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+13. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+14. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+15. Lean hygiene (`check_lean_hygiene.py`)
+16. Static gas model builtin coverage (`check_gas_model_coverage.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/check_interop_matrix_sync.py
+++ b/scripts/check_interop_matrix_sync.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Check Solidity interop support matrix sync across ROADMAP and status docs.
+
+Validates that the matrix rows and status columns in:
+- docs/ROADMAP.md ("Solidity Interop Profile (Issue #586)")
+- docs/VERIFICATION_STATUS.md ("Solidity Interop Support Matrix (Issue #586)")
+
+stay synchronized for migration-critical status reporting.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from property_utils import ROOT
+
+ROADMAP = ROOT / "docs" / "ROADMAP.md"
+VERIFICATION_STATUS = ROOT / "docs" / "VERIFICATION_STATUS.md"
+
+STATUS_COLUMNS = [
+    "Spec support",
+    "Codegen support",
+    "Proof status",
+    "Test status",
+    "Current status",
+]
+
+
+def _normalize_feature(name: str) -> str:
+    """Normalize a feature label to compare semantically-equivalent row names."""
+    normalized = name.strip().lower()
+    normalized = normalized.replace("`", "")
+    normalized = normalized.replace("(", " ").replace(")", " ")
+    normalized = normalized.replace("/", " ")
+    normalized = normalized.replace("+", " plus ")
+    normalized = re.sub(r"[^a-z0-9\s-]", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    replacements = {
+        "full event abi parity indexed dynamic plus tuple hashing": "event abi parity indexed dynamic tuple payloads",
+        "event abi parity for indexed dynamic tuple payloads": "event abi parity indexed dynamic tuple payloads",
+        "low-level calls call staticcall delegatecall plus returndata handling": "low-level calls call staticcall delegatecall returndata",
+        "low-level calls call staticcall delegatecall with returndata": "low-level calls call staticcall delegatecall returndata",
+        "storage layout controls packed fields plus explicit slot mapping": "storage layout controls packed explicit slots",
+        "storage layout controls packing plus explicit slots": "storage layout controls packed explicit slots",
+    }
+    return replacements.get(normalized, normalized)
+
+
+def _extract_table_rows(doc: Path, heading_pattern: str) -> list[list[str]]:
+    text = doc.read_text(encoding="utf-8")
+    heading = re.search(heading_pattern, text, flags=re.MULTILINE)
+    if not heading:
+        raise ValueError(f"{doc}: missing heading matching /{heading_pattern}/")
+
+    after = text[heading.end() :].splitlines()
+    rows: list[list[str]] = []
+    in_table = False
+    for line in after:
+        stripped = line.strip()
+        if not in_table:
+            if stripped.startswith("|"):
+                in_table = True
+            else:
+                continue
+        if not stripped.startswith("|"):
+            break
+        if re.match(r"^\|[-\s|:]+\|$", stripped):
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        rows.append(cells)
+
+    if len(rows) < 2:
+        raise ValueError(f"{doc}: failed to parse interop matrix rows")
+    return rows
+
+
+def _parse_roadmap_rows() -> dict[str, list[str]]:
+    rows = _extract_table_rows(ROADMAP, r"^### Solidity Interop Profile \(Issue #586\)\s*$")
+    header, body = rows[0], rows[1:]
+    expected_header = ["Priority", "Feature", *STATUS_COLUMNS]
+    if header != expected_header:
+        raise ValueError(
+            f"{ROADMAP}: unexpected matrix header {header!r}; expected {expected_header!r}"
+        )
+    parsed: dict[str, list[str]] = {}
+    for row in body:
+        if len(row) != len(expected_header):
+            raise ValueError(f"{ROADMAP}: malformed matrix row: {row!r}")
+        feature = _normalize_feature(row[1])
+        parsed[feature] = row[2:]
+    return parsed
+
+
+def _parse_verification_rows() -> dict[str, list[str]]:
+    rows = _extract_table_rows(
+        VERIFICATION_STATUS, r"^## Solidity Interop Support Matrix \(Issue #586\)\s*$"
+    )
+    header, body = rows[0], rows[1:]
+    expected_header = ["Feature", *STATUS_COLUMNS]
+    if header != expected_header:
+        raise ValueError(
+            f"{VERIFICATION_STATUS}: unexpected matrix header {header!r}; expected {expected_header!r}"
+        )
+    parsed: dict[str, list[str]] = {}
+    for row in body:
+        if len(row) != len(expected_header):
+            raise ValueError(f"{VERIFICATION_STATUS}: malformed matrix row: {row!r}")
+        feature = _normalize_feature(row[0])
+        parsed[feature] = row[1:]
+    return parsed
+
+
+def main() -> None:
+    roadmap = _parse_roadmap_rows()
+    verification = _parse_verification_rows()
+
+    errors: list[str] = []
+
+    roadmap_features = set(roadmap.keys())
+    verification_features = set(verification.keys())
+
+    only_roadmap = sorted(roadmap_features - verification_features)
+    only_verification = sorted(verification_features - roadmap_features)
+
+    if only_roadmap:
+        errors.append(
+            "ROADMAP has interop rows missing in VERIFICATION_STATUS: "
+            + ", ".join(repr(f) for f in only_roadmap)
+        )
+    if only_verification:
+        errors.append(
+            "VERIFICATION_STATUS has interop rows missing in ROADMAP: "
+            + ", ".join(repr(f) for f in only_verification)
+        )
+
+    shared = sorted(roadmap_features & verification_features)
+    for feature in shared:
+        lhs = roadmap[feature]
+        rhs = verification[feature]
+        if lhs != rhs:
+            deltas = []
+            for idx, col in enumerate(STATUS_COLUMNS):
+                if lhs[idx] != rhs[idx]:
+                    deltas.append(f"{col}: roadmap={lhs[idx]!r}, verification_status={rhs[idx]!r}")
+            errors.append(f"Interop matrix drift for {feature!r}: " + "; ".join(deltas))
+
+    if errors:
+        print("Interop matrix sync check failed:", file=sys.stderr)
+        for e in errors:
+            print(f"- {e}", file=sys.stderr)
+        print(
+            "\nKeep docs/ROADMAP.md and docs/VERIFICATION_STATUS.md interop matrices synchronized.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    print(
+        f"Interop matrix is synchronized across docs ({len(shared)} feature rows checked)."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a fail-closed CI/docs guardrail to keep the Solidity interop support matrix synchronized between:
- `docs/ROADMAP.md`
- `docs/VERIFICATION_STATUS.md`

Closes #695.

## Changes
- Added `scripts/check_interop_matrix_sync.py`:
  - parses the interop matrices under the Issue #586 sections,
  - validates row coverage/parity,
  - validates status-column parity (`Spec support`, `Codegen support`, `Proof status`, `Test status`, `Current status`),
  - emits actionable row-level mismatch diagnostics.
- Wired new check into CI (`.github/workflows/verify.yml`) in the fast `checks` job.
- Documented script in `scripts/README.md`:
  - validation script list,
  - local docs-validation command block,
  - CI checks-job ordering list.

## Validation
- `python3 scripts/check_interop_matrix_sync.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/generate_verification_status.py --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new documentation consistency check and wires it into CI; failure modes are limited to CI gating on markdown table formatting/heading drift.
> 
> **Overview**
> Adds a new CI guardrail (`scripts/check_interop_matrix_sync.py`) that parses the Solidity interop support matrices in `docs/ROADMAP.md` and `docs/VERIFICATION_STATUS.md` and fails if row coverage or any status column values drift (with normalized feature-name matching and per-column diagnostics).
> 
> Wires this check into the fast `checks` job in `verify.yml` and documents the new script and its position in the CI script list in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c1fa2f0b2be04ab5a35263555036c7694699748. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->