### PR TITLE
fix: validate all documentation count occurrences

### DIFF
--- a/scripts/test_check_doc_counts.py
+++ b/scripts/test_check_doc_counts.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_doc_counts import apply_fixes, check_file
+
+
+class CheckDocCountsMultiMatchTests(unittest.TestCase):
+    def test_check_file_reports_stale_non_first_occurrence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "README.md"
+            path.write_text(
+                "Theorems: 431 across categories.\n"
+                "Theorems: 401 across categories.\n",
+                encoding="utf-8",
+            )
+            checks = [
+                ("theorem count", re.compile(r"Theorems: (\d+) across"), "431"),
+            ]
+            errors = check_file(path, checks)
+            self.assertEqual(
+                errors,
+                [
+                    "README.md: theorem count occurrence 2 says '401' but expected '431'",
+                ],
+            )
+
+    def test_apply_fixes_updates_all_stale_occurrences(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "README.md"
+            path.write_text(
+                "Foundry tests: 403/403 tests pass.\n"
+                "Foundry tests: 375/403 tests pass.\n"
+                "Foundry tests: 375/403 tests pass.\n",
+                encoding="utf-8",
+            )
+            checks = [
+                (
+                    "test count",
+                    re.compile(r"Foundry tests: (\d+)/403 tests pass"),
+                    "403",
+                ),
+            ]
+            changed = apply_fixes(path, checks)
+            self.assertTrue(changed)
+            self.assertEqual(
+                path.read_text(encoding="utf-8"),
+                "Foundry tests: 403/403 tests pass.\n"
+                "Foundry tests: 403/403 tests pass.\n"
+                "Foundry tests: 403/403 tests pass.\n",
+            )
+
+    def test_contract_name_regex_does_not_overlap(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "README.md"
+            path.write_text(
+                "| `Counter.sol` | `Verity/Examples/Counter.lean` | 28 theorems |\n"
+                "| `SafeCounter.sol` | `Verity/Examples/SafeCounter.lean` | 25 theorems |\n"
+                "| `OwnedCounter.sol` | `Verity/Examples/OwnedCounter.lean` | 48 theorems |\n",
+                encoding="utf-8",
+            )
+            checks = [
+                (
+                    "counter",
+                    re.compile(r"`Verity/Examples/Counter\.lean`\s*\|\s*(\d+) theorems"),
+                    "28",
+                ),
+                (
+                    "safe counter",
+                    re.compile(
+                        r"`Verity/Examples/SafeCounter\.lean`\s*\|\s*(\d+) theorems"
+                    ),
+                    "25",
+                ),
+                (
+                    "owned counter",
+                    re.compile(
+                        r"`Verity/Examples/OwnedCounter\.lean`\s*\|\s*(\d+) theorems"
+                    ),
+                    "48",
+                ),
+            ]
+            self.assertEqual(check_file(path, checks), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR hardens `scripts/check_doc_counts.py` so stale metrics in later occurrences can no longer bypass CI.

### Changes
- Validate **all** occurrences for each configured regex check (not just the first match).
- Apply `--fix` edits to **all** stale matches per pattern.
- Fix an overlapping contract-name matcher in `examples/solidity/README.md` checks (`Counter` no longer matches `SafeCounter` / `OwnedCounter`).
- Add regression tests for:
  - stale non-first occurrence detection,
  - multi-occurrence auto-fixing,
  - non-overlapping contract-name matching.

Closes #755.

## Validation
- `python3 -m unittest scripts/test_check_doc_counts.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation-metrics validation tooling and add regression tests; main risk is stricter regexes causing CI failures until docs are updated.
> 
> **Overview**
> Documentation count validation is hardened so each configured regex check inspects **all** matches in a file, and `--fix` now rewrites **every** stale captured count rather than only the first occurrence.
> 
> The per-contract check for `examples/solidity/README.md` is tightened to match the specific `Verity/Examples/<Contract>.lean` table entry (using `re.escape`) to prevent contract-name overlap (e.g., `Counter` no longer matching `SafeCounter`).
> 
> Adds `scripts/test_check_doc_counts.py` unit tests covering multi-occurrence detection, multi-occurrence fixing, and the non-overlapping contract-name regex behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32b27a74ad64e1725346e838bd5dacf1f25791c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->