### PR TITLE
ci/docs: enforce verify job summary sync in scripts README

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Check verify build/docs sync
         run: python3 scripts/check_verify_build_docs_sync.py
 
+      - name: Check verify CI job/docs sync
+        run: python3 scripts/check_verify_ci_jobs_docs_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,6 +88,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_verify_paths_sync.py`** - Ensures `.github/workflows/verify.yml` keeps `on.push.paths` and `on.pull_request.paths` identical, while validating `jobs.changes.filters.code` remains a duplicate-free subset
 - **`check_verify_checks_docs_sync.py`** - Ensures `.github/workflows/verify.yml` `checks` job python-script command sequence matches the documented `**\`checks\` job**` list in this README
 - **`check_verify_build_docs_sync.py`** - Ensures `.github/workflows/verify.yml` `build` job python-script command sequence matches the documented `**\`build\` job**` list in this README
+- **`check_verify_ci_jobs_docs_sync.py`** - Ensures `.github/workflows/verify.yml` top-level job order matches the CI job summary list in this README (`## CI Integration`)
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -103,6 +104,7 @@ python3 scripts/check_interop_matrix_sync.py
 python3 scripts/check_verify_paths_sync.py
 python3 scripts/check_verify_checks_docs_sync.py
 python3 scripts/check_verify_build_docs_sync.py
+python3 scripts/check_verify_ci_jobs_docs_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -188,7 +190,7 @@ Creates 7 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic 
 
 ## CI Integration
 
-Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
+Scripts run automatically in GitHub Actions (`verify.yml`) across 7 jobs:
 
 **`changes`** — Path filter that gates code-dependent jobs (doc-only PRs skip build/test)
 
@@ -203,17 +205,18 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 8. Verify workflow path-filter sync (`check_verify_paths_sync.py`)
 9. Verify checks/docs sync (`check_verify_checks_docs_sync.py`)
 10. Verify build/docs sync (`check_verify_build_docs_sync.py`)
-11. Solc pin consistency (`check_solc_pin.py`)
-12. Property manifest sync (`check_property_manifest_sync.py`)
-13. Storage layout consistency (`check_storage_layout.py`)
-14. Lean hygiene (`check_lean_hygiene.py`)
-15. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-16. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-17. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-18. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
-19. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-20. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-21. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+11. Verify CI job/docs sync (`check_verify_ci_jobs_docs_sync.py`)
+12. Solc pin consistency (`check_solc_pin.py`)
+13. Property manifest sync (`check_property_manifest_sync.py`)
+14. Storage layout consistency (`check_storage_layout.py`)
+15. Lean hygiene (`check_lean_hygiene.py`)
+16. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+17. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+18. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+19. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
+20. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+21. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+22. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)
@@ -229,6 +232,7 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 5 jobs:
 
 **`foundry-gas-calibration`** — Static-vs-Foundry gas calibration check (`check_gas_calibration.py`) using build-artifact static report + Foundry gas report (runtime + deployment)
 **`foundry`** — 8-shard parallel Foundry tests with seed 42
+**`foundry-patched`** — Patched-Yul smoke gate on differential/property harness (seed 42, no `Random10000`)
 **`foundry-multi-seed`** — 7-seed flakiness detection (seeds: 0, 1, 42, 123, 999, 12345, 67890)
 
 ## Adding New Property Tests

