### PR TITLE
ci: guard multi-seed list sync across workflow/script/docs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Check verify CI job/docs sync
         run: python3 scripts/check_verify_ci_jobs_docs_sync.py
 
+      - name: Check verify multi-seed sync
+        run: python3 scripts/check_verify_multiseed_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -89,6 +89,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_verify_checks_docs_sync.py`** - Ensures `.github/workflows/verify.yml` `checks` job python-script command sequence matches the documented `**\`checks\` job**` list in this README
 - **`check_verify_build_docs_sync.py`** - Ensures `.github/workflows/verify.yml` `build` job python-script command sequence matches the documented `**\`build\` job**` list in this README
 - **`check_verify_ci_jobs_docs_sync.py`** - Ensures `.github/workflows/verify.yml` top-level job order matches the CI job summary list in this README (`## CI Integration`)
+- **`check_verify_multiseed_sync.py`** - Ensures `foundry-multi-seed` seed lists stay synchronized across `.github/workflows/verify.yml`, `scripts/test_multiple_seeds.sh`, and this README
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -105,6 +106,7 @@ python3 scripts/check_verify_paths_sync.py
 python3 scripts/check_verify_checks_docs_sync.py
 python3 scripts/check_verify_build_docs_sync.py
 python3 scripts/check_verify_ci_jobs_docs_sync.py
+python3 scripts/check_verify_multiseed_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -206,17 +208,18 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 7 jobs:
 9. Verify checks/docs sync (`check_verify_checks_docs_sync.py`)
 10. Verify build/docs sync (`check_verify_build_docs_sync.py`)
 11. Verify CI job/docs sync (`check_verify_ci_jobs_docs_sync.py`)
-12. Solc pin consistency (`check_solc_pin.py`)
-13. Property manifest sync (`check_property_manifest_sync.py`)
-14. Storage layout consistency (`check_storage_layout.py`)
-15. Lean hygiene (`check_lean_hygiene.py`)
-16. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-17. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-18. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-19. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
-20. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-21. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-22. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+12. Verify multi-seed sync (`check_verify_multiseed_sync.py`)
+13. Solc pin consistency (`check_solc_pin.py`)
+14. Property manifest sync (`check_property_manifest_sync.py`)
+15. Storage layout consistency (`check_storage_layout.py`)
+16. Lean hygiene (`check_lean_hygiene.py`)
+17. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+18. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+19. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+20. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
+21. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+22. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+23. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)

