### PR TITLE
scripts: enforce foundry-patched workflow/docs sync

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Check verify foundry shard sync
         run: python3 scripts/check_verify_foundry_shard_sync.py
 
+      - name: Check verify foundry-patched sync
+        run: python3 scripts/check_verify_foundry_patched_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,6 +91,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_verify_ci_jobs_docs_sync.py`** - Ensures `.github/workflows/verify.yml` top-level job order matches the CI job summary list in this README (`## CI Integration`)
 - **`check_verify_multiseed_sync.py`** - Ensures `foundry-multi-seed` seed lists stay synchronized across `.github/workflows/verify.yml`, `scripts/test_multiple_seeds.sh`, and this README
 - **`check_verify_foundry_shard_sync.py`** - Ensures `foundry` shard settings stay synchronized across `.github/workflows/verify.yml` (`matrix.shard_index`, `DIFFTEST_SHARD_COUNT`, `DIFFTEST_RANDOM_SEED`) and this README summary
+- **`check_verify_foundry_patched_sync.py`** - Ensures `foundry-patched` smoke-test settings stay synchronized across `.github/workflows/verify.yml` and this README summary (seed, single-shard mode, and `--no-match-test "Random10000"`)
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -109,6 +110,7 @@ python3 scripts/check_verify_build_docs_sync.py
 python3 scripts/check_verify_ci_jobs_docs_sync.py
 python3 scripts/check_verify_multiseed_sync.py
 python3 scripts/check_verify_foundry_shard_sync.py
+python3 scripts/check_verify_foundry_patched_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -212,17 +214,18 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 7 jobs:
 11. Verify CI job/docs sync (`check_verify_ci_jobs_docs_sync.py`)
 12. Verify multi-seed sync (`check_verify_multiseed_sync.py`)
 13. Verify foundry shard sync (`check_verify_foundry_shard_sync.py`)
-14. Solc pin consistency (`check_solc_pin.py`)
-15. Property manifest sync (`check_property_manifest_sync.py`)
-16. Storage layout consistency (`check_storage_layout.py`)
-17. Lean hygiene (`check_lean_hygiene.py`)
-18. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-19. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-20. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-21. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
-22. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-23. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-24. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+14. Verify foundry-patched sync (`check_verify_foundry_patched_sync.py`)
+15. Solc pin consistency (`check_solc_pin.py`)
+16. Property manifest sync (`check_property_manifest_sync.py`)
+17. Storage layout consistency (`check_storage_layout.py`)
+18. Lean hygiene (`check_lean_hygiene.py`)
+19. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+20. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+21. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+22. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
+23. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+24. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+25. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)
@@ -238,7 +241,7 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 7 jobs:
 
 **`foundry-gas-calibration`** — Static-vs-Foundry gas calibration check (`check_gas_calibration.py`) using build-artifact static report + Foundry gas report (runtime + deployment)
 **`foundry`** — 8-shard parallel Foundry tests with seed 42
-**`foundry-patched`** — Patched-Yul smoke gate on differential/property harness (seed 42, no `Random10000`)
+**`foundry-patched`** — Patched-Yul smoke gate on differential/property harness (seed 42, single shard, no `Random10000`)
 **`foundry-multi-seed`** — 7-seed flakiness detection (seeds: 0, 1, 42, 123, 999, 12345, 67890)
 
 ## Adding New Property Tests

