### PR TITLE
Harden Foundry sync checks against run-command decoys

### DIFF
--- a/scripts/check_verify_foundry_job_sync.py
+++ b/scripts/check_verify_foundry_job_sync.py
@@ -7,7 +7,11 @@ import re
 import sys
 from pathlib import Path
 
-from workflow_jobs import extract_job_body, extract_literal_from_mapping_blocks
+from workflow_jobs import (
+    extract_job_body,
+    extract_literal_from_mapping_blocks,
+    extract_run_commands_from_job_body,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
@@ -51,10 +55,15 @@ def _extract_download(job_body: str, artifact_name: str, job: str) -> tuple[str,
 
 
 def _extract_forge_line(job_body: str, job: str) -> str:
-    m = re.search(r"^\s*forge test[^\n]*$", job_body, flags=re.MULTILINE)
-    if not m:
+    run_commands = extract_run_commands_from_job_body(job_body, source=VERIFY_YML, context=job)
+    forge_lines = [cmd for cmd in run_commands if cmd.startswith("forge test")]
+    if not forge_lines:
         raise ValueError(f"Could not locate 'forge test' command in {job} job in {VERIFY_YML}")
-    return m.group(0).strip()
+    if len(forge_lines) > 1:
+        raise ValueError(
+            f"Found multiple 'forge test' commands in {job} job in {VERIFY_YML}; keep a single command for deterministic checks"
+        )
+    return forge_lines[0]
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- add shared workflow helper to parse executable `run:` commands from a job `steps:` block
- switch Foundry sync checks to validate `forge test` commands from parsed run commands (not raw job regex)
- fail closed when no/ambiguous forge commands are present
- add regression tests proving step-name/comment decoys cannot satisfy command checks

## Why
Open issue/PR queues are empty, so this is a proactive CI-hardening pass with high leverage: it removes a parser-level bypass class where non-executable text could satisfy command checks.

## Validation
- `python3 -m unittest scripts/test_workflow_jobs.py`
- `python3 -m unittest scripts/test_check_verify_foundry_env_sync.py`
- `python3 scripts/check_verify_foundry_job_sync.py`
- `python3 scripts/check_verify_foundry_patched_sync.py`
- `python3 scripts/check_verify_foundry_shard_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CI verification logic by changing how `forge test` commands are detected, which could cause new CI failures if workflows contain multiple or non-standard `run:` commands.
> 
> **Overview**
> Hardens the Foundry verify.yml sync scripts to validate *executable* `run:` commands instead of matching raw job text, preventing step-name/comment “decoys” from satisfying checks.
> 
> Adds `extract_run_commands_from_job_body` in `scripts/workflow_jobs.py` and updates the Foundry job/patched sync checks to require exactly one `forge test` command (failing closed when missing or ambiguous). New unit tests cover decoy step names/comments and the new command extraction behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3e1abc47c399b54057cfef1b259047a5da8621f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->