### PR TITLE
feat: add Expr.extcodesize for contract code size queries

### DIFF
--- a/Verity/Proofs/Stdlib/SpecInterpreter.lean
+++ b/Verity/Proofs/Stdlib/SpecInterpreter.lean
@@ -341,6 +341,9 @@ def evalExpr (ctx : EvalContext) (storage : SpecStorage) (fields : List Field) (
   | Expr.contractAddress =>
       -- Contract address is not modeled in the scalar interpreter.
       0
+  | Expr.extcodesize _ =>
+      -- Extcodesize is not modeled in the scalar interpreter.
+      0
   | Expr.chainid =>
       -- chainid is not modeled in the scalar interpreter.
       0
@@ -471,7 +474,7 @@ end
 
 mutual
 def exprUsesUnsupportedLowLevel : Expr → Bool
-  | Expr.contractAddress | Expr.chainid => true
+  | Expr.contractAddress | Expr.chainid | Expr.extcodesize _ => true
   | Expr.mload _ | Expr.keccak256 _ _ => true
   | Expr.call _ _ _ _ _ _ _ => true
   | Expr.staticcall _ _ _ _ _ _ => true


### PR DESCRIPTION
## Summary
- Adds `Expr.extcodesize (addr : Expr)` to the ContractSpec DSL, compiling to the Yul `extcodesize(addr)` builtin
- This expression is used 12 times in morpho-verity raw Yul shims for "require contract has code" guards before external calls (e.g., `if iszero(extcodesize(token)) { revert(0,0) }`)
- Wired into all 10 traversal/validation functions in ContractSpec.lean and 2 functions in SpecInterpreter.lean

## Test plan
- [x] `extcodesize(addr)` compiles to correct Yul builtin
- [x] Works inside `Stmt.require` guard (the primary use case)
- [x] Accepted in `view` functions (reads blockchain state, doesn't write)
- [x] Nested expression `extcodesize(address())` compiles correctly
- [x] Correctly rejected in `pure` functions (reads environment state)
- [x] All 103 modules build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple compiler traversal/validation paths; while the change is mechanically simple, any missed integration could cause miscompilations or incorrect purity/state-effect classification.
> 
> **Overview**
> Adds a new ContractSpec DSL expression, `Expr.extcodesize addr`, to query deployed code size and compile directly to the Yul builtin `extcodesize(addr)`.
> 
> Wires this new expression through the compiler’s name collection, expression compilation, purity/view/state read-write analyses, and multiple validation/traversal passes, and updates the scalar `SpecInterpreter` to treat it as unsupported/unmodeled (evaluates to `0`). Adds feature tests that validate Yul emission and that `extcodesize` is allowed in `view` but rejected in `pure` functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ba0816a0b65c7b31657ec863a807621e83ce86e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->