### PR TITLE
ASTDriver: reject fallback/receive reserved names in AST specs

### DIFF
--- a/Compiler/ASTDriverTest.lean
+++ b/Compiler/ASTDriverTest.lean
@@ -210,6 +210,40 @@ private def badParamIdentifierSpec : ASTContractSpec := {
   | .ok _ =>
     throw (IO.userError "✗ expected invalid parameter identifier to be rejected")
 
+private def badFallbackNameSpec : ASTContractSpec := {
+  name := "BadFallbackName"
+  functions := [
+    { name := "fallback", params := [], returnType := .unit, body := Stmt.stop }
+  ]
+}
+
+#eval! do
+  match compileSpec badFallbackNameSpec [0] with
+  | .error err =>
+    if contains err "reserved for ContractSpec special entrypoints" then
+      IO.println "✓ Reserved function name fallback rejected in AST compileSpec"
+    else
+      throw (IO.userError s!"✗ unexpected reserved-name fallback error: {err}")
+  | .ok _ =>
+    throw (IO.userError "✗ expected reserved function name fallback to be rejected")
+
+private def badReceiveNameSpec : ASTContractSpec := {
+  name := "BadReceiveName"
+  functions := [
+    { name := "receive", params := [], returnType := .unit, body := Stmt.stop }
+  ]
+}
+
+#eval! do
+  match compileSpec badReceiveNameSpec [0] with
+  | .error err =>
+    if contains err "reserved for ContractSpec special entrypoints" then
+      IO.println "✓ Reserved function name receive rejected in AST compileSpec"
+    else
+      throw (IO.userError s!"✗ unexpected reserved-name receive error: {err}")
+  | .ok _ =>
+    throw (IO.userError "✗ expected reserved function name receive to be rejected")
+
 private def badContractIdentifierSpec : ASTContractSpec := {
   name := "0BadContract"
   functions := []


### PR DESCRIPTION
## Summary
Fixes an ABI/runtime consistency footgun in the AST compilation path by rejecting Solidity special-entrypoint names (`fallback`, `receive`) in `ASTContractSpec` function declarations.

This is the short-term safety fix described in issue #770.

## Changes
- `Compiler/ASTDriver.lean`
  - Added reserved-name validation in `validateSpec`:
    - reject AST functions whose name satisfies `isInteropEntrypointName`.
  - Updated selector section note to reflect enforced behavior.
- `Compiler/ASTDriverTest.lean`
  - Added regression tests that `compileSpec` rejects:
    - `fallback`
    - `receive`

## Why
AST runtime dispatch is selector-based, while ABI emission treats `fallback`/`receive` as Solidity special entries by name. Rejecting these names in AST prevents misleading ABI metadata and keeps AST behavior explicit.

## Validation
- `lake build Compiler.ASTDriver Compiler.ASTDriverTest`
- `lake env lean Compiler/ASTDriverTest.lean`
- `lake build`

Fixes #770

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a simple validation guard and tests only; behavior change is limited to rejecting previously-accepted invalid AST function names.
> 
> **Overview**
> Prevents an ABI/runtime mismatch in the AST compilation path by **rejecting Solidity special entrypoint names** in `ASTContractSpec` functions.
> 
> `Compiler.ASTDriver.validateSpec` now errors if a function name matches `isInteropEntrypointName` (e.g. `fallback`/`receive`), and `ASTDriverTest` adds regression cases asserting `compileSpec` fails for those reserved names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b0c9b03645b035b76660eab441faf8b548b35dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->