### PR TITLE
fix(linker): parse function bodies with comment/string-aware brace depth

### DIFF
--- a/Compiler/MainTest.lean
+++ b/Compiler/MainTest.lean
@@ -1,4 +1,5 @@
 import Compiler.Main
+import Compiler.Linker
 
 namespace Compiler.MainTest
 
@@ -24,6 +25,11 @@ private def expectErrorContains (label : String) (args : List String) (needle : 
       throw (IO.userError s!"✗ {label}: expected '{needle}', got:\n{msg}")
     IO.println s!"✓ {label}"
 
+private def expectTrue (label : String) (ok : Bool) : IO Unit := do
+  if !ok then
+    throw (IO.userError s!"✗ {label}")
+  IO.println s!"✓ {label}"
+
 #eval! do
   expectErrorContains "missing --link value" ["--link"] "Missing value for --link"
   expectErrorContains "missing --output value" ["--output"] "Missing value for --output"
@@ -32,5 +38,24 @@ private def expectErrorContains (label : String) (args : List String) (needle : 
   expectErrorContains "missing --patch-report value" ["--patch-report"] "Missing value for --patch-report"
   expectErrorContains "missing --patch-max-iterations value" ["--patch-max-iterations"] "Missing value for --patch-max-iterations"
   expectErrorContains "unknown argument still reported" ["--definitely-unknown-flag"] "Unknown argument: --definitely-unknown-flag"
+
+  let libWithCommentAndStringBraces :=
+    "{\n" ++
+    "function PoseidonT3_hash(a, b) -> result {\n" ++
+    "  // } stray brace in comment\n" ++
+    "  result := add(a, b)\n" ++
+    "}\n\n" ++
+    "function PoseidonT4_hash(a, b, c) -> result {\n" ++
+    "  let marker := \"} in string\"\n" ++
+    "  result := add(add(a, b), c)\n" ++
+    "}\n" ++
+    "}\n"
+
+  let parsed := Compiler.Linker.parseLibrary libWithCommentAndStringBraces
+  expectTrue "linker parses two functions when braces appear in comments/strings" (parsed.length == 2)
+  expectTrue "linker keeps first function boundary intact" ((parsed.getD 0 {name := "", arity := 0, body := []}).name == "PoseidonT3_hash")
+  expectTrue "linker keeps second function boundary intact" ((parsed.getD 1 {name := "", arity := 0, body := []}).name == "PoseidonT4_hash")
+  let firstBody := String.intercalate "\n" ((parsed.getD 0 {name := "", arity := 0, body := []}).body)
+  expectTrue "first function body does not swallow next function" (!contains firstBody "function PoseidonT4_hash")
 
 end Compiler.MainTest


### PR DESCRIPTION
## Summary
Fix linker function extraction so brace depth tracking ignores braces inside:
- line comments (`//`)
- block comments (`/* ... */`)
- quoted strings (`"..."` and `'...'`, with escape handling)

This prevents malformed extraction where a `}` in a comment/string could terminate a function early and swallow the next one.

## What changed
- `Compiler/Linker.lean`
  - Replaced raw `countBraces` with a stateful scanner (`countBracesWithState`) that tracks comment/string context across lines.
  - Updated `extractFunction` to carry scanner state while collecting body lines.
- `Compiler/MainTest.lean`
  - Added regression test case that parses a library containing `}` in a comment and in a string and asserts function boundaries remain correct.

## Validation
- `lake build Compiler.Linker Compiler.MainTest`

Closes #742

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core linker parsing logic; incorrect state handling could mis-parse real-world Yul libraries, though changes are localized and covered by a targeted regression test.
> 
> **Overview**
> Fixes Yul library function extraction in `Compiler/Linker.lean` by replacing naive brace counting with a **stateful scanner** that tracks `//` line comments, `/* ... */` block comments, and quoted strings (including escapes) across lines, so braces inside those contexts don’t affect nesting depth.
> 
> Adds a regression in `Compiler/MainTest.lean` that parses a library containing `}` inside a comment and a string and asserts the linker still returns two correctly-bounded functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f5689ac780d2d3368c955703499125de508753a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->