### PR TITLE
docs: clarify EDSL vs ContractSpec model

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -13,9 +13,63 @@ Verity has two compilation paths:
 
 Formal semantic guarantees apply to Path 1. Path 2 is implemented and tested, but not in the same end-to-end proof chain.
 
+### Terms You Must Separate
+
+Audits are much easier when these names are not mixed:
+
+1. `EDSL` (`Verity/Examples/*`): executable Lean contract code (`Contract α := ContractState -> ContractResult α`).
+2. `Logical spec` (`Verity/Specs/*/Spec.lean`): properties as `Prop`.
+3. `ContractSpec` (`Compiler/ContractSpec.lean`, instances in `Compiler/Specs.lean`): declarative compiler model with function bodies. This is not ABI-only data.
+
+`ContractSpec` contains:
+1. Interface metadata (name, params, returns, mutability, events).
+2. Storage field declarations.
+3. Function and constructor bodies (`Expr` and `Stmt`) used by the compiler.
+
+### Why Path 2 Exists
+
+Path 2 is not a replacement for Path 1 today. It exists for controlled migration and cross-checking.
+
+Simple reasons:
+
+1. It is the target architecture for the unification effort (`Compiler/ASTSpecs.lean`, `Compiler/ASTDriver.lean`).
+2. It gives an independent compiler implementation, which helps detect regressions that can hide inside one pipeline.
+3. It keeps migration incremental: contracts can move to unified AST without blocking the verified ContractSpec flow.
+
+Where it is used now:
+
+1. CLI path selection in `Compiler/Main.lean` via `--ast`.
+2. CI generation of AST artifacts into `compiler/yul-ast` (`.github/workflows/verify.yml`).
+3. AST pipeline regression modules: `Compiler/ASTCompileTest.lean`, `Compiler/ASTDriverTest.lean`, `Compiler/MainTest.lean`.
+4. Cross-path checks:
+   - `scripts/check_selectors.py` (selector consistency in `compiler/yul` and `compiler/yul-ast`)
+   - `scripts/check_storage_layout.py` (EDSL/Spec/Compiler/AST slot drift)
+   - `scripts/check_yul_compiles.py --compare-dirs ... --allow-compare-diff-file ...` (compileability plus controlled diff baseline)
+   - `scripts/check_gas_model_coverage.py` on legacy, patched, and AST outputs
+
+When Path 2 is useful during limitations:
+
+1. During feature migration to unified AST, before full proof integration is complete.
+2. When validating that ABI, storage, and dispatch behavior stay aligned across two compiler front-ends.
+3. When investigating whether a bug is in ContractSpec lowering or in later shared Yul/solc stages.
+
+Bug classes Path 2 helps catch:
+
+1. Selector and dispatch table mismatches.
+2. Constructor/deploy path regressions.
+3. ABI mutability metadata drift (`isPayable`, `isView`, `isPure`).
+4. Storage slot/type mismatches between layers.
+5. Yul shape drift that breaks `solc` compileability or violates the known diff allowlist.
+
+Why not keep only Path 1:
+
+1. One path gives one failure signal; two paths provide differential evidence.
+2. Removing Path 2 would reduce migration safety for the unification roadmap.
+3. Several CI guards are designed to detect cross-path drift; those checks lose value without a second concrete pipeline.
+
 ## Verification Layers (Path 1)
 
-- Layer 1: EDSL behavior matches `ContractSpec` behavior (proven).
+- Layer 1: EDSL behavior matches `ContractSpec` behavior (proven per contract).
 - Layer 2: `ContractSpec` lowering to IR preserves behavior (proven).
 - Layer 3: IR lowering to Yul preserves behavior (proven, with one documented axiom).
 - `solc`: trusted external compiler.

--- a/README.md
+++ b/README.md
@@ -60,30 +60,50 @@ FOUNDRY_PROFILE=difftest forge test           # 403 tests across 35 suites
 
 ---
 
