### PR TITLE
simplify: deduplicate YAML helpers and CSV parser

### DIFF
--- a/scripts/check_verify_foundry_shard_sync.py
+++ b/scripts/check_verify_foundry_shard_sync.py
@@ -7,21 +7,11 @@ import re
 import sys
 from pathlib import Path
 
-from workflow_jobs import extract_job_body, extract_literal_from_mapping_blocks
+from workflow_jobs import extract_job_body, extract_literal_from_mapping_blocks, parse_csv_ints
 
 ROOT = Path(__file__).resolve().parents[1]
 VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
 SCRIPTS_README = ROOT / "scripts" / "README.md"
-
-
-def _parse_csv_ints(raw: str, source: Path) -> list[int]:
-    parts = [part.strip() for part in raw.split(",")]
-    if not parts or any(not part for part in parts):
-        raise ValueError(f"Malformed integer CSV in {source}: {raw!r}")
-    try:
-        return [int(part) for part in parts]
-    except ValueError as exc:
-        raise ValueError(f"Non-integer value in {source}: {raw!r}") from exc
 
 
 def _extract_foundry_job_body(text: str) -> str:
@@ -32,7 +22,7 @@ def _extract_verify_shard_indices(body: str) -> list[int]:
     m = re.search(r"^\s*shard_index:\s*\[(?P<csv>[^\]]+)\]\s*$", body, flags=re.MULTILINE)
     if not m:
         raise ValueError(f"Could not locate foundry matrix shard_index list in {VERIFY_YML}")
-    return _parse_csv_ints(m.group("csv"), VERIFY_YML)
+    return parse_csv_ints(m.group("csv"), VERIFY_YML)
 
 
 def _extract_verify_shard_count(body: str) -> int:


### PR DESCRIPTION
## Summary
- Promote `strip_yaml_inline_comment` and `unquote_yaml_scalar` from private to public in `workflow_jobs.py`; remove exact duplicate copies from `check_verify_artifact_sync.py`
- Extract `parse_csv_ints` into `workflow_jobs.py`; remove duplicate `_parse_csv_ints`/`_parse_seed_csv` from shard and multiseed sync scripts
- Net reduction of 28 lines of duplicated logic

## Files changed
- `scripts/workflow_jobs.py` — make 2 YAML helpers public, add `parse_csv_ints`
- `scripts/check_verify_artifact_sync.py` — import YAML helpers instead of redefining
- `scripts/check_verify_foundry_shard_sync.py` — import `parse_csv_ints` instead of local copy
- `scripts/check_verify_multiseed_sync.py` — import `parse_csv_ints` instead of local copy

## Test plan
- [x] All 151 unit tests pass
- [x] All 3 affected CI scripts pass individually
- [x] `check_lean_hygiene.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to CI helper scripts: logic is moved/renamed but behavior should be unchanged aside from any subtle differences in shared parsing helpers.
> 
> **Overview**
> Deduplicates workflow-parsing utilities used by the `verify.yml` sync check scripts by centralizing them in `scripts/workflow_jobs.py`.
> 
> `strip_yaml_inline_comment` and `unquote_yaml_scalar` are promoted to public helpers and the artifact sync script now imports them instead of maintaining local copies. Integer CSV parsing is similarly consolidated via a new shared `parse_csv_ints`, replacing per-script implementations in the foundry shard and multi-seed sync checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6afb853f645809aa520e1abed6d8a87fd889b9c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->