### PR TITLE
Fix theorem extraction for prefixed Lean declarations

### DIFF
--- a/scripts/test_property_utils.py
+++ b/scripts/test_property_utils.py
@@ -146,7 +146,7 @@ class PropertyUtilsTheoremExtractionTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            names = property_utils.collect_theorems(path)
+            names = property_utils.collect_theorems(path, include_helpers=True)
             self.assertEqual(names, ["plain_theorem", "simp_theorem", "private_theorem"])
 
     def test_collect_theorems_accepts_multiline_attribute_block(self) -> None:
@@ -162,8 +162,24 @@ class PropertyUtilsTheoremExtractionTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            names = property_utils.collect_theorems(path)
+            names = property_utils.collect_theorems(path, include_helpers=True)
             self.assertEqual(names, ["multi_attr_theorem"])
+
+    def test_collect_theorems_excludes_helper_declarations_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "Spec.lean"
+            path.write_text(
+                "theorem plain_theorem : True := by\n"
+                "  trivial\n"
+                "@[simp] theorem simp_theorem : True := by\n"
+                "  trivial\n"
+                "private theorem private_theorem : True := by\n"
+                "  trivial\n",
+                encoding="utf-8",
+            )
+
+            names = property_utils.collect_theorems(path)
+            self.assertEqual(names, ["plain_theorem"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- broaden Lean theorem extraction parsing to support declaration prefixes used in practice
- accept attributes (`@[...]`) and visibility modifiers (`private` / `protected`) in parser matching
- keep manifest semantics stable by excluding helper declarations (`private`/`protected`, `@[simp]`) by default
- add regression tests for prefixed parsing and helper filtering behavior

## Why
`check_property_manifest_sync.py` depends on theorem extraction from `scripts/property_utils.py`. We need robust parsing for prefixed declarations, but we also need stable manifest semantics for auditable property coverage.

This change resolves parser under-approximation for externally-relevant prefixed declarations, while avoiding coverage/docs drift from helper lemmas.

Closes #725.

## Validation
- `python3 scripts/test_property_utils.py`
- `python3 scripts/check_property_manifest_sync.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the theorem-extraction logic that feeds manifest/coverage checks; regex and default filtering could alter discovered theorem sets and cause sync/coverage diffs if edge cases are misclassified.
> 
> **Overview**
> Improves Lean theorem/lemma name extraction in `scripts/property_utils.py` to recognize common declaration prefixes (attribute blocks like `@[...]` and visibility modifiers such as `private`/`protected`) when scanning proof files.
> 
> Adds helper-lemma filtering semantics: `collect_theorems(..., include_helpers=False)` now *excludes* `private`/`protected` and `@[simp]` declarations by default to keep property-manifest coverage stable, with an opt-in flag to include them. Updates unit tests to cover prefixed declarations, multiline attribute blocks, and default helper exclusion behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e2ae0b55b81cb384de292f649ab5a0c42401b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->