### PR TITLE
Validate duplicate parameter names in event definitions

### DIFF
--- a/Compiler/ContractSpecFeatureTest.lean
+++ b/Compiler/ContractSpecFeatureTest.lean
@@ -3801,6 +3801,28 @@ private def featureSpec : ContractSpec := {
       throw (IO.userError "✗ expected duplicate constructor params to fail compilation")
 
 #eval! do
+  let duplicateEventParamSpec : ContractSpec := {
+    name := "DuplicateEventParamSpec"
+    fields := []
+    constructor := none
+    functions := [{ name := "noop", params := [], returnType := none, body := [Stmt.stop] }]
+    events := [
+      { name := "Transfer"
+        params := [
+          { name := "amount", ty := ParamType.uint256, kind := EventParamKind.unindexed },
+          { name := "amount", ty := ParamType.address, kind := EventParamKind.indexed }
+        ] }
+    ]
+  }
+  match compile duplicateEventParamSpec [1] with
+  | .error err =>
+      if !contains err "duplicate parameter name 'amount' in event 'Transfer'" then
+        throw (IO.userError s!"✗ duplicate event param diagnostic mismatch: {err}")
+      IO.println "✓ duplicate event param diagnostic"
+  | .ok _ =>
+      throw (IO.userError "✗ expected duplicate event params to fail compilation")
+
+#eval! do
   let unknownExternalTargetSpec : ContractSpec := {
     name := "UnknownExternalTargetSpec"
     fields := []


### PR DESCRIPTION
## Summary
- Adds `firstDuplicateEventParamName` validation in the compile pipeline, matching the existing pattern for functions (`firstDuplicateFunctionParamName`) and constructors (`firstDuplicateConstructorParamName`)
- Events with duplicate parameter names now produce a clear compile error instead of silently generating incorrect ABI signatures
- Adds a test covering this new validation

Closes #947

## Test plan
- [x] `lake build` passes (all 103 modules)
- [x] `lake build Compiler.ContractSpecFeatureTest` passes (new `✓ duplicate event param diagnostic` test)
- [x] No existing tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized compiler validation that only rejects previously-accepted invalid specs; risk is limited to potential false positives or changed diagnostics for edge cases.
> 
> **Overview**
> Prevents invalid/ambiguous ABI generation by **failing compilation when an `EventDef` contains duplicate parameter names**.
> 
> Adds `firstDuplicateEventParamName` to the `ContractSpec` validation pipeline and surfaces a targeted error message (`duplicate parameter name ... in event ...`). Updates `ContractSpecFeatureTest` with a new case asserting the diagnostic for a `Transfer` event with repeated `amount` params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd3bec5ac1ee2cdbbcfaeb5d5198a55f490b2ea1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->