### PR TITLE
fix(scripts): harden doc metric checks and boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/Th0rgal/verity/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/built%20with-Lean%204-blueviolet.svg" alt="Built with Lean 4"></a>
-  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-401-brightgreen.svg" alt="401 Theorems"></a>
+  <a href="https://github.com/Th0rgal/verity"><img src="https://img.shields.io/badge/theorems-431-brightgreen.svg" alt="431 Theorems"></a>
   <a href="https://github.com/Th0rgal/verity/actions"><img src="https://img.shields.io/github/actions/workflow/status/Th0rgal/verity/verify.yml?label=verify" alt="Verify"></a>
 </p>
 
@@ -55,7 +55,7 @@ lake exe verity-compiler \
 
 **Run tests:**
 ```bash
-FOUNDRY_PROFILE=difftest forge test           # 375 tests across 32 suites
+FOUNDRY_PROFILE=difftest forge test           # 403 tests across 35 suites
 ```
 
 ---

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -561,7 +561,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 403/375 tests pass
+# Expected: 403/403 tests pass
 ```
 
 ### Add New Contract
@@ -602,10 +602,10 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 403/375 passing (100%)
+**Foundry Tests**: 403/403 passing (100%)
 ```bash
 $ FOUNDRY_PROFILE=difftest forge test
-Ran 35 test suites: 375 tests passed, 0 failed, 0 skipped (375 total tests)
+Ran 35 test suites: 403 tests passed, 0 failed, 0 skipped (403 total tests)
 ```
 
 **Coverage**: Unit, property, and differential tests across EDSL and compiled Yul. See `test/` for suites.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 
 ## Current Status
 
-- ✅ **Layer 1 Complete**: 401 theorems across 9 categories (8 contracts + Stdlib math library)
+- ✅ **Layer 1 Complete**: 431 theorems across 11 categories (8 contracts + Stdlib math library)
 - ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
 - ✅ **Property Testing**: 58% coverage (250/431), all testable properties covered


### PR DESCRIPTION
## Summary
- harden `scripts/check_doc_counts.py` to use shared validated boundaries from `property_utils` (`load_manifest`, `load_exclusions`) instead of ad-hoc JSON loading
- make Lean axiom/sorry counting comment-aware by reusing `strip_lean_comments`
- expand high-visibility doc drift checks to cover README theorem badge/alt text, quick-start test+suite comment, compiler ratio denominators and totals, and roadmap Layer 1 theorem/category headline
- regenerate stale literals via `--fix` in `README.md`, `docs-site/content/compiler.mdx`, and `docs/ROADMAP.md`
- add regression tests for comment-only Lean invariance and duplicate-key manifest rejection in `scripts/test_check_doc_counts.py`

## Validation
- `python3 scripts/check_doc_counts.py`
- `python3 -m unittest scripts/test_check_doc_counts.py`
- `python3 -m unittest scripts/test_property_utils.py`

Fixes #735
Fixes #771

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation strings and internal validation scripts/tests, with no impact on compiler/runtime behavior.
> 
> **Overview**
> Updates documentation metrics to reflect the latest project totals (e.g., **431 theorems** and **403 Foundry tests**) across README, compiler docs, and the roadmap.
> 
> Hardens `scripts/check_doc_counts.py` by switching to shared, validated loaders from `property_utils`, making axiom/`sorry` counting comment-aware, and expanding drift checks to cover README badge/alt text plus multiple test-count ratio denominators/totals. Adds regression tests ensuring comment-only Lean content doesn’t affect counts and that duplicate JSON keys in the manifest are rejected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b64dc79055e422db470b74470a363389612af4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->