### PR TITLE
Harden command-wrapper parsing for combined short options

### DIFF
--- a/scripts/test_check_verify_foundry_env_sync.py
+++ b/scripts/test_check_verify_foundry_env_sync.py
@@ -411,7 +411,7 @@ class FoundryEnvSyncTests(unittest.TestCase):
                     with:
                       name: generated-yul-patched
                       path: compiler/yul-patched
-                  - run: command -p -- /usr/bin/env FOUNDRY_PROFILE=difftest forge test --no-match-test "Random10000"
+                  - run: command -pv -- /usr/bin/env FOUNDRY_PROFILE=difftest forge test --no-match-test "Random10000"
 
               foundry-multi-seed:
                 runs-on: ubuntu-latest
@@ -426,7 +426,7 @@ class FoundryEnvSyncTests(unittest.TestCase):
                     with:
                       name: generated-yul
                       path: compiler/yul
-                  - run: command -- env DIFFTEST_RANDOM_SEED=7 forge test --no-match-test "Random10000"
+                  - run: command -Vp -- env DIFFTEST_RANDOM_SEED=7 forge test --no-match-test "Random10000"
             """
         )
         rc, stderr = self._run_job_sync(workflow)

--- a/scripts/test_workflow_jobs.py
+++ b/scripts/test_workflow_jobs.py
@@ -131,6 +131,15 @@ class WorkflowJobsTests(unittest.TestCase):
         self.assertTrue(matched)
         self.assertEqual(forge_tokens[:2], ["forge", "test"])
 
+    def test_match_shell_command_accepts_combined_command_short_options(self) -> None:
+        matched, forge_tokens = match_shell_command(
+            "command -pv -- env FOUNDRY_PROFILE=difftest forge test",
+            program="forge",
+            args_prefix=("test",),
+        )
+        self.assertTrue(matched)
+        self.assertEqual(forge_tokens[:2], ["forge", "test"])
+
     def test_match_shell_command_accepts_time_wrapper(self) -> None:
         matched, forge_tokens = match_shell_command(
             'time -f "%E" env FOUNDRY_PROFILE=difftest forge test -vv',

--- a/scripts/workflow_jobs.py
+++ b/scripts/workflow_jobs.py
@@ -395,6 +395,14 @@ def _consume_command_wrapper(tokens: list[str], i: int) -> int:
         if tok in {"-p", "-v", "-V"}:
             i += 1
             continue
+        if (
+            len(tok) > 1
+            and tok.startswith("-")
+            and not tok.startswith("--")
+            and set(tok[1:]).issubset({"p", "v", "V"})
+        ):
+            i += 1
+            continue
         break
     return i
 


### PR DESCRIPTION
## Summary
- extend `match_shell_command` command-wrapper parsing to accept combined short options (`-pv`, `-Vp`, etc.)
- keep behavior fail-closed by only accepting combinations of known `command` wrapper flags (`p`, `v`, `V`)
- add regression coverage in wrapper unit tests and foundry-sync integration tests

## Why
Several verify sync checks depend on shared shell wrapper parsing. `command` accepts grouped short flags, but the parser only handled single-token flags (`-p`, `-v`, `-V`). This made checks brittle for valid wrapper forms.

## Validation
- `python3 scripts/test_workflow_jobs.py`
- `python3 scripts/test_check_verify_foundry_env_sync.py`
- `python3 scripts/check_verify_foundry_job_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped parsing change gated to a specific wrapper (`command`) and covered by new regression tests; minimal impact outside CI validation logic.
> 
> **Overview**
> The `match_shell_command`/wrapper parsing now accepts grouped short options for the `command` wrapper (e.g. `command -pv -- …`) while still fail-closing by only allowing combinations of `p`/`v`/`V`.
> 
> Tests are updated/added to cover the combined-flag form in both `workflow_jobs` unit tests and the Foundry verify sync integration fixtures (switching existing examples to `-pv`/`-Vp`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 587b7d76628d0006070d98b6a495374843e0cbe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->