### PR TITLE
fix(contractspec): reject constructor runtime return statements

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -3336,6 +3336,27 @@ private def featureSpec : ContractSpec := {
       assertNotContains "ite temp avoids local collision" rendered ["mstore(0, __ite_cond_1)"]
 
 #eval! do
+  let badConstructorReturnSpec : ContractSpec := {
+    name := "BadConstructorReturn"
+    fields := []
+    constructor := some {
+      params := []
+      isPayable := false
+      body := [Stmt.return (Expr.literal 1)]
+    }
+    functions := [
+      { name := "noop", params := [], returnType := none, body := [Stmt.stop] }
+    ]
+  }
+  match compile badConstructorReturnSpec [1] with
+  | .error err =>
+      if !contains err "constructor must not return runtime data directly" then
+        throw (IO.userError s!"✗ constructor return rejection diagnostic mismatch: {err}")
+      IO.println "✓ constructor return(...) rejected in ContractSpec"
+  | .ok _ =>
+      throw (IO.userError "✗ expected constructor return(...) to be rejected")
+
+#eval! do
   let duplicateLetVarSpec : ContractSpec := {
     name := "DuplicateLetVar"
     fields := []


### PR DESCRIPTION
## Summary
- reject runtime returndata statements in `ContractSpec` constructors at compile validation time
- recursively validate nested constructor control-flow blocks (`ite`, `forEach`)
- add regression coverage in `Compiler/ContractSpecFeatureTest.lean`

## Why
`ContractSpec.compile` accepted constructor bodies containing runtime return forms (`Stmt.return`, etc.), while the AST path already rejects them. This created an avoidable boundary inconsistency and deploy-path ambiguity.

## Changes
- added `validateNoRuntimeReturnsInConstructorStmt` in `Compiler/ContractSpec.lean`
- wired constructor validation to call it before existing constructor param/identifier checks
- added feature test: `badConstructorReturnSpec` must fail with `constructor must not return runtime data directly`

## Verification
- `lake build Compiler.ContractSpecFeatureTest`
- repro script from issue now returns:
  - `ERROR: Compilation error: constructor must not return runtime data directly`

Closes #731

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change that tightens compile-time constraints on constructor statements and adds a focused test; limited behavioral impact beyond rejecting previously-accepted invalid specs.
> 
> **Overview**
> Rejects runtime-return statements inside `ContractSpec` constructors by adding a recursive validator that fails compilation on `Stmt.return`, `Stmt.returnValues`, and dynamic return forms (including within nested `ite`/`forEach`).
> 
> Adds a regression feature test ensuring a constructor containing `return(...)` is rejected with the expected diagnostic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b477743978be14606d124544d9a3a3234617a97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->