### PR TITLE
generate_contract: replace vacuous scaffold defaults

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -557,14 +557,17 @@ def gen_spec(cfg: ContractConfig) -> str:
             ret_type = _getter_return_type(fn, cfg.fields)
             param_part = f" {lean_params}" if lean_params else ""
             spec_defs.append(f"def {fn.name}_spec{param_part} (result : {ret_type}) (s : ContractState) : Prop :=")
-            spec_defs.append(f"  -- TODO: Define what the return value should be")
-            spec_defs.append(f"  True")
+            spec_defs.append("  -- Scaffold default: matches the generated placeholder implementation.")
+            if ret_type == "Bool":
+                spec_defs.append("  result = false")
+            else:
+                spec_defs.append("  result = 0")
         else:
             # Mutator spec: state-based (see deposit_spec, store_spec)
             param_part = f" {lean_params}" if lean_params else ""
             spec_defs.append(f"def {fn.name}_spec{param_part} (s s' : ContractState) : Prop :=")
-            spec_defs.append(f"  -- TODO: Define postconditions on s'")
-            spec_defs.append(f"  True")
+            spec_defs.append("  -- Scaffold default: no state/context change.")
+            spec_defs.append("  sameExceptEvents s s'")
         spec_defs.append("")
 
     imports = ["import Verity.Specs.Common"]
@@ -904,10 +907,12 @@ def _gen_single_test(
         );
         require(success, "{fn.name} call failed");
 
-        // TODO: Add assertions matching {fn.name}'s formal spec.
-        // Examples:
-        //   assertEq(readStorage(0), slot0Before + 1, "should increment");
-        //   assertEq(readStorage(1), expectedValue, "should update slot 1");
+        // Scaffold default matches `sameExceptEvents` in generated Lean spec.
+        assertEq(
+            readStorage(0),
+            slot0Before,
+            "scaffold default: slot 0 unchanged (replace with real spec assertions)"
+        );
     }}
 """
 

--- a/scripts/test_generate_contract.py
+++ b/scripts/test_generate_contract.py
@@ -19,6 +19,7 @@ from generate_contract import (
     gen_all_lean_imports,
     gen_basic_proofs,
     gen_compiler_spec,
+    gen_spec,
     gen_property_tests,
     parse_fields,
     parse_functions,
@@ -154,6 +155,30 @@ class GenerateContractGetterPropertyScaffoldTests(unittest.TestCase):
         out = gen_property_tests(cfg)
         self.assertIn("function testProperty_SetStoredValue_MeetsSpec() public {", out)
         self.assertIn("Property: setStoredValue_meets_spec", out)
+        self.assertIn("assertEq(", out)
+        self.assertIn("scaffold default: slot 0 unchanged", out)
+
+
+class GenerateContractSpecScaffoldTests(unittest.TestCase):
+    def test_specs_are_not_vacuous_true(self) -> None:
+        cfg = ContractConfig(
+            name="AuditVacuous",
+            fields=[Field(name="x", ty="uint256")],
+            functions=[
+                Function(name="setX", params=[Param(name="value", ty="uint256")]),
+                Function(name="getX", params=[]),
+                Function(name="isReady", params=[]),
+            ],
+        )
+
+        out = gen_spec(cfg)
+        self.assertNotIn(" : Prop :=\n  True", out)
+        self.assertIn("def setX_spec (value : Uint256) (s s' : ContractState) : Prop :=", out)
+        self.assertIn("sameExceptEvents s s'", out)
+        self.assertIn("def getX_spec (result : Uint256) (s : ContractState) : Prop :=", out)
+        self.assertIn("result = 0", out)
+        self.assertIn("def isReady_spec (result : Bool) (s : ContractState) : Prop :=", out)
+        self.assertIn("result = false", out)
 
 
 class GenerateContractCompilerSpecGetterTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
Fixes #763 by removing vacuous scaffold defaults in generated contract specs and mutator property tests.

### What changed
- `scripts/generate_contract.py`
  - Getter specs no longer emit `Prop := True`.
    - Bool getters now scaffold to `result = false`.
    - Non-bool getters now scaffold to `result = 0`.
  - Mutator specs no longer emit `Prop := True`.
    - Mutators now scaffold to `sameExceptEvents s s'`.
  - Mutator property tests now include an executable default assertion:
    - `assertEq(readStorage(0), slot0Before, ...)`

- `scripts/test_generate_contract.py`
  - Added regression coverage to ensure generated specs are not vacuous `True`.
  - Extended mutator property scaffold test to require an executable assertion.

## Why
The previous scaffold could pass with formally meaningless defaults (`True`) and assertion-free mutator property tests. This change makes the generated baseline non-vacuous and concretely testable.

## Validation
- Ran: `python3 scripts/test_generate_contract.py`
- Result: `Ran 23 tests ... OK`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect generated scaffold output and associated unit tests, with no runtime contract or proof logic modifications.
> 
> **Overview**
> Updates `scripts/generate_contract.py` to avoid vacuous scaffolds in generated Lean specs: getter specs now default to `result = 0` / `result = false`, and mutator specs default to `sameExceptEvents s s'` instead of `True`.
> 
> Also updates generated mutator property tests to include an executable default assertion (slot 0 unchanged) and extends `scripts/test_generate_contract.py` to validate the new non-vacuous spec/test scaffolds via regression tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9985ad80d7833b8fec8483aa835b0825e26b6533. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->