### PR TITLE
scripts: add verify foundry job sync guard

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Check verify foundry-patched sync
         run: python3 scripts/check_verify_foundry_patched_sync.py
 
+      - name: Check verify foundry job sync
+        run: python3 scripts/check_verify_foundry_job_sync.py
+
       - name: Check verify foundry-gas-calibration sync
         run: python3 scripts/check_verify_foundry_gas_calibration_sync.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -92,6 +92,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_verify_multiseed_sync.py`** - Ensures `foundry-multi-seed` seed lists stay synchronized across `.github/workflows/verify.yml`, `scripts/test_multiple_seeds.sh`, and this README
 - **`check_verify_foundry_shard_sync.py`** - Ensures `foundry` shard settings stay synchronized across `.github/workflows/verify.yml` (`matrix.shard_index`, `DIFFTEST_SHARD_COUNT`, `DIFFTEST_RANDOM_SEED`) and this README summary
 - **`check_verify_foundry_patched_sync.py`** - Ensures `foundry-patched` smoke-test settings stay synchronized across `.github/workflows/verify.yml` and this README summary (seed, single-shard mode, and `--no-match-test "Random10000"`)
+- **`check_verify_foundry_job_sync.py`** - Ensures shared Foundry job settings stay synchronized across `foundry`, `foundry-patched`, and `foundry-multi-seed` in `.github/workflows/verify.yml` (profile, random params, Yul dir/download wiring, and `Random10000` skip policy)
 - **`check_verify_foundry_gas_calibration_sync.py`** - Ensures `foundry-gas-calibration` settings stay synchronized across `.github/workflows/verify.yml` and this README summary (profile, static report artifact/input, and calibration command)
 - **`check_verify_artifact_sync.py`** - Ensures downstream artifact downloads in `.github/workflows/verify.yml` match build-job artifact uploads (and rejects duplicate artifact names per producer/consumer job)
 - **`generate_verification_status.py`** - Deterministically generates `artifacts/verification_status.json` (theorem/test/axiom/sorry/toolchain metrics) and supports `--check` mode for CI freshness gating
@@ -113,6 +114,7 @@ python3 scripts/check_verify_ci_jobs_docs_sync.py
 python3 scripts/check_verify_multiseed_sync.py
 python3 scripts/check_verify_foundry_shard_sync.py
 python3 scripts/check_verify_foundry_patched_sync.py
+python3 scripts/check_verify_foundry_job_sync.py
 python3 scripts/check_verify_foundry_gas_calibration_sync.py
 python3 scripts/check_verify_artifact_sync.py
 
@@ -219,19 +221,20 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 7 jobs:
 12. Verify multi-seed sync (`check_verify_multiseed_sync.py`)
 13. Verify foundry shard sync (`check_verify_foundry_shard_sync.py`)
 14. Verify foundry-patched sync (`check_verify_foundry_patched_sync.py`)
-15. Verify foundry-gas-calibration sync (`check_verify_foundry_gas_calibration_sync.py`)
-16. Verify artifact upload/download sync (`check_verify_artifact_sync.py`)
-17. Solc pin consistency (`check_solc_pin.py`)
-18. Property manifest sync (`check_property_manifest_sync.py`)
-19. Storage layout consistency (`check_storage_layout.py`)
-20. Lean hygiene (`check_lean_hygiene.py`)
-21. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-22. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-23. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-24. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
-25. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-26. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-27. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+15. Verify foundry job sync (`check_verify_foundry_job_sync.py`)
+16. Verify foundry-gas-calibration sync (`check_verify_foundry_gas_calibration_sync.py`)
+17. Verify artifact upload/download sync (`check_verify_artifact_sync.py`)
+18. Solc pin consistency (`check_solc_pin.py`)
+19. Property manifest sync (`check_property_manifest_sync.py`)
+20. Storage layout consistency (`check_storage_layout.py`)
+21. Lean hygiene (`check_lean_hygiene.py`)
+22. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+23. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+24. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+25. Builtin list sync (Linker ↔ ContractSpec) (`check_builtin_list_sync.py`)
+26. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+27. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+28. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 
 **`build` job** (requires `lake build` artifacts):
 1. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)

--- a/scripts/check_verify_foundry_job_sync.py
+++ b/scripts/check_verify_foundry_job_sync.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Ensure foundry workflow jobs keep critical shared settings synchronized."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
+
+
+def _extract_job_body(text: str, job: str) -> str:
+    section = re.search(
+        rf"^  {re.escape(job)}:\n(?P<body>.*?)(?:^  [A-Za-z0-9_-]+:|\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not section:
+        raise ValueError(f"Could not locate {job} job in {VERIFY_YML}")
+    return section.group("body")
+
+
+def _extract_env_literal(job_body: str, name: str, job: str) -> str:
+    m = re.search(rf"^\s*{re.escape(name)}:\s*([^\n#]+?)\s*$", job_body, re.MULTILINE)
+    if not m:
+        raise ValueError(f"Could not locate {name} in {job} env block in {VERIFY_YML}")
+    raw = m.group(1).strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {'"', "'"}:
+        return raw[1:-1]
+    return raw
+
+
+def _extract_download(job_body: str, artifact_name: str, job: str) -> tuple[str, str]:
+    step = re.search(
+        rf"^\s*- name:\s+Download\s+{re.escape(artifact_name)}\n"
+        r"(?P<body>.*?)(?:^\s*- name:|\Z)",
+        job_body,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not step:
+        raise ValueError(
+            f"Could not locate '{artifact_name}' download step in {job} job in {VERIFY_YML}"
+        )
+
+    name = re.search(r"^\s*name:\s*([^\s][^\n]*)\s*$", step.group("body"), re.MULTILINE)
+    if not name:
+        raise ValueError(
+            f"Could not locate download artifact name in {job} job for {artifact_name} in {VERIFY_YML}"
+        )
+
+    path = re.search(r"^\s*path:\s*([^\s][^\n]*)\s*$", step.group("body"), re.MULTILINE)
+    if not path:
+        raise ValueError(
+            f"Could not locate download artifact path in {job} job for {artifact_name} in {VERIFY_YML}"
+        )
+
+    return name.group(1).strip(), path.group(1).strip()
+
+
+def _extract_forge_line(job_body: str, job: str) -> str:
+    m = re.search(r"^\s*forge test[^\n]*$", job_body, flags=re.MULTILINE)
+    if not m:
+        raise ValueError(f"Could not locate 'forge test' command in {job} job in {VERIFY_YML}")
+    return m.group(0).strip()
+
+
+def main() -> int:
+    verify_text = VERIFY_YML.read_text(encoding="utf-8")
+
+    foundry_body = _extract_job_body(verify_text, "foundry")
+    patched_body = _extract_job_body(verify_text, "foundry-patched")
+    multiseed_body = _extract_job_body(verify_text, "foundry-multi-seed")
+
+    foundry_profile = _extract_env_literal(foundry_body, "FOUNDRY_PROFILE", "foundry")
+    patched_profile = _extract_env_literal(patched_body, "FOUNDRY_PROFILE", "foundry-patched")
+    multiseed_profile = _extract_env_literal(multiseed_body, "FOUNDRY_PROFILE", "foundry-multi-seed")
+
+    foundry_small = _extract_env_literal(foundry_body, "DIFFTEST_RANDOM_SMALL", "foundry")
+    patched_small = _extract_env_literal(patched_body, "DIFFTEST_RANDOM_SMALL", "foundry-patched")
+    multiseed_small = _extract_env_literal(multiseed_body, "DIFFTEST_RANDOM_SMALL", "foundry-multi-seed")
+
+    foundry_large = _extract_env_literal(foundry_body, "DIFFTEST_RANDOM_LARGE", "foundry")
+    patched_large = _extract_env_literal(patched_body, "DIFFTEST_RANDOM_LARGE", "foundry-patched")
+    multiseed_large = _extract_env_literal(multiseed_body, "DIFFTEST_RANDOM_LARGE", "foundry-multi-seed")
+
+    foundry_yul_dir = _extract_env_literal(foundry_body, "DIFFTEST_YUL_DIR", "foundry")
+    patched_yul_dir = _extract_env_literal(patched_body, "DIFFTEST_YUL_DIR", "foundry-patched")
+    multiseed_yul_dir = _extract_env_literal(multiseed_body, "DIFFTEST_YUL_DIR", "foundry-multi-seed")
+
+    foundry_artifact_name, foundry_artifact_path = _extract_download(foundry_body, "generated Yul", "foundry")
+    patched_artifact_name, patched_artifact_path = _extract_download(
+        patched_body, "patched Yul", "foundry-patched"
+    )
+    multiseed_artifact_name, multiseed_artifact_path = _extract_download(
+        multiseed_body, "generated Yul", "foundry-multi-seed"
+    )
+
+    foundry_cmd = _extract_forge_line(foundry_body, "foundry")
+    patched_cmd = _extract_forge_line(patched_body, "foundry-patched")
+    multiseed_cmd = _extract_forge_line(multiseed_body, "foundry-multi-seed")
+
+    errors: list[str] = []
+
+    profiles = {foundry_profile, patched_profile, multiseed_profile}
+    if profiles != {"difftest"}:
+        errors.append(
+            "foundry job FOUNDRY_PROFILE must be synchronized to 'difftest' across foundry/foundry-patched/foundry-multi-seed."
+        )
+
+    if not (foundry_small == patched_small == multiseed_small):
+        errors.append(
+            "DIFFTEST_RANDOM_SMALL must match across foundry/foundry-patched/foundry-multi-seed."
+        )
+
+    if not (foundry_large == patched_large == multiseed_large):
+        errors.append(
+            "DIFFTEST_RANDOM_LARGE must match across foundry/foundry-patched/foundry-multi-seed."
+        )
+
+    if foundry_artifact_name != "generated-yul" or multiseed_artifact_name != "generated-yul":
+        errors.append(
+            "foundry and foundry-multi-seed must download the 'generated-yul' artifact."
+        )
+
+    if patched_artifact_name != "generated-yul-patched":
+        errors.append("foundry-patched must download the 'generated-yul-patched' artifact.")
+
+    if foundry_artifact_path != foundry_yul_dir:
+        errors.append(
+            "foundry DIFFTEST_YUL_DIR must equal its generated Yul download path."
+        )
+
+    if multiseed_artifact_path != multiseed_yul_dir:
+        errors.append(
+            "foundry-multi-seed DIFFTEST_YUL_DIR must equal its generated Yul download path."
+        )
+
+    if patched_artifact_path != patched_yul_dir:
+        errors.append(
+            "foundry-patched DIFFTEST_YUL_DIR must equal its patched Yul download path."
+        )
+
+    if foundry_yul_dir != multiseed_yul_dir:
+        errors.append(
+            "foundry and foundry-multi-seed must use the same DIFFTEST_YUL_DIR for baseline comparisons."
+        )
+
+    if "--no-match-test" in foundry_cmd:
+        errors.append("foundry baseline job must not use --no-match-test filtering.")
+
+    if '--no-match-test "Random10000"' not in patched_cmd:
+        errors.append(
+            "foundry-patched job must keep '--no-match-test \"Random10000\"'."
+        )
+
+    if '--no-match-test "Random10000"' not in multiseed_cmd:
+        errors.append(
+            "foundry-multi-seed job must keep '--no-match-test \"Random10000\"'."
+        )
+
+    if errors:
+        print("verify foundry job sync check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        return 1
+
+    print(
+        "verify foundry job settings are synchronized "
+        f"(profile={foundry_profile}, random_small={foundry_small}, random_large={foundry_large})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a dedicated CI guard for cross-job Foundry config drift in `.github/workflows/verify.yml`.

### What this PR changes
- Adds `scripts/check_verify_foundry_job_sync.py`.
  - Validates shared settings across `foundry`, `foundry-patched`, and `foundry-multi-seed`:
    - `FOUNDRY_PROFILE` sync (`difftest`)
    - `DIFFTEST_RANDOM_SMALL` sync
    - `DIFFTEST_RANDOM_LARGE` sync
    - artifact download names and `path`/`DIFFTEST_YUL_DIR` wiring
    - baseline parity between `foundry` and `foundry-multi-seed`
    - skip-policy contract (`foundry` unfiltered, patched/multi-seed keep `--no-match-test "Random10000"`)
- Wires the new guard into `verify.yml` `checks` job.
- Documents the new guard in `scripts/README.md` (validation scripts + local command list + CI checks list).

Closes #721

## Validation
- `python3 scripts/check_verify_foundry_job_sync.py`
- `python3 -m py_compile scripts/check_verify_foundry_job_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_ci_jobs_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Python CI validation script plus documentation/workflow wiring; main risk is false positives if `verify.yml` formatting changes or the regex parsing misses edge cases.
> 
> **Overview**
> Adds a new CI guard `check_verify_foundry_job_sync.py` to detect configuration drift across `foundry`, `foundry-patched`, and `foundry-multi-seed` jobs (shared env params, Yul artifact download wiring, and `Random10000` skip policy).
> 
> Wires this check into the `verify.yml` `checks` job and documents it in `scripts/README.md` so workflow steps and docs stay aligned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baaed4bcaa007dbfbca1afd5642430d379b11eb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->