### PR TITLE
ci: guard verify build-job docs sync

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Check verify checks/docs sync
         run: python3 scripts/check_verify_checks_docs_sync.py
 
+      - name: Check verify build/docs sync
+        run: python3 scripts/check_verify_build_docs_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -87,6 +87,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_interop_matrix_sync.py`** - Ensures the Solidity interop support matrix in `docs/ROADMAP.md` and `docs/VERIFICATION_STATUS.md` stays synchronized (row coverage + status-column parity)
 - **`check_verify_paths_sync.py`** - Ensures `.github/workflows/verify.yml` keeps `on.push.paths` and `on.pull_request.paths` identical, while validating `jobs.changes.filters.code` remains a duplicate-free subset
 - **`check_verify_checks_docs_sync.py`** - Ensures `.github/workflows/verify.yml` `checks` job python-script command sequence matches the documented `**\`checks\` job**` list in this README
+- **`check_verify_build_docs_sync.py`** - Ensures `.github/workflows/verify.yml` `build` job python-script command sequence matches the documented `**\`build\` job**` list in this README
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -101,6 +102,7 @@ python3 scripts/check_doc_counts.py
 python3 scripts/check_interop_matrix_sync.py
 python3 scripts/check_verify_paths_sync.py
 python3 scripts/check_verify_checks_docs_sync.py
+python3 scripts/check_verify_build_docs_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -200,29 +202,30 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 7. Solidity interop matrix sync (`check_interop_matrix_sync.py`)
 8. Verify workflow path-filter sync (`check_verify_paths_sync.py`)
 9. Verify checks/docs sync (`check_verify_checks_docs_sync.py`)
-10. Solc pin consistency (`check_solc_pin.py`)
-11. Property manifest sync (`check_property_manifest_sync.py`)
-12. Storage layout consistency (`check_storage_layout.py`)
-13. Lean hygiene (`check_lean_hygiene.py`)
-14. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-15. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-16. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-17. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
-18. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-19. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-20. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+10. Verify build/docs sync (`check_verify_build_docs_sync.py`)
+11. Solc pin consistency (`check_solc_pin.py`)
+12. Property manifest sync (`check_property_manifest_sync.py`)
+13. Storage layout consistency (`check_storage_layout.py`)
+14. Lean hygiene (`check_lean_hygiene.py`)
+15. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+16. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+17. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+18. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
+19. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+20. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+21. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 
 **`build` job** (requires `lake build` artifacts):
-1. Keccak-256 self-test (`keccak256.py --self-test`)
-2. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)
-3. Selector hash verification (`check_selectors.py`)
-4. Yul compilation (legacy + patched + AST) + legacy/AST diff-baseline check (`check_yul_compiles.py`)
-5. Static gas model coverage on generated Yul (legacy + patched + AST) (`check_gas_model_coverage.py`)
+1. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)
+2. Static gas model coverage on generated Yul (legacy + patched + AST) (`check_gas_model_coverage.py`)
+3. Keccak-256 self-test (`keccak256.py --self-test`)
+4. Selector hash verification (`check_selectors.py`)
+5. Yul compilation (legacy + patched + AST) + legacy/AST diff-baseline check (`check_yul_compiles.py`)
 6. Selector fixture check (`check_selector_fixtures.py`)
 7. Static gas report invariants (`check_gas_report.py`)
 8. Save baseline + patch-enabled static gas report artifacts (`gas-report-static.tsv`, `gas-report-static-patched.tsv`)
 9. Patch gas delta non-regression + measurable improvement gate (`check_patch_gas_delta.py`)
-10. Coverage and storage layout reports in workflow summary
+10. Coverage and storage layout reports in workflow summary (`report_property_coverage.py`, `check_storage_layout.py`)
 
 **`foundry-gas-calibration`** — Static-vs-Foundry gas calibration check (`check_gas_calibration.py`) using build-artifact static report + Foundry gas report (runtime + deployment)
 **`foundry`** — 8-shard parallel Foundry tests with seed 42

