### PR TITLE
Unify verify script-command parser and harden inline comment handling

### DIFF
--- a/scripts/test_check_verify_build_docs_sync.py
+++ b/scripts/test_check_verify_build_docs_sync.py
@@ -77,6 +77,27 @@ class VerifyBuildDocsSyncTests(unittest.TestCase):
 
         self.assertEqual(_extract_workflow_build_commands(workflow), ["check_d.py"])
 
+    def test_extracts_with_inline_comments(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: comments
+                    run: |
+                      # decoy
+                      python3 scripts/check_e.py --strict  # keep strict in workflow only
+                      echo done
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(_extract_workflow_build_commands(workflow), ["check_e.py"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_check_verify_checks_docs_sync.py
+++ b/scripts/test_check_verify_checks_docs_sync.py
@@ -132,6 +132,27 @@ class VerifyChecksDocsSyncTests(unittest.TestCase):
             ["check_f.py --strict"],
         )
 
+    def test_preserves_hash_inside_quotes(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              checks:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: quoted
+                    run: python3 scripts/check_g.py --label "a#b"
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(
+            _extract_workflow_checks_commands(workflow),
+            ['check_g.py --label "a#b"'],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- move `python3 scripts/*` extraction into a shared helper in `scripts/workflow_jobs.py`
- make both verify docs-sync checks (`build` + `checks`) use the same extraction path
- harden parsing for shell inline comments and line continuations in one place
- add regressions for inline-comment handling in build extraction and `#` inside quoted args

## Why
Recent hardening work duplicated parser logic across checks. This drift already caused behavior mismatch (`build` parser did not strip inline comments while `checks` parser did). Centralizing removes that class of inconsistency and makes future parser changes auditable.

## Validation
- `python3 scripts/test_check_verify_build_docs_sync.py`
- `python3 scripts/test_check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`
- `python3 scripts/check_verify_checks_docs_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to CI/docs-sync helper scripts and tests, but could alter which `python3 scripts/*` lines are detected in `verify.yml` (potentially causing new CI failures if parsing differs).
> 
> **Overview**
> Centralizes `python3 scripts/*` command extraction into `scripts/workflow_jobs.py` via new `extract_python_script_commands`, and updates both verify docs-sync checks (`check_verify_build_docs_sync.py` and `check_verify_checks_docs_sync.py`) to use the shared parser (with `build` optionally dropping args).
> 
> The shared parser now consistently handles shell line continuations and strips inline `#` comments while preserving `#` inside quoted arguments, with new regression tests covering inline comments in `build` and quoted-`#` args in `checks`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbee75db5d2975c08d7099adb9174ee87ce02da0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->