### PR TITLE
Add missing opcode costs to static gas analysis model

### DIFF
--- a/Compiler/Gas/StaticAnalysis.lean
+++ b/Compiler/Gas/StaticAnalysis.lean
@@ -46,10 +46,18 @@ def builtinBaseCost (cfg : GasConfig) (name : String) : Nat :=
   else if name = "callvalue" then 2
   else if name = "caller" then 2
   else if name = "codesize" then 2
+  else if name = "address" then 2
+  else if name = "chainid" then 2
+  else if name = "timestamp" then 2
+  else if name = "gas" then 2
+  else if name = "returndatasize" then 2
+  else if name = "extcodesize" then 2600
   /- Copy costs depend on payload length and memory expansion.
      Use conservative constants to avoid unknown-call fallback explosions. -/
   else if name = "codecopy" then 5000
   else if name = "datacopy" then 5000
+  else if name = "calldatacopy" then 5000
+  else if name = "returndatacopy" then 5000
   /- `dataoffset`/`datasize` compile to immediate constants; model as verylow. -/
   else if name = "dataoffset" then 3
   else if name = "datasize" then 3


### PR DESCRIPTION
## Summary
- Adds 8 missing EVM opcode entries to `builtinBaseCost` in `Compiler/Gas/StaticAnalysis.lean`
- These opcodes are all emitted by the compiler but previously fell through to `unknownCallCost` (50,000 gas), producing wildly pessimistic gas upper bounds
- Environment reads (`address`, `chainid`, `timestamp`, `gas`, `returndatasize`): 2 gas each
- Cold account access (`extcodesize`): 2,600 gas
- Memory copy operations (`calldatacopy`, `returndatacopy`): 5,000 gas (conservative, matching existing `codecopy`/`datacopy` pattern)

Closes #953

## Test plan
- [x] `lake build` passes (all 103 modules)
- [x] Existing gas model `example : rfl` proofs still hold (test programs don't use the new opcodes)
- [x] No API changes — purely additive cost entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive updates to a static cost table only; main risk is miscalibrated constants affecting gas bound accuracy, not runtime behavior.
> 
> **Overview**
> Improves static gas upper-bound estimation by adding explicit `builtinBaseCost` entries for several EVM environment/copy opcodes that previously fell back to `unknownCallCost` (50,000).
> 
> New modeled costs cover `address`, `chainid`, `timestamp`, `gas`, `returndatasize` (2 each), `extcodesize` (2600), and `calldatacopy`/`returndatacopy` (5000), reducing overly pessimistic estimates without changing any public APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db346b8b59427aaa73f46bf9b60376e8a00cd087. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->