### PR TITLE
Harden workflow command matcher for env -S split-string wrappers

### DIFF
--- a/scripts/test_workflow_jobs.py
+++ b/scripts/test_workflow_jobs.py
@@ -226,6 +226,24 @@ class WorkflowJobsTests(unittest.TestCase):
         self.assertTrue(matched)
         self.assertEqual(forge_tokens[:2], ["forge", "test"])
 
+    def test_match_shell_command_accepts_env_split_string_wrapper(self) -> None:
+        matched, forge_tokens = match_shell_command(
+            "env -S 'FOUNDRY_PROFILE=difftest forge test -vv'",
+            program="forge",
+            args_prefix=("test",),
+        )
+        self.assertTrue(matched)
+        self.assertEqual(forge_tokens[:2], ["forge", "test"])
+
+    def test_match_shell_command_accepts_env_split_string_long_option(self) -> None:
+        matched, forge_tokens = match_shell_command(
+            "env --split-string 'FOUNDRY_PROFILE=difftest forge test --no-match-test Random10000'",
+            program="forge",
+            args_prefix=("test",),
+        )
+        self.assertTrue(matched)
+        self.assertEqual(forge_tokens[:2], ["forge", "test"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/workflow_jobs.py
+++ b/scripts/workflow_jobs.py
@@ -506,6 +506,18 @@ def _consume_env_wrapper(tokens: list[str], i: int) -> int:
             i += 1
             continue
         if not env_options_done and tok in env_opts_with_arg:
+            if tok in {"-S", "--split-string"}:
+                # `env -S 'FOO=1 forge test'` injects split-string tokens as if
+                # they were written in argv directly. Expand in-place so wrapper
+                # normalization can continue on the resulting assignments/command.
+                i += 1
+                if i < len(tokens):
+                    try:
+                        split_tokens = shlex.split(tokens[i], posix=True)
+                    except ValueError:
+                        split_tokens = []
+                    tokens[i : i + 1] = split_tokens
+                continue
             i += 1
             if i < len(tokens):
                 i += 1


### PR DESCRIPTION
## Summary
- teach `match_shell_command` to normalize `env -S` / `env --split-string` wrappers
- expand split-string tokens in-place so env assignments and target commands are matched consistently
- add regression tests for both short and long split-string forms

## Why
Workflow sync checks are intentionally strict but should remain robust to common shell wrapper forms. `env -S` is a valid wrapper form that previously caused false negatives when matching commands like `forge test`.

## Validation
- `python3 scripts/test_workflow_jobs.py`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to shell-wrapper token normalization plus targeted regression tests; main risk is altered matching behavior for unusual `env` invocations.
> 
> **Overview**
> **Improves workflow command matching for `env -S` / `env --split-string`.** The `env` wrapper normalizer now expands the split-string argument in-place (via `shlex.split`) so injected assignments/commands are matched the same as direct argv tokens.
> 
> Adds regression tests to ensure `match_shell_command` correctly recognizes `forge test` when wrapped with both short and long split-string forms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6321577ae5e1dc1132b871cc3d8701dcf7ffcb36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->