### PR TITLE
fix(generator): scaffold AST and SpecCorrectness files

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -191,7 +191,7 @@ python3 scripts/generate_contract.py MyToken \
 python3 scripts/generate_contract.py MyContract --dry-run
 ```
 
-Creates 7 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic proofs, Correctness proofs, and Property tests. Prints instructions for manual steps (All.lean imports, Compiler/Specs.lean entry).
+Creates 9 files: EDSL implementation, AST bridge scaffold, Spec, Invariants, Proofs re-export, Basic proofs, Correctness proofs, SpecCorrectness scaffold, and Property tests. Prints instructions for manual steps (All.lean imports, Compiler/Specs.lean entry).
 
 Identifier rules (fail-fast validation):
 - Contract name: PascalCase alphanumeric (existing rule), e.g. `MyToken`

--- a/scripts/test_generate_contract.py
+++ b/scripts/test_generate_contract.py
@@ -16,9 +16,11 @@ from generate_contract import (
     Field,
     Function,
     Param,
+    gen_all_lean_imports,
     gen_property_tests,
     parse_fields,
     parse_functions,
+    scaffold_files,
 )
 
 
@@ -142,6 +144,36 @@ class GenerateContractGetterPropertyScaffoldTests(unittest.TestCase):
         out = gen_property_tests(cfg)
         self.assertIn("function testProperty_SetStoredValue_MeetsSpec() public {", out)
         self.assertIn("Property: setStoredValue_meets_spec", out)
+
+
+class GenerateContractStructureScaffoldTests(unittest.TestCase):
+    def test_scaffold_files_include_ast_and_spec_correctness(self) -> None:
+        cfg = ContractConfig(
+            name="AuditProbe",
+            fields=[Field(name="storedValue", ty="uint256")],
+            functions=[
+                Function(
+                    name="setStoredValue",
+                    params=[Param(name="value", ty="uint256")],
+                )
+            ],
+        )
+        paths = {str(path) for path, _ in scaffold_files(cfg)}
+
+        self.assertIn(str((SCRIPT_DIR.parent / "Verity" / "AST" / "AuditProbe.lean")), paths)
+        self.assertIn(
+            str((SCRIPT_DIR.parent / "Compiler" / "Proofs" / "SpecCorrectness" / "AuditProbe.lean")),
+            paths,
+        )
+
+    def test_all_lean_imports_include_ast_module(self) -> None:
+        cfg = ContractConfig(
+            name="AuditProbe",
+            fields=[Field(name="storedValue", ty="uint256")],
+            functions=[Function(name="getStoredValue", params=[])],
+        )
+        imports = gen_all_lean_imports(cfg)
+        self.assertIn("import Verity.AST.AuditProbe", imports)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fixes #766 by making `scripts/generate_contract.py` scaffold the two files required by structure checks:
- `Verity/AST/<Name>.lean`
- `Compiler/Proofs/SpecCorrectness/<Name>.lean`

## What changed
- `scripts/generate_contract.py`
  - Added `gen_ast_bridge(...)` scaffold generator.
  - Added `gen_spec_correctness(...)` scaffold generator.
  - `Verity/Specs/<Name>/Proofs.lean` now imports `Compiler.Proofs.SpecCorrectness.<Name>` directly (no commented import TODO), since that module is now generated.
  - Added `scaffold_files(...)` helper to centralize generated output list.
  - Included `Verity.AST.<Name>` in generated `Verity/All.lean` import snippet.
  - Main file-generation path now uses `scaffold_files(...)`.
- `scripts/test_generate_contract.py`
  - Added regression tests that assert scaffold output includes AST + SpecCorrectness files.
  - Added regression test that generated `All.lean` imports include the AST module.
- `scripts/README.md`
  - Updated generator docs from 7 files to 9 files to match actual behavior.

## Why this matters
A fresh generated contract now aligns with `scripts/check_contract_structure.py` expectations, instead of failing immediately due to missing required files.

## Validation
- `python3 -m unittest scripts/test_generate_contract.py`
- `python3 scripts/generate_contract.py AuditProbe --dry-run`
  - Confirms both required files are now included in generated output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffolding-only changes to a developer script plus tests/docs; main risk is minor path/import mismatches affecting newly generated contracts.
> 
> **Overview**
> Updates `scripts/generate_contract.py` to scaffold two additional required modules for new contracts: a unified AST bridge (`Verity/AST/<Name>.lean`) and a compiler-level spec correctness proof stub (`Compiler/Proofs/SpecCorrectness/<Name>.lean`). The generated `Verity/Specs/<Name>/Proofs.lean` now imports `Compiler.Proofs.SpecCorrectness.<Name>` directly, and the `Verity/All.lean` import snippet includes `Verity.AST.<Name>`; file generation is centralized via a new `scaffold_files` helper.
> 
> Adds unit tests asserting the new scaffold outputs/imports, and updates the scripts README to reflect that the generator now creates 9 files (not 7).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 624daf9863ee5553ff484172555852e15a4273ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->