### PR TITLE
fix(generator): reject malformed --functions signatures

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -198,6 +198,8 @@ Identifier rules (fail-fast validation):
 - Field names: `[A-Za-z_][A-Za-z0-9_]*`
 - Function names: `[A-Za-z_][A-Za-z0-9_]*`
 - Reserved Lean/Solidity keywords are rejected for generated field/function names
+- `--functions` signatures must be comma-separated and parenthesis-balanced
+- Supported function parameter types are `uint256` and `address` (unknown types are rejected)
 
 ## Utilities
 


### PR DESCRIPTION
## Summary
Fixes #754 by making `scripts/generate_contract.py --functions` parsing fail-closed instead of silently rewriting malformed signatures.

### What changed
- Hardened `parse_functions` list parsing:
  - Rejects unmatched `)` underflow
  - Rejects unbalanced parentheses at end of parse
  - Rejects empty signatures between commas
  - Rejects trailing comma (empty signature at end)
- Hardened `_parse_single_function` signature parsing:
  - Rejects empty signatures
  - Requires exactly one balanced parameter list for typed signatures
  - Rejects malformed parameter lists with empty entries
  - Rejects unsupported parameter types instead of coercing to `uint256`
- Added regression tests in `scripts/test_generate_contract.py` for malformed inputs from the issue (and related parser edge cases).
- Updated `scripts/README.md` to document strict `--functions` grammar and supported parameter types.

## Validation
- `python3 -m unittest scripts/test_generate_contract.py`
- Manual repro checks:
  - `python3 scripts/generate_contract.py DemoBad2 --functions 'foo(uint256)),bar(' --dry-run` now exits non-zero
  - `python3 scripts/generate_contract.py DemoBad4 --functions 'foo(uint256),' --dry-run` now exits non-zero

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI input validation in a developer-only generator, with added regression tests to lock in behavior.
> 
> **Overview**
> `scripts/generate_contract.py` now *fails closed* when parsing `--functions` input: it rejects empty signatures, unbalanced/extra parentheses, empty parameter entries, and any parameter type outside `uint256`/`address` (instead of silently coercing unknown types).
> 
> Adds focused unit tests covering these malformed signature/list cases, and updates `scripts/README.md` to document the stricter `--functions` grammar and supported parameter types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2806ed3c06f783d613bf4956532af78ad23f76ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->