### PR TITLE
ERC721: revert ownerOf/getApproved for nonexistent tokens

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/ERC721.lean
+++ b/Compiler/Proofs/SpecCorrectness/ERC721.lean
@@ -20,12 +20,12 @@ theorem erc721_balanceOf_spec_correct (s : ContractState) (addr : Address) :
 
 /-- Spec/EDSL agreement for read-only `ownerOf`. -/
 theorem erc721_ownerOf_spec_correct (s : ContractState) (tokenId : Uint256) :
-    ownerOf_spec tokenId ((Verity.Examples.ERC721.ownerOf tokenId).runValue s) s := by
+    ownerOf_spec tokenId ((Verity.Examples.ERC721.ownerOf tokenId).run s) s := by
   simpa using Verity.Proofs.ERC721.ownerOf_meets_spec s tokenId
 
 /-- Spec/EDSL agreement for read-only `getApproved`. -/
 theorem erc721_getApproved_spec_correct (s : ContractState) (tokenId : Uint256) :
-    getApproved_spec tokenId ((Verity.Examples.ERC721.getApproved tokenId).runValue s) s := by
+    getApproved_spec tokenId ((Verity.Examples.ERC721.getApproved tokenId).run s) s := by
   simpa using Verity.Proofs.ERC721.getApproved_meets_spec s tokenId
 
 /-- Spec/EDSL agreement for read-only `isApprovedForAll`. -/

--- a/Verity/Examples/ERC721.lean
+++ b/Verity/Examples/ERC721.lean
@@ -56,9 +56,12 @@ def balanceOf (addr : Address) : Contract Uint256 := do
 
 def ownerOf (tokenId : Uint256) : Contract Address := do
   let ownerWord ← getMappingUint owners tokenId
+  require (ownerWord != 0) "Token does not exist"
   return wordToAddress ownerWord
 
 def getApproved (tokenId : Uint256) : Contract Address := do
+  let ownerWord ← getMappingUint owners tokenId
+  require (ownerWord != 0) "Token does not exist"
   let approvedWord ← getMappingUint tokenApprovals tokenId
   return wordToAddress approvedWord
 

--- a/Verity/Proofs/ERC721/Basic.lean
+++ b/Verity/Proofs/ERC721/Basic.lean
@@ -49,21 +49,23 @@ theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :
   simp [Verity.Examples.ERC721.balanceOf, balanceOf_spec, getMapping, Contract.runValue,
     Verity.Examples.ERC721.balances]
 
-/-- `ownerOf` decodes owner word in slot 4 for `tokenId`. -/
+/-- `ownerOf` reverts for unminted tokens and returns owner for minted tokens. -/
 theorem ownerOf_meets_spec (s : ContractState) (tokenId : Uint256) :
-    ownerOf_spec tokenId ((Verity.Examples.ERC721.ownerOf tokenId).runValue s) s := by
-  simp [ownerOf_spec, Verity.Examples.ERC721.ownerOf, Contract.runValue, Verity.bind, Bind.bind,
-    getMappingUint, Verity.Examples.ERC721.owners,
-    Verity.Examples.ERC721.wordToAddress, Verity.Specs.ERC721.wordToAddress]
-  simp [Pure.pure, Verity.pure]
+    ownerOf_spec tokenId ((Verity.Examples.ERC721.ownerOf tokenId).run s) s := by
+  cases h_owner : (s.storageMapUint 4 tokenId != 0) <;>
+    simp [ownerOf_spec, Verity.Examples.ERC721.ownerOf, Contract.run, Verity.bind, Bind.bind,
+      getMappingUint, Verity.Examples.ERC721.owners, Verity.Examples.ERC721.wordToAddress,
+      Verity.Specs.ERC721.wordToAddress, Pure.pure, Verity.pure,
+      require, h_owner]
 
-/-- `getApproved` decodes approval word in slot 5 for `tokenId`. -/
+/-- `getApproved` reverts for unminted tokens and returns approval for minted tokens. -/
 theorem getApproved_meets_spec (s : ContractState) (tokenId : Uint256) :
-    getApproved_spec tokenId ((Verity.Examples.ERC721.getApproved tokenId).runValue s) s := by
-  simp [getApproved_spec, Verity.Examples.ERC721.getApproved, Contract.runValue, Verity.bind, Bind.bind,
-    getMappingUint, Verity.Examples.ERC721.tokenApprovals,
-    Verity.Examples.ERC721.wordToAddress, Verity.Specs.ERC721.wordToAddress]
-  simp [Pure.pure, Verity.pure]
+    getApproved_spec tokenId ((Verity.Examples.ERC721.getApproved tokenId).run s) s := by
+  cases h_owner : (s.storageMapUint 4 tokenId != 0) <;>
+    simp [getApproved_spec, Verity.Examples.ERC721.getApproved, Contract.run, Verity.bind, Bind.bind,
+      getMappingUint, Verity.Examples.ERC721.owners, Verity.Examples.ERC721.tokenApprovals,
+      Verity.Examples.ERC721.wordToAddress, Verity.Specs.ERC721.wordToAddress, Pure.pure, Verity.pure,
+      require, h_owner]
 
 /-- `isApprovedForAll` checks nonzero operator-approval flag in slot 6. -/
 theorem isApprovedForAll_meets_spec (s : ContractState) (ownerAddr operator : Address) :

--- a/Verity/Proofs/ERC721/Correctness.lean
+++ b/Verity/Proofs/ERC721/Correctness.lean
@@ -18,14 +18,16 @@ theorem balanceOf_preserves_state (s : ContractState) (addr : Address) :
 /-- Read-only `ownerOf` preserves state. -/
 theorem ownerOf_preserves_state (s : ContractState) (tokenId : Uint256) :
     ((Verity.Examples.ERC721.ownerOf tokenId).runState s) = s := by
