### PR TITLE
Fix ABI artifact trust boundary in compile drivers

### DIFF
--- a/Compiler/ASTDriver.lean
+++ b/Compiler/ASTDriver.lean
@@ -378,16 +378,16 @@ def compileAllASTWithOptions
 
   let mut patchRows : List (String × Yul.PatchPassReport) := []
   for spec in ASTSpecs.allSpecs do
-    match abiOutDir with
-    | some dir =>
-        Compiler.ABI.writeContractABIFile dir (astSpecToContractSpecForABI spec)
-        if verbose then
-          IO.println s!"✓ Wrote ABI {dir}/{spec.name}.abi.json"
-    | none => pure ()
     let selectors ← computeSelectors spec
     match compileSpec spec selectors with
     | .ok contract =>
       let patchReport ← writeContract outDir contract libraryPaths verbose options
+      match abiOutDir with
+      | some dir =>
+          Compiler.ABI.writeContractABIFile dir (astSpecToContractSpecForABI spec)
+          if verbose then
+            IO.println s!"✓ Wrote ABI {dir}/{spec.name}.abi.json"
+      | none => pure ()
       patchRows := (contract.name, patchReport) :: patchRows
       if verbose then
         IO.println s!"✓ Compiled {contract.name} (AST path)"

--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -95,18 +95,18 @@ def compileAllWithOptions
 
   let mut patchRows : List (String × Yul.PatchPassReport) := []
   for spec in specs do
-    match abiOutDir with
-    | some dir =>
-        Compiler.ABI.writeContractABIFile dir spec
-        if verbose then
-          IO.println s!"✓ Wrote ABI {dir}/{spec.name}.abi.json"
-    | none => pure ()
     let selectors ← computeSelectors spec
     match compile spec selectors with
     | .ok contract =>
       -- Only pass libraries to contracts that declare external functions
       let contractLibs := if spec.externals.isEmpty then [] else libraryPaths
       let patchReport ← writeContract outDir contract contractLibs verbose options
+      match abiOutDir with
+      | some dir =>
+          Compiler.ABI.writeContractABIFile dir spec
+          if verbose then
+            IO.println s!"✓ Wrote ABI {dir}/{spec.name}.abi.json"
+      | none => pure ()
       patchRows := (contract.name, patchReport) :: patchRows
       if verbose then
         IO.println s!"✓ Compiled {contract.name}"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -1,0 +1,63 @@
+import Compiler.CompileDriver
+
+namespace Compiler.CompileDriverTest
+
+private def contains (haystack needle : String) : Bool :=
+  let h := haystack.toList
+  let n := needle.toList
+  if n.isEmpty then true
+  else
+    let rec go : List Char → Bool
+      | [] => false
+      | c :: cs =>
+        if (c :: cs).take n.length == n then true
+        else go cs
+    go h
+
+private def expectFailureContains (label : String) (action : IO Unit) (needle : String) : IO Unit := do
+  try
+    action
+    throw (IO.userError s!"✗ {label}: expected failure, command succeeded")
+  catch e =>
+    let msg := e.toString
+    if !contains msg needle then
+      throw (IO.userError s!"✗ {label}: expected '{needle}', got:\n{msg}")
+    IO.println s!"✓ {label}"
+
+private def fileExists (path : String) : IO Bool := do
+  try
+    let _ ← IO.FS.readFile path
+    pure true
+  catch _ =>
+    pure false
+
+#eval! do
+  let outDir := "/tmp/verity-compile-driver-test-out"
+  let abiDir := "/tmp/verity-compile-driver-test-abi"
+  let missingLib := "/tmp/definitely-missing-library.yul"
+  let failingAbi := s!"{abiDir}/CryptoHash.abi.json"
+  let successfulAbi := s!"{abiDir}/SimpleStorage.abi.json"
+
+  IO.FS.createDirAll outDir
+  IO.FS.createDirAll abiDir
+
+  -- Remove stale ABI outputs from previous runs so this check is deterministic.
+  try IO.FS.removeFile failingAbi catch _ => pure ()
+  try IO.FS.removeFile successfulAbi catch _ => pure ()
+
+  expectFailureContains
+    "compileAllWithOptions reports missing linked library"
+    (compileAllWithOptions outDir false [missingLib] {} none (some abiDir))
+    missingLib
+
+  let hasFailingAbi ← fileExists failingAbi
+  if hasFailingAbi then
+    throw (IO.userError s!"✗ expected no ABI artifact for failing contract, found: {failingAbi}")
+  IO.println "✓ no ABI artifact emitted for failing contract"
+
+  let hasSuccessfulAbi ← fileExists successfulAbi
+  if !hasSuccessfulAbi then
+    throw (IO.userError s!"✗ expected ABI artifact for successful contract, missing: {successfulAbi}")
+  IO.println "✓ ABI artifacts still emitted for contracts compiled before failure"
+
+end Compiler.CompileDriverTest


### PR DESCRIPTION
## Summary
This fixes the artifact trust-boundary bug in both compilation drivers:

- `Compiler.compileAllWithOptions` no longer writes ABI JSON before compile/write success.
- `Compiler.ASTDriver.compileAllASTWithOptions` now follows the same ordering.

ABI artifacts are now emitted only after the corresponding contract has successfully compiled and been rendered/written.

## Why
Previously, a mid-loop failure could still leave `*.abi.json` artifacts for contracts that did not complete compilation. That allows stale/invalid interfaces to appear authoritative.

## Changes
- Moved ABI emission into the `.ok contract` branch in:
  - `Compiler/CompileDriver.lean`
  - `Compiler/ASTDriver.lean`
- Added regression test:
  - `Compiler/CompileDriverTest.lean`
  - Forces a deterministic compile failure via a missing linked library path.
  - Verifies:
    - failure is surfaced,
    - ABI is **not** emitted for failing `CryptoHash`,
    - ABI is still emitted for successfully compiled earlier contracts.

## Validation
- `lake env lean Compiler/CompileDriverTest.lean`
- `lake build`

Closes #743
Closes #772

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is a simple reordering of ABI file writes plus a regression test, with no changes to compilation semantics beyond when artifacts are emitted.
> 
> **Overview**
> Prevents stale/invalid `*.abi.json` artifacts by moving ABI emission in `Compiler/CompileDriver.lean` and `Compiler/ASTDriver.lean` to occur **only after** the `.ok contract` path completes `writeContract` successfully.
> 
> Adds `Compiler/CompileDriverTest.lean` to regress this behavior by forcing a deterministic failure via a missing linked library and asserting the failing contract’s ABI is not written while earlier successful ABIs remain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e06125826e9b0f08f1145c2a5541ef8061a03079. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->