### PR TITLE
ASTCompile: canonicalize bindBool to 0/1

### DIFF
--- a/Compiler/ASTCompile.lean
+++ b/Compiler/ASTCompile.lean
@@ -103,7 +103,10 @@ def compileStmt : Stmt → List Yul.YulStmt
   | .bindAddr name expr rest =>
       Yul.YulStmt.let_ name (compileExpr expr) :: compileStmt rest
   | .bindBool name expr rest =>
-      Yul.YulStmt.let_ name (compileExpr expr) :: compileStmt rest
+      -- Match denotational semantics: bool bindings are canonicalized to 0/1.
+      Yul.YulStmt.let_ name
+        (Yul.YulExpr.call "iszero" [Yul.YulExpr.call "iszero" [compileExpr expr]])
+        :: compileStmt rest
 
   -- Pure let
   | .letUint name expr rest =>

--- a/Compiler/ASTCompileTest.lean
+++ b/Compiler/ASTCompileTest.lean
@@ -178,4 +178,14 @@ private def assertContains (label : String) (rendered : String) (needles : List 
   let rendered := renderStmts (compileStmt Verity.AST.SimpleToken.getOwnerAST)
   assertContains "SimpleToken.getOwner" rendered ["sload(0)", "return(0, 32)"]
 
+/-!
+## Regression: bindBool normalization
+-/
+
+#eval! do
+  let ast : Stmt := .bindBool "b" (.lit 2) (.sstore 0 (.var "b") .stop)
+  let rendered := renderStmts (compileStmt ast)
+  assertContains "bindBool canonicalizes non-zero to 1" rendered
+    ["let b := iszero(iszero(2))", "sstore(0, b)", "stop()"]
+
 end Compiler.ASTCompileTest


### PR DESCRIPTION
## Summary
- normalize `Stmt.bindBool` lowering in `Compiler.ASTCompile.compileStmt` to canonical bool form (`iszero(iszero(expr))`)
- keep AST compiler semantics aligned with `Verity.Denote.denoteUnit` bool binding behavior
- add regression coverage in `Compiler/ASTCompileTest.lean` for non-comparison source (`.lit 2`)

Closes #765.

## Validation
- `lake build Compiler.ASTCompile Compiler.ASTCompileTest`
- `lake build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to boolean binding lowering plus a regression test; risk is mainly semantic and should surface quickly in compiler output/tests.
> 
> **Overview**
> Updates `ASTCompile.compileStmt` so `.bindBool` bindings are *normalized to canonical booleans* by compiling `let b := expr` into `let b := iszero(iszero(expr))`, ensuring bound bools are always `0` or `1`.
> 
> Adds a regression smoke test in `ASTCompileTest` that binds a non-zero literal and asserts the emitted Yul contains the double-`iszero` normalization before using the value in `sstore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 862691c844a1eeaceaf2be438a5a7652e0c619ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->