### PR TITLE
Harden checks/docs sync parser for multiline workflow commands

### DIFF
--- a/scripts/test_check_verify_checks_docs_sync.py
+++ b/scripts/test_check_verify_checks_docs_sync.py
@@ -63,6 +63,54 @@ class VerifyChecksDocsSyncTests(unittest.TestCase):
             ["check_c.py", "check_d.py --strict"],
         )
 
+    def test_extracts_line_continuation_commands(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              checks:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: continuation
+                    run: |
+                      python3 scripts/check_e.py \\
+                        --strict
+                      echo done
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(
+            _extract_workflow_checks_commands(workflow),
+            ["check_e.py --strict"],
+        )
+
+    def test_extracts_with_inline_comments(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              checks:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: comments
+                    run: |
+                      # decoy comment
+                      python3 scripts/check_f.py --strict  # enforce strict mode
+                      echo done
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(
+            _extract_workflow_checks_commands(workflow),
+            ["check_f.py --strict"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Hardens `scripts/check_verify_checks_docs_sync.py` to parse workflow `run:` commands with the same resilience we already enforce in the build-job checker.

Closes #905.

## Changes
- Support block scalar variants (`|`, `>`, `>-`, etc.) when reading `checks` job `run:` blocks.
- Support backslash line continuations for `python3 scripts/...` commands.
- Normalize command spacing before comparison.
- Ignore comment-only lines and strip trailing inline comments on extracted command lines.
- Add regression tests covering continuation and inline-comment command forms.

## Validation
- `python3 scripts/test_check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/test_check_verify_paths_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a docs/workflow-parsing validation script plus tests; risk is mainly false positives/negatives in the sync check if parsing assumptions are still incomplete.
> 
> **Overview**
> Improves `scripts/check_verify_checks_docs_sync.py` to more robustly extract `python3 scripts/...` invocations from the `verify.yml` `checks` job by handling block scalar `run:` payloads (including folded/variant forms), normalizing whitespace, and supporting backslash line continuations.
> 
> The parser now ignores comment-only lines, strips inline trailing comments from extracted commands, and centralizes extraction in a new helper (`_extract_python_script_commands`). Adds tests covering folded blocks, line continuations, and inline-comment cases to prevent regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4a53effda937ca8956c2a0f1542b69c4c9f789d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->