### PR TITLE
scripts: enforce foundry shard config sync

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -127,6 +127,9 @@ jobs:
       - name: Check verify multi-seed sync
         run: python3 scripts/check_verify_multiseed_sync.py
 
+      - name: Check verify foundry shard sync
+        run: python3 scripts/check_verify_foundry_shard_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -90,6 +90,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_verify_build_docs_sync.py`** - Ensures `.github/workflows/verify.yml` `build` job python-script command sequence matches the documented `**\`build\` job**` list in this README
 - **`check_verify_ci_jobs_docs_sync.py`** - Ensures `.github/workflows/verify.yml` top-level job order matches the CI job summary list in this README (`## CI Integration`)
 - **`check_verify_multiseed_sync.py`** - Ensures `foundry-multi-seed` seed lists stay synchronized across `.github/workflows/verify.yml`, `scripts/test_multiple_seeds.sh`, and this README
+- **`check_verify_foundry_shard_sync.py`** - Ensures `foundry` shard settings stay synchronized across `.github/workflows/verify.yml` (`matrix.shard_index`, `DIFFTEST_SHARD_COUNT`, `DIFFTEST_RANDOM_SEED`) and this README summary
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -107,6 +108,7 @@ python3 scripts/check_verify_checks_docs_sync.py
 python3 scripts/check_verify_build_docs_sync.py
 python3 scripts/check_verify_ci_jobs_docs_sync.py
 python3 scripts/check_verify_multiseed_sync.py
+python3 scripts/check_verify_foundry_shard_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -209,17 +211,18 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 7 jobs:
 10. Verify build/docs sync (`check_verify_build_docs_sync.py`)
 11. Verify CI job/docs sync (`check_verify_ci_jobs_docs_sync.py`)
 12. Verify multi-seed sync (`check_verify_multiseed_sync.py`)
-13. Solc pin consistency (`check_solc_pin.py`)
-14. Property manifest sync (`check_property_manifest_sync.py`)
-15. Storage layout consistency (`check_storage_layout.py`)
-16. Lean hygiene (`check_lean_hygiene.py`)
-17. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-18. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-19. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-20. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
-21. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-22. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-23. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+13. Verify foundry shard sync (`check_verify_foundry_shard_sync.py`)
+14. Solc pin consistency (`check_solc_pin.py`)
+15. Property manifest sync (`check_property_manifest_sync.py`)
+16. Storage layout consistency (`check_storage_layout.py`)
+17. Lean hygiene (`check_lean_hygiene.py`)
+18. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+19. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+20. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+21. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
+22. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+23. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+24. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)