-Verity is a Lean 4 framework that lets you write smart contracts in a domain-specific language, formally verify their correctness, and compile them to EVM bytecode.
+Verity is a Lean 4 framework that lets you write smart contracts in a domain specific language, prove key properties, and compile to EVM bytecode.
 
-**The idea is simple:** humans review 10-line specs that are easy to audit. Agents write 1000-line implementations. Lean proves the implementation matches the spec - no trust required.
+The project has three contract artifacts. Keep them separate:
+1. `EDSL implementation` (`Verity/Examples/*`): executable Lean code in the `Contract` monad.
+2. `Logical spec` (`Verity/Specs/*/Spec.lean`): `Prop` statements that describe intended behavior.
+3. `ContractSpec` (`Compiler/Specs.lean`): declarative compiler model with function bodies (`Expr`/`Stmt`), used for IR and Yul generation.
 
 ## How It Works
 
 ```lean
--- 1. Write a spec (human-readable, ~10 lines)
+-- 1) Logical spec (property, not compiler input)
 def store_spec (value : Uint256) (s s' : ContractState) : Prop :=
   s'.storage 0 = value ∧
   storageUnchangedExcept 0 s s' ∧
   sameAddrMapContext s s'
 
--- 2. Write an implementation
+-- 2) EDSL implementation (executable)
 def store (value : Uint256) : Contract Unit := do
   setStorage storedData value
 
--- 3. Prove correctness - math guarantees the match
+-- 3) Prove implementation satisfies the logical spec
 theorem store_meets_spec (s : ContractState) (value : Uint256) :
   store_spec value s (((store value).run s).snd) := by
   simp [store, store_spec, storedData, setStorage, storageUnchangedExcept, sameAddrMapContext]
 ```
 
-One spec can have many competing implementations - naive, gas-optimized, packed storage - all proven correct against the same rules.
+Then separately, `ContractSpec` drives compilation. It is more than an ABI: it includes storage layout plus function bodies.
+
+```lean
+def simpleStorageSpec : ContractSpec := {
+  name := "SimpleStorage"
+  fields := [{ name := "storedData", ty := .uint256 }]
+  constructor := none
+  functions := [
+    { name := "store"
+      params := [{ name := "value", ty := .uint256 }]
+      returnType := none
+      body := [Stmt.setStorage "storedData" (Expr.param "value"), Stmt.stop]
+    }
+  ]
+}
+```
+
+One logical spec can have many implementations, and one implementation can have multiple compiler backends, as long as the proof obligations hold.
 
 ## Verified Contracts
 
@@ -141,10 +161,11 @@ See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a
 
 ## What's Verified
 
-- **EDSL correctness** - each contract satisfies its spec in Lean (Layer 1)
-- **Compiler correctness** - IR generation preserves semantics (Layer 2), Yul codegen preserves IR (Layer 3)
-- **End-to-end pipeline** - EDSL -> ContractSpec -> IR -> Yul, fully verified with 1 axioms
-- **Trust boundary** - Yul -> EVM bytecode via solc (validated by 70k+ differential tests)
+- **Layer 1 (per contract)**: EDSL behavior matches its `ContractSpec` model.
+- **Layer 2 (framework)**: `ContractSpec -> IR` preserves behavior.
+- **Layer 3 (framework)**: `IR -> Yul` preserves behavior.
+- **Proof-chain note**: the `EDSL -> ContractSpec -> IR -> Yul` chain is verified with 1 axioms.
+- **Trusted boundary**: `solc` compiles Yul to bytecode correctly.
 
 See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for trust boundaries, [`AXIOMS.md`](AXIOMS.md) for axiom documentation, and [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) for full status.
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -9,19 +9,24 @@ description: EDSL to EVM compilation with automatic IR generation
 
 ## Overview
 
