### PR TITLE
Remove hardcoded theorem count banner from docs

### DIFF
--- a/docs-site/app/layout.tsx
+++ b/docs-site/app/layout.tsx
@@ -27,7 +27,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           navbar={navbar}
           pageMap={await getPageMap()}
           docsRepositoryBase="https://github.com/Th0rgal/verity/tree/main/docs-site"
-          banner={<span>431/431 theorems proven</span>}
           sidebar={{ defaultMenuCollapseLevel: 1 }}
           toc={{ backToTop: true }}
         >


### PR DESCRIPTION
## Summary
- Removes the hardcoded `431/431 theorems proven` banner from the docs site layout (`docs-site/app/layout.tsx`)
- This text appears to have been left in unintentionally

## Test plan
- [ ] Verify docs site builds without errors
- [ ] Confirm the banner no longer appears on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)