### PR TITLE
ContractSpec: reject duplicate function/constructor parameter names

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -2745,6 +2745,51 @@ private def featureSpec : ContractSpec := {
       throw (IO.userError "✗ expected payable+view mutability conflict to fail compilation")
 
 #eval! do
+  let duplicateFunctionParamSpec : ContractSpec := {
+    name := "DuplicateFunctionParamSpec"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "setBoth"
+        params := [
+          { name := "x", ty := ParamType.uint256 },
+          { name := "x", ty := ParamType.address }
+        ]
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile duplicateFunctionParamSpec [1] with
+  | .error err =>
+      if !contains err "duplicate parameter name 'x' in function 'setBoth'" then
+        throw (IO.userError s!"✗ duplicate function param diagnostic mismatch: {err}")
+      IO.println "✓ duplicate function param diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected duplicate function params to fail compilation")
+
+#eval! do
+  let duplicateConstructorParamSpec : ContractSpec := {
+    name := "DuplicateConstructorParamSpec"
+    fields := []
+    constructor := some {
+      params := [
+        { name := "owner", ty := ParamType.address },
+        { name := "owner", ty := ParamType.address }
+      ]
+      body := [Stmt.stop]
+    }
+    functions := [{ name := "noop", params := [], returnType := none, body := [Stmt.stop] }]
+  }
+  match compile duplicateConstructorParamSpec [1] with
+  | .error err =>
+      if !contains err "duplicate parameter name 'owner' in constructor" then
+        throw (IO.userError s!"✗ duplicate constructor param diagnostic mismatch: {err}")
+      IO.println "✓ duplicate constructor param diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected duplicate constructor params to fail compilation")
+
+#eval! do
   let invalidSpecialEntrypointMutabilitySpec : ContractSpec := {
     name := "InvalidSpecialEntrypointMutabilitySpec"
     fields := []


### PR DESCRIPTION
## Summary
- reject duplicate parameter names in `ContractSpec.compile` for:
  - function signatures
  - constructor signatures
- fail early with explicit diagnostics before IR/Yul generation
- add regression coverage in `Compiler/ContractSpecFeatureTest.lean`

## Why
`Expr.param` lookup is name-based and first-match. Allowing duplicate parameter names makes references ambiguous while still compiling, which is a compile-boundary correctness and auditability gap.

## Changes
- Added `firstDuplicateFunctionParamName` and `firstDuplicateConstructorParamName` helpers in `Compiler/ContractSpec.lean`
- Added compile-time checks with diagnostics:
  - `Compilation error: duplicate parameter name '<name>' in function '<fn>'`
  - `Compilation error: duplicate parameter name '<name>' in constructor`
- Added tests:
  - duplicate function params are rejected
  - duplicate constructor params are rejected

## Validation
- `lake build Compiler.ContractSpec Compiler.ContractSpecFeatureTest`
- `lake build`

Closes #730.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new compile-time validation that can cause previously-compiling `ContractSpec`s to fail if they used duplicate parameter names in a function or constructor. Logic is localized to upfront spec validation and covered by new regression tests.
> 
> **Overview**
> **Tightens `ContractSpec.compile` validation** by rejecting duplicate parameter names within a single function signature and within the constructor signature, returning explicit diagnostics before any IR/Yul generation.
> 
> Adds regression coverage in `Compiler/ContractSpecFeatureTest.lean` to assert compilation fails with the expected error messages for both duplicate function params and duplicate constructor params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 373f1b4098d0e3cc174264d0fe4406b64d404656. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->