### PR TITLE
feat: configurable mappingSlot scratch memory base

### DIFF
--- a/Compiler/MainTest.lean
+++ b/Compiler/MainTest.lean
@@ -37,6 +37,8 @@ private def expectTrue (label : String) (ok : Bool) : IO Unit := do
   expectErrorContains "missing --abi-output value" ["--abi-output"] "Missing value for --abi-output"
   expectErrorContains "missing --patch-report value" ["--patch-report"] "Missing value for --patch-report"
   expectErrorContains "missing --patch-max-iterations value" ["--patch-max-iterations"] "Missing value for --patch-max-iterations"
+  expectErrorContains "missing --mapping-slot-scratch-base value" ["--mapping-slot-scratch-base"] "Missing value for --mapping-slot-scratch-base"
+  expectErrorContains "invalid --mapping-slot-scratch-base value" ["--mapping-slot-scratch-base", "not-a-number"] "Invalid value for --mapping-slot-scratch-base: not-a-number"
   expectErrorContains "unknown argument still reported" ["--definitely-unknown-flag"] "Unknown argument: --definitely-unknown-flag"
 
   let libWithCommentAndStringBraces :=

--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ lake exe verity-compiler \
   --enable-patches \
   --patch-max-iterations 2 \
   --patch-report compiler/patch-report.tsv \
+  --mapping-slot-scratch-base 128 \
   -o compiler/yul-patched
 ```
+
+`--mapping-slot-scratch-base` controls where compiler-generated `mappingSlot` helpers write temporary words before `keccak256`.
 
 **Run tests:**
 ```bash

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -307,6 +307,12 @@ Options:
   --link <path>      Link external Yul library (can be used multiple times)
   --output <dir>     Output directory (default: compiler/yul)
   -o <dir>           Short form of --output
+  --abi-output <dir> Output ABI JSON artifacts (<Contract>.abi.json)
+  --ast              Use unified AST compilation path
+  --enable-patches   Enable deterministic Yul patch pass
+  --patch-max-iterations <n>  Max patch-pass fixpoint iterations (default: 2)
+  --patch-report <path>       Write TSV patch coverage report
+  --mapping-slot-scratch-base <n>  Scratch memory base for mappingSlot helper (default: 0)
   --verbose          Enable verbose output
   -v                 Short form of --verbose
   --help             Show help message


### PR DESCRIPTION
## Summary
This PR adds a public compiler option to control scratch memory used by the generated `mappingSlot` helper.

It implements a concrete part of issue #803:
- configurable helper scratch-memory policy

## Changes
- Added `YulEmitOptions.mappingSlotScratchBase : Nat := 0`.
- Parameterized helper emission via `mappingSlotFuncAt`.
- Preserved legacy behavior by default (`0` and `32`).
- Added CLI flag:
  - `--mapping-slot-scratch-base <n>`
- Added tests:
  - `Compiler/MainTest.lean` for CLI argument validation
  - `Compiler/ContractSpecFeatureTest.lean` for default and custom helper lowering
- Updated docs:
  - `README.md`
  - `docs-site/content/guides/linking-libraries.mdx`

## Why this matters
Downstream projects that need specific memory conventions can now configure helper scratch space without post-generation Yul string patching.

## Backward compatibility
- Fully backward compatible.
- Default output is unchanged when the new option is not set.

## Validation
- `lake build Compiler.MainTest Compiler.ContractSpecFeatureTest`
- `python3 scripts/check_selectors.py`
- `python3 scripts/check_doc_counts.py`

Partial progress for #803.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Yul code generation for mappings and adds a new CLI flag; incorrect scratch offsets could subtly break generated runtime behavior, though defaults preserve existing output and new tests cover both paths.
> 
> **Overview**
> Adds a new emission option `YulEmitOptions.mappingSlotScratchBase` and threads it through codegen so the compiler-generated `mappingSlot` helper writes its temporary words starting at a configurable scratch-memory base (default `0` to preserve existing `mstore(0/32)` + `keccak256(0,64)` behavior).
> 
> Exposes the setting via a new CLI flag `--mapping-slot-scratch-base <n>`, adds CLI validation tests, and extends feature tests to assert both default and custom-address helper lowering; documentation is updated to mention the new flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7897c357184427f91530ca30ffd89d045d36598. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->