### PR TITLE
Fix fail-open multi-seed sync extraction

### DIFF
--- a/scripts/check_verify_multiseed_sync.py
+++ b/scripts/check_verify_multiseed_sync.py
@@ -25,12 +25,114 @@ def _parse_seed_csv(raw: str, source: Path) -> list[int]:
         raise ValueError(f"Non-integer seed in {source}: {raw!r}") from exc
 
 
+def _line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _is_substantive_line(line: str) -> bool:
+    stripped = line.strip()
+    return bool(stripped) and not stripped.startswith("#")
+
+
+def _find_block_end(lines: list[str], start_idx: int, parent_indent: int) -> int:
+    for idx in range(start_idx + 1, len(lines)):
+        line = lines[idx]
+        if not _is_substantive_line(line):
+            continue
+        if _line_indent(line) <= parent_indent:
+            return idx
+    return len(lines)
+
+
+def _find_key_line(
+    lines: list[str],
+    key: str,
+    *,
+    start_idx: int,
+    end_idx: int,
+    required_indent: int,
+    source: Path,
+) -> tuple[int, str]:
+    key_prefix = f"{key}:"
+    for idx in range(start_idx, end_idx):
+        line = lines[idx]
+        if not _is_substantive_line(line):
+            continue
+        if _line_indent(line) != required_indent:
+            continue
+        stripped = line.strip()
+        if stripped.startswith(key_prefix):
+            return idx, stripped[len(key_prefix) :].strip()
+    raise ValueError(f"Could not locate '{key}' in {source}")
+
+
+def _parse_seed_block_list(lines: list[str], source: Path, *, seed_idx: int, seed_indent: int) -> list[int]:
+    end_idx = _find_block_end(lines, seed_idx, seed_indent)
+    expected_item_indent = seed_indent + 2
+    values: list[int] = []
+    for idx in range(seed_idx + 1, end_idx):
+        line = lines[idx]
+        if not _is_substantive_line(line):
+            continue
+        if _line_indent(line) != expected_item_indent:
+            raise ValueError(f"Malformed seed list indentation in {source}")
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            raise ValueError(f"Malformed seed list item in {source}: {stripped!r}")
+        token = stripped[2:].strip()
+        if not token:
+            raise ValueError(f"Empty seed list item in {source}")
+        try:
+            values.append(int(token))
+        except ValueError as exc:
+            raise ValueError(f"Non-integer seed in {source}: {token!r}") from exc
+    if not values:
+        raise ValueError(f"Empty seed list in {source}")
+    return values
+
+
 def _extract_verify_seeds(text: str) -> list[int]:
     job_body = extract_job_body(text, "foundry-multi-seed", VERIFY_YML)
-    seed_line = re.search(r"^\s*seed:\s*\[(?P<csv>[^\]]+)\]\s*$", job_body, re.MULTILINE)
-    if not seed_line:
-        raise ValueError(f"Could not locate matrix seed list in {VERIFY_YML}")
-    return _parse_seed_csv(seed_line.group("csv"), VERIFY_YML)
+    lines = job_body.splitlines()
+    root_indents = [_line_indent(line) for line in lines if _is_substantive_line(line)]
+    if not root_indents:
+        raise ValueError(f"Could not parse foundry-multi-seed job body in {VERIFY_YML}")
+    root_indent = min(root_indents)
+
+    strategy_idx, _ = _find_key_line(
+        lines,
+        "strategy",
+        start_idx=0,
+        end_idx=len(lines),
+        required_indent=root_indent,
+        source=VERIFY_YML,
+    )
+    strategy_end = _find_block_end(lines, strategy_idx, root_indent)
+
+    matrix_idx, _ = _find_key_line(
+        lines,
+        "matrix",
+        start_idx=strategy_idx + 1,
+        end_idx=strategy_end,
+        required_indent=root_indent + 2,
+        source=VERIFY_YML,
+    )
+    matrix_end = _find_block_end(lines, matrix_idx, root_indent + 2)
+
+    seed_idx, seed_rest = _find_key_line(
+        lines,
+        "seed",
+        start_idx=matrix_idx + 1,
+        end_idx=matrix_end,
+        required_indent=root_indent + 4,
+        source=VERIFY_YML,
+    )
+    if seed_rest:
+        m = re.fullmatch(r"\[(?P<csv>[^\]]+)\]", seed_rest)
+        if not m:
+            raise ValueError(f"Malformed matrix seed list in {VERIFY_YML}: {seed_rest!r}")
+        return _parse_seed_csv(m.group("csv"), VERIFY_YML)
+    return _parse_seed_block_list(lines, VERIFY_YML, seed_idx=seed_idx, seed_indent=root_indent + 4)
 
 
 def _extract_script_seeds(text: str) -> list[int]:
@@ -65,13 +167,17 @@ def _fmt(seeds: list[int]) -> str:
 
 
 def main() -> int:
-    verify_text = VERIFY_YML.read_text(encoding="utf-8")
-    script_text = MULTISEED_SCRIPT.read_text(encoding="utf-8")
-    readme_text = SCRIPTS_README.read_text(encoding="utf-8")
+    try:
+        verify_text = VERIFY_YML.read_text(encoding="utf-8")
+        script_text = MULTISEED_SCRIPT.read_text(encoding="utf-8")
+        readme_text = SCRIPTS_README.read_text(encoding="utf-8")
 