--- a/scripts/check_verify_build_docs_sync.py
+++ b/scripts/check_verify_build_docs_sync.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Ensure verify.yml build-job script list matches scripts/README.md docs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+SCRIPTS_README = ROOT / "scripts" / "README.md"
+
+
+def _normalize_spaces(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _normalize_workflow_cmd(raw: str) -> str:
+    text = _normalize_spaces(raw.strip())
+    if not text.startswith("python3 "):
+        raise ValueError(f"Expected python3 scripts command, got: {raw!r}")
+    text = text[len("python3 ") :].strip()
+    if not text.startswith("scripts/"):
+        raise ValueError(f"Expected scripts/ path command, got: {raw!r}")
+    script_with_args = text[len("scripts/") :]
+    return script_with_args.split()[0]
+
+
+def _extract_job_steps_block(workflow_text: str, job_name: str) -> list[str]:
+    lines = workflow_text.splitlines()
+    job_idx = next((i for i, line in enumerate(lines) if line == f"  {job_name}:"), None)
+    if job_idx is None:
+        raise ValueError(f"Could not locate {job_name} job in {VERIFY_YML}")
+
+    steps_idx = next(
+        (i for i in range(job_idx + 1, len(lines)) if lines[i] == "    steps:"),
+        None,
+    )
+    if steps_idx is None:
+        raise ValueError(f"Could not locate {job_name}.steps in {VERIFY_YML}")
+
+    steps: list[str] = []
+    for line in lines[steps_idx + 1 :]:
+        if re.match(r"^  [A-Za-z0-9_-]+:", line):
+            break
+        steps.append(line)
+    return steps
+
+
+def _extract_run_commands_from_steps(steps_lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    i = 0
+    while i < len(steps_lines):
+        line = steps_lines[i]
+        m = re.match(r"^(\s*)run:\s*(.*?)\s*$", line)
+        if not m:
+            i += 1
+            continue
+
+        indent = len(m.group(1))
+        payload = m.group(2)
+        block_lines: list[str] = []
+        if payload in ("|", ">"):
+            i += 1
+            while i < len(steps_lines):
+                nxt = steps_lines[i]
+                if not nxt.strip():
+                    block_lines.append("")
+                    i += 1
+                    continue
+                if len(nxt) - len(nxt.lstrip(" ")) <= indent:
+                    break
+                block_lines.append(nxt[indent + 2 :])
+                i += 1
+        else:
+            block_lines.append(payload)
+            i += 1
+
+        commands.extend(_extract_python_script_commands(block_lines))
+
+    return commands
+
+
+def _extract_python_script_commands(block_lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    i = 0
+    while i < len(block_lines):
+        stripped = block_lines[i].strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+
+        if not stripped.startswith("python3 scripts/"):
+            i += 1
+            continue
+
+        cmd = stripped
+        while cmd.endswith("\\"):
+            cmd = cmd[:-1].rstrip()
+            i += 1
+            if i >= len(block_lines):
+                raise ValueError(
+                    "Trailing line-continuation in python3 scripts command in "
+                    f"{VERIFY_YML}: {stripped!r}"
+                )
+            continuation = block_lines[i].strip()
+            if continuation:
+                cmd += " " + continuation
+
+        commands.append(_normalize_workflow_cmd(cmd))
+        i += 1
+    return commands
+
+
+def _extract_workflow_build_commands(text: str) -> list[str]:
+    steps = _extract_job_steps_block(text, "build")
+    commands = _extract_run_commands_from_steps(steps)
+    if not commands:
+        raise ValueError(f"No python3 scripts/* run commands found in build job in {VERIFY_YML}")
+    return commands
+
+
+def _extract_readme_build_commands(text: str) -> list[str]:
+    section = re.search(
+        r"^\*\*`build` job\*\*.*?\n(?P<body>(?:^\d+\.\s.*\n)+)",
+        text,
+        flags=re.MULTILINE,
+    )
+    if not section:
+        raise ValueError(f"Could not locate '**`build` job**' numbered list in {SCRIPTS_README}")
+
+    commands: list[str] = []
+    for line in section.group("body").splitlines():
+        code_spans = re.findall(r"`([^`]+)`", line)
+        script_spans = [span for span in code_spans if ".py" in span]
+        for cmd in script_spans:
+            if cmd.startswith("python3 "):
+                cmd = cmd[len("python3 ") :].strip()
+            if cmd.startswith("scripts/"):
+                cmd = cmd[len("scripts/") :]
+            commands.append(_normalize_spaces(cmd).split()[0])
+
+    if not commands:
+        raise ValueError(f"No documented build script commands found in {SCRIPTS_README}")
+    return commands
+
+
+def _compare(expected: list[str], actual: list[str]) -> list[str]:
+    if expected == actual:
+        return []
+
+    errors: list[str] = []
+    expected_set = set(expected)
+    actual_set = set(actual)
+
+    missing = [cmd for cmd in expected if cmd not in actual_set]
+    extra = [cmd for cmd in actual if cmd not in expected_set]
+
+    if missing:
+        errors.append("README build list is missing workflow commands:")
+        errors.extend([f"  - {m}" for m in missing])
+    if extra:
+        errors.append("README build list has commands not present in workflow build job:")
+        errors.extend([f"  - {e}" for e in extra])
+    if not missing and not extra:
+        errors.append(
+            "README build list contains the same commands but in a different order. "
+            "Keep exact order aligned with workflow for auditability."
+        )
+    return errors
+
+
+def main() -> int:
+    workflow_text = VERIFY_YML.read_text(encoding="utf-8")
+    readme_text = SCRIPTS_README.read_text(encoding="utf-8")
+
+    workflow_commands = _extract_workflow_build_commands(workflow_text)
+    readme_commands = _extract_readme_build_commands(readme_text)
+
+    errors = _compare(workflow_commands, readme_commands)
+    if errors:
+        print("verify build/docs sync check failed:", file=sys.stderr)
+        for error in errors:
+            print(error, file=sys.stderr)
+        print(
+            "\nUpdate scripts/README.md '**`build` job**' command list to match "
+            ".github/workflows/verify.yml build job.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "verify build/docs command list is synchronized "
+        f"({len(workflow_commands)} script commands)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_verify_build_docs_sync.py` to enforce parity between:
  - `.github/workflows/verify.yml` `build` job Python script sequence
  - documented `**\`build\` job**` list in `scripts/README.md`
- run the new guard in the fast `checks` CI job
- document the guard and align the README `build` job ordering/content with workflow reality

## Why
The repo already guards `checks` job docs sync, but `build` job script documentation could silently drift. This adds the missing fail-closed check and prevents stale local-run docs.

## Validation
- `python3 scripts/check_verify_build_docs_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_paths_sync.py`
- `python3 scripts/check_doc_counts.py`
- `python3 -m py_compile scripts/check_verify_build_docs_sync.py`

Closes #702

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only tooling/documentation sync changes; risk is limited to potential false failures if the parser misses unusual workflow formatting.
> 
> **Overview**
> Adds a new CI check, `scripts/check_verify_build_docs_sync.py`, that parses `.github/workflows/verify.yml`’s `build` job and compares the ordered list of `python3 scripts/*.py` invocations against the documented `**`build` job**` numbered list in `scripts/README.md`, failing with actionable diffs on mismatch.
> 
> Wires this guard into the fast `checks` GitHub Actions job, and updates `scripts/README.md` to document the new guard and to reorder/clarify the documented `build` job script list to match the workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be7a2eb3af47dfd793ddab9eabac68763246eff9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->