### PR TITLE
feat: Expr.mapping2Word + Stmt.setMapping2Word for double mapping + word offset

### DIFF
--- a/Compiler/ContractSpec.lean
+++ b/Compiler/ContractSpec.lean
@@ -203,6 +203,7 @@ inductive Expr
   | mappingWord (field : String) (key : Expr) (wordOffset : Nat)  -- mappingSlot(base,key) + wordOffset
   | mappingPackedWord (field : String) (key : Expr) (wordOffset : Nat) (packed : PackedBits)
   | mapping2 (field : String) (key1 key2 : Expr)  -- Double mapping (#154)
+  | mapping2Word (field : String) (key1 key2 : Expr) (wordOffset : Nat)  -- Double mapping + word offset
   | mappingUint (field : String) (key : Expr)  -- Uint256-keyed mapping (#154)
   | caller
   | contractAddress
@@ -283,6 +284,7 @@ inductive Stmt
   | setMappingWord (field : String) (key : Expr) (wordOffset : Nat) (value : Expr)  -- mappingSlot(base,key)+wordOffset write
   | setMappingPackedWord (field : String) (key : Expr) (wordOffset : Nat) (packed : PackedBits) (value : Expr)
   | setMapping2 (field : String) (key1 key2 : Expr) (value : Expr)  -- Double mapping write (#154)
+  | setMapping2Word (field : String) (key1 key2 : Expr) (wordOffset : Nat) (value : Expr)  -- Double mapping + word offset write
   | setMappingUint (field : String) (key : Expr) (value : Expr)  -- Uint256-keyed mapping write (#154)
   | require (cond : Expr) (message : String)
   | requireError (cond : Expr) (errorName : String) (args : List Expr)
@@ -570,6 +572,7 @@ private partial def collectExprNames : Expr → List String
   | Expr.mappingWord field key _ => field :: collectExprNames key
   | Expr.mappingPackedWord field key _ _ => field :: collectExprNames key
   | Expr.mapping2 field key1 key2 => field :: collectExprNames key1 ++ collectExprNames key2
+  | Expr.mapping2Word field key1 key2 _ => field :: collectExprNames key1 ++ collectExprNames key2
   | Expr.mappingUint field key => field :: collectExprNames key
   | Expr.caller => []
   | Expr.contractAddress => []
@@ -636,6 +639,8 @@ private partial def collectStmtNames : Stmt → List String
   | Stmt.setMappingWord field key _ value => field :: collectExprNames key ++ collectExprNames value
   | Stmt.setMappingPackedWord field key _ _ value => field :: collectExprNames key ++ collectExprNames value
   | Stmt.setMapping2 field key1 key2 value =>
+    field :: collectExprNames key1 ++ collectExprNames key2 ++ collectExprNames value
+  | Stmt.setMapping2Word field key1 key2 _ value =>
     field :: collectExprNames key1 ++ collectExprNames key2 ++ collectExprNames value
   | Stmt.setMappingUint field key value => field :: collectExprNames key ++ collectExprNames value
   | Stmt.require cond _ => collectExprNames cond
@@ -734,6 +739,19 @@ def compileExpr (fields : List Field)
         let key2Expr ← compileExpr fields dynamicSource key2
         let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
         pure (YulExpr.call "sload" [YulExpr.call "mappingSlot" [innerSlot, key2Expr]])
+      | none => throw s!"Compilation error: unknown mapping field '{field}'"
+  | Expr.mapping2Word field key1 key2 wordOffset =>
+    if !isMapping2 fields field then
+      throw s!"Compilation error: field '{field}' is not a double mapping"
+    else
+      match findFieldSlot fields field with
+      | some slot => do
+        let key1Expr ← compileExpr fields dynamicSource key1
+        let key2Expr ← compileExpr fields dynamicSource key2
+        let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
+        let outerSlot := YulExpr.call "mappingSlot" [innerSlot, key2Expr]
+        let finalSlot := if wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
+        pure (YulExpr.call "sload" [finalSlot])
       | none => throw s!"Compilation error: unknown mapping field '{field}'"
   | Expr.mappingUint field key => do
       compileMappingSlotRead fields field (← compileExpr fields dynamicSource key) "mappingUint"
@@ -1020,7 +1038,7 @@ private partial def exprContainsCallLike (expr : Expr) : Bool :=
   | Expr.externalCall _ _ | Expr.internalCall _ _ => true
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key =>
       exprContainsCallLike key
-  | Expr.mapping2 _ key1 key2 =>
+  | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _ =>
       exprContainsCallLike key1 || exprContainsCallLike key2
   | Expr.arrayElement _ index =>
       exprContainsCallLike index
@@ -1093,7 +1111,7 @@ private partial def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
       args.any exprContainsUnsafeLogicalCallLike
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key =>
       exprContainsUnsafeLogicalCallLike key
-  | Expr.mapping2 _ key1 key2 =>
+  | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _ =>
       exprContainsUnsafeLogicalCallLike key1 || exprContainsUnsafeLogicalCallLike key2
   | Expr.arrayElement _ index | Expr.returndataOptionalBoolAt index =>
       exprContainsUnsafeLogicalCallLike index
@@ -1135,7 +1153,7 @@ private partial def stmtContainsUnsafeLogicalCallLike : Stmt → Bool
       false
   | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value =>
       exprContainsUnsafeLogicalCallLike key || exprContainsUnsafeLogicalCallLike value
-  | Stmt.setMapping2 _ key1 key2 value =>
+  | Stmt.setMapping2 _ key1 key2 value | Stmt.setMapping2Word _ key1 key2 _ value =>
       exprContainsUnsafeLogicalCallLike key1 ||
       exprContainsUnsafeLogicalCallLike key2 ||
       exprContainsUnsafeLogicalCallLike value
@@ -1258,7 +1276,7 @@ private partial def validateScopedExprIdentifiers
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key =>
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount key
-  | Expr.mapping2 _ key1 key2 => do
+  | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _ => do
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount key1
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount key2
   | Expr.call gas target value inOffset inSize outOffset outSize => do
@@ -1350,7 +1368,7 @@ private partial def validateScopedStmtIdentifiers
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount key
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount value
       pure localScope
-  | Stmt.setMapping2 _ key1 key2 value => do
+  | Stmt.setMapping2 _ key1 key2 value | Stmt.setMapping2Word _ key1 key2 _ value => do
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount key1
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount key2
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount value
@@ -1581,7 +1599,7 @@ private partial def exprReadsStateOrEnv : Expr → Bool
   | Expr.mapping _ key => exprReadsStateOrEnv key || true
   | Expr.mappingWord _ key _ => exprReadsStateOrEnv key || true
   | Expr.mappingPackedWord _ key _ _ => exprReadsStateOrEnv key || true
-  | Expr.mapping2 _ key1 key2 => exprReadsStateOrEnv key1 || exprReadsStateOrEnv key2 || true
+  | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _ => exprReadsStateOrEnv key1 || exprReadsStateOrEnv key2 || true
   | Expr.mappingUint _ key => exprReadsStateOrEnv key || true
   | Expr.caller => true
   | Expr.contractAddress => true
@@ -1631,7 +1649,7 @@ private partial def stmtWritesState : Stmt → Bool
       exprWritesState value || true
   | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value =>
       exprWritesState key || exprWritesState value || true
-  | Stmt.setMapping2 _ key1 key2 value =>
+  | Stmt.setMapping2 _ key1 key2 value | Stmt.setMapping2Word _ key1 key2 _ value =>
       exprWritesState key1 || exprWritesState key2 || exprWritesState value || true
   | Stmt.require cond _ =>
       exprWritesState cond
@@ -1694,7 +1712,7 @@ where
         exprWritesState a
     | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key =>
         exprWritesState key
-    | Expr.mapping2 _ key1 key2 =>
+    | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _ =>
         exprWritesState key1 || exprWritesState key2
     | Expr.call gas target value inOffset inSize outOffset outSize =>
         exprWritesState gas || exprWritesState target || exprWritesState value ||
@@ -1749,7 +1767,7 @@ private partial def stmtReadsStateOrEnv : Stmt → Bool
       false
   | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value =>
       exprReadsStateOrEnv key || exprReadsStateOrEnv value || true
-  | Stmt.setMapping2 _ key1 key2 value =>
+  | Stmt.setMapping2 _ key1 key2 value | Stmt.setMapping2Word _ key1 key2 _ value =>
       exprReadsStateOrEnv key1 || exprReadsStateOrEnv key2 || exprReadsStateOrEnv value || true
   | Stmt.ite cond thenBranch elseBranch =>
       exprReadsStateOrEnv cond || thenBranch.any stmtReadsStateOrEnv || elseBranch.any stmtReadsStateOrEnv
@@ -2305,7 +2323,7 @@ private partial def validateInteropExpr (context : String) : Expr → Except Str
   | Expr.mapping _ key => validateInteropExpr context key
   | Expr.mappingWord _ key _ => validateInteropExpr context key
   | Expr.mappingPackedWord _ key _ _ => validateInteropExpr context key
-  | Expr.mapping2 _ key1 key2 => do
+  | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _ => do
       validateInteropExpr context key1
       validateInteropExpr context key2
   | Expr.mappingUint _ key => validateInteropExpr context key
@@ -2354,7 +2372,7 @@ private partial def validateInteropStmt (context : String) : Stmt → Except Str
   | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value => do
       validateInteropExpr context key
       validateInteropExpr context value
-  | Stmt.setMapping2 _ key1 key2 value => do
+  | Stmt.setMapping2 _ key1 key2 value | Stmt.setMapping2Word _ key1 key2 _ value => do
       validateInteropExpr context key1
       validateInteropExpr context key2
       validateInteropExpr context value
@@ -2523,7 +2541,7 @@ private partial def validateInternalCallShapesInExpr
       validateInternalCallShapesInExpr functions callerName key
   | Expr.mappingPackedWord _ key _ _ =>
       validateInternalCallShapesInExpr functions callerName key
-  | Expr.mapping2 _ key1 key2 => do
+  | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _ => do
       validateInternalCallShapesInExpr functions callerName key1
       validateInternalCallShapesInExpr functions callerName key2
   | Expr.mappingUint _ key =>
@@ -2572,7 +2590,7 @@ private partial def validateInternalCallShapesInStmt
   | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value => do
       validateInternalCallShapesInExpr functions callerName key
       validateInternalCallShapesInExpr functions callerName value
-  | Stmt.setMapping2 _ key1 key2 value => do
+  | Stmt.setMapping2 _ key1 key2 value | Stmt.setMapping2Word _ key1 key2 _ value => do
       validateInternalCallShapesInExpr functions callerName key1
       validateInternalCallShapesInExpr functions callerName key2
       validateInternalCallShapesInExpr functions callerName value
@@ -2703,7 +2721,7 @@ private partial def validateExternalCallTargetsInExpr
       validateExternalCallTargetsInExpr externals context key
   | Expr.mappingPackedWord _ key _ _ =>
       validateExternalCallTargetsInExpr externals context key
-  | Expr.mapping2 _ key1 key2 => do
+  | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _ => do
       validateExternalCallTargetsInExpr externals context key1
       validateExternalCallTargetsInExpr externals context key2
   | Expr.mappingUint _ key =>
@@ -2754,7 +2772,7 @@ private partial def validateExternalCallTargetsInStmt
   | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value => do
       validateExternalCallTargetsInExpr externals context key
       validateExternalCallTargetsInExpr externals context value
-  | Stmt.setMapping2 _ key1 key2 value => do
+  | Stmt.setMapping2 _ key1 key2 value | Stmt.setMapping2Word _ key1 key2 _ value => do
       validateExternalCallTargetsInExpr externals context key1
       validateExternalCallTargetsInExpr externals context key2
       validateExternalCallTargetsInExpr externals context value
@@ -3415,6 +3433,36 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
                 )
               ]
       | none => throw s!"Compilation error: unknown mapping field '{field}' in setMapping2"
+  | Stmt.setMapping2Word field key1 key2 wordOffset value =>
+    if !isMapping2 fields field then
+      throw s!"Compilation error: field '{field}' is not a double mapping"
+    else
+      match findFieldWriteSlots fields field with
+      | some slots => do
+          let key1Expr ← compileExpr fields dynamicSource key1
+          let key2Expr ← compileExpr fields dynamicSource key2
+          let valueExpr ← compileExpr fields dynamicSource value
+          match slots with
+          | [] =>
+              throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in setMapping2Word"
+          | [slot] =>
+              let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
+              let outerSlot := YulExpr.call "mappingSlot" [innerSlot, key2Expr]
+              let finalSlot := if wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
+              pure [
+                YulStmt.expr (YulExpr.call "sstore" [finalSlot, valueExpr])
+              ]
+          | _ =>
+              pure [
+                YulStmt.block (
+                  [YulStmt.let_ "__compat_key1" key1Expr, YulStmt.let_ "__compat_key2" key2Expr, YulStmt.let_ "__compat_value" valueExpr] ++
+                  slots.map (fun slot =>
+                    let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
+                    let outerSlot := YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"]
+                    let finalSlot := if wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
+                    YulStmt.expr (YulExpr.call "sstore" [finalSlot, YulExpr.ident "__compat_value"])))
+              ]
+      | none => throw s!"Compilation error: unknown mapping field '{field}' in setMapping2Word"
   | Stmt.setMappingUint field key value => do
       compileMappingSlotWrite fields field
         (← compileExpr fields dynamicSource key)
@@ -4406,7 +4454,7 @@ private partial def exprUsesArrayElement : Expr → Bool
   | Expr.mapping _ key => exprUsesArrayElement key
   | Expr.mappingWord _ key _ => exprUsesArrayElement key
   | Expr.mappingPackedWord _ key _ _ => exprUsesArrayElement key
-  | Expr.mapping2 _ key1 key2 => exprUsesArrayElement key1 || exprUsesArrayElement key2
+  | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _ => exprUsesArrayElement key1 || exprUsesArrayElement key2
   | Expr.mappingUint _ key => exprUsesArrayElement key
   | Expr.call gas target value inOffset inSize outOffset outSize =>
       exprUsesArrayElement gas || exprUsesArrayElement target || exprUsesArrayElement value ||
@@ -4458,7 +4506,7 @@ private partial def stmtUsesArrayElement : Stmt → Bool
       exprUsesArrayElement destOffset || exprUsesArrayElement sourceOffset || exprUsesArrayElement size
   | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value =>
       exprUsesArrayElement key || exprUsesArrayElement value
-  | Stmt.setMapping2 _ key1 key2 value =>
+  | Stmt.setMapping2 _ key1 key2 value | Stmt.setMapping2Word _ key1 key2 _ value =>
       exprUsesArrayElement key1 || exprUsesArrayElement key2 || exprUsesArrayElement value
   | Stmt.ite cond thenBranch elseBranch =>
       exprUsesArrayElement cond || thenBranch.any stmtUsesArrayElement || elseBranch.any stmtUsesArrayElement

--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -5726,5 +5726,174 @@ private def viewCalldataloadSpec : ContractSpec := {
   let _result := interpretSpec spec initialStorage tx
   -- calldatasize/calldataload are unsupported low-level, so the interpreter should skip
   IO.println s!"✓ SpecInterpreter handles calldata access specs (low-level unsupported path)"
+-- ============ mapping2Word / setMapping2Word ============
+
+-- Test: mapping2Word read compiles to sload(add(mappingSlot(mappingSlot(slot, key1), key2), wordOffset))
+#eval! do
+  let mapping2WordSpec : ContractSpec := {
+    name := "Mapping2WordSpec"
+    fields := [
+      { name := "positions", ty := FieldType.mappingTyped (MappingType.nested MappingKeyType.uint256 MappingKeyType.address), slot := some 3 }
+    ]
+    constructor := none
+    functions := [
+      { name := "getBalance"
+        params := [{ name := "id", ty := ParamType.uint256 }, { name := "user", ty := ParamType.address }]
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.mapping2Word "positions" (Expr.param "id") (Expr.param "user") 1)]
+      },
+      { name := "setBalance"
+        params := [{ name := "id", ty := ParamType.uint256 }, { name := "user", ty := ParamType.address }, { name := "amount", ty := ParamType.uint256 }]
+        returnType := none
+        body := [Stmt.setMapping2Word "positions" (Expr.param "id") (Expr.param "user") 1 (Expr.param "amount"), Stmt.stop]
+      }
+    ]
+    events := []
+  }
+  match compile mapping2WordSpec [1, 2] with
+  | .error err =>
+      throw (IO.userError s!"✗ mapping2Word compile failed: {err}")
+  | .ok ir =>
+      let rendered := Yul.render (emitYul ir)
+      assertContains "mapping2Word read lowers to nested mappingSlot + wordOffset" rendered
+        ["sload(add(mappingSlot(mappingSlot(3, id), user), 1))"]
+      assertContains "setMapping2Word write lowers to nested mappingSlot + wordOffset" rendered
+        ["sstore(add(mappingSlot(mappingSlot(3, id), user), 1), amount)"]
+
+-- Test: mapping2Word with wordOffset 0 omits the add
+#eval! do
+  let mapping2WordZeroSpec : ContractSpec := {
+    name := "Mapping2WordZeroSpec"
+    fields := [
+      { name := "positions", ty := FieldType.mappingTyped (MappingType.nested MappingKeyType.uint256 MappingKeyType.address), slot := some 3 }
+    ]
+    constructor := none
+    functions := [
+      { name := "getBase"
+        params := [{ name := "id", ty := ParamType.uint256 }, { name := "user", ty := ParamType.address }]
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.mapping2Word "positions" (Expr.param "id") (Expr.param "user") 0)]
+      }
+    ]
+    events := []
+  }
+  match compile mapping2WordZeroSpec [1] with
+  | .error err =>
+      throw (IO.userError s!"✗ mapping2Word zero offset compile failed: {err}")
+  | .ok ir =>
+      let rendered := Yul.render (emitYul ir)
+      assertContains "mapping2Word with offset 0 omits add" rendered
+        ["sload(mappingSlot(mappingSlot(3, id), user))"]
+      -- Ensure the add variant is NOT present
+      if contains rendered "add(mappingSlot(mappingSlot(3, id), user), 0)" then
+        throw (IO.userError "✗ mapping2Word with offset 0 should not emit add(..., 0)")
+      IO.println "✓ mapping2Word with offset 0 correctly omits add"
+
+-- Test: setMapping2Word with alias slots writes to both canonical and alias
+#eval! do
+  let mapping2WordAliasSpec : ContractSpec := {
+    name := "Mapping2WordAliasSpec"
+    fields := [
+      { name := "positions", ty := FieldType.mappingTyped (MappingType.nested MappingKeyType.uint256 MappingKeyType.address), slot := some 3, aliasSlots := [15] }
+    ]
+    constructor := none
+    functions := [
+      { name := "setBalance"
+        params := [{ name := "id", ty := ParamType.uint256 }, { name := "user", ty := ParamType.address }, { name := "amount", ty := ParamType.uint256 }]
+        returnType := none
+        body := [Stmt.setMapping2Word "positions" (Expr.param "id") (Expr.param "user") 1 (Expr.param "amount"), Stmt.stop]
+      }
+    ]
+    events := []
+  }
+  match compile mapping2WordAliasSpec [1] with
+  | .error err =>
+      throw (IO.userError s!"✗ mapping2Word alias compile failed: {err}")
+  | .ok ir =>
+      let rendered := Yul.render (emitYul ir)
+      assertContains "setMapping2Word alias mirror writes include canonical and alias slots" rendered
+        ["sstore(add(mappingSlot(mappingSlot(3, __compat_key1), __compat_key2), 1), __compat_value)",
+         "sstore(add(mappingSlot(mappingSlot(15, __compat_key1), __compat_key2), 1), __compat_value)"]
+
+-- Test: mapping2Word view function allowed, pure function rejected
+#eval! do
+  let mapping2WordViewSpec : ContractSpec := {
+    name := "Mapping2WordViewSpec"
+    fields := [
+      { name := "positions", ty := FieldType.mappingTyped (MappingType.nested MappingKeyType.uint256 MappingKeyType.address), slot := some 3 }
+    ]
+    constructor := none
+    functions := [
+      { name := "getBalance"
+        params := [{ name := "id", ty := ParamType.uint256 }, { name := "user", ty := ParamType.address }]
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.mapping2Word "positions" (Expr.param "id") (Expr.param "user") 1)]
+        isView := true
+      }
+    ]
+    events := []
+  }
+  match compile mapping2WordViewSpec [1] with
+  | .error _ => throw (IO.userError "✗ mapping2Word view function should compile")
+  | .ok _ => IO.println "✓ mapping2Word allowed in view function"
+
+  let mapping2WordPureSpec : ContractSpec := {
+    name := "Mapping2WordPureSpec"
+    fields := [
+      { name := "positions", ty := FieldType.mappingTyped (MappingType.nested MappingKeyType.uint256 MappingKeyType.address), slot := some 3 }
+    ]
+    constructor := none
+    functions := [
+      { name := "getBalance"
+        params := [{ name := "id", ty := ParamType.uint256 }, { name := "user", ty := ParamType.address }]
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.mapping2Word "positions" (Expr.param "id") (Expr.param "user") 1)]
+        isPure := true
+      }
+    ]
+    events := []
+  }
+  match compile mapping2WordPureSpec [1] with
+  | .error _ => IO.println "✓ mapping2Word correctly rejected in pure function"
+  | .ok _ => throw (IO.userError "✗ mapping2Word should be rejected in pure function")
+
+-- Test: SpecInterpreter for mapping2Word read/write
+#eval! do
+  let mapping2WordInterpSpec : ContractSpec := {
+    name := "Mapping2WordInterpSpec"
+    fields := [
+      { name := "positions", ty := FieldType.mappingTyped (MappingType.nested MappingKeyType.uint256 MappingKeyType.address), slot := some 3 }
+    ]
+    constructor := none
+    functions := [
+      { name := "setBalance"
+        params := [{ name := "id", ty := ParamType.uint256 }, { name := "user", ty := ParamType.address }, { name := "amount", ty := ParamType.uint256 }]
+        returnType := none
+        body := [
+          Stmt.setMapping2Word "positions" (Expr.param "id") (Expr.param "user") 1 (Expr.param "amount"),
+          Stmt.stop
+        ]
+      },
+      { name := "getBalance"
+        params := [{ name := "id", ty := ParamType.uint256 }, { name := "user", ty := ParamType.address }]
+        returnType := some FieldType.uint256
+        body := [Stmt.return (Expr.mapping2Word "positions" (Expr.param "id") (Expr.param "user") 1)]
+      }
+    ]
+    events := []
+  }
+  let initialStorage := SpecStorage.empty
+  let marketId := 42
+  let user := 0xBEEF
+  let amount := 999
+  let writeTx : Transaction := { sender := 0, functionName := "setBalance", args := [marketId, user, amount] }
+  let writeResult := interpretSpec mapping2WordInterpSpec initialStorage writeTx
+  if !writeResult.success then
+    throw (IO.userError s!"✗ mapping2Word interpreter write reverted: {writeResult.revertReason}")
+  let readTx : Transaction := { sender := 0, functionName := "getBalance", args := [marketId, user] }
+  let readResult := interpretSpec mapping2WordInterpSpec writeResult.finalStorage readTx
+  if readResult.returnValue != some amount then
+    throw (IO.userError s!"✗ mapping2Word interpreter read mismatch: expected {amount}, got {readResult.returnValue}")
+  IO.println "✓ SpecInterpreter mapping2Word read/write round-trip succeeds"
 
 end Compiler.ContractSpecFeatureTest


