### PR TITLE
Fix #773: bounds-check Expr.arrayElement dynamic reads

### DIFF
--- a/Compiler/Codegen.lean
+++ b/Compiler/Codegen.lean
@@ -115,7 +115,7 @@ def runtimeCodeWithOptions (contract : IRContract) (options : YulEmitOptions) : 
 
 private def deployCode (contract : IRContract) : List YulStmt :=
   let valueGuard := if contract.constructorPayable then [] else [callvalueGuard]
-  valueGuard ++ contract.deploy ++ [yulDatacopy, yulReturnRuntime]
+  valueGuard ++ contract.internalFunctions ++ contract.deploy ++ [yulDatacopy, yulReturnRuntime]
 
 def emitYul (contract : IRContract) : YulObject :=
   { name := contract.name

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -255,7 +255,7 @@ The ContractSpec DSL provides a complete expression and statement language for s
 | `externalCall "f" args` | Call linked library function | `f(args...)` |
 | `internalCall "f" args` | Call internal contract function | `internal_f(args...)` |
 | `arrayLength "arr"` | Length of dynamic array parameter | `arr_length` |
-| `arrayElement "arr" idx` | Element of dynamic array parameter | `calldataload(arr_data_offset + idx*32)` |
+| `arrayElement "arr" idx` | Checked element of dynamic array parameter (reverts if `idx >= arr_length`) | `__verity_array_element_*_checked(arr_data_offset, arr_length, idx)` |
 | `add a b` | Addition | `add(a, b)` |
 | `sub a b` | Subtraction | `sub(a, b)` |
 | `mul a b` | Multiplication | `mul(a, b)` |


### PR DESCRIPTION
## Summary
Fixes #773 by making `Expr.arrayElement` checked-by-default.

Before this change, dynamic-array indexing lowered to raw `calldataload`/`mload` with no `idx < length` guard, so out-of-range reads silently produced zero-ish behavior at runtime.

After this change:
- `Expr.arrayElement` lowers to checked helper calls that `revert(0,0)` on `idx >= length`.
- Helper variants are emitted for both calldata and memory-backed dynamic params.
- Helper emission is usage-gated (only injected if the spec uses `Expr.arrayElement`).
- Internal helper definitions are emitted in deploy code as well, so constructor-side array reads are valid and checked.

## Changes
- `Compiler/ContractSpec.lean`
  - Added checked helper function definitions:
    - `__verity_array_element_calldata_checked`
    - `__verity_array_element_memory_checked`
  - Changed `compileExpr` for `Expr.arrayElement` to call checked helpers.
  - Added recursive usage detection (`contractUsesArrayElement`) to avoid injecting helpers when unused.
  - Updated `Expr.arrayElement` doc comment to reflect checked semantics.

- `Compiler/Codegen.lean`
  - Emit `contract.internalFunctions` in deploy code as well as runtime code.
  - Ensures constructor code can call generated helper/internal functions.

- `Compiler/ContractSpecFeatureTest.lean`
  - Updated constructor dynamic read regression to assert checked helper usage and guard presence.
  - Added regression ensuring helper injection is usage-gated.

- `docs-site/content/compiler.mdx`
  - Updated `arrayElement` docs to checked semantics.

## Validation
- `lake env lean Compiler/ContractSpecFeatureTest.lean`
- `lake build`

Both pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Yul code generation semantics for dynamic array reads and injects new helper functions into deploy/runtime output, which could affect contract behavior and gas usage; scope is limited and covered by updated tests.
> 
> **Overview**
> Fixes dynamic array indexing safety by making `Expr.arrayElement` lower to *checked* helper calls that `revert(0,0)` when `idx >= length`, instead of raw `calldataload`/`mload`.
> 
> Adds calldata+memory helper function definitions and usage-gated injection of those helpers into `internalFunctions`, updates codegen to include `internalFunctions` in deploy code (so constructors can use the helpers), and updates feature tests + docs to match the new checked semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0173d3b46f4b4318bbdc6033d88f541d6a60a7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->