### PR TITLE
scripts: guard verify artifact upload/download sync

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Check verify foundry-gas-calibration sync
         run: python3 scripts/check_verify_foundry_gas_calibration_sync.py
 
+      - name: Check verify artifact sync
+        run: python3 scripts/check_verify_artifact_sync.py
+
       - name: Check solc pin consistency
         run: python3 scripts/check_solc_pin.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -93,6 +93,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_verify_foundry_shard_sync.py`** - Ensures `foundry` shard settings stay synchronized across `.github/workflows/verify.yml` (`matrix.shard_index`, `DIFFTEST_SHARD_COUNT`, `DIFFTEST_RANDOM_SEED`) and this README summary
 - **`check_verify_foundry_patched_sync.py`** - Ensures `foundry-patched` smoke-test settings stay synchronized across `.github/workflows/verify.yml` and this README summary (seed, single-shard mode, and `--no-match-test "Random10000"`)
 - **`check_verify_foundry_gas_calibration_sync.py`** - Ensures `foundry-gas-calibration` settings stay synchronized across `.github/workflows/verify.yml` and this README summary (profile, static report artifact/input, and calibration command)
+- **`check_verify_artifact_sync.py`** - Ensures downstream artifact downloads in `.github/workflows/verify.yml` match build-job artifact uploads (and rejects duplicate artifact names per producer/consumer job)
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
 - **`check_solc_pin.py`** - Enforces pinned solc consistency across CI/tooling/docs: `verify.yml` (`SOLC_VERSION`, `SOLC_URL`, `SOLC_SHA256`), `foundry.toml` (`solc_version`), `setup-solc` action URL/SHA usage, and `TRUST_ASSUMPTIONS.md` pinned version line
 - **`check_axiom_locations.py`** - Validates that AXIOMS.md line number references match actual axiom locations in source files
@@ -113,6 +114,7 @@ python3 scripts/check_verify_multiseed_sync.py
 python3 scripts/check_verify_foundry_shard_sync.py
 python3 scripts/check_verify_foundry_patched_sync.py
 python3 scripts/check_verify_foundry_gas_calibration_sync.py
+python3 scripts/check_verify_artifact_sync.py
 
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
@@ -218,17 +220,18 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 7 jobs:
 13. Verify foundry shard sync (`check_verify_foundry_shard_sync.py`)
 14. Verify foundry-patched sync (`check_verify_foundry_patched_sync.py`)
 15. Verify foundry-gas-calibration sync (`check_verify_foundry_gas_calibration_sync.py`)
-16. Solc pin consistency (`check_solc_pin.py`)
-17. Property manifest sync (`check_property_manifest_sync.py`)
-18. Storage layout consistency (`check_storage_layout.py`)
-19. Lean hygiene (`check_lean_hygiene.py`)
-20. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-21. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-22. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-23. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
-24. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-25. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-26. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+16. Verify artifact upload/download sync (`check_verify_artifact_sync.py`)
+17. Solc pin consistency (`check_solc_pin.py`)
+18. Property manifest sync (`check_property_manifest_sync.py`)
+19. Storage layout consistency (`check_storage_layout.py`)
+20. Lean hygiene (`check_lean_hygiene.py`)
+21. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+22. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+23. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+24. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
+25. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+26. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+27. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)

--- a/scripts/check_verify_artifact_sync.py
+++ b/scripts/check_verify_artifact_sync.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Ensure verify.yml artifact uploads/downloads stay synchronized."""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+
+
+def _extract_job_block(text: str, job_name: str) -> str:
+    m = re.search(
+        rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?:^  [A-Za-z0-9_-]+:|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not m:
+        raise ValueError(f"Could not locate '{job_name}' job in {VERIFY_YML}")
+    return m.group("body")
+
+
+def _extract_upload_names(build_body: str) -> list[str]:
+    return re.findall(
+        r"actions/upload-artifact@v\d+\n\s+with:\n\s+name:\s*([^\s]+)",
+        build_body,
+        flags=re.MULTILINE,
+    )
+
+
+def _extract_download_names(job_body: str) -> list[str]:
+    return re.findall(
+        r"actions/download-artifact@v\d+\n\s+with:\n\s+name:\s*([^\s]+)",
+        job_body,
+        flags=re.MULTILINE,
+    )
+
+
+def _extract_job_names(text: str) -> list[str]:
+    lines = text.splitlines()
+    jobs_idx = next((i for i, line in enumerate(lines) if line == "jobs:"), None)
+    if jobs_idx is None:
+        raise ValueError(f"Could not locate jobs section in {VERIFY_YML}")
+
+    jobs: list[str] = []
+    for line in lines[jobs_idx + 1 :]:
+        if line and not line.startswith(" "):
+            break
+        m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+        if m:
+            jobs.append(m.group(1))
+    if not jobs:
+        raise ValueError(f"Could not locate any top-level jobs in {VERIFY_YML}")
+    return jobs
+
+
+def _duplicates(items: list[str]) -> list[str]:
+    counts = Counter(items)
+    return sorted([name for name, count in counts.items() if count > 1])
+
+
+def main() -> int:
+    verify_text = VERIFY_YML.read_text(encoding="utf-8")
+    job_names = _extract_job_names(verify_text)
+
+    build_body = _extract_job_block(verify_text, "build")
+    upload_names = _extract_upload_names(build_body)
+    if not upload_names:
+        raise ValueError(
+            "Could not locate any build upload-artifact names in "
+            f"{VERIFY_YML} build job"
+        )
+
+    upload_dupes = _duplicates(upload_names)
+    errors: list[str] = []
+    if upload_dupes:
+        errors.append(
+            "build job has duplicate upload-artifact names: "
+            + ", ".join(upload_dupes)
+        )
+
+    uploaded = set(upload_names)
+    consumed_missing: list[tuple[str, str]] = []
+    consumed_summary: list[tuple[str, str]] = []
+
+    for job in job_names:
+        if job == "build":
+            continue
+        body = _extract_job_block(verify_text, job)
+        downloads = _extract_download_names(body)
+        if not downloads:
+            continue
+        download_dupes = _duplicates(downloads)
+        if download_dupes:
+            errors.append(
+                f"{job} job has duplicate download-artifact names: "
+                + ", ".join(download_dupes)
+            )
+        for name in downloads:
+            consumed_summary.append((job, name))
+            if name not in uploaded:
+                consumed_missing.append((job, name))
+
+    if consumed_missing:
+        errors.append(
+            "Downloaded artifacts missing from build uploads:\n"
+            + "\n".join([f"  - {job}: {name}" for job, name in consumed_missing])
+        )
+
+    if errors:
+        print("verify artifact upload/download sync check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        print(
+            "\nBuild uploads found: "
+            + ", ".join(sorted(uploaded)),
+            file=sys.stderr,
+        )
+        if consumed_summary:
+            print("Downloads found:", file=sys.stderr)
+            for job, name in consumed_summary:
+                print(f"  - {job}: {name}", file=sys.stderr)
+        return 1
+
+    print(
+        "verify artifact upload/download names are synchronized "
+        f"(build uploads: {len(upload_names)}, downstream downloads: {len(consumed_summary)})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a fast CI guard to keep artifact producer/consumer wiring in `.github/workflows/verify.yml` synchronized.

## Changes
- add `scripts/check_verify_artifact_sync.py`
  - parses `verify.yml`
  - collects build-job `actions/upload-artifact` names
  - collects downstream `actions/download-artifact` names
  - fails if any consumed artifact is not uploaded by `build`
  - fails on duplicate upload names in `build`
  - fails on duplicate download names within each consumer job
- wire new guard into `checks` job:
  - `python3 scripts/check_verify_artifact_sync.py`
- update `scripts/README.md`
  - validation script catalog
  - local run command list
  - `checks` job command list/numbering

Closes #718

## Validation
- `python3 scripts/check_verify_artifact_sync.py`
- `python3 -m py_compile scripts/check_verify_artifact_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`
- `python3 scripts/check_verify_ci_jobs_docs_sync.py`
- `python3 scripts/check_verify_paths_sync.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Python lint-style CI validation step and documentation updates; it doesn’t affect runtime, proof, or compiler logic.
> 
> **Overview**
> Adds a new fast CI guard (`scripts/check_verify_artifact_sync.py`) that parses `.github/workflows/verify.yml` to ensure `build` artifact uploads and downstream `download-artifact` consumers stay in sync, and that artifact names are not duplicated.
> 
> Wires this check into the `verify.yml` `checks` job and updates `scripts/README.md` to document the new guard and its position in the CI/checks lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53d3cc658b2483f197ae04d9a6d4eb56c5d9dbe6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->