### PR TITLE
Fix property tooling contract-name regex to match compiler identifiers

### DIFF
--- a/scripts/property_utils.py
+++ b/scripts/property_utils.py
@@ -25,7 +25,7 @@ PROPERTY_SIMPLE_RE = re.compile(
     r"Property\s*:\s*([A-Za-z0-9_']+)(?:\s*\(.*\))?\s*$"
 )
 FILE_RE = re.compile(r"^Property(.+)\.t\.sol$")
-CONTRACT_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
+CONTRACT_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 THEOREM_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_']*$")
 
 # Regex pattern for extracting theorems from Lean files

--- a/scripts/test_property_utils.py
+++ b/scripts/test_property_utils.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import property_utils
+
+
+class PropertyUtilsContractNameTests(unittest.TestCase):
+    def test_load_manifest_allows_contract_names_starting_with_underscore(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "property_manifest.json"
+            manifest.write_text('{"_Vault":["theorem_ok"]}\n', encoding="utf-8")
+
+            original_manifest = property_utils.MANIFEST
+            try:
+                property_utils.MANIFEST = manifest
+                loaded = property_utils.load_manifest()
+            finally:
+                property_utils.MANIFEST = original_manifest
+
+            self.assertEqual(loaded, {"_Vault": {"theorem_ok"}})
+
+    def test_collect_covered_allows_property_files_with_underscore_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_dir = Path(tmpdir)
+            (test_dir / "Property_Vault.t.sol").write_text(
+                "// SPDX-License-Identifier: MIT\n"
+                "/// Property 1: theorem_ok\n"
+                "contract Property_Vault {}\n",
+                encoding="utf-8",
+            )
+
+            original_test_dir = property_utils.TEST_DIR
+            try:
+                property_utils.TEST_DIR = test_dir
+                covered = property_utils.collect_covered()
+            finally:
+                property_utils.TEST_DIR = original_test_dir
+
+            self.assertEqual(covered, {"_Vault": {"theorem_ok"}})
+
+    def test_extract_manifest_from_proofs_allows_underscore_contract_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            proofs_dir = root / "Proofs"
+            examples_dir = root / "Examples"
+            proofs_dir.mkdir()
+            examples_dir.mkdir()
+
+            contract_dir = proofs_dir / "_Vault"
+            contract_dir.mkdir()
+            (contract_dir / "Spec.lean").write_text(
+                "theorem theorem_ok : True := by\n"
+                "  trivial\n",
+                encoding="utf-8",
+            )
+
+            original_proofs_dir = property_utils.PROOFS_DIR
+            original_examples_dir = property_utils.EXAMPLES_DIR
+            try:
+                property_utils.PROOFS_DIR = proofs_dir
+                property_utils.EXAMPLES_DIR = examples_dir
+                manifest = property_utils.extract_manifest_from_proofs()
+            finally:
+                property_utils.PROOFS_DIR = original_proofs_dir
+                property_utils.EXAMPLES_DIR = original_examples_dir
+
+            self.assertEqual(manifest, {"_Vault": ["theorem_ok"]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `scripts/property_utils.py` contract-name validator to allow leading underscore identifiers (`[A-Za-z_]`)
- add regression tests in `scripts/test_property_utils.py` covering:
  - manifest loading with `_Contract` keys
  - property coverage collection from `Property_Contract.t.sol`
  - proof-manifest extraction from `Verity/Proofs/_Contract/`

## Why
`ContractSpec`/`ASTDriver` identifier rules allow `_` as the first character, but property tooling rejected that shape. This caused cross-boundary schema mismatch and false failures in property-manifest tooling.

Closes #740

## Validation
- `python3 -m unittest scripts/test_property_utils.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_coverage.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small regex change in scripting/CI tooling plus regression tests; main risk is only that it could broaden accepted identifiers and affect manifest/coverage checks.
> 
> **Overview**
> Aligns `scripts/property_utils.py` contract-name validation with compiler identifier rules by allowing leading underscores in `CONTRACT_NAME_RE`.
> 
> Adds `scripts/test_property_utils.py` unit tests to prevent regressions across manifest loading, property coverage collection from `Property*.t.sol`, and proof-manifest extraction from `Verity/Proofs` when contract names start with `_`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f93b159f7a147b1602c7d2e8d45b158c86b9470. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->