### PR TITLE
feat(contractspec): add mapping member word-offset APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ lake exe verity-compiler \
 
 `--mapping-slot-scratch-base` controls where compiler-generated `mappingSlot` helpers write temporary words before `keccak256`.
 
+For mapping-backed struct layouts, `ContractSpec` now supports `Expr.mappingWord field key wordOffset` and `Stmt.setMappingWord field key wordOffset value`, which lower to `mappingSlot(base,key) + wordOffset`.
+
 **Run tests:**
 ```bash
 FOUNDRY_PROFILE=difftest forge test           # 404 tests across 35 suites

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -161,8 +161,8 @@ forge create SimpleStorage --from 0x... --private-key ...
 
 **`Compiler/ContractSpec.lean`**
 - Declarative contract DSL
-- Expression language: `literal`, `param`, `storage`, `mapping`, `mapping2`, `mappingUint`, `caller`, `msgValue`, `blockTimestamp`, `localVar`, `externalCall`, `internalCall`, `arrayLength`, `arrayElement`, arithmetic, bitwise, comparisons, logical operators
-- Statement language: `letVar`, `assignVar`, `setStorage`, `setMapping`, `setMapping2`, `setMappingUint`, `require`, `return`, `stop`, `ite`, `forEach`, `emit`, `internalCall`
+- Expression language: `literal`, `param`, `storage`, `mapping`, `mappingWord`, `mapping2`, `mappingUint`, `caller`, `msgValue`, `blockTimestamp`, `localVar`, `externalCall`, `internalCall`, `arrayLength`, `arrayElement`, arithmetic, bitwise, comparisons, logical operators
+- Statement language: `letVar`, `assignVar`, `setStorage`, `setMapping`, `setMappingWord`, `setMapping2`, `setMappingUint`, `require`, `return`, `stop`, `ite`, `forEach`, `emit`, `internalCall`
 - Automatic IR generation from specs
 - Constructor parameter handling (bytecode argument loading)
 - Storage slot inference (field order → slots 0, 1, 2, ...)
@@ -251,6 +251,7 @@ The ContractSpec DSL provides a complete expression and statement language for s
 | `constructorArg i` | Deploy-time argument | `argN` (from bytecode) |
 | `storage "f"` | Read storage field | `sload(slot)` |
 | `mapping "f" key` | Read mapping entry | `sload(mappingSlot(slot, key))` |
+| `mappingWord "f" key offset` | Read mapping member word | `sload(add(mappingSlot(slot, key), offset))` |
 | `mapping2 "f" k1 k2` | Read nested mapping (e.g., allowances) | `sload(mappingSlot(mappingSlot(slot, k1), k2))` |
 | `mappingUint "f" key` | Read uint256-keyed mapping | `sload(mappingSlot(slot, key))` |
 | `caller` | Transaction sender | `caller()` |
@@ -300,6 +301,7 @@ Use typed intrinsics (`Expr.mload`, `Expr.keccak256`, `Expr.contractAddress`, `E
 | `assignVar "x" expr` | Reassign existing variable | `x := expr` |
 | `setStorage "f" expr` | Write storage field | `sstore(slot, expr)` |
 | `setMapping "f" key val` | Write mapping entry | `sstore(mappingSlot(slot, key), val)` |
+| `setMappingWord "f" key offset val` | Write mapping member word | `sstore(add(mappingSlot(slot, key), offset), val)` |
 | `setMapping2 "f" k1 k2 val` | Write nested mapping entry | `sstore(mappingSlot(mappingSlot(slot, k1), k2), val)` |
 | `setMappingUint "f" key val` | Write uint256-keyed mapping | `sstore(mappingSlot(slot, key), val)` |
 | `require cond "msg"` | Guard with revert message | `if iszero(cond) { revert(...) }` |


### PR DESCRIPTION
## Summary
This PR adds first-class contiguous mapping member addressing in `ContractSpec`.

New DSL constructs:
- `Expr.mappingWord field key wordOffset`
- `Stmt.setMappingWord field key wordOffset value`

Lowering shape:
- read: `sload(add(mappingSlot(slot, key), wordOffset))`
- write: `sstore(add(mappingSlot(slot, key), wordOffset), value)`

Alias/compat mirror behavior is preserved for writes, including `slotAliasRanges`-derived alias slots.

## Why
Issue #803 tracks removal of downstream Yul patching for Solidity-compatible storage patterns. This PR addresses the mapping member contiguous-addressing part directly in Verity's typed DSL.

## Changes
- `Compiler/ContractSpec.lean`
  - Added `Expr.mappingWord` and `Stmt.setMappingWord`.
  - Wired compile lowering, validation, mutability analysis, interop checks, and array-element usage checks.
  - Extended mapping read/write helper paths with `wordOffset` support.
- `Verity/Proofs/Stdlib/SpecInterpreter.lean`
  - Added interpreter support for `mappingWord` and `setMappingWord` so spec execution remains aligned with DSL surface.
- `Compiler/ContractSpecFeatureTest.lean`
  - Added regression test that asserts emitted Yul for read/write offset paths, including alias mirror writes.
- Docs
  - `README.md`
  - `docs-site/content/compiler.mdx`

## Validation
- `lake build`
- `lake build Compiler.ContractSpecFeatureTest`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_axiom_locations.py`
- `python3 scripts/check_selectors.py`

## Issue linkage
- Progress on #803

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core ContractSpec DSL/compilation paths for mapping storage reads/writes and extends interpreter + validations; incorrect slot arithmetic or alias mirroring could produce wrong storage access.
> 
> **Overview**
> Adds `Expr.mappingWord` and `Stmt.setMappingWord` to address mapping-backed struct “member words” via `mappingSlot(base,key) + wordOffset`.
> 
> Updates compiler lowering so mapping reads/writes can optionally add a word offset (including mirror writes across alias slots/`slotAliasRanges`), and threads the new constructs through name collection, scoping/interop validation, and state read/write analyses.
> 
> Extends `SpecInterpreter` to evaluate the new expression/statement and adds a regression test asserting the emitted Yul for offset reads and alias-mirrored offset writes; docs are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27673bb04f69388a94852fd55cf50d3e8a186938. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->