### PR TITLE
ContractSpec: reject invalid identifiers at compile boundary

### DIFF
--- a/Compiler/ASTDriver.lean
+++ b/Compiler/ASTDriver.lean
@@ -20,6 +20,7 @@ import Compiler.Linker
 import Compiler.Selector
 import Compiler.Hex
 import Compiler.ABI
+import Compiler.Identifier
 
 namespace Compiler.ASTDriver
 
@@ -182,26 +183,8 @@ private def ensureNonEmpty (kind name : String) : Except String Unit := do
   if name.trim.isEmpty then
     throw s!"{kind} name cannot be empty"
 
-private def isAsciiLetter (c : Char) : Bool :=
-  ('a' ≤ c && c ≤ 'z') || ('A' ≤ c && c ≤ 'Z')
-
-private def isAsciiDigit (c : Char) : Bool :=
-  '0' ≤ c && c ≤ '9'
-
-private def isIdentifierStart (c : Char) : Bool :=
-  isAsciiLetter c || c = '_'
-
-private def isIdentifierContinue (c : Char) : Bool :=
-  isIdentifierStart c || isAsciiDigit c
-
-private def isValidIdentifier (name : String) : Bool :=
-  match name.data with
-  | [] => false
-  | c :: cs => isIdentifierStart c && cs.all isIdentifierContinue
-
 private def ensureValidIdentifier (kind name : String) : Except String Unit := do
-  if !isValidIdentifier name then
-    throw s!"{kind} name must be a valid identifier: {name}"
+  Compiler.ensureValidIdentifier kind name
 
 private def validateParamNames (kind : String) (params : List Param) : Except String Unit := do
   for param in params do