-The Verity compiler transforms high-level, verified contract specifications into deployable EVM bytecode. All contracts compile automatically from declarative specifications—no manual IR writing required.
+The Verity compiler transforms `ContractSpec` models into deployable EVM bytecode. No manual IR writing is required.
 
-**Pipeline**: EDSL Contract → Declarative Spec → IR → Yul → EVM Bytecode
+**Pipeline**: EDSL Contract → ContractSpec → IR → Yul → EVM Bytecode
 
-**Spec sources**:
-- User-facing specs: `Verity/Specs/<Name>/Spec.lean`
-- Compiler specs (for codegen): `Compiler/Specs.lean` (generated/maintained separately)
+Important: Verity has two different "spec" concepts.
+
+1. Logical specs in `Verity/Specs/<Name>/Spec.lean` are `Prop` statements used for proofs.
+2. Compiler specs in `Compiler/Specs.lean` are `ContractSpec` values used for code generation.
+
+`ContractSpec` is not only an ABI. It also contains storage fields and function bodies (`Expr`/`Stmt`).
 
 ## Trust Model
 
 ### What's Verified (Zero Trust Required)
-- **EDSL + compiler proofs**: Lean theorems for contract specs, IR generation, and Yul codegen
-- **Machine-checked proofs**: 2 documented axioms (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 sorry — all proofs complete
+- **Layer 1 per contract**: EDSL behavior is proven equivalent to its `ContractSpec`.
+- **Layer 2 framework proof**: `ContractSpec -> IR` preserves semantics.
+- **Layer 3 framework proof**: `IR -> Yul` preserves semantics.
+- **Machine-checked proofs**: 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 sorry.
 - **Interpreter semantics**: Spec, IR, and Yul semantics defined and linked in Lean
 
 ### What's Tested (High Confidence)

--- a/docs-site/content/getting-started.mdx
+++ b/docs-site/content/getting-started.mdx
@@ -61,6 +61,12 @@ The first build downloads Mathlib and compiles everything — expect **20–45 m
 
 While the first build runs (or after it completes), get a feel for what Verity does:
 
+Before reading files, keep this map:
+
+1. `Verity/Examples/*`: EDSL implementation, executable Lean code.
+2. `Verity/Specs/*`: logical behavior specs (`Prop`) and invariants.
+3. `Compiler/Specs.lean`: `ContractSpec` compiler models that generate IR/Yul.
+
 **1. Open an example contract** — [`Verity/Examples/SimpleStorage.lean`](https://github.com/Th0rgal/verity/blob/main/Verity/Examples/SimpleStorage.lean):
 ```lean
 -- A contract with a single uint256 storage slot


### PR DESCRIPTION
## Summary
- simplify and compress docs language for EDSL vs logical spec vs ContractSpec
- add explicit artifact map in README and getting-started docs
- clarify verification layer ownership in README/compiler docs
- expand AUDIT architecture overview with concrete Path 2 justification and CI usage

## CI failure identified
- failure came from branch drift: previous work was based on an older branch state where docs checks did not match the latest docs-site layout and count setup
- rebasing these docs changes onto current `main` resolved the mismatch (`check_doc_counts.py` now passes)

## Validation
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_axiom_locations.py`
- `python3 scripts/check_selectors.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes; risk is limited to potential confusion from wording inaccuracies, with no impact on compiler/runtime behavior.
> 
> **Overview**
> Clarifies documentation terminology by explicitly separating the three contract artifacts—`EDSL` implementation, logical `Prop` specs, and the compiler’s `ContractSpec` model—and updating examples/wording accordingly in `README.md`, `docs-site/content/compiler.mdx`, and `docs-site/content/getting-started.mdx`.
> 
> Expands `AUDIT.md` with a more concrete architecture overview, including why the `--ast` (Unified AST) pipeline exists, where it is used in CI, and how it supports cross-path regression detection; also tightens verification-layer wording to specify what is proven per-contract vs framework-wide.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5f0378991f79eae4fc1c7f81ef1acdfc2970490. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->