### PR TITLE
fix(generator): reject invalid mapping getter key params

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -990,7 +990,23 @@ def gen_compiler_spec(cfg: ContractConfig) -> str:
             target = _getter_target_field(fn, cfg.fields)
             if target and target.is_mapping:
                 # Mapping getter: Expr.mapping with key param (see balanceOf in SimpleToken)
-                key_param = fn.params[0].name if fn.params else "key"
+                expected_key_ty = "address" if target.ty == "mapping" else "uint256"
+                if not fn.params:
+                    print(
+                        f"Error: Mapping getter '{fn.name}' for field '{target.name}' requires "
+                        f"a first parameter of type '{expected_key_ty}'.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                provided_key_ty = fn.params[0].ty
+                if provided_key_ty != expected_key_ty:
+                    print(
+                        f"Error: Mapping getter '{fn.name}' for field '{target.name}' requires "
+                        f"first parameter type '{expected_key_ty}', got '{provided_key_ty}'.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                key_param = fn.params[0].name
                 body_expr = f'Expr.mapping "{target.name}" (Expr.param "{key_param}")'
             elif target:
                 body_expr = f'Expr.storage "{target.name}"'


### PR DESCRIPTION
## Summary
Fixes a scaffold soundness bug in `scripts/generate_contract.py` where mapping getters could emit invalid `Expr.mapping` nodes with undeclared or wrongly-typed key parameters.

Previously, this path silently fell back to `Expr.param "key"` when no params were provided, which could compile through spec generation and fail only later in Yul/solc.

## Changes
- Add hard validation in `gen_compiler_spec` for mapping getters:
  - Require at least one parameter.
  - Require the first parameter type to match the mapping key type:
    - `mapping(address => uint256)` -> first param must be `address`
    - `mapping(uint256 => uint256)` -> first param must be `uint256`
- Emit clear, actionable error messages and exit non-zero when invalid.

## Tests
Updated `scripts/test_generate_contract.py` with regression coverage:
- rejects mapping getter without key param
- rejects mapping getter with wrong key type
- allows valid address-key mapping getter
- allows valid uint-key mapping getter

Also verified with a direct repro command:
- `python3 scripts/generate_contract.py MyToken --fields "balances:mapping" --functions "getBalance" --dry-run`
- now fails fast with a clear error message

Closes #757.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to scaffold generation error handling and add tests, but may cause previously-generated (invalid) configs to fail fast with a non-zero exit.
> 
> **Overview**
> Fixes `scripts/generate_contract.py` to **fail fast** when generating compiler specs for mapping getters: mapping getter functions must declare a first key parameter and its type must match the mapping key (`address` for `mapping`, `uint256` for `mapping_uint`), otherwise the generator prints a clear error and exits.
> 
> Adds regression tests in `scripts/test_generate_contract.py` to assert rejection of missing/incorrect key params and acceptance of valid mapping getter signatures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c49e72fa73ad739bacd8dd033c8c1134e2d91604. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->