### PR TITLE
fix(scripts): reject unknown generate_contract field types

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -242,8 +242,12 @@ def parse_fields(spec: str) -> List[Field]:
             name = _validate_identifier(name, "field")
             ty = _normalize_field_type(ty_raw)
             if not ty:
-                print(f"Warning: Unknown type '{ty_raw.strip()}', defaulting to uint256", file=sys.stderr)
-                ty = "uint256"
+                print(
+                    f"Error: Unsupported field type '{ty_raw.strip()}' for field '{name}'. "
+                    "Supported types: uint256, address, mapping(address), mapping(uint256)",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             fields.append(Field(name, ty))
         else:
             name = _validate_identifier(part.strip(), "field")

--- a/scripts/test_generate_contract.py
+++ b/scripts/test_generate_contract.py
@@ -74,6 +74,14 @@ class GenerateContractIdentifierValidationTests(unittest.TestCase):
         self.assertEqual([f.name for f in fields], ["storedData", "owner_address"])
         self.assertEqual([f.name for f in funcs], ["setStoredData", "getStoredData"])
 
+    def test_parse_fields_rejects_unknown_field_type(self) -> None:
+        err = self._assert_exits_with_error(parse_fields, "flag:bool")
+        self.assertIn("Unsupported field type 'bool'", err)
+
+    def test_parse_fields_accepts_supported_mapping_field_types(self) -> None:
+        fields = parse_fields("balances:mapping(address),scores:mapping(uint256)")
+        self.assertEqual([f.ty for f in fields], ["mapping", "mapping_uint"])
+
 
 class GenerateContractFunctionSignatureValidationTests(unittest.TestCase):
     def _assert_parse_functions_error(self, spec: str) -> str:


### PR DESCRIPTION
## Summary
Fixes a trust-boundary bug in `scripts/generate_contract.py`: unknown field types are no longer silently coerced to `uint256`.

Changes:
- Make `parse_fields` fail-fast on unsupported field types with a clear error message and exit code 1.
- Add regression tests covering:
  - rejection of unknown field type (`bool`)
  - acceptance of supported mapping forms (`mapping(address)`, `mapping(uint256)`).

## Why
The generator should preserve intent and reject invalid schemas explicitly. Silent coercion can create scaffolds that look valid but encode different semantics.

Closes #729.

## Verification
- `python3 -m unittest scripts/test_generate_contract.py`
- Repro now fails as expected:
  - `python3 scripts/generate_contract.py AuditTypeCoercion --fields 'flag:bool,count:uint256' --functions 'setFlag(bool),setOwner(bytes32),getFlag()' --dry-run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to a developer-only scaffold script; risk is limited to slightly stricter CLI validation causing previously-invalid inputs to fail.
> 
> **Overview**
> Prevents `scripts/generate_contract.py` from silently coercing unknown `--fields` types to `uint256` by making `parse_fields` **exit with an explicit error** that lists supported types.
> 
> Adds unit tests ensuring unknown field types (e.g. `bool`) are rejected and that supported mapping forms (`mapping(address)`, `mapping(uint256)`) are accepted and normalized correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3758ad4c3e6a3c35c1d79c47eece0af8ed224eea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->