--- a/scripts/check_verify_multiseed_sync.py
+++ b/scripts/check_verify_multiseed_sync.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Ensure multi-seed lists stay synchronized across workflow, script, and docs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+MULTISEED_SCRIPT = ROOT / "scripts" / "test_multiple_seeds.sh"
+SCRIPTS_README = ROOT / "scripts" / "README.md"
+
+
+def _parse_seed_csv(raw: str, source: Path) -> list[int]:
+    items = [part.strip() for part in raw.split(",")]
+    if not items or any(not item for item in items):
+        raise ValueError(f"Malformed seed list in {source}: {raw!r}")
+    try:
+        return [int(item) for item in items]
+    except ValueError as exc:
+        raise ValueError(f"Non-integer seed in {source}: {raw!r}") from exc
+
+
+def _extract_verify_seeds(text: str) -> list[int]:
+    section = re.search(
+        r"^  foundry-multi-seed:\n(?P<body>.*?)(?:^  [A-Za-z0-9_-]+:|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not section:
+        raise ValueError(f"Could not locate foundry-multi-seed job in {VERIFY_YML}")
+
+    seed_line = re.search(r"^\s*seed:\s*\[(?P<csv>[^\]]+)\]\s*$", section.group("body"), re.MULTILINE)
+    if not seed_line:
+        raise ValueError(f"Could not locate matrix seed list in {VERIFY_YML}")
+    return _parse_seed_csv(seed_line.group("csv"), VERIFY_YML)
+
+
+def _extract_script_seeds(text: str) -> list[int]:
+    m = re.search(r"^DEFAULT_SEEDS=\((?P<vals>[^)]+)\)\s*$", text, re.MULTILINE)
+    if not m:
+        raise ValueError(f"Could not locate DEFAULT_SEEDS in {MULTISEED_SCRIPT}")
+    raw_tokens = m.group("vals").split()
+    if not raw_tokens:
+        raise ValueError(f"DEFAULT_SEEDS is empty in {MULTISEED_SCRIPT}")
+    try:
+        return [int(token) for token in raw_tokens]
+    except ValueError as exc:
+        raise ValueError(f"Non-integer DEFAULT_SEEDS value in {MULTISEED_SCRIPT}") from exc
+
+
+def _extract_readme_seeds(text: str) -> list[int]:
+    line = re.search(
+        r"^\*\*`foundry-multi-seed`\*\*.*\(seeds:\s*(?P<csv>[^)]+)\)\s*$",
+        text,
+        flags=re.MULTILINE,
+    )
+    if not line:
+        raise ValueError(
+            "Could not locate foundry-multi-seed seeds summary in "
+            f"{SCRIPTS_README}"
+        )
+    return _parse_seed_csv(line.group("csv"), SCRIPTS_README)
+
+
+def _fmt(seeds: list[int]) -> str:
+    return ", ".join(str(seed) for seed in seeds)
+
+
+def main() -> int:
+    verify_text = VERIFY_YML.read_text(encoding="utf-8")
+    script_text = MULTISEED_SCRIPT.read_text(encoding="utf-8")
+    readme_text = SCRIPTS_README.read_text(encoding="utf-8")
+
+    verify_seeds = _extract_verify_seeds(verify_text)
+    script_seeds = _extract_script_seeds(script_text)
+    readme_seeds = _extract_readme_seeds(readme_text)
+
+    errors: list[str] = []
+    if script_seeds != verify_seeds:
+        errors.append(
+            "scripts/test_multiple_seeds.sh DEFAULT_SEEDS differs from "
+            "verify.yml foundry-multi-seed matrix."
+        )
+    if readme_seeds != verify_seeds:
+        errors.append(
+            "scripts/README.md foundry-multi-seed seeds summary differs from "
+            "verify.yml foundry-multi-seed matrix."
+        )
+
+    if errors:
+        print("verify multi-seed sync check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        print(f"  verify.yml seeds: {_fmt(verify_seeds)}", file=sys.stderr)
+        print(f"  script seeds:     {_fmt(script_seeds)}", file=sys.stderr)
+        print(f"  README seeds:     {_fmt(readme_seeds)}", file=sys.stderr)
+        return 1
+
+    print(
+        "verify multi-seed lists are synchronized across workflow/script/docs "
+        f"({len(verify_seeds)} seeds)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a CI guard for one remaining unprotected drift vector: the multi-seed list is duplicated across workflow, local script, and docs.

## Changes
- Added `scripts/check_verify_multiseed_sync.py` to enforce exact seed-list parity across:
  - `.github/workflows/verify.yml` (`foundry-multi-seed` matrix)
  - `scripts/test_multiple_seeds.sh` (`DEFAULT_SEEDS`)
  - `scripts/README.md` (`foundry-multi-seed` CI summary)
- Wired the check into `verify.yml` `checks` job.
- Updated `scripts/README.md`:
  - Validation script catalog
  - Local preflight commands
  - `checks` job command list (new command + renumber)

Closes #707

## Validation
- `python3 scripts/check_verify_multiseed_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_ci_jobs_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`
- `python3 scripts/check_doc_counts.py`
- `python3 -m py_compile scripts/check_verify_multiseed_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new consistency check and documentation updates without changing build/test behavior beyond failing CI on seed-list drift.
> 
> **Overview**
> Adds a new Python CI guard (`scripts/check_verify_multiseed_sync.py`) that parses and compares the `foundry-multi-seed` seed list across `.github/workflows/verify.yml`, `scripts/test_multiple_seeds.sh`, and `scripts/README.md`, failing with a clear diff when they diverge.
> 
> Wires this guard into the `verify.yml` `checks` job and updates `scripts/README.md` to document the new check, include it in recommended local preflight commands, and renumber the documented `checks` job sequence accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7782475868d6a852d53e2464b5b4d21fa1a1ecc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->