### PR TITLE
Fix duplicate letVar declarations at ContractSpec compile boundary

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -960,6 +960,10 @@ private partial def validateScopedStmtIdentifiers
     (localScope : List String) : Stmt → Except String (List String)
   | Stmt.letVar name value => do
       validateScopedExprIdentifiers context paramScope dynamicParams localScope value
+      if paramScope.contains name then
+        throw s!"Compilation error: {context} declares local variable '{name}' that shadows a parameter"
+      if localScope.contains name then
+        throw s!"Compilation error: {context} redeclares local variable '{name}' in the same scope"
       pure (name :: localScope)
   | Stmt.assignVar name value => do
       if !localScope.contains name then


### PR DESCRIPTION
## Summary
- reject `Stmt.letVar` redeclarations in the current local scope during `ContractSpec.compile`
- reject `Stmt.letVar` declarations that shadow function parameters
- add regression tests proving both failures are caught at compile boundary

## Why
Issue #758 reports that duplicate local declarations compile in Verity but fail later in `solc --strict-assembly`. This change moves the failure to Verity's compile boundary with direct diagnostics.

## Validation
- `lake build Compiler.ContractSpec Compiler.ContractSpecFeatureTest`
- `python3 scripts/check_selectors.py`
- `python3 scripts/check_axiom_locations.py`

Closes #758

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, compile-time-only validation change plus tests; risk is limited to newly rejecting previously-accepted (but invalid) specs.
> 
> **Overview**
> **Tightens `ContractSpec.compile` identifier validation for `Stmt.letVar`.** Local `letVar` declarations now fail compilation when they *redeclare a name in the same local scope* or *shadow a function parameter*, producing explicit diagnostics.
> 
> Adds feature/regression tests in `ContractSpecFeatureTest.lean` asserting both failure modes are caught at the compile boundary with the expected error messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be668da7f860f1dcaf1faf36d847a22ab1642402. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->