### PR TITLE
fix: correct docs URL to verity.thomas.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,11 +321,11 @@ The compiler validates function names, arities, and prevents name collisions. Se
 
 ## Documentation
 
-**Full documentation**: [verity.thomasm.ar](https://verity.thomasm.ar/) — guides, DSL reference, examples, and verification details.
+**Full documentation**: [verity.thomas.md](https://verity.thomas.md/) — guides, DSL reference, examples, and verification details.
 
 | | |
 |---|---|
-| [Docs Site](https://verity.thomasm.ar/) | Full documentation site with guides and DSL reference |
+| [Docs Site](https://verity.thomas.md/) | Full documentation site with guides and DSL reference |
 | [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) | What's verified, what's trusted, trust reduction roadmap |
 | [`AXIOMS.md`](AXIOMS.md) | All axioms with soundness justifications (1 remaining) |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Coding conventions, workflow, PR guidelines |

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -106,16 +106,16 @@ Use the Linker to inject production Yul libraries (Poseidon, Groth16, etc.) into
 
 ## Documentation URLs
 
-- Main: https://verity.thomasm.ar/
-- Verification: https://verity.thomasm.ar/verification
-- Research: https://verity.thomasm.ar/research
-- Examples: https://verity.thomasm.ar/examples
-- Core: https://verity.thomasm.ar/core
-- Compiler: https://verity.thomasm.ar/compiler
-- Guides (First Contract): https://verity.thomasm.ar/guides/first-contract
-- Guides (Linking Libraries): https://verity.thomasm.ar/guides/linking-libraries
-- Guides (Debugging Proofs): https://verity.thomasm.ar/guides/debugging-proofs
-- Add a Contract: https://verity.thomasm.ar/add-contract
+- Main: https://verity.thomas.md/
+- Verification: https://verity.thomas.md/verification
+- Research: https://verity.thomas.md/research
+- Examples: https://verity.thomas.md/examples
+- Core: https://verity.thomas.md/core
+- Compiler: https://verity.thomas.md/compiler
+- Guides (First Contract): https://verity.thomas.md/guides/first-contract
+- Guides (Linking Libraries): https://verity.thomas.md/guides/linking-libraries
+- Guides (Debugging Proofs): https://verity.thomas.md/guides/debugging-proofs
+- Add a Contract: https://verity.thomas.md/add-contract
 
 Add `.md` to any URL for raw markdown (saves tokens).
 


### PR DESCRIPTION
## Summary
- Replaces `verity.thomasm.ar` with `verity.thomas.md` across all documentation links
- 2 occurrences in `README.md` (inline link + docs table)
- 10 occurrences in `docs-site/public/llms.txt` (all documentation URLs)

## Test plan
- [ ] Verify links resolve to the correct docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only link updates with no impact on runtime behavior or verification logic.
> 
> **Overview**
> Switches the project’s documentation domain from `verity.thomasm.ar` to `verity.thomas.md`.
> 
> Updates the README’s documentation link/table and refreshes all documentation URLs listed in `docs-site/public/llms.txt` to point at the new domain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17470b91e14f0a9614f01ca150e2a80982e018e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->