### PR TITLE
Fix checks/docs sync parser for multiline run steps

### DIFF
--- a/scripts/test_check_verify_checks_docs_sync.py
+++ b/scripts/test_check_verify_checks_docs_sync.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_verify_checks_docs_sync import _extract_workflow_checks_commands
+
+
+class VerifyChecksDocsSyncTests(unittest.TestCase):
+    def test_extracts_single_line_and_block_run_commands(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              checks:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: single-line
+                    run: python3 scripts/check_a.py
+                  - name: block
+                    run: |
+                      python3 scripts/check_b.py
+                      echo done
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(
+            _extract_workflow_checks_commands(workflow),
+            ["check_a.py", "check_b.py"],
+        )
+
+    def test_extracts_folded_block_run_commands(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              checks:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: folded
+                    run: >-
+                      python3 scripts/check_c.py
+                      python3 scripts/check_d.py --strict
+                      echo done
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(
+            _extract_workflow_checks_commands(workflow),
+            ["check_c.py", "check_d.py --strict"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- parse `checks` job `run` steps in both single-line and block-scalar forms (`|`, `>`, including chomping variants)
- extract `python3 scripts/...` invocations from multiline run bodies instead of silently ignoring them
- add regression tests covering mixed single-line + block commands and folded block commands

## Why
`check_verify_checks_docs_sync.py` previously only parsed one-line `run:` commands, so multiline `run: |`/`run: >` commands could bypass docs/workflow sync enforcement.

Fixes #865.

## Validation
- `python3 scripts/test_check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the parser that enforces `.github/workflows/verify.yml` vs `scripts/README.md` sync; mistakes could cause new false CI failures or miss commands. Scope is limited to a repo maintenance script and adds regression tests to reduce risk.
> 
> **Overview**
> Fixes `scripts/check_verify_checks_docs_sync.py` to extract `python3 scripts/...` invocations not only from single-line `run:` steps but also from block-scalar `run: |` / `run: >` (including chomping variants), ensuring multiline steps can’t bypass checks/docs sync enforcement.
> 
> Adds `scripts/test_check_verify_checks_docs_sync.py` unit tests covering mixed single-line + block runs and folded block runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01d791b989d72faf31c0c6d9ca4527387f594996. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->