### PR TITLE
Finalize EDSL-only CLI messaging/docs after --input removal

### DIFF
--- a/Compiler/Lowering/FromEDSL.lean
+++ b/Compiler/Lowering/FromEDSL.lean
@@ -6,8 +6,7 @@ namespace Compiler.Lowering
 open Compiler.CompilationModel
 
 /-- Explicit core input artifact for the compiler lowering boundary.
-Today this wraps `CompilationModel`; future work can populate it from
-an elaborated contract AST. -/
+Today this wraps `CompilationModel`; the CLI exposes only the EDSL-driven path. -/
 structure ContractCore where
   model : CompilationModel
   deriving Repr
@@ -23,8 +22,7 @@ def LoweringError.message : LoweringError → String
       "Use the generalized EDSL/macro path for compiler input. " ++
       details
 
-/-- Transition helper: embeds today's manual compiler input into the
-lowering boundary. -/
+/-- Helper: embed compiler-facing contract data into the lowering boundary. -/
 def liftModel (model : CompilationModel) : ContractCore :=
   { model := model }
 
@@ -42,7 +40,7 @@ def findDuplicateRawContract? (seen : List String) (remaining : List String) : O
       else
         findDuplicateRawContract? (raw :: seen) rest
 
-/-- Current manual compilation path routed through the lowering boundary. -/
+/-- Lowering path routed through the shared lowering boundary. -/
 def lowerModelPath (model : CompilationModel) : Except LoweringError CompilationModel :=
   .ok (lowerContractCore (liftModel model))
 
@@ -50,7 +48,7 @@ def edslInputReservedMessage : String :=
   LoweringError.message (.unsupported "(pending extended verified EDSL elaboration/lowering)")
 
 def edslInputLinkedLibrariesUnsupportedMessage : String :=
-  "Linked external Yul libraries are not yet supported through --input edsl. " ++
+  "Linked external Yul libraries are not yet supported through the EDSL-only CLI path. " ++
   "External-library specs cannot be compiled through the edsl-only CLI path."
 
 /-! ## Generalized selected-contract lowering (authoritative path)

--- a/Compiler/MainTest.lean
+++ b/Compiler/MainTest.lean
@@ -100,7 +100,7 @@ private def contractArtifactPath (outDir : String) (contract : Compiler.Lowering
   expectErrorContains
     "edsl input mode rejects linked-library path"
     ["--link", "examples/external-libs/PoseidonT3.yul", "--output", edslOutDir]
-    "Linked external Yul libraries are not yet supported through --input edsl"
+    "Linked external Yul libraries are not yet supported through the EDSL-only CLI path"
   expectErrorContains "missing --patch-report value" ["--patch-report"] "Missing value for --patch-report"
   expectErrorContains "missing --patch-max-iterations value" ["--patch-max-iterations"] "Missing value for --patch-max-iterations"
   expectErrorContains "missing --backend-profile value" ["--backend-profile"] "Missing value for --backend-profile"
@@ -139,7 +139,7 @@ private def contractArtifactPath (outDir : String) (contract : Compiler.Lowering
     rewriteBundleId := "missing-rewrite-bundle" }
   expectTrue "parity pack proof composition rejects unknown rewrite bundle IDs"
     (!missingBundlePack.proofCompositionValid)
-  expectTrue "manual model path lowers successfully through EDSL boundary"
+  expectTrue "lowering boundary path succeeds for canonical spec artifacts"
     (match Compiler.Lowering.lowerModelPath Compiler.Specs.simpleStorageSpec with
     | .ok lowered => lowered.name == Compiler.Specs.simpleStorageSpec.name
     | .error _ => false)

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -11,12 +11,11 @@ Verity uses a single supported compilation path:
 The formal Layer 1/2/3 guarantees apply to this path.
 
 Compiler UX status:
-- `--input model` compiles the full `CompilationModel` set (including linked-library flows).
-- `--input edsl` compiles a curated supported EDSL subset through the same lowering boundary.
-- `--edsl-contract <id>` optionally narrows `--input edsl` to selected supported contracts.
-- linked-library flows remain fail-closed for `--input edsl` and require `--input model`.
-Both modes route through `Compiler.Lowering` helpers, keeping one centralized
-transition point for future automatic EDSL reification.
+- the CLI compiles the canonical EDSL-generated contract set.
+- `--edsl-contract <id>` optionally narrows compilation to selected supported contracts.
+- linked-library flows remain fail-closed on this EDSL-only CLI path.
+Compilation is routed through `Compiler.Lowering` helpers, keeping one centralized
+boundary for generated EDSL artifacts.
 
 ## Verification Chain
 
@@ -139,7 +138,7 @@ High-level semantics can expose intermediate state in a reverted computation mod
 
 ## Security Audit Checklist
 
-1. Confirm deployment uses a supported input path (`--input model` for full model/external-link flows, or the curated `--input edsl` subset path).
+1. Confirm deployment uses the supported EDSL-only CLI path (optionally narrowed with `--edsl-contract`), and treat linked-library flows as out of path.
 2. Review `AXIOMS.md` and ensure the axiom list is unchanged and justified.
 3. If linked libraries are used, audit each linked Yul file as trusted code.
 4. Validate selector checks, Yul compile checks, and storage-layout checks in CI.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -19,12 +19,11 @@ EVM Bytecode
 ```
 
 Compiler UX status:
-- `--input model`: full current compiler path (`CompilationModel` set, including linked-library flows).
-- `--input edsl`: curated supported EDSL subset lowered through the same boundary API.
+- canonical CLI path: compile the EDSL-generated contract set.
 - `--edsl-contract <id>`: optional selector for compiling a subset of supported EDSL contracts.
-- linked-library flows are intentionally fail-closed for `--input edsl` and remain on `--input model`.
-Both modes are routed through `Compiler.Lowering` so model-mode and EDSL-mode
-share one lowering API surface.
+- linked-library flows are intentionally fail-closed on this EDSL-only path.
+Compilation is routed through `Compiler.Lowering` so parsing/lowering diagnostics
+stay centralized.
 `Compiler/Proofs/Lowering/FromEDSL.lean` now includes explicit transition bridge
 theorems that reuse existing Layer-1 EDSL correctness proofs through lowered
 supported inputs:


### PR DESCRIPTION
## Summary
- remove stale `--input edsl` wording from lowering diagnostics
- align `Compiler/MainTest` expected diagnostic text and boundary-check label
- update `TRUST_ASSUMPTIONS.md` and `docs/VERIFICATION_STATUS.md` to EDSL-only CLI language

## Validation
- `lake build Compiler.MainTest`
- `python3 scripts/check_doc_counts.py`
- `python3 -m unittest scripts/test_cli_argv_injection.py`

Closes #1000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to diagnostic strings, test expectations, and documentation wording around the now EDSL-only CLI path, with no functional compilation/verification logic changes.
> 
> **Overview**
> Clarifies the compiler’s lowering boundary and CLI as **EDSL-only**, updating `Compiler.Lowering` diagnostics to remove stale `--input edsl/model` wording and to describe the canonical EDSL-driven path.
> 
> Updates `Compiler/MainTest.lean` expectations/labels to match the new linked-library rejection message and renames the lowering-boundary sanity check. Refreshes `TRUST_ASSUMPTIONS.md` and `docs/VERIFICATION_STATUS.md` to describe the EDSL-only CLI and keep linked-library flows explicitly out-of-path/fail-closed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72cd3dfb70e699334817476d36a5aac97a4b916b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->