### PR TITLE
generate_contract: reject ambiguous getter-to-field mapping

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -990,7 +990,13 @@ def gen_compiler_spec(cfg: ContractConfig) -> str:
             elif target:
                 body_expr = f'Expr.storage "{target.name}"'
             else:
-                body_expr = f'Expr.storage "{cfg.fields[0].name if cfg.fields else "field"}"  -- TODO: match actual field'
+                print(
+                    f"Error: Cannot infer target field for getter '{fn.name}'. "
+                    "Rename the getter to match a field (e.g. getTotalSupply → totalSupply) "
+                    "or declare a matching field.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             func_strs.append(f"""    {{ name := "{fn.name}"
       params := {params_str}
       returnType := some {compiler_ret}


### PR DESCRIPTION
## Summary
- make `scripts/generate_contract.py` fail fast when a getter name cannot be mapped to a storage field
- remove the silent fallback that previously bound unknown getters to the first field (or synthetic `field`)
- add regression tests for both failure and valid getter mapping

## Why
Issue #747 reported that unknown getters could silently generate plausible but incorrect `ContractSpec` code. This patch changes that path into an explicit generation error so bad scaffolds are not mistaken as valid.

## Changes
- `scripts/generate_contract.py`
  - in `gen_compiler_spec`, unknown getter target now prints a clear error and exits with code 1
- `scripts/test_generate_contract.py`
  - add `test_unknown_getter_target_field_fails`
  - add `test_matching_getter_target_field_is_used`

## Validation
- `python3 -m unittest scripts/test_generate_contract.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- manual repro:
  - `python3 scripts/generate_contract.py AuditDemo --fields "owner:address,totalSupply:uint256" --functions "getSupply" --dry-run`
  - now exits with `Error: Cannot infer target field for getter 'getSupply' ...`

Fixes #747

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to the contract scaffolding script and adds tests; the main impact is a deliberate behavior change that stops generating potentially incorrect compiler specs for ambiguous getters.
> 
> **Overview**
> Prevents `scripts/generate_contract.py` from silently generating an incorrect `gen_compiler_spec` getter body when the getter name can’t be matched to a storage field.
> 
> Instead of defaulting to the first field (or a synthetic `field`), it now prints a clear stderr error and exits with status `1`; new unit tests assert both the failure path (`getSupply`) and correct mapping (`getTotalSupply` → `Expr.storage "totalSupply"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1459730e1339370b7e05403a5ea79eb83e5c9707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->