### PR TITLE
Harden verify build/checks docs sync run parsing

### DIFF
--- a/scripts/test_check_verify_build_docs_sync.py
+++ b/scripts/test_check_verify_build_docs_sync.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from check_verify_build_docs_sync import _extract_workflow_build_commands
+
+
+class VerifyBuildDocsSyncTests(unittest.TestCase):
+    def test_extracts_inline_dash_run_style(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: python3 scripts/check_a.py
+                  - run: echo done
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(_extract_workflow_build_commands(workflow), ["check_a.py"])
+
+    def test_extracts_folded_block_run_commands(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: folded
+                    run: >-
+                      python3 scripts/check_b.py
+                      python3 scripts/check_c.py --strict
+                      echo done
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(
+            _extract_workflow_build_commands(workflow),
+            ["check_b.py", "check_c.py"],
+        )
+
+    def test_extracts_line_continuation_commands(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: continuation
+                    run: |
+                      python3 scripts/check_d.py \\
+                        --strict
+                      echo done
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(_extract_workflow_build_commands(workflow), ["check_d.py"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_verify_checks_docs_sync.py
+++ b/scripts/test_check_verify_checks_docs_sync.py
@@ -14,6 +14,27 @@ from check_verify_checks_docs_sync import _extract_workflow_checks_commands
 
 
 class VerifyChecksDocsSyncTests(unittest.TestCase):
+    def test_extracts_inline_dash_run_style(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              checks:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: python3 scripts/check_inline.py --strict
+                  - run: echo done
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(
+            _extract_workflow_checks_commands(workflow),
+            ["check_inline.py --strict"],
+        )
+
     def test_extracts_single_line_and_block_run_commands(self) -> None:
         workflow = textwrap.dedent(
             """

--- a/scripts/workflow_jobs.py
+++ b/scripts/workflow_jobs.py
@@ -206,7 +206,7 @@ def extract_run_commands_from_job_body(body: str, *, source: Path, context: str)
         indent = len(m.group("indent"))
         payload = m.group("payload")
         block_lines: list[str] = []
-        if payload in {"|", ">"}:
+        if payload.startswith("|") or payload.startswith(">"):
             i += 1
             while i < len(step_lines):
                 nxt = step_lines[i]


### PR DESCRIPTION
## Summary
- route `check_verify_checks_docs_sync.py` and `check_verify_build_docs_sync.py` through `workflow_jobs.extract_run_commands_from_job_body`
- remove duplicated ad-hoc `run:` parsing paths in both scripts
- add regression coverage for inline `- run:` style and add a dedicated build/docs sync parser test suite
- harden shared workflow parser to accept YAML block style indicators beyond bare `|` / `>` (for example `|-` and `>-`)

## Why
These checkers were still using local parsing logic that could diverge from the hardened shared extractor and miss valid workflow forms (`- run:`). Consolidating extraction reduces parser drift and improves fail-closed behavior.

## Validation
- `python3 scripts/test_check_verify_checks_docs_sync.py`
- `python3 scripts/test_check_verify_build_docs_sync.py`
- `python3 scripts/test_workflow_jobs.py`
- `python3 scripts/test_cli_argv_injection.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/docs-sync helper scripts and their parsing logic, with added unit tests to prevent regressions; only potential impact is false positives/negatives in the sync checks.
> 
> **Overview**
> Routes `check_verify_build_docs_sync.py` and `check_verify_checks_docs_sync.py` through the shared `workflow_jobs.extract_run_commands_from_job_body` helper, removing duplicated ad-hoc parsing of `steps:`/`run:` blocks.
> 
> Hardens `extract_run_commands_from_job_body` to recognize YAML block scalar variants like `|-`/`>-` (not just bare `|`/`>`), and adds/expands unit tests to cover inline `- run:` steps, folded blocks, and line continuations (including a new dedicated build/docs sync test suite).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce023bad5bef14e0f4f24af9aa5e7dc617129373. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->