### PR TITLE
simplify: deduplicate compare_lists across sync-check scripts

### DIFF
--- a/scripts/check_verify_paths_sync.py
+++ b/scripts/check_verify_paths_sync.py
@@ -13,7 +13,7 @@ import re
 import sys
 from pathlib import Path
 
-from workflow_jobs import extract_job_body
+from workflow_jobs import compare_lists, extract_job_body
 
 ROOT = Path(__file__).resolve().parents[1]
 VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
@@ -65,31 +65,6 @@ def duplicates(values: list[str]) -> list[str]:
             dups.append(value)
         seen.add(value)
     return dups
-
-
-def compare_lists(reference_name: str, reference: list[str], other_name: str, other: list[str]) -> list[str]:
-    errors: list[str] = []
-    if reference == other:
-        return errors
-
-    ref_set = set(reference)
-    other_set = set(other)
-    missing = sorted(ref_set - other_set)
-    extra = sorted(other_set - ref_set)
-
-    if missing:
-        errors.append(f"{other_name} is missing {len(missing)} path(s) present in {reference_name}:")
-        errors.extend([f"  - {m}" for m in missing])
-    if extra:
-        errors.append(f"{other_name} has {len(extra)} extra path(s) not present in {reference_name}:")
-        errors.extend([f"  - {e}" for e in extra])
-
-    if not missing and not extra:
-        errors.append(
-            f"{other_name} has the same entries as {reference_name} but in a different order. "
-            "Keep order aligned to reduce review noise."
-        )
-    return errors
 
 
 def ensure_subset(parent_name: str, parent: list[str], subset_name: str, subset: list[str]) -> list[str]:

--- a/scripts/workflow_jobs.py
+++ b/scripts/workflow_jobs.py
@@ -1,4 +1,4 @@
-"""Helpers for extracting top-level GitHub Actions jobs from verify.yml."""
+"""Helpers for extracting and comparing GitHub Actions workflow data."""
 
 from __future__ import annotations
 
@@ -810,3 +810,37 @@ def match_shell_command(
             return False, tokens
 
     return True, tokens[i:]
+
+
+def compare_lists(
+    reference_name: str,
+    reference: list[str],
+    other_name: str,
+    other: list[str],
+) -> list[str]:
+    """Compare two ordered lists and return human-readable error descriptions.
+
+    Detects missing items, extra items, and order-only mismatches.
+    Returns an empty list when the lists are identical.
+    """
+    if reference == other:
+        return []
+
+    errors: list[str] = []
+    ref_set = set(reference)
+    other_set = set(other)
+
+    missing = [item for item in reference if item not in other_set]
+    extra = [item for item in other if item not in ref_set]
+
+    if missing:
+        errors.append(f"{other_name} is missing entries present in {reference_name}:")
+        errors.extend([f"  - {m}" for m in missing])
+    if extra:
+        errors.append(f"{other_name} has entries not present in {reference_name}:")
+        errors.extend([f"  - {e}" for e in extra])
+    if not missing and not extra:
+        errors.append(
+            f"{other_name} contains the same entries as {reference_name} but in a different order."
+        )
+    return errors


### PR DESCRIPTION
## Summary
- Extract the identical `_compare` function (copy-pasted in 3 scripts) and the equivalent `compare_lists` (in `check_verify_paths_sync.py`) into the shared `workflow_jobs.py` module
- All 4 sync-check scripts now import `compare_lists` from the shared module
- Net reduction of 64 lines of duplicated logic

## Files changed
- `scripts/workflow_jobs.py` — add `compare_lists` function
- `scripts/check_verify_build_docs_sync.py` — remove local `_compare`, use shared
- `scripts/check_verify_checks_docs_sync.py` — remove local `_compare`, use shared
- `scripts/check_verify_ci_jobs_docs_sync.py` — remove local `_compare`, use shared
- `scripts/check_verify_paths_sync.py` — remove local `compare_lists`, use shared

## Test plan
- [x] All 151 unit tests pass (`python3 -m unittest discover`)
- [x] All 4 affected CI scripts pass individually
- [x] `check_lean_hygiene.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to CI/doc-sync helper scripts; main behavior should be unchanged aside from slightly different error wording and ordering of reported items.
> 
> **Overview**
> Deduplicates the repeated list-diff logic used by the verify.yml sync-check scripts by moving it into `scripts/workflow_jobs.py` as a shared `compare_lists` helper.
> 
> Updates the build/checks/CI-jobs and path-filter sync check scripts to import and use the shared function, removing their local comparison implementations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7055e542a96830cfaed4d9702ca7487877744437. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->