--- a/scripts/check_verify_foundry_patched_sync.py
+++ b/scripts/check_verify_foundry_patched_sync.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Ensure foundry-patched workflow settings stay synchronized with docs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+SCRIPTS_README = ROOT / "scripts" / "README.md"
+
+
+def _extract_foundry_patched_job(text: str) -> str:
+    section = re.search(
+        r"^  foundry-patched:\n(?P<body>.*?)(?:^  [A-Za-z0-9_-]+:|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not section:
+        raise ValueError(f"Could not locate foundry-patched job in {VERIFY_YML}")
+    return section.group("body")
+
+
+def _extract_env_literal(job_body: str, name: str) -> str:
+    m = re.search(rf'^\s*{re.escape(name)}:\s*"([^"]+)"\s*$', job_body, re.MULTILINE)
+    if not m:
+        raise ValueError(f"Could not locate {name} in foundry-patched env block in {VERIFY_YML}")
+    return m.group(1)
+
+
+def _extract_no_match_test_target(job_body: str) -> str:
+    m = re.search(
+        r'^\s*forge test --no-match-test "([^"]+)"\s*$',
+        job_body,
+        flags=re.MULTILINE,
+    )
+    if not m:
+        raise ValueError(
+            "Could not locate 'forge test --no-match-test \"...\"' in "
+            f"foundry-patched job in {VERIFY_YML}"
+        )
+    return m.group(1)
+
+
+def _extract_readme_foundry_patched_line(text: str) -> str:
+    m = re.search(r"^\*\*`foundry-patched`\*\*.*$", text, re.MULTILINE)
+    if not m:
+        raise ValueError(f"Could not locate foundry-patched summary line in {SCRIPTS_README}")
+    return m.group(0)
+
+
+def _extract_readme_seed(line: str) -> str:
+    m = re.search(r"\(seed\s+(\d+),", line)
+    if not m:
+        raise ValueError(
+            "Could not parse seed from scripts/README.md foundry-patched summary. "
+            "Expected format containing '(seed <n>, ...)'"
+        )
+    return m.group(1)
+
+
+def main() -> int:
+    verify_text = VERIFY_YML.read_text(encoding="utf-8")
+    readme_text = SCRIPTS_README.read_text(encoding="utf-8")
+
+    job_body = _extract_foundry_patched_job(verify_text)
+    workflow_seed = _extract_env_literal(job_body, "DIFFTEST_RANDOM_SEED")
+    workflow_shard_count = _extract_env_literal(job_body, "DIFFTEST_SHARD_COUNT")
+    workflow_shard_index = _extract_env_literal(job_body, "DIFFTEST_SHARD_INDEX")
+    workflow_no_match = _extract_no_match_test_target(job_body)
+
+    readme_line = _extract_readme_foundry_patched_line(readme_text)
+    readme_seed = _extract_readme_seed(readme_line)
+    readme_mentions_single_shard = "single shard" in readme_line
+    readme_no_match = "`Random10000`" in readme_line
+
+    errors: list[str] = []
+    if workflow_seed != readme_seed:
+        errors.append(
+            "README foundry-patched seed differs from verify.yml DIFFTEST_RANDOM_SEED."
+        )
+    if workflow_shard_count != "1" or workflow_shard_index != "0":
+        errors.append(
+            "verify.yml foundry-patched must stay single-shard "
+            "(DIFFTEST_SHARD_COUNT=1, DIFFTEST_SHARD_INDEX=0)."
+        )
+    if not readme_mentions_single_shard:
+        errors.append(
+            "README foundry-patched summary must mention single-shard mode."
+        )
+    if workflow_no_match != "Random10000":
+        errors.append(
+            "verify.yml foundry-patched must keep --no-match-test target as Random10000."
+        )
+    if not readme_no_match:
+        errors.append(
+            "README foundry-patched summary must mention no `Random10000`."
+        )
+
+    if errors:
+        print("verify foundry-patched sync check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        print(f"  verify.yml seed:             {workflow_seed}", file=sys.stderr)
+        print(f"  README seed:                 {readme_seed}", file=sys.stderr)
+        print(f"  verify.yml shard count/index {workflow_shard_count}/{workflow_shard_index}", file=sys.stderr)
+        print(f"  verify.yml --no-match-test:  {workflow_no_match}", file=sys.stderr)
+        print(f"  README mentions single shard: {readme_mentions_single_shard}", file=sys.stderr)
+        print(f"  README mentions Random10000:  {readme_no_match}", file=sys.stderr)
+        return 1
+
+    print(
+        "verify foundry-patched settings are synchronized across workflow/docs "
+        f"(seed {workflow_seed}, single shard, no {workflow_no_match})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a CI guard for `foundry-patched` workflow/docs parity and wires it into the fast `checks` job.

## Changes
- add `scripts/check_verify_foundry_patched_sync.py`
  - parses `.github/workflows/verify.yml` `foundry-patched` job
  - enforces pinned smoke settings:
    - `DIFFTEST_RANDOM_SEED`
    - single-shard mode (`DIFFTEST_SHARD_COUNT=1`, `DIFFTEST_SHARD_INDEX=0`)
    - `forge test --no-match-test "Random10000"`
  - checks `scripts/README.md` summary parity for seed + single-shard + `Random10000`
- run the new check in `.github/workflows/verify.yml` `checks` job
- update `scripts/README.md` validation script docs, local command list, and checks-job command list

## Validation
- `python3 scripts/check_verify_foundry_patched_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_ci_jobs_docs_sync.py`
- `python3 scripts/check_doc_counts.py`
- `python3 -m py_compile scripts/check_verify_foundry_patched_sync.py`

Closes #714

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/docs-only changes that add a new validation script and workflow step; no runtime, security, or proof logic is modified.
> 
> **Overview**
> Adds a new CI consistency guard `check_verify_foundry_patched_sync.py` to ensure the `foundry-patched` job’s smoke-test settings in `verify.yml` stay in sync with the documented summary (seed, single-shard mode, and `--no-match-test "Random10000"`).
> 
> Wires this check into the fast `checks` job in `.github/workflows/verify.yml` and updates `scripts/README.md` to document the new script and the adjusted `foundry-patched` description (explicitly calling out single-shard + `Random10000` skip).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 656461329ce85656621d03d2a6bd9ab0f1726337. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->