### PR TITLE
fix: resolve linter warnings in proof files

### DIFF
--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -106,7 +106,7 @@ def evalIRExprs (state : IRState) : List YulExpr → Option (List Nat)
 termination_by es => exprsSize es
 decreasing_by
   all_goals
-    simp [exprsSize, exprSize]
+    simp [exprsSize]
     omega
 
 /-- Evaluate an IR function call by evaluating all arguments first, then dispatching.
@@ -126,7 +126,7 @@ def evalIRCall (state : IRState) (func : String) : List YulExpr → Option Nat
       state.storage state.sender state.selector state.calldata func argVals
 termination_by args => exprsSize args + 1
 decreasing_by
-  simp [exprsSize, exprSize]
+  omega
 
 /-- Evaluate a Yul expression in the IR context.
 
@@ -139,7 +139,7 @@ def evalIRExpr (state : IRState) : YulExpr → Option Nat
   | .call func args => evalIRCall state func args
 termination_by e => exprSize e
 decreasing_by
-  simp [exprsSize, exprSize]
+  simp [exprSize]
 
 end -- mutual
 
@@ -309,7 +309,7 @@ noncomputable def execIRFunction (fn : IRFunction) (args : List Nat) (initialSta
       returnValue := none
       finalStorage := s.storage
       finalMappings := Compiler.Proofs.storageAsMappings s.storage }
-  | .revert s =>
+  | .revert _ =>
     { success := false
       returnValue := none
       -- On revert, storage and mappings roll back to the initial state

--- a/Compiler/Proofs/YulGeneration/Equivalence.lean
+++ b/Compiler/Proofs/YulGeneration/Equivalence.lean
@@ -137,7 +137,7 @@ theorem resultsMatch_of_execResultsAligned
   · -- continue / continue
     cases hExec
     simp [irResultOfExecWithRollback, yulResultOfExecWithRollback, resultsMatch,
-      statesAligned, yulStateOfIR]
+      yulStateOfIR]
   · -- continue / return
     cases hExec
   · -- continue / stop
@@ -162,7 +162,7 @@ theorem resultsMatch_of_execResultsAligned
   · -- stop / stop
     cases hExec
     simp [irResultOfExecWithRollback, yulResultOfExecWithRollback, resultsMatch,
-      statesAligned, yulStateOfIR]
+      yulStateOfIR]
   · -- stop / revert
     cases hExec
   · -- revert / continue
@@ -267,7 +267,7 @@ def execIRFunctionFuel (fuel : Nat) (fn : IRFunction) (args : List Nat) (initial
         returnValue := none
         finalStorage := s.storage
         finalMappings := Compiler.Proofs.storageAsMappings s.storage }
