### PR TITLE
Document revert-state modeling boundary (#1009)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Verity's restricted DSL prevents raw external calls for safety. Instead, call pa
 **Layer-1 hybrid note**: Layer 1 currently uses a hybrid strategy — generated `EDSL -> CompilationModel` proofs for the supported subset, plus a manual escape hatch for advanced constructs. See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for details.
 
 See [`TRUST_ASSUMPTIONS.md`](TRUST_ASSUMPTIONS.md) for trust boundaries, [`AXIOMS.md`](AXIOMS.md) for axiom documentation, and [`docs/VERIFICATION_STATUS.md`](docs/VERIFICATION_STATUS.md) for full status.
+Revert-state caveat details are documented in [`docs/REVERT_STATE_MODEL.md`](docs/REVERT_STATE_MODEL.md).
 
 ## How Verity Compares
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -136,6 +136,8 @@ All backend profiles use identical wrapping arithmetic. See [`docs/ARITHMETIC_PR
 
 High-level semantics can expose intermediate state in a reverted computation model. EVM runtime reverts discard state. Contracts should preserve checks-before-effects discipline.
 
+See [`docs/REVERT_STATE_MODEL.md`](docs/REVERT_STATE_MODEL.md) for the precise modeling note and proof-author guidance.
+
 ## Security Audit Checklist
 
 1. Confirm deployment uses the supported EDSL-only CLI path (optionally narrowed with `--edsl-contract`), and treat linked-library flows as out of path.
@@ -158,6 +160,7 @@ If this file is stale, audit conclusions may be invalid.
 - [AUDIT.md](AUDIT.md)
 - [AXIOMS.md](AXIOMS.md)
 - [docs/ARITHMETIC_PROFILE.md](docs/ARITHMETIC_PROFILE.md)
+- [docs/REVERT_STATE_MODEL.md](docs/REVERT_STATE_MODEL.md)
 - [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md)
 - [docs/SOLIDITY_PARITY_PROFILE.md](docs/SOLIDITY_PARITY_PROFILE.md)
 - [docs/PARITY_PACKS.md](docs/PARITY_PACKS.md)

--- a/docs/REVERT_STATE_MODEL.md
+++ b/docs/REVERT_STATE_MODEL.md
@@ -1,0 +1,24 @@
+# Revert-State Modeling Note
+
+Issue: [#1009](https://github.com/Th0rgal/verity/issues/1009)
+
+This note clarifies a subtle but important modeling boundary:
+
+- EVM runtime reverts are transaction-atomic: reverted writes are not externally visible.
+- Verity's high-level `Contract` interpreter computes through the monadic body and applies rollback at `Contract.run`.
+
+In other words, intermediate states can be produced during evaluation and then discarded by the final revert result.
+
+## Why this matters
+
+For most existing Verity proof patterns, this does not change the result because proofs are phrased over observable post-state outcomes (`success` / `revert` result at run boundary). But proofs that reason about internal intermediate states across revert boundaries can overfit to interpreter internals that EVM users cannot observe.
+
+## Current guidance
+
+1. Phrase contract-correctness theorems over run-boundary behavior, not internal transient states.
+2. Preserve checks-before-effects discipline in contract logic.
+3. Treat intermediate reverted state as an interpreter artifact, not an externally observable EVM behavior.
+
+## Scope statement
+
+This is a semantic caveat, not a known soundness break in currently verified contract suites. It remains part of the trust-boundary discussion for reviewers and future model hardening.


### PR DESCRIPTION
## Summary
Adds explicit documentation for the revert-state modeling caveat tracked in #1009.

## Changes
- New note: `docs/REVERT_STATE_MODEL.md`
  - clarifies run-boundary rollback vs internal transient evaluation states,
  - describes proof-author guidance (reason over observable run outcomes),
  - records scope statement for reviewers.
- Linked this note from:
  - `TRUST_ASSUMPTIONS.md` (Revert-State Modeling section + related docs)
  - `README.md` trust-boundary references

This is a documentation hardening slice: no semantic/runtime changes.

Closes #1009.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies a semantic modeling caveat; no runtime/compiler logic is modified, so risk is limited to potential reviewer/user interpretation changes.
> 
> **Overview**
> Adds a new `docs/REVERT_STATE_MODEL.md` note documenting the revert-state modeling boundary: the `Contract` interpreter may produce transient intermediate state during evaluation but rolls back at `Contract.run`, unlike EVM’s transaction-atomic revert semantics.
> 
> Links this caveat from `TRUST_ASSUMPTIONS.md` (Revert-State Modeling section + related docs list) and `README.md` so proof authors and auditors are directed to reason about run-boundary outcomes rather than internal transient state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b407f2b54ee4967306eb8c76b8bdcbd39734b130. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->