### PR TITLE
Handle attached env split-string forms in workflow matcher

### DIFF
--- a/scripts/test_workflow_jobs.py
+++ b/scripts/test_workflow_jobs.py
@@ -244,6 +244,24 @@ class WorkflowJobsTests(unittest.TestCase):
         self.assertTrue(matched)
         self.assertEqual(forge_tokens[:2], ["forge", "test"])
 
+    def test_match_shell_command_accepts_env_split_string_long_option_equals_form(self) -> None:
+        matched, forge_tokens = match_shell_command(
+            "env --split-string='FOUNDRY_PROFILE=difftest forge test -vv'",
+            program="forge",
+            args_prefix=("test",),
+        )
+        self.assertTrue(matched)
+        self.assertEqual(forge_tokens[:2], ["forge", "test"])
+
+    def test_match_shell_command_accepts_env_split_string_short_attached_form(self) -> None:
+        matched, forge_tokens = match_shell_command(
+            "env -S'FOUNDRY_PROFILE=difftest forge test --no-match-test Random10000'",
+            program="forge",
+            args_prefix=("test",),
+        )
+        self.assertTrue(matched)
+        self.assertEqual(forge_tokens[:2], ["forge", "test"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/workflow_jobs.py
+++ b/scripts/workflow_jobs.py
@@ -498,6 +498,7 @@ def _consume_env_wrapper(tokens: list[str], i: int) -> int:
         return i
     i += 1
     env_opts_with_arg = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
+    split_string_long_eq = "--split-string="
     env_options_done = False
     while i < len(tokens):
         tok = tokens[i]
@@ -521,6 +522,32 @@ def _consume_env_wrapper(tokens: list[str], i: int) -> int:
             i += 1
             if i < len(tokens):
                 i += 1
+            continue
+        if not env_options_done and tok.startswith(split_string_long_eq):
+            try:
+                split_tokens = shlex.split(tok[len(split_string_long_eq) :], posix=True)
+            except ValueError:
+                split_tokens = []
+            tokens[i : i + 1] = split_tokens
+            continue
+        if not env_options_done and tok.startswith("-S") and tok != "-S":
+            try:
+                split_tokens = shlex.split(tok[2:], posix=True)
+            except ValueError:
+                split_tokens = []
+            tokens[i : i + 1] = split_tokens
+            continue
+        if (
+            not env_options_done
+            and (tok.startswith("--unset=") or tok.startswith("--chdir="))
+        ):
+            i += 1
+            continue
+        if not env_options_done and tok.startswith("-u") and tok != "-u":
+            i += 1
+            continue
+        if not env_options_done and tok.startswith("-C") and tok != "-C":
+            i += 1
             continue
         if not env_options_done and tok.startswith("-"):
             i += 1


### PR DESCRIPTION
## Summary
- handle attached env split-string forms in `match_shell_command` parsing
- normalize `env --split-string=...` and `env -S...` the same way as separated `-S '...'`
- add regression tests for both attached forms

## Why
Workflow sync checks should remain robust across equivalent shell spellings. Attached split-string forms were previously missed, causing false negatives in wrapper normalization.

## Validation
- `python3 scripts/test_workflow_jobs.py`
- `python3 scripts/test_check_verify_foundry_env_sync.py`
- `python3 scripts/check_verify_foundry_job_sync.py`
- `python3 scripts/check_verify_foundry_patched_sync.py`

Closes #922

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-scoped changes to workflow command parsing plus regression tests; impact is limited to CI/workflow verification scripts.
> 
> **Overview**
> Improves `match_shell_command`’s `env` wrapper parsing to recognize attached option forms, especially `env --split-string=...` and `env -S...`, expanding split-string payloads into tokens the same way as the spaced `-S '...'` form.
> 
> Also adds coverage in `scripts/test_workflow_jobs.py` to prevent regressions for both attached split-string spellings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7ddb694a1b99c9304d716d40749a1f2d4ee2676. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->