-    verify_seeds = _extract_verify_seeds(verify_text)
-    script_seeds = _extract_script_seeds(script_text)
-    readme_seeds = _extract_readme_seeds(readme_text)
+        verify_seeds = _extract_verify_seeds(verify_text)
+        script_seeds = _extract_script_seeds(script_text)
+        readme_seeds = _extract_readme_seeds(readme_text)
+    except ValueError as exc:
+        print(f"verify multi-seed sync check failed: {exc}", file=sys.stderr)
+        return 1
 
     errors: list[str] = []
     if script_seeds != verify_seeds:

--- a/scripts/test_check_verify_multiseed_sync.py
+++ b/scripts/test_check_verify_multiseed_sync.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import textwrap
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_verify_multiseed_sync
+import property_utils
+
+
+class VerifyMultiseedSyncTests(unittest.TestCase):
+    def _run_check(self, verify_body: str, script_body: str, readme_body: str) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory(dir=property_utils.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            verify = root / "verify.yml"
+            script = root / "test_multiple_seeds.sh"
+            readme = root / "README.md"
+            verify.write_text(verify_body, encoding="utf-8")
+            script.write_text(script_body, encoding="utf-8")
+            readme.write_text(readme_body, encoding="utf-8")
+
+            old_verify = check_verify_multiseed_sync.VERIFY_YML
+            old_script = check_verify_multiseed_sync.MULTISEED_SCRIPT
+            old_readme = check_verify_multiseed_sync.SCRIPTS_README
+            check_verify_multiseed_sync.VERIFY_YML = verify
+            check_verify_multiseed_sync.MULTISEED_SCRIPT = script
+            check_verify_multiseed_sync.SCRIPTS_README = readme
+            try:
+                stderr = io.StringIO()
+                with redirect_stderr(stderr):
+                    rc = check_verify_multiseed_sync.main()
+                return rc, stderr.getvalue()
+            finally:
+                check_verify_multiseed_sync.VERIFY_YML = old_verify
+                check_verify_multiseed_sync.MULTISEED_SCRIPT = old_script
+                check_verify_multiseed_sync.SCRIPTS_README = old_readme
+
+    def test_rejects_seed_defined_outside_strategy_matrix(self) -> None:
+        verify = textwrap.dedent(
+            """\
+            jobs:
+              foundry-multi-seed:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: unrelated
+                    with:
+                      seed: [101, 202, 303]
+            """
+        )
+        script = "DEFAULT_SEEDS=(101 202 303)\n"
+        readme = "**`foundry-multi-seed`** smoke (seeds: 101, 202, 303)\n"
+        rc, stderr = self._run_check(verify, script, readme)
+        self.assertEqual(rc, 1)
+        self.assertIn("Could not locate 'strategy'", stderr)
+
+    def test_accepts_inline_matrix_seed_list(self) -> None:
+        verify = textwrap.dedent(
+            """\
+            jobs:
+              foundry-multi-seed:
+                runs-on: ubuntu-latest
+                strategy:
+                  matrix:
+                    seed: [7, 11, 13]
+                steps: []
+            """
+        )
+        script = "DEFAULT_SEEDS=(7 11 13)\n"
+        readme = "**`foundry-multi-seed`** smoke (seeds: 7, 11, 13)\n"
+        rc, stderr = self._run_check(verify, script, readme)
+        self.assertEqual(rc, 0, stderr)
+
+    def test_accepts_block_matrix_seed_list(self) -> None:
+        verify = textwrap.dedent(
+            """\
+            jobs:
+              foundry-multi-seed:
+                runs-on: ubuntu-latest
+                strategy:
+                  matrix:
+                    seed:
+                      - 2
+                      - 3
+                      - 5
+                steps: []
+            """
+        )
+        script = "DEFAULT_SEEDS=(2 3 5)\n"
+        readme = "**`foundry-multi-seed`** smoke (seeds: 2, 3, 5)\n"
+        rc, stderr = self._run_check(verify, script, readme)
+        self.assertEqual(rc, 0, stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `check_verify_multiseed_sync.py` to read only `jobs.foundry-multi-seed.strategy.matrix.seed`
- reject unrelated `seed:` lines from other sections (e.g. step `with:` blocks)
- support both inline list form (`seed: [..]`) and block list form (`seed:\n  - ..`)
- add regression tests including the security repro from #870
- fail cleanly with explicit diagnostics on malformed workflow structure

## Validation
- `python3 scripts/test_check_verify_multiseed_sync.py`
- `python3 scripts/check_verify_multiseed_sync.py`
- repro from issue #870 now returns `EXIT 1`

Closes #870

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to CI/dev tooling: tighter parsing and new tests, with main risk being accidental false negatives if workflow formatting diverges from the expected indentation-based structure.
> 
> **Overview**
> Fixes the multi-seed sync checker to **only** accept seeds defined under `jobs.foundry-multi-seed.strategy.matrix.seed`, avoiding false matches from unrelated `seed:` keys elsewhere in the workflow, and adds support for both `seed: [..]` and block list YAML forms.
> 
> The script now validates workflow structure/indentation and **fails closed** with explicit diagnostics (returning non-zero on parse errors), and a new `scripts/test_check_verify_multiseed_sync.py` regression suite covers the fail-open repro plus inline/block parsing cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50fc423539eaf9738582a2b88b79725786c77461. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->