### PR TITLE
feat: Expr.calldatasize, Expr.calldataload, Stmt.calldatacopy for calldata access

### DIFF
--- a/Verity/Proofs/Stdlib/SpecInterpreter.lean
+++ b/Verity/Proofs/Stdlib/SpecInterpreter.lean
@@ -364,6 +364,12 @@ def evalExpr (ctx : EvalContext) (storage : SpecStorage) (fields : List Field) (
   | Expr.delegatecall _gas _target _inOffset _inSize _outOffset _outSize =>
       -- Low-level call semantics are not modeled in the scalar SpecInterpreter yet.
       0
+  | Expr.calldatasize =>
+      -- Calldata access is not modeled in the scalar SpecInterpreter yet.
+      0
+  | Expr.calldataload _offset =>
+      -- Calldata access is not modeled in the scalar SpecInterpreter yet.
+      0
   | Expr.returndataSize =>
       -- Returndata buffers are not modeled in the scalar SpecInterpreter yet.
       0
@@ -475,6 +481,8 @@ end
 mutual
 def exprUsesUnsupportedLowLevel : Expr → Bool
   | Expr.contractAddress | Expr.chainid | Expr.extcodesize _ => true
+  | Expr.calldatasize => true
+  | Expr.calldataload _ => true
   | Expr.mload _ | Expr.keccak256 _ _ => true
   | Expr.call _ _ _ _ _ _ _ => true
   | Expr.staticcall _ _ _ _ _ _ => true
@@ -520,6 +528,8 @@ def stmtUsesUnsupportedLowLevel : Stmt → Bool
   | Stmt.revertError _ args | Stmt.emit _ args | Stmt.returnValues args =>
       exprListUsesUnsupportedLowLevel args
   | Stmt.mstore _ _ =>
+      true
+  | Stmt.calldatacopy _ _ _ =>
       true
   | Stmt.returndataCopy _ _ _ | Stmt.revertReturndata =>
       true
@@ -733,6 +743,10 @@ def execStmt (ctx : EvalContext) (fields : List Field) (paramNames : List String
   | Stmt.mstore _offset _value =>
       -- Memory writes are not modeled in the scalar SpecInterpreter.
       none
+
+  | Stmt.calldatacopy _destOffset _sourceOffset _size =>
+      -- Calldata copy to memory is not modeled in the scalar SpecInterpreter.
+      some (ctx, state)
 
   | Stmt.returndataCopy _destOffset _sourceOffset _size =>
       -- Returndata memory effects are not modeled in the scalar SpecInterpreter.


### PR DESCRIPTION
## Summary

- Adds **Expr.calldatasize** — zero-arg expression returning `calldatasize()`, the byte length of the current call's calldata
- Adds **Expr.calldataload(offset)** — loads a 32-byte word from calldata at the given byte offset (`calldataload(offset)`)
- Adds **Stmt.calldatacopy(destOffset, sourceOffset, size)** — copies `size` bytes from calldata at `sourceOffset` to memory at `destOffset`

These three primitives are the most impactful missing features for converting Morpho Blue's raw Yul shims to proper ContractSpec DSL. They are used across **all 9 Morpho Blue operations** (77 calldataload usages, 24 calldatasize usages, 5 calldatacopy usages).

## Implementation

- Added variants to `Expr` and `Stmt` inductive types in ContractSpec.lean
- Updated all 20+ pattern-match functions: `collectExprNames`, `collectStmtNames`, `compileExpr`, `compileStmt`, `exprContainsUnsafeLogicalCallLike`, `stmtContainsUnsafeLogicalCallLike`, `validateScopedExprIdentifiers`, `validateScopedStmtIdentifiers`, `exprReadsStateOrEnv`, `stmtReadsStateOrEnv`, `stmtWritesState`, `exprWritesState`, `validateInteropExpr`, `validateInteropStmt`, `validateInternalCallShapesInExpr`, `validateInternalCallShapesInStmt`, `validateExternalCallTargetsInExpr`, `validateExternalCallTargetsInStmt`, `exprUsesArrayElement`, `stmtUsesArrayElement`
- Updated SpecInterpreter.lean (evalExpr, exprUsesUnsupportedLowLevel, stmtUsesUnsupportedLowLevel, execStmt)
- Added comprehensive tests verifying: correct Yul opcode emission, pure function rejection for calldatasize, view function acceptance for calldataload, SpecInterpreter low-level marking

## Test plan

- [x] `lake build` passes (all 103 compilation units)
- [x] All existing tests pass (no regressions)
- [x] New tests verify calldatasize/calldataload/calldatacopy compile to correct Yul
- [x] Pure function with calldatasize correctly rejected
- [x] View function with calldataload correctly accepted
- [x] SpecInterpreter correctly handles calldata access specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core DSL AST and many cross-cutting validation/codegen passes, so regressions could impact compilation or purity/view checks across contracts, though behavior is mostly additive and well-tested.
> 
> **Overview**
> Adds first-class calldata access to the ContractSpec DSL via `Expr.calldatasize`, `Expr.calldataload(offset)`, and `Stmt.calldatacopy(dest, src, size)`, and wires them through codegen/analysis/validation so they compile to the expected Yul opcodes.
> 
> Updates the scalar `SpecInterpreter` to recognize these as unsupported low-level operations (returning `0` / skipping memory effects), and adds feature tests covering Yul emission plus purity/view-mode restrictions (e.g., rejecting calldata ops in `pure` functions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d1cd0778d25f067540fb65ef7b3aaea07afb821. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->