### PR TITLE
Add checked selector validation wrapper for ContractSpec compile

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -3730,11 +3730,11 @@ def compileConstructor (fields : List Field) (events : List EventDef) (errors : 
     return argLoads ++ bodyChunks
 
 -- Main compilation function
--- SAFETY REQUIREMENTS (enforced at runtime by `compile` and at CI-time by check_selectors.py):
---   1. selectors.length == spec.functions.length (external functions only)
---   2. selectors[i] matches the Solidity signature of spec.functions[i]
+-- NOTE: this is the pure core compiler and does *not* verify canonical
+-- selector/signature correspondence (it only checks count/duplicates).
+-- Use `Compiler.Selector.compileChecked` on caller-provided selector lists.
 -- WARNING: Order matters! If selector list is reordered but function list isn't,
---          functions will be mapped to wrong selectors with no runtime error.
+-- functions will be mapped to wrong selectors with no runtime error.
 def firstDuplicateSelector (selectors : List Nat) : Option Nat :=
   let rec go (seen : List Nat) : List Nat → Option Nat
     | [] => none


### PR DESCRIPTION
## Summary
This PR adds a checked compile boundary for caller-supplied selector lists.

- Adds `Compiler.Selector.validateSelectors : ContractSpec -> List Nat -> IO (Except String Unit)`.
- Adds `Compiler.Selector.compileChecked : ContractSpec -> List Nat -> IO (Except String IRContract)`.
- `compileChecked` computes canonical selectors from signatures and rejects count/order/value mismatches before calling `ContractSpec.compile`.
- Clarifies `Compiler.ContractSpec.compile` comment: it is the pure core compiler and does not validate canonical selector/signature correspondence.
- Adds regression coverage in `Compiler/ContractSpecFeatureTest.lean` asserting mismatched selectors are rejected with a function-specific diagnostic.

## Why
Issue #736 reports that `ContractSpec.compile` accepts arbitrary selectors when called directly.

Because `ContractSpec.compile` is intentionally pure (`Except`) and canonical selector derivation currently depends on IO (`keccak256.py`), this change introduces an explicit checked API (`compileChecked`) that enforces selector/signature agreement at the call boundary where IO is available.

## Validation
- `lake build Compiler.Selector Compiler.ContractSpecFeatureTest`
- New passing test line: `✓ compileChecked rejects selector/signature mismatch`

Refs #736

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an IO-based preflight that can cause previously-accepted selector lists to fail compilation; risk is mainly around false negatives/ordering assumptions and the external `keccak256.py` dependency.
> 
> **Overview**
> Adds `Compiler.Selector.validateSelectors` and `Compiler.Selector.compileChecked` to *verify caller-supplied selector lists* by recomputing canonical Solidity selectors from function signatures and rejecting count/order/value mismatches before delegating to `ContractSpec.compile`.
> 
> Updates `ContractSpec.compile` documentation to clarify it is the pure core compiler and does not enforce selector/signature correspondence, and adds a `ContractSpecFeatureTest` regression asserting `compileChecked` emits a function-specific mismatch diagnostic when selectors are wrong.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38c767705db96b06160b85f178bf4bbe3ecfa234. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->