### PR TITLE
ci(docs): enforce verify checks/docs sync

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Check verify.yml path filter sync
         run: python3 scripts/check_verify_paths_sync.py
 
+      - name: Check verify checks/docs sync
+        run: python3 scripts/check_verify_checks_docs_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,6 +86,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_doc_counts.py`** - Validates theorem, axiom, test, suite, coverage, and contract counts across 14 documentation files (README, llms.txt, compiler.mdx, verification.mdx, research.mdx, index.mdx, core.mdx, examples.mdx, getting-started.mdx, TRUST_ASSUMPTIONS, VERIFICATION_STATUS, ROADMAP, test/README, layout.tsx), theorem-name completeness in verification.mdx tables, and proven-theorem counts in Property*.t.sol file headers
 - **`check_interop_matrix_sync.py`** - Ensures the Solidity interop support matrix in `docs/ROADMAP.md` and `docs/VERIFICATION_STATUS.md` stays synchronized (row coverage + status-column parity)
 - **`check_verify_paths_sync.py`** - Ensures `.github/workflows/verify.yml` keeps `on.push.paths` and `on.pull_request.paths` identical, while validating `jobs.changes.filters.code` remains a duplicate-free subset
+- **`check_verify_checks_docs_sync.py`** - Ensures `.github/workflows/verify.yml` `checks` job python-script command sequence matches the documented `**\`checks\` job**` list in this README
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -99,6 +100,7 @@ python3 scripts/generate_verification_status.py
 python3 scripts/check_doc_counts.py
 python3 scripts/check_interop_matrix_sync.py
 python3 scripts/check_verify_paths_sync.py
+python3 scripts/check_verify_checks_docs_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -193,19 +195,22 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 2. Property coverage validation (`check_property_coverage.py`)
 3. Contract file structure validation (`check_contract_structure.py`)
 4. Axiom location validation (`check_axiom_locations.py`)
-5. Documentation count validation (`check_doc_counts.py`)
-6. Solidity interop matrix sync (`check_interop_matrix_sync.py`)
-7. Verify workflow path-filter sync (`check_verify_paths_sync.py`)
-8. Solc pin consistency (`check_solc_pin.py`)
-9. Property manifest sync (`check_property_manifest_sync.py`)
-10. Storage layout consistency (`check_storage_layout.py`)
-11. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-12. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-13. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-14. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-15. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
-16. Lean hygiene (`check_lean_hygiene.py`)
-17. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+5. Verification status artifact freshness (`generate_verification_status.py --check`)
+6. Documentation count validation (`check_doc_counts.py`)
+7. Solidity interop matrix sync (`check_interop_matrix_sync.py`)
+8. Verify workflow path-filter sync (`check_verify_paths_sync.py`)
+9. Verify checks/docs sync (`check_verify_checks_docs_sync.py`)
+10. Solc pin consistency (`check_solc_pin.py`)
+11. Property manifest sync (`check_property_manifest_sync.py`)
+12. Storage layout consistency (`check_storage_layout.py`)
+13. Lean hygiene (`check_lean_hygiene.py`)
+14. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+15. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+16. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+17. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
+18. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+19. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+20. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Keccak-256 self-test (`keccak256.py --self-test`)

