### PR TITLE
docs: remove top verification banner from docs

### DIFF
--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -1,5 +1,5 @@
 import { Layout, Navbar } from 'nextra-theme-docs'
-import { Banner, Head } from 'nextra/components'
+import { Head } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
 import 'nextra-theme-docs/style.css'
 
@@ -10,12 +10,6 @@ export const metadata = {
   },
   description: 'Minimal Lean 4 EDSL for Smart Contracts with Formal Verification',
 }
-
-const banner = (
-  <Banner storageKey="verification-complete">
-    431/431 theorems proven — 100% formal verification
-  </Banner>
-)
 
 const navbar = (
   <Navbar
@@ -30,7 +24,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <Head />
       <body>
         <Layout
-          banner={banner}
           navbar={navbar}
           pageMap={await getPageMap()}
           docsRepositoryBase="https://github.com/Th0rgal/verity/tree/main/docs-site"


### PR DESCRIPTION
## Summary
- remove the top docs banner showing theorem-proof completion status
- delete the `Banner` import and `banner` JSX constant in `docs-site/app/layout.tsx`
- remove `banner={banner}` from the docs `Layout` props

## Testing
- not run (docs UI change only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes a decorative docs UI element and associated props/imports; no business logic, data handling, or security-sensitive code changes.
> 
> **Overview**
> Removes the top-of-page verification status `Banner` from the docs site by deleting the `Banner` import/JSX and dropping the `banner` prop from `Layout` in `docs-site/app/layout.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3e9bc546f00ad90ccabc8591340719a265d638b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->