### PR TITLE
Fix check_doc_counts main() for programmatic invocation

### DIFF
--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -466,7 +466,7 @@ def check_verification_theorem_names(path: Path) -> list[str]:
     return errors
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         description="Check documentation count claims against manifest/code metrics."
     )
@@ -481,7 +481,7 @@ def main() -> None:
         default=ROOT / "artifacts" / "verification_status.json",
         help="Path to verification status artifact JSON.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     artifact_metrics = load_metrics_from_artifact(args.artifact)
     live_metrics = collect_metrics()

--- a/scripts/test_check_doc_counts.py
+++ b/scripts/test_check_doc_counts.py
@@ -28,7 +28,7 @@ class CheckDocCountsMultiMatchTests(unittest.TestCase):
 
         check_doc_counts.check_and_maybe_fix = _record
         try:
-            check_doc_counts.main()
+            check_doc_counts.main([])
         finally:
             check_doc_counts.check_and_maybe_fix = original
 


### PR DESCRIPTION
## Summary
- make `scripts/check_doc_counts.py` `main()` accept optional argv (`main(argv: list[str] | None = None)`)
- parse provided argv via `parser.parse_args(argv)` to avoid ambient harness argument leakage
- update `scripts/test_check_doc_counts.py` to call `main([])` explicitly for deterministic programmatic execution

## Why
`unittest discover` (and similar harnesses) can inject unrelated CLI args into `sys.argv`, causing `check_doc_counts.main()` to raise `SystemExit(2)` when called from tests.

## Validation
- `python3 -m unittest scripts.test_check_doc_counts`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

Closes #907

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CLI argument parsing for `scripts/check_doc_counts.py` and updates a unit test to pass an explicit argv list, without changing verification logic.
> 
> **Overview**
> Makes `scripts/check_doc_counts.py`’s `main()` accept an optional `argv` and passes it to `argparse.parse_args()` to prevent test/runner `sys.argv` leakage causing `SystemExit(2)`.
> 
> Updates `scripts/test_check_doc_counts.py` to call `main([])` explicitly for deterministic programmatic invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 495bca7ccd41c10d66590db78b0113d5c62d81b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->