--- a/scripts/check_verify_checks_docs_sync.py
+++ b/scripts/check_verify_checks_docs_sync.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Ensure verify.yml checks-job script list matches scripts/README.md docs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+SCRIPTS_README = ROOT / "scripts" / "README.md"
+
+
+def _normalize_workflow_cmd(raw: str) -> str:
+    text = raw.strip()
+    if not text.startswith("python3 "):
+        raise ValueError(f"Expected python3 scripts command, got: {raw!r}")
+    text = text[len("python3 ") :].strip()
+    if not text.startswith("scripts/"):
+        raise ValueError(f"Expected scripts/ path command, got: {raw!r}")
+    return text[len("scripts/") :]
+
+
+def _extract_workflow_checks_commands(text: str) -> list[str]:
+    lines = text.splitlines()
+    checks_idx = next((i for i, line in enumerate(lines) if line == "  checks:"), None)
+    if checks_idx is None:
+        raise ValueError(f"Could not locate checks job in {VERIFY_YML}")
+
+    steps_idx = next(
+        (
+            i
+            for i in range(checks_idx + 1, len(lines))
+            if lines[i] == "    steps:"
+        ),
+        None,
+    )
+    if steps_idx is None:
+        raise ValueError(f"Could not locate checks.steps in {VERIFY_YML}")
+
+    steps: list[str] = []
+    for line in lines[steps_idx + 1 :]:
+        if re.match(r"^  [A-Za-z0-9_-]+:", line):
+            break
+        steps.append(line)
+
+    commands: list[str] = []
+    for line in steps:
+        cmd = re.match(r"^\s*run:\s*(python3\s+scripts/[^\n]+?)\s*$", line)
+        if cmd:
+            commands.append(_normalize_workflow_cmd(cmd.group(1)))
+    if not commands:
+        raise ValueError(f"No python3 scripts/* run commands found in checks job in {VERIFY_YML}")
+    return commands
+
+
+def _extract_readme_checks_commands(text: str) -> list[str]:
+    section = re.search(
+        r"^\*\*`checks` job\*\*.*?\n(?P<body>(?:^\d+\.\s.*\n)+)",
+        text,
+        flags=re.MULTILINE,
+    )
+    if not section:
+        raise ValueError(f"Could not locate '**`checks` job**' numbered list in {SCRIPTS_README}")
+
+    commands: list[str] = []
+    for line in section.group("body").splitlines():
+        cmd = re.search(r"\(`([^`]+)`\)", line)
+        if not cmd:
+            raise ValueError(f"Could not parse command from README checks line: {line!r}")
+        commands.append(cmd.group(1).strip())
+    if not commands:
+        raise ValueError(f"No documented checks commands found in {SCRIPTS_README}")
+    return commands
+
+
+def _compare(expected: list[str], actual: list[str]) -> list[str]:
+    if expected == actual:
+        return []
+
+    errors: list[str] = []
+    expected_set = set(expected)
+    actual_set = set(actual)
+
+    missing = [cmd for cmd in expected if cmd not in actual_set]
+    extra = [cmd for cmd in actual if cmd not in expected_set]
+
+    if missing:
+        errors.append("README checks list is missing workflow commands:")
+        errors.extend([f"  - {m}" for m in missing])
+    if extra:
+        errors.append("README checks list has commands not present in workflow checks job:")
+        errors.extend([f"  - {e}" for e in extra])
+    if not missing and not extra:
+        errors.append(
+            "README checks list contains the same commands but in a different order. "
+            "Keep exact order aligned with workflow for auditability."
+        )
+    return errors
+
+
+def main() -> int:
+    workflow_text = VERIFY_YML.read_text(encoding="utf-8")
+    readme_text = SCRIPTS_README.read_text(encoding="utf-8")
+
+    workflow_commands = _extract_workflow_checks_commands(workflow_text)
+    readme_commands = _extract_readme_checks_commands(readme_text)
+
+    errors = _compare(workflow_commands, readme_commands)
+    if errors:
+        print("verify checks/docs sync check failed:", file=sys.stderr)
+        for error in errors:
+            print(error, file=sys.stderr)
+        print(
+            "\nUpdate scripts/README.md '**`checks` job**' command list to match "
+            ".github/workflows/verify.yml checks job.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "verify checks/docs command list is synchronized "
+        f"({len(workflow_commands)} commands)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_verify_checks_docs_sync.py` to enforce sync between:
  - `.github/workflows/verify.yml` `checks` job python script commands
  - `scripts/README.md` documented `**\`checks\` job**` numbered command list
- add a `verify.yml` checks-step to run the new guard
- update `scripts/README.md` checks-job list to exact parity/order with workflow (including recently added entries)

## Why
`verify.yml` and docs can drift independently; this weakens CI/docs auditability and misleads contributors running local preflight checks.

## Validation
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_paths_sync.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_interop_matrix_sync.py`

Closes #700

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/doc synchronization only; no production code paths or security-sensitive logic are changed, with the main risk being a false-positive CI failure if parsing assumptions change.
> 
> **Overview**
> Adds a new CI check (`scripts/check_verify_checks_docs_sync.py`) that extracts the `python3 scripts/*` commands from the `verify.yml` `checks` job and compares them against the numbered `**`checks` job**` list in `scripts/README.md`, failing on missing/extra commands or ordering drift.
> 
> Wires this guard into `.github/workflows/verify.yml` and updates `scripts/README.md` to reflect the current `checks` job sequence (including newer entries like `generate_verification_status.py --check` and `check_builtin_list_sync.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd1bfef16dfea5369379c8c9ae83ce9b4415ef4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->