--- a/scripts/check_verify_foundry_shard_sync.py
+++ b/scripts/check_verify_foundry_shard_sync.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Ensure foundry shard configuration stays synchronized across workflow and docs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+SCRIPTS_README = ROOT / "scripts" / "README.md"
+
+
+def _parse_csv_ints(raw: str, source: Path) -> list[int]:
+    parts = [part.strip() for part in raw.split(",")]
+    if not parts or any(not part for part in parts):
+        raise ValueError(f"Malformed integer CSV in {source}: {raw!r}")
+    try:
+        return [int(part) for part in parts]
+    except ValueError as exc:
+        raise ValueError(f"Non-integer value in {source}: {raw!r}") from exc
+
+
+def _extract_foundry_job_body(text: str) -> str:
+    m = re.search(
+        r"^  foundry:\n(?P<body>.*?)(?:^  [A-Za-z0-9_-]+:|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not m:
+        raise ValueError(f"Could not locate foundry job in {VERIFY_YML}")
+    return m.group("body")
+
+
+def _extract_verify_shard_indices(body: str) -> list[int]:
+    m = re.search(r"^\s*shard_index:\s*\[(?P<csv>[^\]]+)\]\s*$", body, flags=re.MULTILINE)
+    if not m:
+        raise ValueError(f"Could not locate foundry matrix shard_index list in {VERIFY_YML}")
+    return _parse_csv_ints(m.group("csv"), VERIFY_YML)
+
+
+def _extract_verify_shard_count(body: str) -> int:
+    m = re.search(r'^\s*DIFFTEST_SHARD_COUNT:\s*"(?P<count>\d+)"\s*$', body, flags=re.MULTILINE)
+    if not m:
+        raise ValueError(f"Could not locate DIFFTEST_SHARD_COUNT in foundry job in {VERIFY_YML}")
+    return int(m.group("count"))
+
+
+def _extract_readme_foundry_summary(text: str) -> tuple[int, int]:
+    m = re.search(
+        r"^\*\*`foundry`\*\*\s+—\s+(?P<shards>\d+)-shard parallel Foundry tests with seed (?P<seed>\d+)\s*$",
+        text,
+        flags=re.MULTILINE,
+    )
+    if not m:
+        raise ValueError(
+            "Could not locate foundry CI summary line in "
+            f"{SCRIPTS_README}"
+        )
+    return int(m.group("shards")), int(m.group("seed"))
+
+
+def _extract_verify_seed(body: str) -> int:
+    m = re.search(r'^\s*DIFFTEST_RANDOM_SEED:\s*"(?P<seed>\d+)"\s*$', body, flags=re.MULTILINE)
+    if not m:
+        raise ValueError(f"Could not locate DIFFTEST_RANDOM_SEED in foundry job in {VERIFY_YML}")
+    return int(m.group("seed"))
+
+
+def _fmt_indices(values: list[int]) -> str:
+    return ", ".join(str(v) for v in values)
+
+
+def main() -> int:
+    verify_text = VERIFY_YML.read_text(encoding="utf-8")
+    readme_text = SCRIPTS_README.read_text(encoding="utf-8")
+
+    foundry_body = _extract_foundry_job_body(verify_text)
+    shard_indices = _extract_verify_shard_indices(foundry_body)
+    shard_count = _extract_verify_shard_count(foundry_body)
+    verify_seed = _extract_verify_seed(foundry_body)
+    readme_shards, readme_seed = _extract_readme_foundry_summary(readme_text)
+
+    errors: list[str] = []
+    if not shard_indices:
+        errors.append("verify.yml foundry matrix shard_index list is empty.")
+    if len(set(shard_indices)) != len(shard_indices):
+        errors.append("verify.yml foundry matrix shard_index list has duplicates.")
+
+    expected_indices = list(range(len(shard_indices)))
+    if shard_indices != expected_indices:
+        errors.append(
+            "verify.yml foundry matrix shard_index list must be contiguous "
+            f"0..N-1. got: [{_fmt_indices(shard_indices)}]"
+        )
+
+    if shard_count != len(shard_indices):
+        errors.append(
+            "verify.yml DIFFTEST_SHARD_COUNT differs from foundry matrix size. "
+            f"count={shard_count}, matrix-size={len(shard_indices)}"
+        )
+
+    if readme_shards != len(shard_indices):
+        errors.append(
+            "scripts/README.md foundry shard summary differs from verify.yml foundry matrix size. "
+            f"README={readme_shards}, matrix-size={len(shard_indices)}"
+        )
+
+    if readme_seed != verify_seed:
+        errors.append(
+            "scripts/README.md foundry seed summary differs from verify.yml DIFFTEST_RANDOM_SEED. "
+            f"README={readme_seed}, verify.yml={verify_seed}"
+        )
+
+    if errors:
+        print("verify foundry shard sync check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        return 1
+
+    print(
+        "verify foundry shard config is synchronized across workflow/docs "
+        f"({len(shard_indices)} shards, seed {verify_seed})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_verify_foundry_shard_sync.py` to enforce `foundry` shard config parity
- validate sync between `verify.yml` foundry matrix (`shard_index`), `DIFFTEST_SHARD_COUNT`, and README foundry summary (shards + seed)
- wire the new guard into `verify.yml` `checks` job and document it in `scripts/README.md`

## Validation
- `python3 scripts/check_verify_foundry_shard_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_ci_jobs_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`
- `python3 scripts/check_doc_counts.py`
- `python3 -m py_compile scripts/check_verify_foundry_shard_sync.py`

Closes #709

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/doc consistency-only change; main risk is false failures if workflow/README formatting changes without updating the regex-based checker.
> 
> **Overview**
> Adds a new CI guard `check_verify_foundry_shard_sync.py` that verifies the `foundry` job’s sharding config is consistent between `verify.yml` (matrix `shard_index`, `DIFFTEST_SHARD_COUNT`, `DIFFTEST_RANDOM_SEED`) and the shard/seed summary documented in `scripts/README.md`.
> 
> Wires this check into the `verify.yml` `checks` job and updates `scripts/README.md` to document the new check and its position in the checks list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8b1f0ad44412eaef8b6b6cfb5436b9875b41653. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->