--- a/scripts/check_verify_ci_jobs_docs_sync.py
+++ b/scripts/check_verify_ci_jobs_docs_sync.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Ensure verify.yml job list matches scripts/README.md CI Integration summary."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+SCRIPTS_README = ROOT / "scripts" / "README.md"
+
+
+def _extract_workflow_jobs(text: str) -> list[str]:
+    lines = text.splitlines()
+    jobs_idx = next((i for i, line in enumerate(lines) if line == "jobs:"), None)
+    if jobs_idx is None:
+        raise ValueError(f"Could not locate jobs section in {VERIFY_YML}")
+
+    jobs: list[str] = []
+    for line in lines[jobs_idx + 1 :]:
+        if not line:
+            continue
+        if not line.startswith(" "):
+            break
+        m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+        if m:
+            jobs.append(m.group(1))
+    if not jobs:
+        raise ValueError(f"No top-level jobs found in {VERIFY_YML}")
+    return jobs
+
+
+def _extract_readme_ci_jobs(text: str) -> list[str]:
+    section = re.search(
+        r"^## CI Integration\n(?P<body>.*?)(?:^## |\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not section:
+        raise ValueError(f"Could not locate '## CI Integration' section in {SCRIPTS_README}")
+
+    jobs: list[str] = []
+    for line in section.group("body").splitlines():
+        m = re.match(r"^\*\*`([^`]+)`(?: job)?\*\*", line)
+        if m:
+            jobs.append(m.group(1))
+    if not jobs:
+        raise ValueError(f"No CI job summary entries found in {SCRIPTS_README}")
+    return jobs
+
+
+def _compare(expected: list[str], actual: list[str]) -> list[str]:
+    if expected == actual:
+        return []
+
+    errors: list[str] = []
+    expected_set = set(expected)
+    actual_set = set(actual)
+
+    missing = [job for job in expected if job not in actual_set]
+    extra = [job for job in actual if job not in expected_set]
+
+    if missing:
+        errors.append("README CI Integration is missing workflow jobs:")
+        errors.extend([f"  - {job}" for job in missing])
+    if extra:
+        errors.append("README CI Integration has jobs not present in workflow:")
+        errors.extend([f"  - {job}" for job in extra])
+    if not missing and not extra:
+        errors.append(
+            "README CI Integration contains the same jobs but in a different order. "
+            "Keep order aligned with workflow for quick cross-referencing."
+        )
+    return errors
+
+
+def main() -> int:
+    workflow_text = VERIFY_YML.read_text(encoding="utf-8")
+    readme_text = SCRIPTS_README.read_text(encoding="utf-8")
+
+    workflow_jobs = _extract_workflow_jobs(workflow_text)
+    readme_jobs = _extract_readme_ci_jobs(readme_text)
+
+    errors = _compare(workflow_jobs, readme_jobs)
+    if errors:
+        print("verify CI job/docs sync check failed:", file=sys.stderr)
+        for error in errors:
+            print(error, file=sys.stderr)
+        print(
+            "\nUpdate scripts/README.md '## CI Integration' job summary to match "
+            ".github/workflows/verify.yml job order.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"verify CI job/docs list is synchronized ({len(workflow_jobs)} jobs).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_verify_ci_jobs_docs_sync.py` to enforce sync between:
  - `.github/workflows/verify.yml` top-level job order
  - `scripts/README.md` `## CI Integration` job summary
- run the new guard in `verify.yml` `checks` job
- fix existing docs drift by documenting `foundry-patched` and correcting CI job count (`7` jobs)
- update local validation command list and checks-job command list in `scripts/README.md`

## Why
`verify.yml` already had a `foundry-patched` job, but the README CI summary omitted it. This patch both corrects the current drift and prevents recurrence.

Closes #704

## Validation
- `python3 scripts/check_verify_ci_jobs_docs_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`
- `python3 scripts/check_doc_counts.py`
- `python3 -m py_compile scripts/check_verify_ci_jobs_docs_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a lightweight CI/documentation consistency check and updates README text; no production code paths or security-sensitive logic are affected.
> 
> **Overview**
> Adds a new guard script, `scripts/check_verify_ci_jobs_docs_sync.py`, that fails CI if the `scripts/README.md` **CI Integration** job list is missing/extra/out-of-order versus `.github/workflows/verify.yml` top-level jobs.
> 
> Wires this check into the `verify.yml` `checks` job, and updates `scripts/README.md` to fix existing drift (job count now 7 and includes `foundry-patched`) and to document the new local validation command and checks-job step ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10d7d244b2ef44b0f3a2cfe3383ffcab9c4fcc8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->