### PR TITLE
feat(backend): expand solidity-parity normalization rules (v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ lake exe verity-compiler --backend-profile solidity-parity-ordering
 lake exe verity-compiler --backend-profile solidity-parity
 ```
 
+Normalization rules, scope levels, and reproducibility guarantees are versioned in [`docs/SOLIDITY_PARITY_PROFILE.md`](docs/SOLIDITY_PARITY_PROFILE.md).
+
 For mapping-backed struct layouts, `ContractSpec` supports:
 - `Expr.mappingWord field key wordOffset`
 - `Stmt.setMappingWord field key wordOffset value`

--- a/docs/SOLIDITY_PARITY_PROFILE.md
+++ b/docs/SOLIDITY_PARITY_PROFILE.md
@@ -1,0 +1,41 @@
+# Solidity-Parity Backend Profile
+
+Issue: [#802](https://github.com/Th0rgal/verity/issues/802)
+
+This document defines the opt-in backend profile used for deterministic output-shape alignment with Solidity-style workflows.
+
+## Profile Levels (v1)
+
+`v1` exposes three explicit levels:
+
+1. `semantic` (default)
+2. `solidity-parity-ordering`
+3. `solidity-parity`
+
+All levels preserve Verity's semantic guarantees. Parity levels only normalize output shape.
+
+## Normalization Rules (v1)
+
+| Rule ID | Description | `semantic` | `solidity-parity-ordering` | `solidity-parity` |
+|---|---|---|---|---|
+| `dispatch.selector.sort.asc` | Sort runtime dispatch `case` blocks by selector (ascending) | no | yes | yes |
+| `helpers.funcdef.sort.lex` | Sort compiler-generated/internal helper function declarations lexicographically by name | no | yes | yes |
+| `patch.pass.enable` | Enable deterministic expression patch pass | no (opt-in only) | no (opt-in only) | yes (forced on) |
+
+## Reproducibility Contract
+
+For a fixed source, fixed profile, fixed tool version, and fixed CLI options:
+
+- emitted Yul output is deterministic;
+- profile-normalized ordering is stable across repeated runs;
+- profile behavior is fully opt-in (`semantic` remains default).
+
+## Non-Goals (v1)
+
+`v1` does not attempt full byte-for-byte `solc` output identity. In particular:
+
+- it does not rewrite all helper naming patterns to mirror `solc` internals;
+- it does not force ABI/content layout rewrites beyond documented deterministic normalizations;
+- it does not weaken verification constraints to chase shape parity.
+
+Future versions can add additional rules with explicit IDs and migration notes.


### PR DESCRIPTION
## Summary
- extend backend profile normalization under issue #802 with deterministic internal helper declaration ordering for parity profiles
- keep `semantic` behavior unchanged while applying ordering normalization to both deploy and runtime helper sections for `solidity-parity-ordering` and `solidity-parity`
- add regression tests covering helper-order normalization plus repeated-run deterministic emission under `solidity-parity`
- add versioned profile documentation (`docs/SOLIDITY_PARITY_PROFILE.md`) with explicit rule IDs, scope levels, reproducibility contract, and non-goals

## Why
Issue #802 asked for an opt-in, documented, deterministic backend profile strategy. The first MVP covered selector ordering + patch enablement; this PR adds another deterministic normalization rule (helper declaration ordering) and formalizes the profile contract as a versioned ruleset (`v1`) for downstream diff tooling.

## Validation
- `lake env lean Compiler/ContractSpecFeatureTest.lean`
- `lake build verity-compiler`

Refs #802

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Yul emission ordering in both deploy and runtime paths under parity profiles, which can affect downstream diff tooling and any consumers relying on prior output shape (though semantics should be unchanged). Scope is contained to ordering/normalization plus added regression tests and docs.
> 
> **Overview**
> **Expands Solidity-parity normalization** by sorting internal/helper `funcDef` declarations lexicographically under `solidity-parity-ordering` and `solidity-parity`, while leaving the default `semantic` profile unchanged.
> 
> This ordering normalization is applied consistently to both *runtime* (`runtimeCodeWithEmitOptions`) and *deploy* (`deployCodeWithProfile`) emission paths, and is covered by new regression tests that assert helper ordering and repeated-run determinism.
> 
> Adds versioned documentation in `docs/SOLIDITY_PARITY_PROFILE.md` (linked from `README.md`) describing the `v1` profile levels, rule IDs, and reproducibility contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c576e08ea597430fe23945b8ad05295e98136099. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->