### PR TITLE
scripts: centralize theorem identifier boundary checks

### DIFF
--- a/scripts/property_utils.py
+++ b/scripts/property_utils.py
@@ -41,11 +41,14 @@ def _require_contract_identifier(contract: str, source: Path) -> str:
     return contract
 
 
-def _require_theorem_identifier(theorem: str, source: Path) -> str:
+def _require_theorem_identifier(
+    theorem: str, source: Path, *, context: str | None = None
+) -> str:
     """Validate and return a theorem identifier from a filesystem-derived source."""
     if theorem != theorem.strip() or not THEOREM_NAME_RE.fullmatch(theorem):
+        location = f"{source} ({context})" if context else str(source)
         raise SystemExit(
-            f"Invalid theorem identifier from {source}: {theorem!r}"
+            f"Invalid theorem identifier from {location}: {theorem!r}"
         )
     return theorem
 
@@ -112,7 +115,7 @@ def _load_contract_name_sets(path: Path, *, missing_ok: bool) -> dict[str, set[s
                 raise SystemExit(
                     f"Invalid schema in {path}: entry {name!r} in {contract!r} must be a non-empty string."
                 )
-            _require_theorem_identifier(name, path)
+            _require_theorem_identifier(name, path, context=f"contract {contract!r}")
         duplicate_names = _find_duplicates(names)
         if duplicate_names:
             raise SystemExit(


### PR DESCRIPTION
## Summary
- add `_require_theorem_identifier` as a single theorem-name boundary validator
- reuse it for JSON manifest/exclusion loading, Solidity property tag extraction, and Lean theorem extraction
- keep public interfaces unchanged while enforcing one invariant consistently

## Validation
- ran the full CI `checks` job command set locally (all green)

## Dependency impact
- compatible with existing callers in `scripts/check_property_manifest.py`, `scripts/check_property_coverage.py`, `scripts/check_property_manifest_sync.py`, and reporting scripts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to script-side validation; behavior should be equivalent aside from slightly different error wording/context for invalid theorem names.
> 
> **Overview**
> Centralizes theorem-name boundary validation in `scripts/property_utils.py` by adding `_require_theorem_identifier` and reusing it wherever theorem identifiers are parsed.
> 
> This replaces inline `THEOREM_NAME_RE` checks in JSON manifest/exclusion loading, Solidity property tag extraction, and Lean theorem/lemma extraction, and slightly improves error messages by including optional context about the source.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c294278d4c8ff6655fd18c438d9795c6436f90c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->