### PR TITLE
ContractSpec: validate external call signature arity and Expr return shape

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -2299,6 +2299,9 @@ private partial def validateExternalCallTargetsInExpr
       | some ext =>
           if args.length != ext.params.length then
             throw s!"Compilation error: {context} calls external '{name}' with {args.length} args, but spec.externals declares {ext.params.length} ({issue184Ref})."
+          let returns ← externalFunctionReturns ext
+          if returns.length != 1 then
+            throw s!"Compilation error: {context} uses Expr.externalCall '{name}' but spec.externals declares {returns.length} return values; Expr.externalCall requires exactly 1 ({issue184Ref})."
       args.forM (validateExternalCallTargetsInExpr externals context)
   | Expr.call gas target value inOffset inSize outOffset outSize => do
       validateExternalCallTargetsInExpr externals context gas


### PR DESCRIPTION
## Summary
This PR strengthens `ContractSpec` validation for declared external functions used via `Expr.externalCall`, advancing issue #184's goal of safer, auditable external integration.

## Changes
- Keep existing external target existence validation (`Issue #732`) and argument arity validation (`Issue #184`).
- Add a new compile-time check that `Expr.externalCall` can only target externals declaring exactly **one** return value.
  - Rejects void externals used in expression position.
  - Rejects multi-return externals used in expression position.
- Add regression tests in `Compiler/ContractSpecFeatureTest.lean`:
  - external call arity mismatch diagnostic
  - expression-form call against void external declaration
  - expression-form call against multi-return external declaration

## Why
`Expr.externalCall` lowers to a single Yul expression value, so allowing declarations with 0 or >1 returns creates an interface mismatch that can silently invalidate assumptions. This check makes external interface contracts explicit and enforced at compile time.

## Validation
- `lake build Compiler.ContractSpecFeatureTest`

Closes #184

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens compile-time validation for `Expr.externalCall`, which may break existing specs that declared/used void or multi-return externals in expression position. Changes are localized to validation and backed by new regression tests.
> 
> **Overview**
> Strengthens `ContractSpec` validation so `Expr.externalCall` may only target externals that declare **exactly one** return value (in addition to existing target existence + argument arity checks).
> 
> Adds feature tests ensuring compilation fails with clear diagnostics when an expression-form external call targets a void-return or multi-return external declaration, alongside the existing arity-mismatch diagnostic coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dd65a74d12018badb9c6adb9d96bd50755e0765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->