### PR TITLE
Add fail-closed manual-spec quarantine gate for canonical paths

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -154,6 +154,9 @@ jobs:
       - name: Check storage layout consistency
         run: python3 scripts/check_storage_layout.py
 
+      - name: Check manual-spec quarantine boundary
+        run: python3 scripts/check_manual_spec_quarantine.py
+
       - name: Check Lean hygiene
         run: python3 scripts/check_lean_hygiene.py
 

--- a/scripts/check_manual_spec_quarantine.py
+++ b/scripts/check_manual_spec_quarantine.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Fail closed if canonical compiler paths reference quarantined manual specs.
+
+Issue #999 keeps legacy/manual specs available for compatibility and proof migration,
+but canonical compile/lowering/gas/CLI paths must not depend on manual `*Spec`
+artifacts (except explicit compatibility allowlist entries).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from property_utils import ROOT, strip_lean_comments
+
+CANONICAL_FILES = [
+    ROOT / "Compiler" / "CompileDriver.lean",
+    ROOT / "Compiler" / "Gas" / "Report.lean",
+    ROOT / "Compiler" / "Lowering" / "FromEDSL.lean",
+    ROOT / "Compiler" / "Main.lean",
+    ROOT / "Compiler" / "MainTest.lean",
+]
+
+ALLOWED_QUALIFIED_SPEC_REFERENCES = {
+    "Compiler.Specs.cryptoHashSpec",
+    "Specs.cryptoHashSpec",
+}
+
+QUALIFIED_SPEC_RE = re.compile(
+    r"\b(?P<qual>(?:Compiler\.)?Specs\.(?P<name>[A-Za-z_][A-Za-z0-9_']*Spec))\b"
+)
+
+
+def _strip_lean_strings(text: str) -> str:
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_string = False
+    raw_hashes: int | None = None
+
+    while i < n:
+        ch = text[i]
+
+        if raw_hashes is not None:
+            if ch == "\n":
+                out.append("\n")
+                i += 1
+                continue
+            if ch == '"':
+                j = i + 1
+                hashes = 0
+                while j < n and text[j] == "#" and hashes < raw_hashes:
+                    hashes += 1
+                    j += 1
+                if hashes == raw_hashes:
+                    out.append('"')
+                    out.extend("#" * hashes)
+                    i = j
+                    raw_hashes = None
+                    continue
+            out.append(" ")
+            i += 1
+            continue
+
+        if in_string:
+            if ch == "\n":
+                out.append("\n")
+                i += 1
+                continue
+            if ch == "\\" and i + 1 < n:
+                out.extend([" ", " "])
+                i += 2
+                continue
+            if ch == '"':
+                out.append('"')
+                in_string = False
+                i += 1
+                continue
+            out.append(" ")
+            i += 1
+            continue
+
+        if ch == '"':
+            out.append('"')
+            in_string = True
+            i += 1
+            continue
+
+        if ch == "r":
+            j = i + 1
+            hashes = 0
+            while j < n and text[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and text[j] == '"':
+                out.append("r")
+                out.extend("#" * hashes)
+                out.append('"')
+                i = j + 1
+                raw_hashes = hashes
+                continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
+def scrub_lean_code(text: str) -> str:
+    return _strip_lean_strings(strip_lean_comments(text))
+
+
+def find_disallowed_references(content: str) -> list[str]:
+    disallowed: list[str] = []
+    for match in QUALIFIED_SPEC_RE.finditer(content):
+        qualified = match.group("qual")
+        if qualified in ALLOWED_QUALIFIED_SPEC_REFERENCES:
+            continue
+        disallowed.append(qualified)
+    return disallowed
+
+
+def main() -> int:
+    errors: list[str] = []
+    for path in CANONICAL_FILES:
+        if not path.exists():
+            errors.append(f"Missing canonical file: {path.relative_to(ROOT)}")
+            continue
+        scrubbed = scrub_lean_code(path.read_text(encoding="utf-8"))
+        bad = sorted(set(find_disallowed_references(scrubbed)))
+        if bad:
+            rel = path.relative_to(ROOT)
+            errors.append(
+                f"{rel}: found quarantined manual spec reference(s): {', '.join(bad)}"
+            )
+
+    if errors:
+        print("Manual-spec quarantine check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        print(
+            "\nCanonical compiler paths must not reference manual Compiler.Specs.*Spec symbols. "
+            "Route canonical flows through generated EDSL contracts and Specs.allSpecs.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "Manual-spec quarantine check passed "
+        f"({len(CANONICAL_FILES)} canonical files; only allowlisted compatibility specs used)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_manual_spec_quarantine.py
+++ b/scripts/test_check_manual_spec_quarantine.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_manual_spec_quarantine
+
+
+class ManualSpecQuarantineTests(unittest.TestCase):
+    def _run_check(self, file_contents: dict[str, str]) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as tmpdir:
+            root = Path(tmpdir)
+            canonical_files: list[Path] = []
+            for rel in check_manual_spec_quarantine.CANONICAL_FILES:
+                rel_path = rel.relative_to(check_manual_spec_quarantine.ROOT)
+                path = root / rel_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(file_contents.get(str(rel_path), "-- empty\n"), encoding="utf-8")
+                canonical_files.append(path)
+
+            old_root = check_manual_spec_quarantine.ROOT
+            old_files = check_manual_spec_quarantine.CANONICAL_FILES
+            check_manual_spec_quarantine.ROOT = root
+            check_manual_spec_quarantine.CANONICAL_FILES = canonical_files
+            try:
+                stderr = io.StringIO()
+                with redirect_stderr(stderr):
+                    rc = check_manual_spec_quarantine.main()
+                return rc, stderr.getvalue()
+            finally:
+                check_manual_spec_quarantine.ROOT = old_root
+                check_manual_spec_quarantine.CANONICAL_FILES = old_files
+
+    def test_fails_on_manual_spec_reference(self) -> None:
+        rc, stderr = self._run_check(
+            {
+                "Compiler/MainTest.lean": "def bad := Compiler.Specs.simpleStorageSpec\n",
+            }
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("Compiler.Specs.simpleStorageSpec", stderr)
+
+    def test_allows_allowlisted_crypto_hash_compat_reference(self) -> None:
+        rc, stderr = self._run_check(
+            {
+                "Compiler/CompileDriver.lean": "def ok := Specs.cryptoHashSpec\n",
+            }
+        )
+        self.assertEqual(rc, 0, stderr)
+
+    def test_ignores_comment_and_string_decoys(self) -> None:
+        rc, stderr = self._run_check(
+            {
+                "Compiler/Main.lean": (
+                    "-- Compiler.Specs.simpleStorageSpec\n"
+                    "def msg := \"Compiler.Specs.counterSpec\"\n"
+                ),
+            }
+        )
+        self.assertEqual(rc, 0, stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a fail-closed `check_manual_spec_quarantine.py` CI boundary for canonical compiler paths
- add unit tests for quarantine checker comment/string decoy resistance and allowlist handling
- remove remaining canonical `Compiler.MainTest` dependence on `Compiler.Specs.simpleStorageSpec`
- wire the new check into `verify.yml` + `scripts/README.md` sync list

## Why
Issue #999 tracks manual-spec quarantine to prevent drift while proof migration is still in progress. This slice makes canonical compile/lowering/gas/CLI paths fail closed if manual `Compiler.Specs.*Spec` references leak back in.

## Validation
- `python3 scripts/test_check_manual_spec_quarantine.py`
- `python3 scripts/check_manual_spec_quarantine.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`
- `lake build Compiler.MainTest`

Refs: #999

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new fail-closed CI gate that can block merges if the reference scanner misidentifies Lean source patterns or the allowlist is incomplete. Functional compiler behavior is unchanged, but CI behavior and test expectations change.
> 
> **Overview**
> Adds a new fail-closed `check_manual_spec_quarantine.py` that scans canonical Lean entrypoints and rejects non-allowlisted references to `Compiler.Specs.*Spec` (with comment and string literal scrubbing), plus unit tests for allowlist and decoy-resistance.
> 
> Wires this quarantine check into the `verify.yml` `checks` job and documents it in `scripts/README.md`.
> 
> Updates `Compiler/MainTest.lean` to stop depending on `Compiler.Specs.simpleStorageSpec`, validating lowering via an EDSL contract (`counter`) instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 720a352eec1f229545efe1d24f577caad9055b18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->