-  simp [Verity.Examples.ERC721.ownerOf, getMappingUint, Contract.runState, Verity.bind, Bind.bind]
-  simp [Pure.pure, Verity.pure]
+  cases h_owner : (s.storageMapUint Verity.Examples.ERC721.owners.slot tokenId != 0) <;>
+    simp [Verity.Examples.ERC721.ownerOf, getMappingUint, Contract.runState, Verity.bind, Bind.bind,
+      require, Pure.pure, Verity.pure, h_owner]
 
 /-- Read-only `getApproved` preserves state. -/
 theorem getApproved_preserves_state (s : ContractState) (tokenId : Uint256) :
     ((Verity.Examples.ERC721.getApproved tokenId).runState s) = s := by
-  simp [Verity.Examples.ERC721.getApproved, getMappingUint, Contract.runState, Verity.bind, Bind.bind]
-  simp [Pure.pure, Verity.pure]
+  cases h_owner : (s.storageMapUint Verity.Examples.ERC721.owners.slot tokenId != 0) <;>
+    simp [Verity.Examples.ERC721.getApproved, getMappingUint, Contract.runState, Verity.bind, Bind.bind,
+      require, Pure.pure, Verity.pure, h_owner]
 
 /-- Read-only `isApprovedForAll` preserves state. -/
 theorem isApprovedForAll_preserves_state (s : ContractState) (ownerAddr operator : Address) :

--- a/Verity/Specs/ERC721/Spec.lean
+++ b/Verity/Specs/ERC721/Spec.lean
@@ -34,13 +34,21 @@ def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
 def balanceOf_spec (addr : Address) (result : Uint256) (s : ContractState) : Prop :=
   result = s.storageMap 3 addr
 
-/-- ownerOf: returns the decoded owner word for `tokenId` -/
-def ownerOf_spec (tokenId : Uint256) (result : Address) (s : ContractState) : Prop :=
-  result = wordToAddress (s.storageMapUint 4 tokenId)
+/-- ownerOf: reverts when `tokenId` is unminted, otherwise returns token owner -/
+def ownerOf_spec (tokenId : Uint256) (result : ContractResult Address) (s : ContractState) : Prop :=
+  let ownerWord := s.storageMapUint 4 tokenId
+  if ownerWord != 0 then
+    result = ContractResult.success (wordToAddress ownerWord) s
+  else
+    result = ContractResult.revert "Token does not exist" s
 
-/-- getApproved: returns the decoded approval word for `tokenId` -/
-def getApproved_spec (tokenId : Uint256) (result : Address) (s : ContractState) : Prop :=
-  result = wordToAddress (s.storageMapUint 5 tokenId)
+/-- getApproved: reverts when `tokenId` is unminted, otherwise returns approval -/
+def getApproved_spec (tokenId : Uint256) (result : ContractResult Address) (s : ContractState) : Prop :=
+  let ownerWord := s.storageMapUint 4 tokenId
+  if ownerWord != 0 then
+    result = ContractResult.success (wordToAddress (s.storageMapUint 5 tokenId)) s
+  else
+    result = ContractResult.revert "Token does not exist" s
 
 /-- isApprovedForAll: nonzero flag means approved -/
 def isApprovedForAll_spec (ownerAddr operator : Address) (result : Bool) (s : ContractState) : Prop :=


### PR DESCRIPTION
## Summary
- enforce ERC721 nonexistent-token semantics in the executable model:
  - `ownerOf` now reverts with `"Token does not exist"` when token is unminted
  - `getApproved` now also reverts when token is unminted
- align formal ERC721 specs with revert-aware behavior using `ContractResult` (instead of `runValue` defaulting)
- update proof bridge and preservation proofs to cover both success/revert branches

## Why
Previously, `ownerOf`/`getApproved` on unminted tokens returned zero-address through `runValue`, which diverges from ERC-721 expectations and weakens auditability.

This change makes the executable contract and formal spec explicit about revert behavior for nonexistent token IDs.

## Changes
- `Verity/Examples/ERC721.lean`
  - added existence guard in `ownerOf`
  - added existence guard in `getApproved` (checks ownership map first)
- `Verity/Specs/ERC721/Spec.lean`
  - `ownerOf_spec` and `getApproved_spec` now specify `ContractResult Address`
  - both specs model: success when owner word is nonzero, revert otherwise
- `Verity/Proofs/ERC721/Basic.lean`
  - updated `ownerOf_meets_spec` / `getApproved_meets_spec` to prove full `run` result (success + revert)
- `Compiler/Proofs/SpecCorrectness/ERC721.lean`
  - updated theorem statements to use `.run` for ownerOf/getApproved spec correctness
- `Verity/Proofs/ERC721/Correctness.lean`
  - updated state-preservation proofs for `ownerOf` and `getApproved` under new revert guards

## Validation
- `lake build`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_coverage.py`

Closes #776.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core ERC721 query semantics and migrates specs/proofs from value-only reasoning to full `ContractResult`, which may affect downstream proofs and consumers expecting zero-address defaults.
> 
> **Overview**
> Updates the executable ERC721 model so `ownerOf` and `getApproved` `require` a nonzero owner entry and `revert "Token does not exist"` for unminted `tokenId`s.
> 
> Aligns formal specs by changing `ownerOf_spec`/`getApproved_spec` to return `ContractResult Address` (success vs revert), and updates the corresponding bridge theorems and proofs (`Basic.lean`, `Correctness.lean`, `SpecCorrectness/ERC721.lean`) to use `.run` and cover both branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6adf5d3cab9803b5194cfc13d42f55258bc9c26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->