### PR TITLE
Harden Lean warning baseline schema boundary

### DIFF
--- a/scripts/test_check_lean_warning_regression.py
+++ b/scripts/test_check_lean_warning_regression.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent / "check_lean_warning_regression.py"
+
+
+class CheckLeanWarningRegressionScriptTests(unittest.TestCase):
+    def test_accepts_valid_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            log_path = root / "lake-build.log"
+            baseline_path = root / "lean_warning_baseline.json"
+            log_path.write_text(
+                "warning: Compiler/Main.lean:1:1: declaration uses 'sorry'\n",
+                encoding="utf-8",
+            )
+            baseline_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "total_warnings": 1,
+                        "by_file": {"Compiler/Main.lean": 1},
+                        "by_message": {"declaration uses 'sorry'": 1},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--log", str(log_path), "--baseline", str(baseline_path)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Lean warning non-regression check passed", proc.stdout)
+
+    def test_rejects_invalid_baseline_counter_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            log_path = root / "lake-build.log"
+            baseline_path = root / "lean_warning_baseline.json"
+            log_path.write_text("", encoding="utf-8")
+            baseline_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "total_warnings": 0,
+                        "by_file": [],
+                        "by_message": {},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--log", str(log_path), "--baseline", str(baseline_path)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("'by_file' must be an object", proc.stderr)
+
+    def test_rejects_invariant_mismatch_in_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            log_path = root / "lake-build.log"
+            baseline_path = root / "lean_warning_baseline.json"
+            log_path.write_text("", encoding="utf-8")
+            baseline_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "total_warnings": 2,
+                        "by_file": {"Compiler/Main.lean": 1},
+                        "by_message": {"m": 2},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--log", str(log_path), "--baseline", str(baseline_path)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("sum(by_file)=1 must equal total_warnings=2", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- harden `scripts/check_lean_warning_regression.py` baseline loading with explicit schema validation
- reject malformed baseline JSON shape and invariant mismatches (`sum(by_file)`, `sum(by_message)`, `total_warnings`)
- add script integration tests covering valid baseline + malformed baseline rejection
- rewrite `AUDIT.md` into a minimal auditor-first format and document this trust boundary

## Why
`artifacts/lean_warning_baseline.json` is a CI trust boundary. Previously the checker relied on permissive casting and implicit defaults. This PR makes invalid baseline states explicit and fail-closed.

## Validation
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_lean_warning_regression.py --log /dev/null --baseline artifacts/lean_warning_baseline.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to a CI check script and its tests, reducing the chance of silent misconfiguration; main risk is stricter validation causing CI failures if existing baselines are malformed.
> 
> **Overview**
> Updates the Lean warning non-regression gate to **fail closed** by strictly validating the baseline JSON schema (required keys, types, non-negative counts) and enforcing invariants that `total_warnings` matches the sums of `by_file`/`by_message`.
> 
> Adds integration-style unit tests that run `scripts/check_lean_warning_regression.py` as a subprocess to ensure valid baselines pass and malformed or inconsistent baselines are rejected. `AUDIT.md` is rewritten into a shorter auditor-first doc and explicitly documents the CI baseline artifact as a trust boundary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da5f98c2c2af148f666d5b4044ac7ace10d13a64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->