-  | .revert s =>
+  | .revert _ =>
       { success := false
         returnValue := none
         finalStorage := initialState.storage
@@ -303,13 +303,13 @@ theorem execIRStmtsFuel_equiv_execYulStmtsFuel_of_stmt_equiv
   induction stmts with
   | nil =>
       intro fuel irState yulState hAligned
-      simp [execIRStmts_equiv_execYulStmts_goal, execIRStmtsFuel, execIRStmts,
+      simp [execIRStmtsFuel, execIRStmts,
         execYulStmtsFuel_nil, execResultsAligned, hAligned]
   | cons stmt rest ih =>
       intro fuel irState yulState hAligned
       cases fuel with
       | zero =>
-          simp [execIRStmts_equiv_execYulStmts_goal, execIRStmtsFuel, execIRStmts,
+          simp [execIRStmtsFuel, execIRStmts,
             execYulStmtsFuel, execYulFuel, execResultsAligned, hAligned]
       | succ fuel =>
           have hStmt := stmt_equiv selector fuel stmt irState yulState hAligned
@@ -323,15 +323,15 @@ theorem execIRStmtsFuel_equiv_execYulStmtsFuel_of_stmt_equiv
                   simpa [execIRStmtsFuel, execIRStmts, execYulStmtsFuel_cons, hIR, hYul] using hRest
               | «return» v y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
               | «stop» y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
               | «revert» y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
           | «return» v ir' =>
               cases hYul : execYulStmtFuel fuel yulState stmt with
@@ -339,15 +339,15 @@ theorem execIRStmtsFuel_equiv_execYulStmtsFuel_of_stmt_equiv
                   simpa [execIRStmtsFuel, execIRStmts, execYulStmtsFuel_cons, execResultsAligned, hIR, hYul] using hStmt
               | «continue» y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
               | «stop» y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
               | «revert» y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
           | «stop» ir' =>
               cases hYul : execYulStmtFuel fuel yulState stmt with
@@ -355,15 +355,15 @@ theorem execIRStmtsFuel_equiv_execYulStmtsFuel_of_stmt_equiv
                   simpa [execIRStmtsFuel, execIRStmts, execYulStmtsFuel_cons, execResultsAligned, hIR, hYul] using hStmt
               | «continue» y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
               | «return» v y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
               | «revert» y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
           | «revert» ir' =>
               cases hYul : execYulStmtFuel fuel yulState stmt with
@@ -371,15 +371,15 @@ theorem execIRStmtsFuel_equiv_execYulStmtsFuel_of_stmt_equiv
                   simpa [execIRStmtsFuel, execIRStmts, execYulStmtsFuel_cons, execResultsAligned, hIR, hYul] using hStmt
               | «continue» y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
               | «return» v y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
               | «stop» y' =>
                   have : False := by
-                    simpa [execResultsAligned, hIR, hYul] using hStmt
+                    simp [execResultsAligned, hIR, hYul] at hStmt
                   cases this
 
 theorem execIRStmtsFuel_equiv_execYulStmts_of_stmt_equiv

--- a/Compiler/Proofs/YulGeneration/Semantics.lean
+++ b/Compiler/Proofs/YulGeneration/Semantics.lean
@@ -92,7 +92,7 @@ def evalYulExprs (state : YulState) : List YulExpr → Option (List Nat)
 termination_by es => exprsSize es
 decreasing_by
   all_goals
-    simp [exprsSize, exprSize]
+    simp [exprsSize]
     omega
 
 def evalYulCall (state : YulState) (func : String) : List YulExpr → Option Nat
@@ -103,7 +103,7 @@ def evalYulCall (state : YulState) (func : String) : List YulExpr → Option Nat
       state.storage state.sender state.selector state.calldata func argVals
 termination_by args => exprsSize args + 1
 decreasing_by
-  simp [exprsSize, exprSize]
+  omega
 
 /-- Evaluate a Yul expression -/
 def evalYulExpr (state : YulState) : YulExpr → Option Nat
@@ -114,7 +114,7 @@ def evalYulExpr (state : YulState) : YulExpr → Option Nat
   | .call func args => evalYulCall state func args
 termination_by e => exprSize e
 decreasing_by
-  simp [exprsSize, exprSize]
+  simp [exprSize]
 
 end
 
@@ -132,8 +132,8 @@ inductive YulExecTarget
   | stmts (ss : List YulStmt)
 
 def execYulFuel : Nat → YulState → YulExecTarget → YulExecResult
-  | fuel, state, .stmts [] => .continue state
-  | fuel, state, .stmt (YulStmt.funcDef _ _ _ _) => .continue state
+  | _, state, .stmts [] => .continue state
+  | _, state, .stmt (YulStmt.funcDef _ _ _ _) => .continue state
   | 0, state, _ => .revert state
   | Nat.succ fuel, state, target =>
       match target with


### PR DESCRIPTION
## Summary
- Clean up 27 linter warnings across 3 proof files (`IRInterpreter.lean`, `Semantics.lean`, `Equivalence.lean`)
- Remove unused `simp` arguments (`exprSize`, `statesAligned`, `execIRStmts_equiv_execYulStmts_goal`)
- Replace `simp` with `omega` where the goal is pure arithmetic (`exprsSize args < exprsSize args + 1`)
- Replace `simpa ... using hStmt` with `simp ... at hStmt` for `False` derivation (12 instances)
- Replace unused variables with wildcards (2 instances)

## Test plan
- [x] `lake build Compiler.Proofs.IRGeneration.IRInterpreter` — 0 warnings
- [x] `lake build Compiler.Proofs.YulGeneration.Semantics` — 0 warnings
- [x] `lake build Compiler.Proofs.YulGeneration.Equivalence` — 0 warnings
- [x] `check_lean_hygiene.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Lean proof/termination scripts and unused-pattern cleanups; they should not affect runtime semantics, but could break proof compilation if a simplification step was relied on implicitly.
> 
> **Overview**
> Cleans up Lean linter warnings in the IR/Yul proof modules by tightening termination proofs (`simp` only on needed measures and using `omega` for pure arithmetic goals) and removing unused patterns/arguments.
> 
> Refactors several proof steps in `Equivalence.lean` to avoid `simpa`-based `False` derivations (switching to `simp … at`), and replaces unused match binders (e.g., `.revert _`, `| _, state, …`) to eliminate warnings without changing the underlying semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 265178fa13c4bcec9484e2f71a0d15062d023d01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->