### PR TITLE
Fix artifact sync parsing when with.name is not first

### DIFF
--- a/scripts/test_check_verify_artifact_sync.py
+++ b/scripts/test_check_verify_artifact_sync.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import textwrap
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_verify_artifact_sync
+
+
+class VerifyArtifactSyncTests(unittest.TestCase):
+    def _run_main(self, workflow_body: str) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as d:
+            wf = Path(d) / "verify.yml"
+            wf.write_text(workflow_body, encoding="utf-8")
+            old_verify = check_verify_artifact_sync.VERIFY_YML
+            check_verify_artifact_sync.VERIFY_YML = wf
+            try:
+                stderr = io.StringIO()
+                with redirect_stderr(stderr):
+                    try:
+                        rc = check_verify_artifact_sync.main()
+                        return rc, stderr.getvalue()
+                    except Exception as exc:
+                        print(str(exc), file=sys.stderr)
+                        return 1, stderr.getvalue()
+            finally:
+                check_verify_artifact_sync.VERIFY_YML = old_verify
+
+    def test_extract_names_supports_non_first_name_key(self) -> None:
+        body = textwrap.dedent(
+            """
+                  - name: Upload generated Yul
+                    uses: actions/upload-artifact@v4
+                    with:
+                      path: artifacts/out.txt
+                      name: generated-yul
+                  - name: Download generated Yul
+                    uses: actions/download-artifact@v4
+                    with:
+                      path: artifacts
+                      name: generated-yul
+            """
+        )
+        self.assertEqual(
+            check_verify_artifact_sync._extract_upload_names(body),
+            ["generated-yul"],
+        )
+        self.assertEqual(
+            check_verify_artifact_sync._extract_download_names(body),
+            ["generated-yul"],
+        )
+
+    def test_rejects_download_step_without_name(self) -> None:
+        body = textwrap.dedent(
+            """
+                  - uses: actions/download-artifact@v4
+                    with:
+                      path: artifacts
+            """
+        )
+        with self.assertRaisesRegex(ValueError, "download-artifact step"):
+            check_verify_artifact_sync._extract_download_names(body)
+
+    def test_main_supports_non_first_name_key(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            on: {}
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Upload generated Yul
+                    uses: actions/upload-artifact@v4
+                    with:
+                      path: compiler/generated
+                      name: generated-yul
+              foundry:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Download generated Yul
+                    uses: actions/download-artifact@v4
+                    with:
+                      path: compiler/generated
+                      name: generated-yul
+            """
+        )
+        rc, stderr = self._run_main(workflow)
+        self.assertEqual(rc, 0, stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace position-sensitive regex parsing in `check_verify_artifact_sync.py` with structural step parsing
- extract artifact action `uses:` from full step mappings, not only `- uses:` first-line form
- extract `with.name` regardless of key order and fail closed when upload/download steps have no literal `with.name`
- add regression tests for reordered keys and real step shape (`- name` then `uses`)

## Validation
- `python3 scripts/test_check_verify_artifact_sync.py`
- `python3 scripts/check_verify_artifact_sync.py`

Closes #864

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tightens parsing of a CI verification script and adds unit tests; the main risk is false positives/negatives in the sync check due to the custom YAML-like parsing logic.
> 
> **Overview**
> Fixes `check_verify_artifact_sync.py` artifact name extraction so it no longer depends on `with.name` being the first key or `uses:` appearing only in the step’s first line.
> 
> Replaces the prior regex approach with lightweight step-block parsing that strips inline comments, supports quoted scalars, and **fails closed** when an `upload-artifact`/`download-artifact` step lacks a literal `with.name`. Adds regression tests covering reordered `with:` keys, missing `name`, and an end-to-end `main()` run against a temporary `verify.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c5d1528a48ccf16cb447e4304f7c7e51dc1ddb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->