--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -228,6 +228,120 @@ private def featureSpec : ContractSpec := {
       throw (IO.userError "✗ expected invalid returnBytes parameter to fail compilation")
 
 #eval! do
+  let invalidContractIdentifierSpec : ContractSpec := {
+    name := "Bad-Contract"
+    fields := []
+    constructor := none
+    functions := []
+  }
+  match compile invalidContractIdentifierSpec [] with
+  | .error err =>
+      if !contains err "contract name must be a valid identifier: Bad-Contract" then
+        throw (IO.userError s!"✗ contract identifier validation mismatch: {err}")
+      IO.println "✓ contract identifier validation"
+  | .ok _ =>
+      throw (IO.userError "✗ expected invalid contract identifier to fail compilation")
+
+#eval! do
+  let invalidFunctionIdentifierSpec : ContractSpec := {
+    name := "InvalidFunctionIdentifier"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "bad-fn"
+        params := []
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile invalidFunctionIdentifierSpec [1] with
+  | .error err =>
+      if !contains err "function name must be a valid identifier: bad-fn" then
+        throw (IO.userError s!"✗ function identifier validation mismatch: {err}")
+      IO.println "✓ function identifier validation"
+  | .ok _ =>
+      throw (IO.userError "✗ expected invalid function identifier to fail compilation")
+
+#eval! do
+  let invalidFieldIdentifierSpec : ContractSpec := {
+    name := "InvalidFieldIdentifier"
+    fields := [{ name := "stored-data", ty := FieldType.uint256 }]
+    constructor := none
+    functions := []
+  }
+  match compile invalidFieldIdentifierSpec [] with
+  | .error err =>
+      if !contains err "field name must be a valid identifier: stored-data" then
+        throw (IO.userError s!"✗ field identifier validation mismatch: {err}")
+      IO.println "✓ field identifier validation"
+  | .ok _ =>
+      throw (IO.userError "✗ expected invalid field identifier to fail compilation")
+
+#eval! do
+  let invalidFunctionParamIdentifierSpec : ContractSpec := {
+    name := "InvalidFunctionParamIdentifier"
+    fields := []
+    constructor := none
+    functions := [
+      { name := "store"
+        params := [{ name := "value-1", ty := ParamType.uint256 }]
+        returnType := none
+        body := [Stmt.stop]
+      }
+    ]
+  }
+  match compile invalidFunctionParamIdentifierSpec [1] with
+  | .error err =>
+      if !contains err "function parameter name must be a valid identifier: value-1" then
+        throw (IO.userError s!"✗ function parameter identifier validation mismatch: {err}")
+      IO.println "✓ function parameter identifier validation"
+  | .ok _ =>
+      throw (IO.userError "✗ expected invalid function parameter identifier to fail compilation")
+
+#eval! do
+  let invalidEventIdentifierSpec : ContractSpec := {
+    name := "InvalidEventIdentifier"
+    fields := []
+    constructor := none
+    events := [
+      { name := "Value-Set"
+        params := [{ name := "who", ty := ParamType.address, kind := EventParamKind.indexed }]
+      }
+    ]
+    functions := []
+  }
+  match compile invalidEventIdentifierSpec [] with
+  | .error err =>
+      if !contains err "event name must be a valid identifier: Value-Set" then
+        throw (IO.userError s!"✗ event identifier validation mismatch: {err}")
+      IO.println "✓ event identifier validation"
+  | .ok _ =>
+      throw (IO.userError "✗ expected invalid event identifier to fail compilation")
+
+#eval! do
+  let invalidExternalIdentifierSpec : ContractSpec := {
+    name := "InvalidExternalIdentifier"
+    fields := []
+    constructor := none
+    externals := [
+      { name := "hash-two"
+        params := [ParamType.uint256, ParamType.uint256]
+        returns := [ParamType.uint256]
+        axiomNames := ["hash_two_sound"]
+      }
+    ]
+    functions := []
+  }
+  match compile invalidExternalIdentifierSpec [] with
+  | .error err =>
+      if !contains err "external declaration name must be a valid identifier: hash-two" then
+        throw (IO.userError s!"✗ external identifier validation mismatch: {err}")
+      IO.println "✓ external declaration identifier validation"
+  | .ok _ =>
+      throw (IO.userError "✗ expected invalid external declaration identifier to fail compilation")
+
+#eval! do
   let payableMsgValueSpec : ContractSpec := {
     name := "PayableMsgValue"
     fields := []

--- a/Compiler/Identifier.lean
+++ b/Compiler/Identifier.lean
@@ -1,0 +1,30 @@
+namespace Compiler
+
+/-- ASCII letter check used for Solidity-style identifiers. -/
+def isAsciiLetter (c : Char) : Bool :=
+  ('a' ≤ c && c ≤ 'z') || ('A' ≤ c && c ≤ 'Z')
+
+/-- ASCII digit check used for Solidity-style identifiers. -/
+def isAsciiDigit (c : Char) : Bool :=
+  '0' ≤ c && c ≤ '9'
+
+/-- Identifier start character: ASCII letter or underscore. -/
+def isIdentifierStart (c : Char) : Bool :=
+  isAsciiLetter c || c = '_'
+
+/-- Identifier continuation character: start chars plus ASCII digits. -/
+def isIdentifierContinue (c : Char) : Bool :=
+  isIdentifierStart c || isAsciiDigit c
+
+/-- Shared identifier validator for AST and ContractSpec frontends. -/
+def isValidIdentifier (name : String) : Bool :=
+  match name.data with
+  | [] => false
+  | c :: cs => isIdentifierStart c && cs.all isIdentifierContinue
+
+/-- Shared diagnostic helper for frontend identifier validation. -/
+def ensureValidIdentifier (kind name : String) : Except String Unit := do
+  if !isValidIdentifier name then
+    throw s!"{kind} name must be a valid identifier: {name}"
+
+end Compiler


### PR DESCRIPTION
## Summary
- add a shared identifier validator module (`Compiler/Identifier.lean`) used by frontend validators
- reuse shared identifier validation in `Compiler.ASTDriver` (removes duplicated logic)
- enforce fail-fast identifier validation in `Compiler.ContractSpec.compile` for:
  - contract name
  - field names
  - function names
  - function parameter names
  - constructor parameter names
  - event names and event parameter names
  - custom error names
  - external declaration names
- add regression tests in `Compiler/ContractSpecFeatureTest.lean` covering invalid contract/function/field/param/event/external identifiers

## Why
`ContractSpec` previously accepted malformed identifiers while AST validation rejected them, creating frontend parity drift and allowing malformed symbols to reach codegen.

## Validation
- `lake env lean Compiler/ContractSpecFeatureTest.lean`
- `lake env lean Compiler/ASTDriverTest.lean`

Fixes #728

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens compile-time validation at the `ContractSpec` boundary, which may break previously-accepted specs and slightly reshapes error paths, but does not change codegen for valid inputs.
> 
> **Overview**
> Adds a shared `Compiler.Identifier` module and switches `ASTDriver` to reuse it, removing duplicated identifier parsing logic.
> 
> `ContractSpec.compile` now **fails fast** on invalid identifier shapes across contract/field/function/parameter/event/error/external names, and constructor bodies are validated to reject any `return*` statements that would return runtime data.
> 
> Extends `ContractSpecFeatureTest` with regression cases asserting these new compilation diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 826cb4b00d6eddcc5964fb856f027aaaa4364d33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->