### PR TITLE
fix(generator): make getter property scaffolds explicit TODO stubs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -200,6 +200,7 @@ Identifier rules (fail-fast validation):
 - Reserved Lean/Solidity keywords are rejected for generated field/function names
 - `--functions` signatures must be comma-separated and parenthesis-balanced
 - Supported function parameter types are `uint256` and `address` (unknown types are rejected)
+- Getter property test scaffolds are emitted as explicit `testTODO_*` placeholders that revert until return-value and non-mutation assertions are implemented
 
 ## Utilities
 

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -829,23 +829,18 @@ def _gen_single_test(
 
     if is_getter:
         return f"""    //═══════════════════════════════════════════════════════════════════════
-    // Property {idx + 1}: {fn.name}_meets_spec
-    // Theorem: {fn.name}({', '.join(p.solidity_type for p in fn.params)}) meets its formal specification
+    // Property {idx + 1}: TODO_{fn.name}_meets_spec
+    // Getter theorem extraction requires manual return/storage assertions.
     //═══════════════════════════════════════════════════════════════════════
 
-    /// Property: {fn.name}_meets_spec
-    function testProperty_{camel}_MeetsSpec() public {{
-        // Read-only function: verify it returns expected value and
-        // does not modify storage.
-        uint256 slot0Before = readStorage(0);
-
-        (bool success, bytes memory data) = target.call(
-            abi.encodeWithSignature({encode_args})
-        );
-        require(success, "{fn.name} call failed");
-
-        // Storage should be unchanged after a read-only call
-        assertEq(readStorage(0), slot0Before, "{fn.name} should not modify storage");
+    /// Property TODO: {fn.name}_meets_spec
+    function testTODO_{camel}_GetterNeedsSpecAssertions() public {{
+        // TODO: Implement getter-specific checks:
+        // 1) set up deterministic storage,
+        // 2) decode return data from `{fn.name}`,
+        // 3) assert decoded value matches spec/state,
+        // 4) assert no unintended storage mutation (all relevant slots/mappings).
+        revert("TODO: implement getter property assertions");
     }}
 """
     else:


### PR DESCRIPTION
## Summary
Fixes #774 by removing misleading getter property-test scaffolds that appeared to validate semantics but did not assert return values or full non-mutation behavior.

### What changed
- `scripts/generate_contract.py`
  - Getter scaffolds in `_gen_single_test(...)` now emit explicit TODO placeholders:
    - test function renamed to `testTODO_*`
    - property annotation updated to `Property TODO`
    - generated test now reverts with `TODO: implement getter property assertions`
  - Removed pseudo-validation logic that previously:
    - captured return bytes without decoding/asserting them
    - asserted only `readStorage(0)` immutability
- `scripts/test_generate_contract.py`
  - Added regression tests to ensure getter scaffolds are explicit TODO placeholders and no longer contain misleading pseudo-assertions.
  - Added guard test confirming non-getter scaffolds remain unchanged.
- `scripts/README.md`
  - Documented getter scaffold behavior (`testTODO_*` + explicit revert) to set correct expectations.

## Why this is safer
This fails closed: generated getter tests cannot pass while implying theorem-level validation unless the author implements explicit return-value and storage-mutation assertions.

## Validation
- `python3 -m unittest scripts/test_generate_contract.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to scaffold generation and its unit tests, making getter property tests fail-closed rather than implying coverage.
> 
> **Overview**
> Updates `scripts/generate_contract.py` so generated *getter* property tests are no longer pseudo-validations; they now emit explicit `testTODO_*` stubs with `Property TODO` annotations and an unconditional `revert("TODO: implement getter property assertions")`.
> 
> Adds unit tests in `scripts/test_generate_contract.py` to lock in the new getter stub output and to ensure non-getter scaffolds remain unchanged, and documents the new getter behavior in `scripts/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd89a2411d9c3282ae0728eafd35b67282e7dafe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->