### PR TITLE
Fix test README property-coverage total drift checks

### DIFF
--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -661,6 +661,11 @@ def main() -> None:
                     str(covered_count),
                 ),
                 (
+                    "theorem total in tree coverage",
+                    re.compile(r"covering \d+/(\d+) theorems"),
+                    str(total_theorems),
+                ),
+                (
                     "property test function count",
                     re.compile(r"(\d+) functions, covering"),
                     str(property_fn_count),

--- a/scripts/test_check_doc_counts.py
+++ b/scripts/test_check_doc_counts.py
@@ -91,6 +91,28 @@ class CheckDocCountsMultiMatchTests(unittest.TestCase):
             ]
             self.assertEqual(check_file(path, checks), [])
 
+    def test_check_file_reports_stale_ratio_denominator(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "README.md"
+            path.write_text(
+                "Property tests (197 functions, covering 250/401 theorems)\n",
+                encoding="utf-8",
+            )
+            checks = [
+                (
+                    "theorem total in tree coverage",
+                    re.compile(r"covering \d+/(\d+) theorems"),
+                    "431",
+                ),
+            ]
+            errors = check_file(path, checks)
+            self.assertEqual(
+                errors,
+                [
+                    "README.md: theorem total in tree coverage occurrence 1 says '401' but expected '431'",
+                ],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/README.md
+++ b/test/README.md
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (197 functions, covering 250/401 theorems)
+├── Property*.t.sol           # Property tests (197 functions, covering 250/431 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests


### PR DESCRIPTION
## Summary
- fix stale `test/README.md` property tree line from `250/401` to `250/431`
- extend `scripts/check_doc_counts.py` to validate the denominator in `covering X/Y theorems`
- add regression test that fails when this denominator drifts

## Why
`check_doc_counts.py` already verified covered-count in the tree line but not total-count, allowing contradictory totals in the same document to pass CI.

## Validation
- `python3 -m unittest scripts/test_check_doc_counts.py`
- `python3 scripts/check_doc_counts.py`

Closes #745

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, regex-based documentation-checking change plus a doc count update; low blast radius limited to CI validation and tests.
> 
> **Overview**
> Prevents silent drift in property coverage ratios by extending `scripts/check_doc_counts.py` to validate the *denominator* in `covering X/Y theorems` (not just the covered count).
> 
> Updates `test/README.md` to reflect the current total (`250/431`) and adds a unit test in `scripts/test_check_doc_counts.py` to ensure stale denominators are reported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcae911cac7deb86ed7bca3eea12e42bf35f1852. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->