### PR TITLE
ci: fetch mathlib cache and use 4 threads to fix build timeout

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -186,7 +186,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:


### PR DESCRIPTION
## Summary
- Adds `lake exe cache get` to download precompiled mathlib `.olean` files from the community cloud cache instead of compiling 6,726 mathlib source files from scratch
- Bumps `LEAN_NUM_THREADS` from 2 to 4, matching the vCPU count available on `ubuntu-latest` runners
- Improves cache key strategy: replaces `github.sha` (unique per commit, always misses) with content hashes of `lake-manifest.json` + source `.lean` files for better hit rates
- Raises timeout from 20 to 30 minutes as safety margin while measuring improvement

## Context
The CI "Build compiler" step has been consistently timing out after 20 minutes on every branch including main. Root cause: mathlib (the largest transitive dependency at ~1GB compiled) was being compiled from source because `lake exe cache get` was never called. The mathlib community maintains precompiled cloud caches for every tagged release — this is the standard Lean/mathlib CI pattern.

Expected improvement: ~10-15 min saved from mathlib cache + ~20-30% faster compilation from doubled thread count. The build should now complete well within the 30-minute timeout.

## Test plan
- [ ] CI build job completes successfully within timeout
- [ ] `lake exe cache get` downloads mathlib oleans (visible in build log)
- [ ] All 151 Python validation tests pass
- [ ] All sync-check scripts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the GitHub Actions workflow (timeouts, caching, and parallelism) and don’t affect production code. Main risk is CI flakiness or stale cache behavior from the new cache keys and increased `LEAN_NUM_THREADS`.
> 
> **Overview**
> **CI build performance is improved to avoid Lean timeouts.** The `verify.yml` `build` job now fetches the precompiled mathlib cache via `lake exe cache get`, increases `LEAN_NUM_THREADS` from 2→4 across Lean build steps, and extends the job timeout to 45 minutes.
> 
> **Lake caching is retuned for better hit rates.** The `.lake` cache key is changed from per-commit (`github.sha`) to content-based hashing (`lean-toolchain`, `lake-manifest.json`, and Lean sources under `Verity/` and `Compiler/`), with updated restore keys to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae3c0277e5896df2472a1e1f7238d2afe0547fdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->