### PR TITLE
Fix fail-open parsing in foundry gas calibration sync check

### DIFF
--- a/scripts/test_check_verify_foundry_gas_calibration_sync.py
+++ b/scripts/test_check_verify_foundry_gas_calibration_sync.py
@@ -118,6 +118,58 @@ class VerifyFoundryGasCalibrationSyncTests(unittest.TestCase):
         rc, stderr = self._run_check(verify, readme)
         self.assertEqual(rc, 0, stderr)
 
+    def test_step_names_allow_inline_comments(self) -> None:
+        verify = textwrap.dedent(
+            """
+            name: Verify proofs
+            jobs:
+              foundry-gas-calibration:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Download static gas report # keep
+                    uses: actions/download-artifact@v4
+                    with:
+                      name: static-gas-report
+
+                  - name: Check static-vs-foundry gas calibration # keep
+                    env:
+                      FOUNDRY_PROFILE: difftest
+                    run: python3 scripts/check_gas_calibration.py --static-report gas-report-static.tsv
+            """
+        )
+        readme = (
+            "**`foundry-gas-calibration`** Runs `check_gas_calibration.py` "
+            "using Foundry gas report against static report baseline.\n"
+        )
+        rc, stderr = self._run_check(verify, readme)
+        self.assertEqual(rc, 0, stderr)
+
+    def test_download_artifact_allows_non_v4_ref(self) -> None:
+        verify = textwrap.dedent(
+            """
+            name: Verify proofs
+            jobs:
+              foundry-gas-calibration:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Download static gas report
+                    uses: "actions/download-artifact@v4.1.0"
+                    with:
+                      name: static-gas-report
+
+                  - name: Check static-vs-foundry gas calibration
+                    env:
+                      FOUNDRY_PROFILE: difftest
+                    run: python3 scripts/check_gas_calibration.py --static-report gas-report-static.tsv
+            """
+        )
+        readme = (
+            "**`foundry-gas-calibration`** Runs `check_gas_calibration.py` "
+            "using Foundry gas report against static report baseline.\n"
+        )
+        rc, stderr = self._run_check(verify, readme)
+        self.assertEqual(rc, 0, stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- scope foundry-gas-calibration extraction to the intended step blocks instead of scanning the whole job body
- validate artifact name from `Download static gas report` and `FOUNDRY_PROFILE`/command from `Check static-vs-foundry gas calibration`
- support multiline `run: |` in the calibration step extraction
- add regression tests for decoy values outside target steps

## Validation
- `python3 scripts/test_check_verify_foundry_gas_calibration_sync.py`
- `python3 scripts/check_verify_foundry_gas_calibration_sync.py`

Closes #869

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens and restructures YAML parsing for a CI sync-check script, which could introduce new false negatives and fail the workflow if verify.yml formatting differs from expectations. Changes are limited to tooling/tests and don’t affect runtime behavior of the product.
> 
> **Overview**
> Prevents the `check_verify_foundry_gas_calibration_sync.py` script from *fail-open* matching by scoping extraction to the specific `Download static gas report` and `Check static-vs-foundry gas calibration` steps, normalizing quoted/commented scalars, and validating the download step actually uses `actions/download-artifact@...`.
> 
> Adds parsing support for multiline `run: |` blocks when locating the `check_gas_calibration.py --static-report ...` command, and introduces a new `unittest` suite to catch decoy/misleading values outside the target steps and to cover inline comments and non-`v4` action refs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b692330f6deea87e9f02e5178e88d43101d2c158. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->