### PR TITLE
fix: reject invalid event declarations at compile boundary

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -1722,6 +1722,37 @@ private def featureSpec : ContractSpec := {
          "log1(__evt_ptr, __evt_data_tail, __evt_topic0)"]
 
 #eval! do
+  let unusedInvalidIndexedEventSpec : ContractSpec := {
+    name := "UnusedInvalidIndexedEventRejected"
+    fields := []
+    constructor := none
+    events := [
+      { name := "TooManyIndexed"
+        params := [
+          { name := "a", ty := ParamType.uint256, kind := EventParamKind.indexed },
+          { name := "b", ty := ParamType.uint256, kind := EventParamKind.indexed },
+          { name := "c", ty := ParamType.uint256, kind := EventParamKind.indexed },
+          { name := "d", ty := ParamType.uint256, kind := EventParamKind.indexed }
+        ]
+      }
+    ]
+    functions := [
+      { name := "f"
+        params := []
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile unusedInvalidIndexedEventSpec [1] with
+  | .error err =>
+      if !(contains err "event 'TooManyIndexed' has 4 indexed params; max is 3") then
+        throw (IO.userError s!"✗ invalid unused event declaration diagnostic mismatch: {err}")
+      IO.println "✓ invalid unused event declaration rejected at compile boundary"
+  | .ok _ =>
+      throw (IO.userError "✗ expected unused invalid event declaration to fail compilation")
+
+#eval! do
   let indexedBytesEventSpec : ContractSpec := {
     name := "IndexedBytesEventSupported"
     fields := []


### PR DESCRIPTION
## Summary
This fixes issue #744 by validating event declarations directly in `ContractSpec.compile`, not only when a matching `Stmt.emit` is lowered.

Changes:
- Add `validateEventDef` in `Compiler/ContractSpec.lean`.
- Reject events with more than 3 indexed params at declaration boundary.
- Keep existing emit-path validation as defense in depth.
- Add regression test in `Compiler/ContractSpecFeatureTest.lean` that verifies an unused invalid event declaration now fails compilation.

## Why
Previously, an invalid event declaration could compile successfully if no function emitted that event. This delayed failures and weakened compile-boundary guarantees.

## Validation
- `lake build`
- `lake build Compiler.Codegen Compiler.ContractSpecFeatureTest`

Both pass locally.

Closes #744.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new compile-time validation that can cause previously-compiling specs with invalid event declarations to fail earlier, but does not change generated code for valid contracts.
> 
> **Overview**
> Ensures invalid event declarations are rejected during `ContractSpec.compile`, not only when an event is actually emitted.
> 
> Adds `validateEventDef` to enforce the EVM limit of **max 3 indexed params per event**, and introduces a regression test proving an *unused* invalid event now fails compilation with the expected diagnostic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cb13e8e41cc69445755a48cad565ca252e8e212. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->