### PR TITLE
scripts: accept empty compile selector lists

### DIFF
--- a/scripts/check_selectors.py
+++ b/scripts/check_selectors.py
@@ -380,7 +380,8 @@ def compute_selectors(signatures: Iterable[str]) -> List[int]:
 
 def extract_compile_selectors(text: str) -> List[CompileSelectors]:
     items: List[CompileSelectors] = []
-    pattern = re.compile(r"compile\s+(\w+)Spec\s*\[([^\]]+)\]")
+    # Allow empty selector tables (`compile fooSpec []`) as valid Lean syntax.
+    pattern = re.compile(r"compile\s+(\w+)Spec\s*\[([^\]]*)\]")
     for match in pattern.finditer(text):
         def_name = match.group(1) + "Spec"
         raw_list = match.group(2)

--- a/scripts/test_check_selectors.py
+++ b/scripts/test_check_selectors.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_selectors import extract_compile_selectors
+
+
+class CheckSelectorsExtractCompileSelectorsTests(unittest.TestCase):
+    def test_extract_compile_selectors_allows_empty_list(self) -> None:
+        text = (
+            "theorem t : compile emptySpec [] = .ok emptyIR := by\n"
+            "  trivial\n"
+        )
+        rows = extract_compile_selectors(text)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].def_name, "emptySpec")
+        self.assertEqual(rows[0].selectors, [])
+
+    def test_extract_compile_selectors_parses_non_empty_list(self) -> None:
+        text = (
+            "theorem t : compile counterSpec [0xd09de08a, 0x8ada066e] "
+            "= .ok counterIR := by\n"
+            "  trivial\n"
+        )
+        rows = extract_compile_selectors(text)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].def_name, "counterSpec")
+        self.assertEqual(rows[0].selectors, [0xD09DE08A, 0x8ADA066E])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `extract_compile_selectors` to accept valid Lean syntax with empty selector lists (`compile fooSpec []`)
- keep existing hex extraction behavior so empty lists map naturally to `selectors == []`
- add regression tests for empty and non-empty compile selector list parsing

## Testing
- `python3 -m unittest scripts/test_check_selectors.py`
- `python3 scripts/check_selectors.py`

Closes #746

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to a regex in a CI-style script plus new unit tests; minimal impact outside selector-list parsing.
> 
> **Overview**
> Updates `extract_compile_selectors` in `scripts/check_selectors.py` to treat empty selector tables (e.g. `compile fooSpec []`) as valid by allowing an empty bracketed list in the regex match, while keeping the same hex selector extraction behavior.
> 
> Adds `scripts/test_check_selectors.py` unit tests covering both empty and non-empty `compile ...Spec [...]` selector list parsing to prevent regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09c0681d5acf5fa43ee006c09cf28aa4f441f0cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->