### PR TITLE
ci: add verify.yml path-filter consistency guard

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Check Solidity interop matrix sync
         run: python3 scripts/check_interop_matrix_sync.py
 
+      - name: Check verify.yml path filter sync
+        run: python3 scripts/check_verify_paths_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -85,6 +85,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`generate_evmyullean_adapter_report.py`** - Deterministically generates `artifacts/evmyullean_adapter_report.json` with constructor-level lowering coverage (`supported`/`partial`/`gap`) for `lowerExpr` and `lowerStmt` plus explicit adapter-gap reasons and runtime-seam status (`stub-none` vs `implemented`); supports `--check` mode for CI freshness gating
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_interop_matrix_sync.py`** - Ensures the Solidity interop support matrix in `docs/ROADMAP.md` and `docs/VERIFICATION_STATUS.md` stays synchronized (row coverage + status-column parity)
+- **`check_verify_paths_sync.py`** - Ensures `.github/workflows/verify.yml` keeps `on.push.paths` and `on.pull_request.paths` identical, while validating `jobs.changes.filters.code` remains a duplicate-free subset
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -97,6 +98,7 @@ These CI-critical scripts validate cross-layer consistency:
 python3 scripts/generate_verification_status.py
 python3 scripts/check_doc_counts.py
 python3 scripts/check_interop_matrix_sync.py
+python3 scripts/check_verify_paths_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -193,16 +195,17 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 4. Axiom location validation (`check_axiom_locations.py`)
 5. Documentation count validation (`check_doc_counts.py`)
 6. Solidity interop matrix sync (`check_interop_matrix_sync.py`)
-7. Solc pin consistency (`check_solc_pin.py`)
-8. Property manifest sync (`check_property_manifest_sync.py`)
-9. Storage layout consistency (`check_storage_layout.py`)
-10. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-11. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-12. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-13. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-14. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
-15. Lean hygiene (`check_lean_hygiene.py`)
-16. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+7. Verify workflow path-filter sync (`check_verify_paths_sync.py`)
+8. Solc pin consistency (`check_solc_pin.py`)
+9. Property manifest sync (`check_property_manifest_sync.py`)
+10. Storage layout consistency (`check_storage_layout.py`)
+11. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+12. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+13. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+14. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+15. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+16. Lean hygiene (`check_lean_hygiene.py`)
+17. Static gas model builtin coverage (`check_gas_model_coverage.py`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/check_verify_paths_sync.py
+++ b/scripts/check_verify_paths_sync.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Ensure verify.yml path filters stay consistent.
+
+Guards against drift between:
+- `on.push.paths`
+- `on.pull_request.paths`
+- `jobs.changes.steps[*].with.filters.code` (dorny/paths-filter)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+
+
+def normalize_path(raw: str) -> str:
+    value = raw.strip()
+    if value.startswith("- "):
+        value = value[2:].strip()
+    if (value.startswith("'") and value.endswith("'")) or (
+        value.startswith('"') and value.endswith('"')
+    ):
+        value = value[1:-1]
+    return value
+
+
+def extract_list_block(text: str, pattern: str, label: str) -> list[str]:
+    match = re.search(pattern, text, re.MULTILINE)
+    if not match:
+        raise ValueError(f"Could not locate {label} in {VERIFY_YML}")
+    block = match.group("block")
+    entries = [normalize_path(line) for line in block.splitlines() if line.strip()]
+    if not entries:
+        raise ValueError(f"{label} is empty in {VERIFY_YML}")
+    return entries
+
+
+def duplicates(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    dups: list[str] = []
+    for value in values:
+        if value in seen and value not in dups:
+            dups.append(value)
+        seen.add(value)
+    return dups
+
+
+def compare_lists(reference_name: str, reference: list[str], other_name: str, other: list[str]) -> list[str]:
+    errors: list[str] = []
+    if reference == other:
+        return errors
+
+    ref_set = set(reference)
+    other_set = set(other)
+    missing = sorted(ref_set - other_set)
+    extra = sorted(other_set - ref_set)
+
+    if missing:
+        errors.append(f"{other_name} is missing {len(missing)} path(s) present in {reference_name}:")
+        errors.extend([f"  - {m}" for m in missing])
+    if extra:
+        errors.append(f"{other_name} has {len(extra)} extra path(s) not present in {reference_name}:")
+        errors.extend([f"  - {e}" for e in extra])
+
+    if not missing and not extra:
+        errors.append(
+            f"{other_name} has the same entries as {reference_name} but in a different order. "
+            "Keep order aligned to reduce review noise."
+        )
+    return errors
+
+
+def ensure_subset(parent_name: str, parent: list[str], subset_name: str, subset: list[str]) -> list[str]:
+    errors: list[str] = []
+    parent_set = set(parent)
+    extra = sorted(set(subset) - parent_set)
+    if extra:
+        errors.append(f"{subset_name} contains {len(extra)} path(s) not present in {parent_name}:")
+        errors.extend([f"  - {e}" for e in extra])
+    return errors
+
+
+def main() -> int:
+    text = VERIFY_YML.read_text(encoding="utf-8")
+
+    push_paths = extract_list_block(
+        text,
+        r"^  push:\n(?:^    .*\n)*?^    paths:\n(?P<block>(?:^      - .*\n)+)",
+        "on.push.paths",
+    )
+    pr_paths = extract_list_block(
+        text,
+        r"^  pull_request:\n(?:^    .*\n)*?^    paths:\n(?P<block>(?:^      - .*\n)+)",
+        "on.pull_request.paths",
+    )
+    filter_paths = extract_list_block(
+        text,
+        r"^          filters: \|\n(?:^            .*\n)*?^            code:\n(?P<block>(?:^              - .*\n)+)",
+        "changes.filter.code",
+    )
+
+    errors: list[str] = []
+
+    for label, values in [
+        ("on.push.paths", push_paths),
+        ("on.pull_request.paths", pr_paths),
+        ("changes.filter.code", filter_paths),
+    ]:
+        dup = duplicates(values)
+        if dup:
+            errors.append(f"{label} contains duplicate path entries:")
+            errors.extend([f"  - {d}" for d in dup])
+
+    errors.extend(compare_lists("on.push.paths", push_paths, "on.pull_request.paths", pr_paths))
+    errors.extend(ensure_subset("on.push.paths", push_paths, "changes.filter.code", filter_paths))
+
+    if errors:
+        print("verify.yml path-filter inconsistency detected:", file=sys.stderr)
+        for line in errors:
+            print(line, file=sys.stderr)
+        print(
+            "\nUpdate .github/workflows/verify.yml so push/pull_request lists match and "
+            "changes.filter.code remains a valid subset.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "verify.yml path filters are consistent "
+        f"({len(push_paths)} push/pull_request entries; {len(filter_paths)} changes.filter.code entries)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_verify_paths_sync.py` to validate `verify.yml` path-filter invariants
- enforce `on.push.paths == on.pull_request.paths`
- enforce `jobs.changes.filters.code` is duplicate-free and a subset of push/pull paths
- run the new guard in the fast `checks` job
- document the script in `scripts/README.md`

## Validation
- `python3 scripts/check_verify_paths_sync.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_interop_matrix_sync.py`

Closes #697

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds a deterministic validation script; main risk is false failures if `verify.yml` formatting changes beyond the script’s regex expectations.
> 
> **Overview**
> Adds a new CI guard script, `scripts/check_verify_paths_sync.py`, to prevent drift between `verify.yml`’s `on.push.paths`, `on.pull_request.paths`, and the `dorny/paths-filter` `changes.filter.code` list (including duplicate detection and subset enforcement).
> 
> Wires this check into the fast `checks` job in `.github/workflows/verify.yml` and documents how to run it in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39aba284bc42989a959d27586ece87eb6e4c8573. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->