### PR TITLE
Add packed mapping member primitives to ContractSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ lake exe verity-compiler \
 
 `--mapping-slot-scratch-base` controls where compiler-generated `mappingSlot` helpers write temporary words before `keccak256`.
 
-For mapping-backed struct layouts, `ContractSpec` now supports `Expr.mappingWord field key wordOffset` and `Stmt.setMappingWord field key wordOffset value`, which lower to `mappingSlot(base,key) + wordOffset`.
+For mapping-backed struct layouts, `ContractSpec` supports:
+- `Expr.mappingWord field key wordOffset`
+- `Stmt.setMappingWord field key wordOffset value`
+- `Expr.mappingPackedWord field key wordOffset { offset, width }`
+- `Stmt.setMappingPackedWord field key wordOffset { offset, width } value`
+
+The `mappingPackedWord` forms perform masked/shifted packed read-modify-write at `mappingSlot(base,key) + wordOffset`.
 
 **Run tests:**
 ```bash

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -161,8 +161,8 @@ forge create SimpleStorage --from 0x... --private-key ...
 
 **`Compiler/ContractSpec.lean`**
 - Declarative contract DSL
-- Expression language: `literal`, `param`, `storage`, `mapping`, `mappingWord`, `mapping2`, `mappingUint`, `caller`, `msgValue`, `blockTimestamp`, `localVar`, `externalCall`, `internalCall`, `arrayLength`, `arrayElement`, arithmetic, bitwise, comparisons, logical operators
-- Statement language: `letVar`, `assignVar`, `setStorage`, `setMapping`, `setMappingWord`, `setMapping2`, `setMappingUint`, `require`, `return`, `stop`, `ite`, `forEach`, `emit`, `internalCall`
+- Expression language: `literal`, `param`, `storage`, `mapping`, `mappingWord`, `mappingPackedWord`, `mapping2`, `mappingUint`, `caller`, `msgValue`, `blockTimestamp`, `localVar`, `externalCall`, `internalCall`, `arrayLength`, `arrayElement`, arithmetic, bitwise, comparisons, logical operators
+- Statement language: `letVar`, `assignVar`, `setStorage`, `setMapping`, `setMappingWord`, `setMappingPackedWord`, `setMapping2`, `setMappingUint`, `require`, `return`, `stop`, `ite`, `forEach`, `emit`, `internalCall`
 - Automatic IR generation from specs
 - Constructor parameter handling (bytecode argument loading)
 - Storage slot inference (field order → slots 0, 1, 2, ...)
@@ -252,6 +252,7 @@ The ContractSpec DSL provides a complete expression and statement language for s
 | `storage "f"` | Read storage field | `sload(slot)` |
 | `mapping "f" key` | Read mapping entry | `sload(mappingSlot(slot, key))` |
 | `mappingWord "f" key offset` | Read mapping member word | `sload(add(mappingSlot(slot, key), offset))` |
+| `mappingPackedWord "f" key offset {offset=o,width=w}` | Read packed bits from mapping member word | `and(shr(o, sload(add(mappingSlot(slot, key), offset))), mask)` |
 | `mapping2 "f" k1 k2` | Read nested mapping (e.g., allowances) | `sload(mappingSlot(mappingSlot(slot, k1), k2))` |
 | `mappingUint "f" key` | Read uint256-keyed mapping | `sload(mappingSlot(slot, key))` |
 | `caller` | Transaction sender | `caller()` |
@@ -302,6 +303,7 @@ Use typed intrinsics (`Expr.mload`, `Expr.keccak256`, `Expr.contractAddress`, `E
 | `setStorage "f" expr` | Write storage field | `sstore(slot, expr)` |
 | `setMapping "f" key val` | Write mapping entry | `sstore(mappingSlot(slot, key), val)` |
 | `setMappingWord "f" key offset val` | Write mapping member word | `sstore(add(mappingSlot(slot, key), offset), val)` |
+| `setMappingPackedWord "f" key offset {offset=o,width=w} val` | Packed mapping member write (RMW) | `slotWord := sload(...); sstore(..., or(and(slotWord, not(mask<<o)), shl(o, and(val, mask))))` |
 | `setMapping2 "f" k1 k2 val` | Write nested mapping entry | `sstore(mappingSlot(mappingSlot(slot, k1), k2), val)` |
 | `setMappingUint "f" key val` | Write uint256-keyed mapping | `sstore(mappingSlot(slot, key), val)` |
 | `require cond "msg"` | Guard with revert message | `if iszero(cond) { revert(...) }` |


### PR DESCRIPTION
## Summary
This PR adds first-class packed mapping member APIs to the ContractSpec DSL and runtime model.

### New DSL constructors
- `Expr.mappingPackedWord field key wordOffset packed`
- `Stmt.setMappingPackedWord field key wordOffset packed value`

### Lowering behavior
- Read: masked+shifted extraction from `sload(add(mappingSlot(base,key), wordOffset))`
- Write: masked read-modify-write at `add(mappingSlot(base,key), wordOffset)`
- Alias mirror writes are preserved for all configured `aliasSlots`

### Interpreter parity
- `SpecInterpreter` now executes packed mapping word reads/writes with the same mask/shift semantics and alias mirror behavior.

### Docs
- Updated `README.md` and `docs-site/content/compiler.mdx` with the new primitives.

## Tests
- `lake build Compiler.ContractSpecFeatureTest`
- `lake build`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_axiom_locations.py`
- `python3 scripts/check_selectors.py`

Closes #803

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new compiler lowering for packed mapping member reads/writes (mask/shift + read-modify-write), which can affect generated Yul storage semantics if the bit-range math or slot mirroring is wrong. Changes are localized but touch state write paths and interpreter parity.
> 
> **Overview**
> Adds new `ContractSpec` DSL primitives `Expr.mappingPackedWord` and `Stmt.setMappingPackedWord` to read/write packed bit ranges within mapping-backed struct words.
> 
> The compiler now lowers packed mapping reads to `shr`+`and` over `sload(add(mappingSlot(base,key), wordOffset))`, and lowers packed writes to a masked read-modify-write `sstore` that preserves existing bits and mirrors to any mapping `aliasSlots`.
> 
> Updates `SpecInterpreter` to execute the same packed mapping semantics (including validation of `{offset,width}`), and extends feature tests plus README/docs to cover the new APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8ae3d7fe6b14c0576567a558bb1afb093211e23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->