### PR DESCRIPTION
## Summary
- Adds `Expr.mapping2Word(field, key1, key2, wordOffset)` for reading double mappings with a word offset: generates `sload(add(mappingSlot(mappingSlot(slot, key1), key2), wordOffset))`
- Adds `Stmt.setMapping2Word(field, key1, key2, wordOffset, value)` for writing: generates `sstore(add(..., wordOffset), value)`
- When `wordOffset == 0`, the `add` is optimized away
- Alias slot mirror writes are fully supported (same as `setMapping2`)
- SpecInterpreter models the word offset by folding it into key2
- 5 new test groups: codegen, zero-offset optimization, alias mirrors, view/pure validation, SpecInterpreter round-trip

This unlocks 7 of 9 Morpho Blue shims that use patterns like `add(mappingSlot(mappingSlot(2, id), addr), 1)`.

## Test plan
- [x] `lake build` passes (103/103 units)
- [x] `lake build Compiler.ContractSpecFeatureTest` passes with all new tests
- [x] Codegen: `sload(add(mappingSlot(mappingSlot(3, id), user), 1))` for read
- [x] Codegen: `sstore(add(mappingSlot(mappingSlot(3, id), user), 1), amount)` for write
- [x] Zero offset optimization: no `add(..., 0)` emitted
- [x] Alias slots: both canonical and alias slots written
- [x] View function accepted, pure function rejected
- [x] SpecInterpreter write then read returns the same value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches storage addressing semantics and Yul emission for nested mappings, so incorrect offset/slot handling could silently read/write the wrong storage locations despite added tests.
> 
> **Overview**
> Adds new DSL operations `Expr.mapping2Word` and `Stmt.setMapping2Word` to address *double mappings with an additional word offset*.
> 
> Compilation/codegen is extended to lower these to nested `mappingSlot` with an optional `add(..., wordOffset)` (optimized away when the offset is `0`), including compatibility mirror writes across alias slots; all relevant analyses/validators are updated to treat the new constructors like `mapping2`/`setMapping2`. The `SpecInterpreter` is updated to model the offset by folding it into the second mapping key, and `ContractSpecFeatureTest` adds coverage for codegen, zero-offset optimization, alias mirrors, view-vs-pure restrictions, and interpreter round-trip behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48b2e4468343d13e0200ddd17552d203e18dfdcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->