### PR TITLE
Replace redundant hex conversion in PrettyPrint with shared Hex module helper

### DIFF
--- a/Compiler/Hex.lean
+++ b/Compiler/Hex.lean
@@ -41,13 +41,20 @@ def addressToNat (addr : String) : Nat :=
 def hexDigit (n : Nat) : Char :=
   if n < 10 then Char.ofNat (n + 48) else Char.ofNat (n - 10 + 97)
 
+/-- Core recursive helper: convert a positive Nat to hex digit chars (big-endian). -/
+private def natToHexCore (val : Nat) (acc : List Char) : List Char :=
+  if val = 0 then acc
+  else natToHexCore (val / 16) (hexDigit (val % 16) :: acc)
+
 /-- Convert a Nat to a zero-padded hex string (e.g. selector → "0x12345678") -/
 def natToHex (n : Nat) (digits : Nat := 8) : String :=
-  let rec go (val : Nat) (acc : List Char) : List Char :=
-    if val = 0 then acc
-    else go (val / 16) (hexDigit (val % 16) :: acc)
-  let raw := go n []
+  let raw := natToHexCore n []
   let padded := List.replicate (digits - raw.length) '0' ++ raw
   "0x" ++ String.mk padded
+
+/-- Convert a Nat to a minimal unpadded hex string without prefix (e.g. 255 → "ff"). -/
+def natToHexUnpadded (n : Nat) : String :=
+  if n = 0 then "0"
+  else String.mk (natToHexCore n [])
 
 end Compiler.Hex

--- a/Compiler/Yul/PrettyPrint.lean
+++ b/Compiler/Yul/PrettyPrint.lean
@@ -4,24 +4,7 @@ import Compiler.Hex
 namespace Compiler.Yul
 
 open YulExpr
-open Compiler.Hex (hexDigit)
-
-def toHex (n : Nat) : String :=
-  if n == 0 then
-    "0"
-  else
-    let rec loop (x : Nat) (acc : List Char) : List Char :=
-      if x == 0 then acc
-      else
-        let d := x % 16
-        let acc' := hexDigit d :: acc
-        loop (x / 16) acc'
-    termination_by x
-    decreasing_by
-      simp_wf
-      simp at *
-      exact Nat.div_lt_self (by omega) (by omega)
-    String.mk (loop n [])
+open Compiler.Hex (natToHexUnpadded)
 
 private def indentStr (n : Nat) : String :=
   String.mk (List.replicate (n * 4) ' ')
@@ -29,7 +12,7 @@ private def indentStr (n : Nat) : String :=
 mutual
 def ppExpr : YulExpr → String
   | lit n => toString n
-  | hex n => "0x" ++ toHex n
+  | hex n => "0x" ++ natToHexUnpadded n
   | str s => "\"" ++ (s.replace "\\" "\\\\").replace "\"" "\\\"" ++ "\""
   | ident name => name
   | call func args =>
@@ -101,7 +84,7 @@ def ppStmts (indent : Nat) : List YulStmt → List String
 def ppCases (indent : Nat) : List (Nat × List YulStmt) → List String
   | [] => []
   | (c, body) :: rest =>
-      let caseHeader := indentStr indent ++ "case 0x" ++ toHex c ++ " {"
+      let caseHeader := indentStr indent ++ "case 0x" ++ natToHexUnpadded c ++ " {"
       let bodyLines := ppStmts (indent + 1) body
       let footer := s!"{indentStr indent}}"
       (caseHeader :: bodyLines ++ [footer]) ++ ppCases indent rest


### PR DESCRIPTION
## Summary
- Extracts the shared nat-to-hex-digits loop into a `private def natToHexCore` in `Compiler/Hex.lean`, reused by both `natToHex` (zero-padded, for selectors) and a new `natToHexUnpadded` (minimal, for Yul literals)
- Replaces the local `toHex` function in `Compiler/Yul/PrettyPrint.lean` — which carried 4 lines of explicit termination proof (`simp_wf`, `omega`) — with a call to the shared `natToHexUnpadded`
- Net result: **-10 lines** (14 insertions, 24 deletions), single source of truth for hex digit generation

Closes #955

## Test plan
- [x] `lake build` passes (all 103 modules including all proof files)
- [x] `lake build Compiler.ContractSpecFeatureTest` passes (all feature tests)
- [x] Yul hex literal rendering (`ppExpr`) and switch case labels (`ppCases`) use same output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor/DRY change limited to hex formatting and Yul pretty-print output; behavior should be equivalent aside from any edge-case formatting differences (notably handling of `0`).
> 
> **Overview**
> Refactors Nat→hex string generation into a shared helper in `Compiler/Hex.lean` by introducing private `natToHexCore` and a new public `natToHexUnpadded` for minimal (unpadded) output.
> 
> Updates Yul pretty-printing to remove its local `toHex` implementation (and associated termination proof boilerplate) and instead use `natToHexUnpadded` for hex literals (`ppExpr`) and `switch` case labels (`ppCases`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03a269a06ca8b941505d4bfd9fe5372576e1383f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->