### PR TITLE
ContractSpec: enforce view/pure semantics against function bodies

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -1211,7 +1211,7 @@ private partial def stmtWritesState : Stmt → Bool
   | Stmt.forEach _ count body =>
       exprWritesState count || body.any stmtWritesState
   | Stmt.emit _ args =>
-      args.any exprWritesState
+      args.any exprWritesState || true
   | Stmt.internalCall _ args | Stmt.internalCallAssign _ _ args =>
       args.any exprWritesState || true
 where


### PR DESCRIPTION
## Summary
This PR enforces `FunctionSpec.isView` / `isPure` semantics at the `ContractSpec` compile boundary instead of treating mutability as ABI-only metadata.

Fixes #734.

## What changed
- Added mutability semantic analysis in `Compiler/ContractSpec.lean`:
  - `exprReadsStateOrEnv`
  - `stmtWritesState`
  - `stmtReadsStateOrEnv`
- Extended `validateFunctionSpec` to reject:
  - `view` functions that write state
  - `pure` functions that write state
  - `pure` functions that read state/environment
- Added regression coverage in `Compiler/ContractSpecFeatureTest.lean`:
  - `view` + `Stmt.setStorage` must fail
  - `pure` + `Expr.storage` read must fail

## Notes
- The checks are intentionally conservative for internal/external/low-level calls to preserve the mutability contract as a hard boundary invariant.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler validation to reject contracts that previously compiled despite mismatched mutability, which may break existing specs. The analysis is conservative around calls/events, so reviewers should watch for false positives in real-world contracts.
> 
> **Overview**
> **Mutability markers are now enforced semantically at compile time.** `validateFunctionSpec` rejects `view` functions whose bodies write state, and rejects `pure` functions that either write state or read state/environment.
> 
> This introduces new AST scanners (`exprReadsStateOrEnv`, `stmtWritesState`, `stmtReadsStateOrEnv`) that conservatively treat storage ops, event emission, and internal/external/low-level calls as stateful, and adds regression tests in `ContractSpecFeatureTest.lean` to ensure the new diagnostics trigger for representative invalid specs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73ab412af1bec9d03df2259db2e1efe2f2ed84ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->