### PR TITLE
Fix short-calldata selector misdispatch in codegen

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -2321,6 +2321,11 @@ private def featureSpec : ContractSpec := {
       let rendered := Yul.render (emitYul ir)
       assertContains "receive+fallback split dispatch" rendered
         ["if __is_empty_calldata {", "/* receive() */", "if iszero(__is_empty_calldata) {", "/* fallback() */"]
+      assertContains "short-calldata guard before selector dispatch" rendered
+        ["let __has_selector := iszero(lt(calldatasize(), 4))",
+         "if iszero(__has_selector) {",
+         "/* fallback() */",
+         "if __has_selector {"]
 
 #eval! do
   let receiveNotPayableSpec : ContractSpec := {


### PR DESCRIPTION
## Summary
Fixes short-calldata dispatch in runtime codegen by ensuring selector switching only happens when `calldatasize() >= 4`.

Previously, `buildSwitch` always read `calldataload(0)` and switched on it. For calldata lengths `1..3`, right-padding could produce accidental selector matches and route execution into function cases.

## Changes
- `Compiler/Codegen.lean`
  - Wrapped selector dispatch in a top-level guard:
    - `__has_selector := iszero(lt(calldatasize(), 4))`
    - when false: execute default dispatch path (receive/fallback/revert)
    - when true: run selector switch as before
- `Compiler/ContractSpecFeatureTest.lean`
  - Added regression assertion that emitted Yul includes the short-calldata guard before selector dispatch.

## Why this matches Solidity semantics
- `calldatasize() == 0`: default path can route to `receive` (if present) else fallback/revert.
- `0 < calldatasize() < 4`: selector dispatch is skipped and default path is used.
- `calldatasize() >= 4`: selector-based dispatch runs.

## Validation
- `lake update`
- `lake build Compiler.Codegen`
- `lake build Compiler.ContractSpecFeatureTest`

All commands passed locally.

Closes #750

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the contract entrypoint dispatch logic, which can affect routing between functions vs fallback/receive; however the change is small and narrowly targeted to short-calldata behavior.
> 
> **Overview**
> Fixes runtime dispatch codegen to **avoid accidental selector matches on short calldata**.
> 
> `buildSwitch` now emits a top-level `calldatasize() >= 4` guard (`__has_selector`): calls with fewer than 4 bytes skip the selector `switch` and take the default receive/fallback/revert path. A regression assertion was added to `ContractSpecFeatureTest` to ensure the emitted Yul includes this short-calldata guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66868efd4830986c3e86e18207ffaab7a8e21fd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->