### PR TITLE
Add opt-in backend profile modes for deterministic parity output

### DIFF
--- a/Compiler/MainTest.lean
+++ b/Compiler/MainTest.lean
@@ -37,6 +37,8 @@ private def expectTrue (label : String) (ok : Bool) : IO Unit := do
   expectErrorContains "missing --abi-output value" ["--abi-output"] "Missing value for --abi-output"
   expectErrorContains "missing --patch-report value" ["--patch-report"] "Missing value for --patch-report"
   expectErrorContains "missing --patch-max-iterations value" ["--patch-max-iterations"] "Missing value for --patch-max-iterations"
+  expectErrorContains "missing --backend-profile value" ["--backend-profile"] "Missing value for --backend-profile"
+  expectErrorContains "invalid --backend-profile value" ["--backend-profile", "invalid-profile"] "Invalid value for --backend-profile: invalid-profile"
   expectErrorContains "missing --mapping-slot-scratch-base value" ["--mapping-slot-scratch-base"] "Missing value for --mapping-slot-scratch-base"
   expectErrorContains "invalid --mapping-slot-scratch-base value" ["--mapping-slot-scratch-base", "not-a-number"] "Invalid value for --mapping-slot-scratch-base: not-a-number"
   expectErrorContains "unknown argument still reported" ["--definitely-unknown-flag"] "Unknown argument: --definitely-unknown-flag"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ lake exe verity-compiler \
 
 `--mapping-slot-scratch-base` controls where compiler-generated `mappingSlot` helpers write temporary words before `keccak256`.
 
+**With backend profile (issue #802, opt-in):**
+```bash
+# Default semantic profile
+lake exe verity-compiler --backend-profile semantic
+
+# Solidity-parity ordering only: sort dispatch `case` blocks by selector
+lake exe verity-compiler --backend-profile solidity-parity-ordering
+
+# Full Solidity-parity profile (current MVP):
+# - sort dispatch `case` blocks by selector
+# - enable deterministic patch pass
+lake exe verity-compiler --backend-profile solidity-parity
+```
+
 For mapping-backed struct layouts, `ContractSpec` supports:
 - `Expr.mappingWord field key wordOffset`
 - `Stmt.setMappingWord field key wordOffset value`

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -377,6 +377,21 @@ function PoseidonT3_hash(a, b) -> result {
 
 See [`examples/external-libs/`](https://github.com/Th0rgal/verity/tree/main/examples/external-libs) for example library files.
 
+### Backend Profiles
+
+The compiler supports an opt-in backend profile for deterministic output-shape normalization:
+
+```bash
+# Default semantic profile
+lake exe verity-compiler --backend-profile semantic
+
+# Sort dispatch `case` blocks by selector
+lake exe verity-compiler --backend-profile solidity-parity-ordering
+
+# Sort selector cases + enable deterministic patch pass
+lake exe verity-compiler --backend-profile solidity-parity
+```
+
 ### If/Else Branching
 
 Conditional logic for contract functions:

--- a/docs-site/content/guides/linking-libraries.mdx
+++ b/docs-site/content/guides/linking-libraries.mdx
@@ -309,6 +309,7 @@ Options:
   -o <dir>           Short form of --output
   --abi-output <dir> Output ABI JSON artifacts (<Contract>.abi.json)
   --ast              Use unified AST compilation path
+  --backend-profile <semantic|solidity-parity-ordering|solidity-parity>
   --enable-patches   Enable deterministic Yul patch pass
   --patch-max-iterations <n>  Max patch-pass fixpoint iterations (default: 2)
   --patch-report <path>       Write TSV patch coverage report
@@ -317,6 +318,11 @@ Options:
   -v                 Short form of --verbose
   --help             Show help message
 ```
+
+`--backend-profile` controls deterministic output-shape normalization:
+- `semantic`: default behavior.
+- `solidity-parity-ordering`: sort dispatch `case` blocks by selector.
+- `solidity-parity`: `solidity-parity-ordering` plus deterministic patch pass enabled.
 
 **Examples**:
 ```bash


### PR DESCRIPTION
## Summary
Adds a first-class backend profile switch for deterministic output-shape normalization and wires it through codegen, CLI, docs, and tests.

## What changed
- Added `BackendProfile` in `Compiler/Codegen.lean`:
  - `semantic` (default)
  - `solidity-parity-ordering`
  - `solidity-parity`
- Added `backendProfile` to `YulEmitOptions`.
- Added deterministic selector-case sorting in dispatcher generation when parity profiles are enabled.
- Added CLI flag `--backend-profile <semantic|solidity-parity-ordering|solidity-parity>`.
- `solidity-parity` now auto-enables deterministic patch pass.
- Added tests:
  - CLI parse validation in `Compiler/MainTest.lean`
  - Profile behavior checks in `Compiler/ContractSpecFeatureTest.lean`
- Updated docs:
  - `README.md`
  - `docs-site/content/compiler.mdx`
  - `docs-site/content/guides/linking-libraries.mdx`

## Why
This is an MVP toward issue #802. It introduces an explicit profile model and deterministic ordering behavior so downstream migration workflows can standardize on parity output without ad hoc scripts.

## Validation
- `lake build verity-compiler`
- `lake env lean Compiler/MainTest.lean`
- `lake env lean Compiler/ContractSpecFeatureTest.lean`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_axiom_locations.py`
- `python3 scripts/check_selectors.py`

Refs #802

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the generated runtime dispatcher shape and patch-pass enablement behavior, which can affect downstream consumers and any proofs/tests that assume the previous codegen structure.
> 
> **Overview**
> Adds an opt-in `BackendProfile` to `YulEmitOptions` and exposes it via a new `--backend-profile` CLI flag.
> 
> When using the Solidity-parity profiles, codegen now **sorts dispatch `switch` cases by selector** for deterministic output; the full `solidity-parity` profile also **forces the deterministic patch pass on** even if `--enable-patches` isn’t set. Tests and docs are updated to validate/profile these behaviors and document the new flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 818a69c6522075ddcd6e9ed3a49130e44d4966a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->