### PR TITLE
scripts: enforce foundry-gas-calibration workflow/docs sync

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Check verify foundry-patched sync
         run: python3 scripts/check_verify_foundry_patched_sync.py
 
+      - name: Check verify foundry-gas-calibration sync
+        run: python3 scripts/check_verify_foundry_gas_calibration_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -92,6 +92,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_verify_multiseed_sync.py`** - Ensures `foundry-multi-seed` seed lists stay synchronized across `.github/workflows/verify.yml`, `scripts/test_multiple_seeds.sh`, and this README
 - **`check_verify_foundry_shard_sync.py`** - Ensures `foundry` shard settings stay synchronized across `.github/workflows/verify.yml` (`matrix.shard_index`, `DIFFTEST_SHARD_COUNT`, `DIFFTEST_RANDOM_SEED`) and this README summary
 - **`check_verify_foundry_patched_sync.py`** - Ensures `foundry-patched` smoke-test settings stay synchronized across `.github/workflows/verify.yml` and this README summary (seed, single-shard mode, and `--no-match-test "Random10000"`)
+- **`check_verify_foundry_gas_calibration_sync.py`** - Ensures `foundry-gas-calibration` settings stay synchronized across `.github/workflows/verify.yml` and this README summary (profile, static report artifact/input, and calibration command)
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -111,6 +112,7 @@ python3 scripts/check_verify_ci_jobs_docs_sync.py
 python3 scripts/check_verify_multiseed_sync.py
 python3 scripts/check_verify_foundry_shard_sync.py
 python3 scripts/check_verify_foundry_patched_sync.py
+python3 scripts/check_verify_foundry_gas_calibration_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -215,17 +217,18 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 7 jobs:
 12. Verify multi-seed sync (`check_verify_multiseed_sync.py`)
 13. Verify foundry shard sync (`check_verify_foundry_shard_sync.py`)
 14. Verify foundry-patched sync (`check_verify_foundry_patched_sync.py`)
-15. Solc pin consistency (`check_solc_pin.py`)
-16. Property manifest sync (`check_property_manifest_sync.py`)
-17. Storage layout consistency (`check_storage_layout.py`)
-18. Lean hygiene (`check_lean_hygiene.py`)
-19. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-20. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-21. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-22. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
-23. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-24. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-25. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+15. Verify foundry-gas-calibration sync (`check_verify_foundry_gas_calibration_sync.py`)
+16. Solc pin consistency (`check_solc_pin.py`)
+17. Property manifest sync (`check_property_manifest_sync.py`)
+18. Storage layout consistency (`check_storage_layout.py`)
+19. Lean hygiene (`check_lean_hygiene.py`)
+20. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+21. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+22. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+23. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
+24. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+25. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+26. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)

--- a/scripts/check_verify_foundry_gas_calibration_sync.py
+++ b/scripts/check_verify_foundry_gas_calibration_sync.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Ensure foundry-gas-calibration workflow settings stay synchronized with docs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+SCRIPTS_README = ROOT / "scripts" / "README.md"
+
+
+def _extract_foundry_gas_calibration_job(text: str) -> str:
+    m = re.search(
+        r"^  foundry-gas-calibration:\n(?P<body>.*?)(?:^  [A-Za-z0-9_-]+:|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not m:
+        raise ValueError(f"Could not locate foundry-gas-calibration job in {VERIFY_YML}")
+    return m.group("body")
+
+
+def _extract_foundry_profile(job_body: str) -> str:
+    m = re.search(r'^\s*FOUNDRY_PROFILE:\s*(?:"([^"]+)"|(\S+))\s*$', job_body, re.MULTILINE)
+    if not m:
+        raise ValueError(
+            f"Could not locate FOUNDRY_PROFILE in foundry-gas-calibration job in {VERIFY_YML}"
+        )
+    return m.group(1) or m.group(2)
+
+
+def _extract_static_report_artifact(job_body: str) -> str:
+    m = re.search(
+        r"^\s*with:\s*\n\s*name:\s*(\S+)\s*$",
+        job_body,
+        flags=re.MULTILINE,
+    )
+    if not m:
+        raise ValueError(
+            "Could not locate download-artifact name in foundry-gas-calibration "
+            f"job in {VERIFY_YML}"
+        )
+    return m.group(1)
+
+
+def _extract_calibration_command(job_body: str) -> str:
+    m = re.search(
+        r"^\s*run:\s*(python3\s+scripts/check_gas_calibration\.py\s+--static-report\s+\S+)\s*$",
+        job_body,
+        flags=re.MULTILINE,
+    )
+    if not m:
+        raise ValueError(
+            "Could not locate check_gas_calibration command in "
+            f"foundry-gas-calibration job in {VERIFY_YML}"
+        )
+    return re.sub(r"\s+", " ", m.group(1).strip())
+
+
+def _extract_readme_summary_line(text: str) -> str:
+    m = re.search(r"^\*\*`foundry-gas-calibration`\*\*.*$", text, flags=re.MULTILINE)
+    if not m:
+        raise ValueError(
+            "Could not locate foundry-gas-calibration CI summary line in "
+            f"{SCRIPTS_README}"
+        )
+    return m.group(0)
+
+
+def main() -> int:
+    verify_text = VERIFY_YML.read_text(encoding="utf-8")
+    readme_text = SCRIPTS_README.read_text(encoding="utf-8")
+
+    job_body = _extract_foundry_gas_calibration_job(verify_text)
+    foundry_profile = _extract_foundry_profile(job_body)
+    artifact_name = _extract_static_report_artifact(job_body)
+    command = _extract_calibration_command(job_body)
+    readme_line = _extract_readme_summary_line(readme_text)
+
+    errors: list[str] = []
+    if foundry_profile != "difftest":
+        errors.append(
+            "verify.yml foundry-gas-calibration must keep FOUNDRY_PROFILE=difftest."
+        )
+    if artifact_name != "static-gas-report":
+        errors.append(
+            "verify.yml foundry-gas-calibration must download static-gas-report artifact."
+        )
+    if "check_gas_calibration.py" not in command:
+        errors.append(
+            "verify.yml foundry-gas-calibration must run scripts/check_gas_calibration.py."
+        )
+    if "--static-report gas-report-static.tsv" not in command:
+        errors.append(
+            "verify.yml foundry-gas-calibration must pass --static-report gas-report-static.tsv."
+        )
+    if "check_gas_calibration.py" not in readme_line:
+        errors.append(
+            "scripts/README.md foundry-gas-calibration summary must mention check_gas_calibration.py."
+        )
+    if "static report" not in readme_line.lower():
+        errors.append(
+            "scripts/README.md foundry-gas-calibration summary must mention static report input."
+        )
+    if "Foundry gas report" not in readme_line:
+        errors.append(
+            "scripts/README.md foundry-gas-calibration summary must mention Foundry gas report input."
+        )
+
+    if errors:
+        print("verify foundry-gas-calibration sync check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        print(f"  verify.yml FOUNDRY_PROFILE: {foundry_profile}", file=sys.stderr)
+        print(f"  verify.yml artifact name:   {artifact_name}", file=sys.stderr)
+        print(f"  verify.yml command:         {command}", file=sys.stderr)
+        print(f"  README summary line:        {readme_line}", file=sys.stderr)
+        return 1
+
+    print(
+        "verify foundry-gas-calibration settings are synchronized across workflow/docs "
+        "(profile difftest, static-gas-report, check_gas_calibration.py)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a dedicated sync guard for the `foundry-gas-calibration` CI job so workflow/runtime settings cannot drift from `scripts/README.md`.

Closes #716.

## What changed
- Added `scripts/check_verify_foundry_gas_calibration_sync.py`.
  - Validates `foundry-gas-calibration` keeps `FOUNDRY_PROFILE=difftest`.
  - Validates artifact source remains `static-gas-report`.
  - Validates command shape stays `python3 scripts/check_gas_calibration.py --static-report gas-report-static.tsv`.
  - Validates README summary still documents the calibration script and static-vs-Foundry report inputs.
- Added workflow checks step:
  - `python3 scripts/check_verify_foundry_gas_calibration_sync.py`
- Updated `scripts/README.md`:
  - Validation script catalog entry
  - Local doc-change command list
  - `checks` job command list numbering

## Validation
- `python3 scripts/check_verify_foundry_gas_calibration_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`
- `python3 scripts/check_verify_ci_jobs_docs_sync.py`
- `python3 scripts/check_doc_counts.py`
- `python3 -m py_compile scripts/check_verify_foundry_gas_calibration_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/documentation consistency enforcement only; no runtime or proof logic changes, with limited risk beyond potential CI failures if regex expectations drift.
> 
> **Overview**
> Adds a new sync-check script (`check_verify_foundry_gas_calibration_sync.py`) that asserts the `foundry-gas-calibration` job in `verify.yml` keeps specific settings (e.g., `FOUNDRY_PROFILE=difftest`, downloads `static-gas-report`, and runs `check_gas_calibration.py --static-report gas-report-static.tsv`) aligned with the documented CI summary line.
> 
> Wires this check into the `checks` job in `.github/workflows/verify.yml` and updates `scripts/README.md` to document the new guard and include it in the recommended local/CI check lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6d5c4109ee26a9ce03d1f3b1859dd6aaa3e0c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->