### PR TITLE
feat: Stmt.safeTransfer and Stmt.safeTransferFrom

### DIFF
--- a/Verity/Proofs/Stdlib/SpecInterpreter.lean
+++ b/Verity/Proofs/Stdlib/SpecInterpreter.lean
@@ -536,6 +536,10 @@ def stmtUsesUnsupportedLowLevel : Stmt → Bool
       exprListUsesUnsupportedLowLevel args
   | Stmt.externalCallWithReturn _ target _ args _ =>
       exprUsesUnsupportedLowLevel target || exprListUsesUnsupportedLowLevel args
+  | Stmt.safeTransfer token to amount =>
+      exprUsesUnsupportedLowLevel token || exprUsesUnsupportedLowLevel to || exprUsesUnsupportedLowLevel amount
+  | Stmt.safeTransferFrom token fromAddr to amount =>
+      exprUsesUnsupportedLowLevel token || exprUsesUnsupportedLowLevel fromAddr || exprUsesUnsupportedLowLevel to || exprUsesUnsupportedLowLevel amount
   | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _ | Stmt.stop =>
       false
 
@@ -775,6 +779,12 @@ def execStmt (ctx : EvalContext) (fields : List Field) (paramNames : List String
   | Stmt.externalCallWithReturn _resultVar _target _selector _args _isStatic =>
       -- ABI-encoded external calls require linked Yul; not modeled in basic interpreter.
       none
+  | Stmt.safeTransfer _token _to _amount =>
+      -- ERC20 safe transfers require linked Yul; not modeled in basic interpreter.
+      none
+  | Stmt.safeTransferFrom _token _from _to _amount =>
+      -- ERC20 safe transfers require linked Yul; not modeled in basic interpreter.
+      none
 
 -- Execute a list of statements sequentially
 -- Thread both context and state through the computation
@@ -875,6 +885,12 @@ def execStmtsFuel (fuel : Nat) (ctx : EvalContext) (fields : List Field) (paramN
               none
           | Stmt.externalCallWithReturn _resultVar _target _selector _args _isStatic =>
               -- ABI-encoded external calls require linked Yul; not modeled in fuel-based interpreter.
+              none
+          | Stmt.safeTransfer _token _to _amount =>
+              -- ERC20 safe transfers require linked Yul; not modeled in fuel-based interpreter.
+              none
+          | Stmt.safeTransferFrom _token _from _to _amount =>
+              -- ERC20 safe transfers require linked Yul; not modeled in fuel-based interpreter.
               none
           | other => execStmt ctx fields paramNames externalFns state other
         match result with


### PR DESCRIPTION
## Summary

- Adds `Stmt.safeTransfer` for ERC20 `transfer(address,uint256)` with safe return handling
- Adds `Stmt.safeTransferFrom` for ERC20 `transferFrom(address,address,uint256)` with safe return handling
- Both generate the standard safe transfer pattern: ABI-encode calldata, `call(gas(), token, ...)`, revert on failure, handle optional bool return for non-standard tokens

## Motivation

The morpho-verity codebase currently uses 9 hand-written Yul shims for core operations (supply, withdraw, borrow, repay, etc.). All of these require ERC20 token transfers. By adding first-class `Stmt.safeTransfer` / `Stmt.safeTransferFrom` to the Verity DSL, morpho-verity can eliminate the raw Yul shim for safe transfer patterns and express them declaratively.

## Implementation

Each variant generates Yul that:
1. Stores the function selector at memory[0] (`0xa9059cbb` for transfer, `0x23b872dd` for transferFrom)
2. Stores arguments at sequential 32-byte offsets (memory[4], memory[36], etc.)
3. Calls the token with `call(gas(), token, 0, 0, calldataSize, 0, 32)`
4. Reverts with `Error(string)` encoding on call failure
5. Checks optional bool return: if `returndatasize() == 32 && mload(0) == 0`, reverts with descriptive message

Pattern matches added to all 13 required locations (10 in ContractSpec.lean, 3 in SpecInterpreter.lean).

## Test plan

- [x] `safeTransfer` compilation test: verifies selector, call pattern, revert messages, returndatasize check
- [x] `safeTransferFrom` compilation test: verifies selector, call pattern, revert messages, returndatasize check
- [x] View function rejection test: verifies `safeTransfer` is rejected in `isView` functions
- [x] Full `lake build` passes (103/103 modules)
- [x] Full `lake build Compiler.ContractSpecFeatureTest` passes (all assertions green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compiler codegen/validation for external-call-like behavior; incorrect calldata layout or return-value handling could produce wrong runtime behavior or unexpected reverts for generated contracts.
> 
> **Overview**
> Adds new DSL statements `Stmt.safeTransfer` and `Stmt.safeTransferFrom` to express ERC20 transfers without hand-written Yul.
> 
> The compiler now lowers these statements to ABI-encoded `call(gas(), token, ...)` sequences with revert-forwarding and *optional bool return* handling (revert on call failure or explicit `false`). All relevant analysis/validation passes are extended to account for the new statement shapes (name collection, scope validation, mutability checks, interop/external-target validation, array-element use).
> 
> Updates the `SpecInterpreter` to treat these statements as unsupported (like other linked-Yul operations), and adds feature tests asserting the generated Yul contains the expected selectors, call pattern, revert encodings, and that `safeTransfer` is rejected in `view` functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15b3f987c941f0b3f15375b7965119e237f144fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->