### PR TITLE
fix: fail fast on invalid generated identifiers (#767)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -193,6 +193,12 @@ python3 scripts/generate_contract.py MyContract --dry-run
 
 Creates 7 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic proofs, Correctness proofs, and Property tests. Prints instructions for manual steps (All.lean imports, Compiler/Specs.lean entry).
 
+Identifier rules (fail-fast validation):
+- Contract name: PascalCase alphanumeric (existing rule), e.g. `MyToken`
+- Field names: `[A-Za-z_][A-Za-z0-9_]*`
+- Function names: `[A-Za-z_][A-Za-z0-9_]*`
+- Reserved Lean/Solidity keywords are rejected for generated field/function names
+
 ## Utilities
 
 - **`property_utils.py`** - Shared utilities for loading manifests, exclusions, and test coverage

--- a/scripts/test_generate_contract.py
+++ b/scripts/test_generate_contract.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from generate_contract import parse_fields, parse_functions
+
+
+class GenerateContractIdentifierValidationTests(unittest.TestCase):
+    def _assert_exits_with_error(self, fn, *args: object) -> str:
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            with self.assertRaises(SystemExit) as ctx:
+                fn(*args)
+        self.assertEqual(ctx.exception.code, 1)
+        return buf.getvalue()
+
+    def test_parse_fields_rejects_hyphenated_identifier(self) -> None:
+        err = self._assert_exits_with_error(parse_fields, "bad-name:uint256")
+        self.assertIn("Invalid field identifier 'bad-name'", err)
+
+    def test_parse_fields_rejects_leading_digit_identifier(self) -> None:
+        err = self._assert_exits_with_error(parse_fields, "1field:uint256")
+        self.assertIn("Invalid field identifier '1field'", err)
+
+    def test_parse_fields_rejects_reserved_identifier(self) -> None:
+        err = self._assert_exits_with_error(parse_fields, "contract:uint256")
+        self.assertIn("Invalid field identifier 'contract'", err)
+        self.assertIn("reserved", err)
+
+    def test_parse_functions_rejects_hyphenated_identifier(self) -> None:
+        err = self._assert_exits_with_error(
+            parse_functions,
+            "set-value(uint256),getValue()",
+            [],
+        )
+        self.assertIn("Invalid function identifier 'set-value'", err)
+
+    def test_parse_functions_rejects_leading_digit_identifier(self) -> None:
+        err = self._assert_exits_with_error(
+            parse_functions,
+            "1setter(uint256)",
+            [],
+        )
+        self.assertIn("Invalid function identifier '1setter'", err)
+
+    def test_parse_functions_rejects_reserved_identifier(self) -> None:
+        err = self._assert_exits_with_error(parse_functions, "return(uint256)", [])
+        self.assertIn("Invalid function identifier 'return'", err)
+        self.assertIn("reserved", err)
+
+    def test_parse_fields_and_functions_accept_valid_identifiers(self) -> None:
+        fields = parse_fields("storedData:uint256,owner_address:address")
+        funcs = parse_functions("setStoredData(uint256),getStoredData()", fields)
+        self.assertEqual([f.name for f in fields], ["storedData", "owner_address"])
+        self.assertEqual([f.name for f in funcs], ["setStoredData", "getStoredData"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #767 by making `scripts/generate_contract.py` fail fast on invalid generated identifiers, instead of producing uncompilable Lean/Solidity scaffolds.

## Changes
- Added shared identifier validation in `generate_contract.py` for field/function names:
  - regex: `[A-Za-z_][A-Za-z0-9_]*`
  - rejects reserved Lean/Solidity keywords
  - prints actionable error and exits non-zero
- Enforced validation in both parsing paths:
  - `parse_fields(...)`
  - `parse_functions(...)` / `_parse_single_function(...)`
- Added regression tests in `scripts/test_generate_contract.py` for:
  - hyphenated names (`bad-name`, `set-value`)
  - leading-digit names (`1field`, `1setter`)
  - reserved keywords (`contract`, `return`)
  - valid identifiers still accepted
- Documented identifier constraints in `scripts/README.md` and CLI `--help` text.

## Validation
- `python3 -m unittest scripts/test_generate_contract.py`
- `python3 -m unittest scripts/test_check_selectors.py scripts/test_check_doc_counts.py scripts/test_generate_contract.py`
- Repro check:
  - invalid input now returns exit code `1` with clear error
  - valid `--dry-run` still generates scaffold plan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `scripts/generate_contract.py` behavior to hard-fail on invalid or reserved field/function names, which may break existing generator invocations that previously produced (but wouldn’t compile) output. Scope is limited to developer tooling and is covered by new unit tests.
> 
> **Overview**
> Prevents `scripts/generate_contract.py` from generating uncompilable Lean/Solidity scaffolds by adding shared identifier validation for generated field/function names (regex enforcement + reserved Lean/Solidity keyword denylist) and exiting with a clear error on invalid input.
> 
> Adds regression coverage in `scripts/test_generate_contract.py`, and updates `scripts/README.md` plus CLI `--help` text to document the identifier rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e0534de38bd4aff5ead345aba4e8c8841b26df4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->