### PR TITLE
docs(trust): enforce single-axiom wording across docs

### DIFF
--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -26,7 +26,7 @@ Important: Verity has two different "spec" concepts.
 - **Layer 1 per contract**: EDSL behavior is proven equivalent to its `ContractSpec`.
 - **Layer 2 framework proof**: `ContractSpec -> IR` preserves semantics.
 - **Layer 3 framework proof**: `IR -> Yul` preserves semantics.
-- **Machine-checked proofs**: 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 sorry.
+- **Machine-checked proofs**: 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)) — `keccak256_first_4_bytes` only, 0 sorry.
 - **Interpreter semantics**: Spec, IR, and Yul semantics defined and linked in Lean
 
 ### What's Tested (High Confidence)

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -129,7 +129,7 @@ See [/verification](/verification) for the complete, always-current theorem list
 
 **What's `sorry`?** A placeholder in Lean that says "I'll prove this later." It's how incomplete proofs compile. This project has 0 `sorry` — all proofs are fully complete.
 
-**What are axioms?** Statements assumed true without proof. This project uses 1 documented axiom for keccak256 hashing, and address injectivity — each with soundness justification in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**What are axioms?** Statements assumed true without proof. This project uses 1 documented axiom: `keccak256_first_4_bytes` for selector hashing (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)).
 
 Example proof technique (simplified):
 ```lean

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -18,7 +18,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Core Size**: 351 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 431 across 11 categories (431 fully proven, 0 `sorry` placeholders)
-- **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256, address injectivity
+- **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256_first_4_bytes only
 - **Tests**: 403 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity


### PR DESCRIPTION
## Summary
- align trust-model wording in docs to the current axiom reality: only `keccak256_first_4_bytes` is active
- update `docs-site/content/compiler.mdx`, `docs-site/content/index.mdx`, and `docs-site/public/llms.txt`
- extend `scripts/check_doc_counts.py` with explicit required/forbidden phrase checks so stale wording (e.g. `address injectivity`) fails validation

## Why
Issue #723 identifies trust-model drift across user-facing and LLM-facing docs. This change removes stale statements and adds guardrails so the wording cannot silently regress.

## Validation
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_axiom_locations.py`

Closes #723.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation text and a docs validation script; the main impact is potential CI failures if required phrases drift.
> 
> **Overview**
> Updates the trust-model wording in `compiler.mdx`, `index.mdx`, and `llms.txt` to consistently state that the only documented axiom is `keccak256_first_4_bytes` (and removes stale references like *address injectivity*).
> 
> Extends `scripts/check_doc_counts.py` with a substring validator to **require** the new phrasing and **forbid** stale phrases, causing doc validation to fail if the trust-model text regresses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1305b5d459cdaa0ef1606fb34eddf1dc101ac5d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->