### PR TITLE
fix(scaffold): generate success-aware Basic proof templates

### DIFF
--- a/scripts/test_generate_contract.py
+++ b/scripts/test_generate_contract.py
@@ -230,8 +230,15 @@ class GenerateContractBasicProofScaffoldTests(unittest.TestCase):
 
         out = gen_basic_proofs(cfg)
         self.assertNotIn("sorry", out)
+        self.assertNotIn(".fst", out)
+        self.assertNotIn(".snd", out)
         self.assertIn("simp [getStoredValue_spec]", out)
         self.assertIn("simp [setStoredValue_spec]", out)
+        self.assertIn("match (getStoredValue).run s with", out)
+        self.assertIn("| ContractResult.success result _ => getStoredValue_spec result s", out)
+        self.assertIn("| ContractResult.revert _ _ => True := by", out)
+        self.assertIn("match (setStoredValue value).run s with", out)
+        self.assertIn("| ContractResult.success _ s' => setStoredValue_spec value s s'", out)
 
 
 class GenerateContractStructureScaffoldTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- update `generate_contract.py` Basic proof scaffolds to avoid direct `.fst` / `.snd` extraction
- generate theorem templates that pattern-match on full `ContractResult` with explicit success/revert branches
- add regression assertions in `scripts/test_generate_contract.py` to prevent reintroducing `.fst`/`.snd` in generated proofs

## Why
Issue #761 notes that generated proof stubs were revert-unsafe by default because `ContractResult.fst` defaults on revert and `.snd` can expose revert-point state. This change makes the scaffold success-aware and explicit about revert handling.

## Validation
- `python3 -m unittest scripts/test_generate_contract.py`

Closes #761.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects scaffolded proof output and associated tests; no runtime contract/compiler logic changes, with risk limited to breaking downstream expectations of the generated template format.
> 
> **Overview**
> Generated `Basic.lean` proof templates now pattern-match on the full `ContractResult` from `(.run s)` and only apply the spec in the `success` branch, avoiding revert-unsafe `.fst`/`.snd` extraction in both getter and mutator stubs.
> 
> Updates the unit tests in `scripts/test_generate_contract.py` to assert the new `match`-based scaffolding and to prevent reintroducing `.fst`/`.snd` in generated proofs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e99ad7e5c6e89efa67e88eb593aec1ffa3d9861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->