### PR TITLE
Harden check scripts against ambient argv leakage

### DIFF
--- a/scripts/check_gas_calibration.py
+++ b/scripts/check_gas_calibration.py
@@ -22,7 +22,7 @@ STATIC_HEADER = "contract\tdeploy_upper_bound\truntime_upper_bound\ttotal_upper_
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--static-report",
@@ -68,7 +68,7 @@ def parse_args() -> argparse.Namespace:
             "Can be repeated."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def run_command(cmd: list[str], env: dict[str, str] | None = None) -> str:
@@ -300,8 +300,8 @@ def validate_contract_coverage(
     return failures
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     try:
         static_bounds = load_static_bounds(args.static_report)
         if args.foundry_report is None:

--- a/scripts/check_gas_model_coverage.py
+++ b/scripts/check_gas_model_coverage.py
@@ -20,7 +20,7 @@ MODELED_CALL_RE = re.compile(r'name\s*=\s*"([A-Za-z_][A-Za-z0-9_]*)"')
 NON_CALL_KEYWORDS = {"function", "if", "switch", "object", "code"}
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--dir",
@@ -29,7 +29,7 @@ def parse_args() -> argparse.Namespace:
         default=[],
         help="Yul directory to scan (repeatable). Default: compiler/yul",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def load_modeled_calls() -> set[str]:
@@ -71,8 +71,8 @@ def collect_yul_calls(scan_dirs: list[Path]) -> set[str]:
     return calls
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     scan_dirs = normalize_scan_dirs(args.dirs)
 
     if not STATIC_ANALYSIS.exists():

--- a/scripts/check_lean_warning_regression.py
+++ b/scripts/check_lean_warning_regression.py
@@ -175,7 +175,7 @@ def compare_against_baseline(
     return errors
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--log", required=True, type=Path, help="Path to lake build output log")
     parser.add_argument(
@@ -189,7 +189,7 @@ def main() -> None:
         type=Path,
         help="Write baseline artifact from current log and exit",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     by_file, by_message = parse_warnings(args.log)
 

--- a/scripts/check_patch_gas_delta.py
+++ b/scripts/check_patch_gas_delta.py
@@ -21,7 +21,7 @@ class GasRow:
     total: int
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--baseline-report",
@@ -59,7 +59,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Optional markdown output path for CI summaries.",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def percentile(values: list[float], p: float) -> float:
@@ -169,8 +169,8 @@ def render_markdown(
     return "\n".join(lines)
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     try:
         baseline = load_report(args.baseline_report)
         patched = load_report(args.patched_report)

--- a/scripts/check_yul_compiles.py
+++ b/scripts/check_yul_compiles.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from property_utils import ROOT, YUL_DIR, report_errors
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Compile generated Yul with solc and optionally compare bytecode parity."
     )
@@ -51,7 +51,7 @@ def parse_args() -> argparse.Namespace:
             "'mismatch:<file>', 'missing_in_a:<file>', or 'missing_in_b:<file>'."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def resolve_dir(path_str: str) -> Path:
@@ -155,8 +155,8 @@ def load_allowed_compare_diffs(path: str | None) -> set[tuple[str, str]]:
     return allowed
 
 
-def main() -> None:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
     yul_dirs = [resolve_dir(d) for d in (args.dirs or [str(YUL_DIR)])]
     files, failures = collect_yul_files(yul_dirs)
     if not files and not failures:

--- a/scripts/test_cli_argv_injection.py
+++ b/scripts/test_cli_argv_injection.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_gas_calibration
+import check_gas_model_coverage
+import check_lean_warning_regression
+import check_patch_gas_delta
+import check_yul_compiles
+
+
+@contextmanager
+def _ambient_argv(*args: str):
+    old = sys.argv
+    sys.argv = ["prog", *args]
+    try:
+        yield
+    finally:
+        sys.argv = old
+
+
+class CliArgvInjectionTests(unittest.TestCase):
+    def test_check_gas_model_coverage_parse_args_ignores_ambient_sys_argv(self) -> None:
+        with _ambient_argv("--unexpected-harness-flag"):
+            parsed = check_gas_model_coverage.parse_args(["--dir", "compiler/yul"])
+        self.assertEqual(parsed.dirs, ["compiler/yul"])
+
+    def test_check_patch_gas_delta_parse_args_ignores_ambient_sys_argv(self) -> None:
+        with _ambient_argv("--unexpected-harness-flag"):
+            parsed = check_patch_gas_delta.parse_args(
+                ["--baseline-report", "a.tsv", "--patched-report", "b.tsv"]
+            )
+        self.assertEqual(Path(parsed.baseline_report), Path("a.tsv"))
+        self.assertEqual(Path(parsed.patched_report), Path("b.tsv"))
+
+    def test_check_gas_calibration_parse_args_ignores_ambient_sys_argv(self) -> None:
+        with _ambient_argv("--unexpected-harness-flag"):
+            parsed = check_gas_calibration.parse_args([])
+        self.assertEqual(parsed.match_path, check_gas_calibration.DEFAULT_FOUNDRY_PATH_GLOB)
+
+    def test_check_yul_compiles_parse_args_ignores_ambient_sys_argv(self) -> None:
+        with _ambient_argv("--unexpected-harness-flag"):
+            parsed = check_yul_compiles.parse_args(["--dir", "compiler/yul"])
+        self.assertEqual(parsed.dirs, ["compiler/yul"])
+
+    def test_check_lean_warning_main_accepts_injected_argv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            log = root / "lake-build.log"
+            baseline = root / "baseline.json"
+            log.write_text("", encoding="utf-8")
+            with _ambient_argv("--unexpected-harness-flag"):
+                check_lean_warning_regression.main(
+                    ["--log", str(log), "--write-baseline", str(baseline)]
+                )
+            self.assertTrue(baseline.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make core argparse-driven check scripts accept optional injected argv (`parse_args(argv=None)` / `main(argv=None)`)
- cover `check_gas_calibration.py`, `check_gas_model_coverage.py`, `check_patch_gas_delta.py`, `check_yul_compiles.py`, and `check_lean_warning_regression.py`
- add regression tests in `scripts/test_cli_argv_injection.py` to ensure explicit argv parsing is isolated from ambient `sys.argv` (e.g. unittest harness flags)

## Why
Recent fixes showed that ambient harness arguments can break programmatic invocation of check scripts. This patch applies the same hardening pattern to other CI-critical checks to prevent accidental `argparse` failures from unrelated runner args.

## Validation
- `python3 -m unittest scripts.test_cli_argv_injection`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CLI-argument parsing hardening plus unit tests; behavior for normal command-line execution should remain unchanged aside from improved robustness when embedded.
> 
> **Overview**
> Hardens several CI check scripts to be safely invoked programmatically by adding optional `argv` parameters to `parse_args()` and/or `main()` and forwarding them to `argparse` instead of implicitly consuming ambient `sys.argv`.
> 
> Adds `scripts/test_cli_argv_injection.py` to regression-test that unexpected harness flags in `sys.argv` do not affect these scripts’ argument parsing, and that `check_lean_warning_regression.main()` can be driven with an injected argv to write a baseline artifact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0707151fec35c0162275c54623fd38b7f429bc78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->