### PR TITLE
Add regression test for docs count checker layout independence

### DIFF
--- a/scripts/test_check_doc_counts.py
+++ b/scripts/test_check_doc_counts.py
@@ -18,6 +18,22 @@ from check_doc_counts import apply_fixes, check_file
 
 
 class CheckDocCountsMultiMatchTests(unittest.TestCase):
+    def test_main_does_not_check_docs_layout_banner(self) -> None:
+        visited: list[Path] = []
+        original = check_doc_counts.check_and_maybe_fix
+
+        def _record(path: Path, checks: list[tuple[str, re.Pattern[str], str]], fix: bool) -> list[str]:
+            visited.append(path)
+            return original(path, checks, fix)
+
+        check_doc_counts.check_and_maybe_fix = _record
+        try:
+            check_doc_counts.main()
+        finally:
+            check_doc_counts.check_and_maybe_fix = original
+
+        self.assertNotIn(check_doc_counts.ROOT / "docs-site" / "app" / "layout.tsx", visited)
+
     def test_check_file_reports_stale_non_first_occurrence(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "README.md"


### PR DESCRIPTION
## Summary
- add a regression test asserting `check_doc_counts.main()` does not read `docs-site/app/layout.tsx`
- guard against reintroducing the removed layout banner dependency that previously broke CI

## Validation
- `python3 scripts/test_check_doc_counts.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change adding a regression guard around `check_doc_counts.main()` file traversal; no production logic is modified.
> 
> **Overview**
> Adds a regression unit test that runs `check_doc_counts.main()` with an instrumented `check_and_maybe_fix` to record which files are processed, and asserts it *does not* read `docs-site/app/layout.tsx`.
> 
> This protects against reintroducing a docs-site layout/banner dependency that previously broke CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27fed50403649b12d1c940ee328553f68eba8602. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->