### PR TITLE
Fix verify path-sync decoy filter bypass

### DIFF
--- a/scripts/test_check_verify_paths_sync.py
+++ b/scripts/test_check_verify_paths_sync.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import textwrap
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_verify_paths_sync
+
+
+class VerifyPathsSyncTests(unittest.TestCase):
+    def _run_check(self, workflow_body: str) -> tuple[int, str]:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", delete=False, dir=SCRIPT_DIR.parent
+        ) as tmp:
+            tmp.write(workflow_body)
+            workflow_path = Path(tmp.name)
+
+        old_verify = check_verify_paths_sync.VERIFY_YML
+        check_verify_paths_sync.VERIFY_YML = workflow_path
+        try:
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                try:
+                    rc = check_verify_paths_sync.main()
+                    return rc, stderr.getvalue()
+                except Exception as exc:  # main currently surfaces parse errors directly
+                    print(str(exc), file=sys.stderr)
+                    return 1, stderr.getvalue()
+        finally:
+            check_verify_paths_sync.VERIFY_YML = old_verify
+            workflow_path.unlink(missing_ok=True)
+
+    def test_decoy_filters_outside_changes_job_fails(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            on:
+              push:
+                paths:
+                  - src/**
+                  - docs/**
+                  - docs-site/**
+                  - AXIOMS.md
+                  - README.md
+                  - TRUST_ASSUMPTIONS.md
+              pull_request:
+                paths:
+                  - src/**
+                  - docs/**
+                  - docs-site/**
+                  - AXIOMS.md
+                  - README.md
+                  - TRUST_ASSUMPTIONS.md
+            jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: echo no real filters block here
+              decoy:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: dorny/paths-filter@v3
+                    with:
+                      filters: |
+                        code:
+                          - src/**
+            """
+        )
+        rc, stderr = self._run_check(workflow)
+        self.assertEqual(rc, 1)
+        self.assertIn("changes.filter.code", stderr)
+
+    def test_changes_job_filters_are_used_even_with_decoy(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            on:
+              push:
+                paths:
+                  - src/**
+                  - docs/**
+                  - docs-site/**
+                  - AXIOMS.md
+                  - README.md
+                  - TRUST_ASSUMPTIONS.md
+              pull_request:
+                paths:
+                  - src/**
+                  - docs/**
+                  - docs-site/**
+                  - AXIOMS.md
+                  - README.md
+                  - TRUST_ASSUMPTIONS.md
+            jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: dorny/paths-filter@v3
+                    with:
+                      filters: |
+                        code:
+                          - src/**
+              decoy:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: dorny/paths-filter@v3
+                    with:
+                      filters: |
+                        code:
+                          - not/real/**
+            """
+        )
+        rc, stderr = self._run_check(workflow)
+        self.assertEqual(rc, 0, stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- scope `changes.filter.code` extraction to the `jobs.changes` block instead of global regex search
- reuse `workflow_jobs.extract_job_body` so decoy `filters/code` blocks in other jobs cannot satisfy the check
- add regression tests covering the reported bypass and an ignore-decoy pass case

## Why
`check_verify_paths_sync.py` could be satisfied by a decoy `filters: | code:` block outside `jobs.changes`, allowing fail-open validation of workflow gating.

## Validation
- `python3 scripts/test_check_verify_paths_sync.py`
- `python3 scripts/check_verify_paths_sync.py`

Closes #871

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens parsing/validation for CI workflow gating, and regex-based extraction changes could cause false failures if the verify workflow format differs from expectations.
> 
> **Overview**
> Prevents `scripts/check_verify_paths_sync.py` from being satisfied by a decoy `filters: | code:` block elsewhere in `verify.yml` by scoping `changes.filter.code` extraction to the `jobs.changes` block via `workflow_jobs.extract_job_body`.
> 
> Adds `scripts/test_check_verify_paths_sync.py` regression tests to ensure a decoy block outside `changes` fails validation and that a valid `changes` filter is used even when other jobs contain similar blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9048efbfcda4acbfcdf5de625d0decb892582a7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->