### PR TITLE
Fix differential harness revert decoding on non-success paths

### DIFF
--- a/test/DifferentialLedger.t.sol
+++ b/test/DifferentialLedger.t.sol
@@ -68,7 +68,7 @@ contract DifferentialLedger is YulTestBase, DiffTestConfig, DifferentialTestBase
             revert("Unknown function");
         }
 
-        uint256 evmReturnValue = evmReturnData.length > 0 ? abi.decode(evmReturnData, (uint256)) : 0;
+        uint256 evmReturnValue = evmSuccess && evmReturnData.length > 0 ? abi.decode(evmReturnData, (uint256)) : 0;
 
         // Get EVM mapping storage for sender (and recipient for transfer)
         // Important: Mapping storage slot = keccak256(abi.encode(key, slot))

--- a/test/DifferentialOwned.t.sol
+++ b/test/DifferentialOwned.t.sol
@@ -55,7 +55,7 @@ contract DifferentialOwned is YulTestBase, DiffTestConfig, DifferentialTestBase 
         address evmOwnerAfter = address(uint160(uint256(vm.load(owned, bytes32(uint256(0))))));
         address evmReturnAddress = address(0);
 
-        if (evmReturnData.length > 0) {
+        if (evmSuccess && evmReturnData.length > 0) {
             if (functionSig == keccak256(bytes("getOwner"))) {
                 evmReturnAddress = abi.decode(evmReturnData, (address));
             }

--- a/test/DifferentialOwnedCounter.t.sol
+++ b/test/DifferentialOwnedCounter.t.sol
@@ -82,7 +82,7 @@ contract DifferentialOwnedCounter is YulTestBase, DiffTestConfig, DifferentialTe
         uint256 evmReturnValue = 0;
         address evmReturnAddress = address(0);
 
-        if (evmReturnData.length > 0) {
+        if (evmSuccess && evmReturnData.length > 0) {
             if (functionSig == keccak256(bytes("getOwner"))) {
                 evmReturnAddress = abi.decode(evmReturnData, (address));
             } else {

--- a/test/DifferentialSafeCounter.t.sol
+++ b/test/DifferentialSafeCounter.t.sol
@@ -55,7 +55,7 @@ contract DifferentialSafeCounter is YulTestBase, DiffTestConfig, DifferentialTes
         }
 
         uint256 evmStorageAfter = uint256(vm.load(safeCounter, bytes32(uint256(0))));
-        uint256 evmReturnValue = evmReturnData.length > 0 ? abi.decode(evmReturnData, (uint256)) : 0;
+        uint256 evmReturnValue = evmSuccess && evmReturnData.length > 0 ? abi.decode(evmReturnData, (uint256)) : 0;
 
         // 2. Execute on EDSL interpreter (via vm.ffi)
         string memory storageState = _buildStorageString();

--- a/test/DifferentialSimpleStorage.t.sol
+++ b/test/DifferentialSimpleStorage.t.sol
@@ -50,7 +50,7 @@ contract DifferentialSimpleStorage is YulTestBase, DiffTestConfig, DifferentialT
         }
 
         uint256 evmStorageAfter = uint256(vm.load(simpleStorage, bytes32(uint256(0))));
-        uint256 evmReturnValue = evmReturnData.length > 0 ? abi.decode(evmReturnData, (uint256)) : 0;
+        uint256 evmReturnValue = evmSuccess && evmReturnData.length > 0 ? abi.decode(evmReturnData, (uint256)) : 0;
 
         // 2. Execute on EDSL interpreter (via vm.ffi)
         // Build storage state string: "slot:value,..." for all non-zero slots

--- a/test/DifferentialSimpleToken.t.sol
+++ b/test/DifferentialSimpleToken.t.sol
@@ -82,7 +82,7 @@ contract DifferentialSimpleToken is YulTestBase, DiffTestConfig, DifferentialTes
         uint256 evmReturnValue = 0;
         address evmReturnAddress = address(0);
 
-        if (evmReturnData.length > 0) {
+        if (evmSuccess && evmReturnData.length > 0) {
             if (functionSig == keccak256(bytes("owner"))) {
                 evmReturnAddress = abi.decode(evmReturnData, (address));
             } else {


### PR DESCRIPTION
## Summary
This PR fixes a differential-harness bug where some suites attempted to decode `evmReturnData` as `uint256` even when the EVM call reverted.

### Changes
- Guarded all differential return decoding so it only runs on success:
  - `evmSuccess && evmReturnData.length > 0 ? abi.decode(..., (uint256)) : 0`
  - and `if (evmSuccess && evmReturnData.length > 0)` for address/uint return branches.
- Added a regression test in `DifferentialCounter`:
  - `testDifferential_RevertDecodeGuard_CustomError`
  - uses a local custom-error revert and asserts guarded decode does not attempt to parse revert payload bytes.

## Why
Without this guard, custom-error revert payloads (and other non-return ABI payloads) can trigger invalid decode assumptions and make differential comparison semantics brittle.

## Validation
- `forge test --ffi --match-test testDifferential_RevertDecodeGuard_CustomError`
- `forge test --ffi --match-contract DifferentialSimpleStorage --match-test testDifferential_BasicOperations`
- `forge test --ffi --match-contract DifferentialOwnedCounter --match-test testDifferential_Increment`
- `forge test --ffi --match-contract DifferentialSimpleToken --match-test testDifferential_Mint`
- `forge test --ffi --match-contract DifferentialOwned --match-test testDifferential_GetOwner`

Closes #724

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Solidity test harnesses and only affect how return data is decoded on revert paths. Main risk is masking a previously-detected mismatch if a suite incorrectly relied on decoding revert payloads as return values.
> 
> **Overview**
> Fixes differential test harnesses to **only ABI-decode `evmReturnData` when `evmSuccess` is true**, preventing accidental decoding of revert/custom-error payloads as `uint256`/`address`.
> 
> Adds a regression in `DifferentialCounter` (`testDifferential_RevertDecodeGuard_CustomError`) that triggers a custom-error revert and asserts the guarded decode path does not parse revert bytes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63826fe9d0d30912b3faeeac2ffd1fe2da37d7cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->