### PR TITLE
Extend verity_contract expression support (math/bitwise/comparison batch)

### DIFF
--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -181,9 +181,55 @@ partial def translatePureExpr
   | `(term| $n:num) => `(Compiler.CompilationModel.Expr.literal $n)
   | `(term| add $a $b) => `(Compiler.CompilationModel.Expr.add $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
   | `(term| sub $a $b) => `(Compiler.CompilationModel.Expr.sub $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| mul $a $b) => `(Compiler.CompilationModel.Expr.mul $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| div $a $b) => `(Compiler.CompilationModel.Expr.div $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| mod $a $b) => `(Compiler.CompilationModel.Expr.mod $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| bitAnd $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| bitOr $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| bitXor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| bitNot $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExpr params locals a))
+  | `(term| shl $shift $value) => `(Compiler.CompilationModel.Expr.shl $(← translatePureExpr params locals shift) $(← translatePureExpr params locals value))
+  | `(term| shr $shift $value) => `(Compiler.CompilationModel.Expr.shr $(← translatePureExpr params locals shift) $(← translatePureExpr params locals value))
   | `(term| $a == $b) => `(Compiler.CompilationModel.Expr.eq $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| $a != $b) =>
+      `(Compiler.CompilationModel.Expr.logicalNot
+          (Compiler.CompilationModel.Expr.eq
+            $(← translatePureExpr params locals a)
+            $(← translatePureExpr params locals b)))
   | `(term| $a >= $b) => `(Compiler.CompilationModel.Expr.ge $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
-  | _ => throwErrorAt stx "unsupported expression in verity_contract body"
+  | `(term| $a > $b) => `(Compiler.CompilationModel.Expr.gt $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| $a < $b) => `(Compiler.CompilationModel.Expr.lt $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| $a <= $b) => `(Compiler.CompilationModel.Expr.le $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| and $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| or $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| xor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| not $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExpr params locals a))
+  | `(term| mulDivDown $a $b $c) =>
+      `(Compiler.CompilationModel.Expr.mulDivDown
+          $(← translatePureExpr params locals a)
+          $(← translatePureExpr params locals b)
+          $(← translatePureExpr params locals c))
+  | `(term| mulDivUp $a $b $c) =>
+      `(Compiler.CompilationModel.Expr.mulDivUp
+          $(← translatePureExpr params locals a)
+          $(← translatePureExpr params locals b)
+          $(← translatePureExpr params locals c))
+  | `(term| wMulDown $a $b) =>
+      `(Compiler.CompilationModel.Expr.wMulDown
+          $(← translatePureExpr params locals a)
+          $(← translatePureExpr params locals b))
+  | `(term| wDivUp $a $b) =>
+      `(Compiler.CompilationModel.Expr.wDivUp
+          $(← translatePureExpr params locals a)
+          $(← translatePureExpr params locals b))
+  | `(term| min $a $b) => `(Compiler.CompilationModel.Expr.min $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| max $a $b) => `(Compiler.CompilationModel.Expr.max $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| ite $cond $thenVal $elseVal) =>
+      `(Compiler.CompilationModel.Expr.ite
+          $(← translatePureExpr params locals cond)
+          $(← translatePureExpr params locals thenVal)
+          $(← translatePureExpr params locals elseVal))
+  | _ => throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
 
 private def translateBindSource
     (fields : Array StorageFieldDecl)


### PR DESCRIPTION
## Summary
This is a #1003 batch that expands `verity_contract` expression lowering to cover Morpho-relevant arithmetic and bitwise constructors.

### Added macro expression lowering
- arithmetic: `mul`, `div`, `mod`
- bitwise: `bitAnd`, `bitOr`, `bitXor`, `bitNot`
- shift: `shl`, `shr`
- comparisons: `>`, `<`, `<=`, `!=` (lowered via `logicalNot(eq ...)`)
- aliases for bitwise convenience: `and`, `or`, `xor`, `not`
- fixed-point/math helpers: `mulDivDown`, `mulDivUp`, `wMulDown`, `wDivUp`, `min`, `max`
- expression-level conditional: `ite cond thenVal elseVal`

### Smoke coverage
- Added `Counter.previewOps` in `Verity/Examples/MacroContracts.lean` to exercise the new lowering paths through `verity_contract`.
- Added local helper defs in `MacroContracts.lean` for executable Lean-side parity of these names.

### Diagnostics
- Tightened unsupported-expression error message to explicitly point at #1003.

## Validation
- `lake build Verity.Examples.MacroContracts`
- `lake build Compiler.MainTest`

## Notes
- This is intentionally a partial #1003 slice (does not yet add storage-struct/internal-function support).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the macro-to-IR lowering surface area in `translatePureExpr`, which can affect how contracts compile and execute if any pattern is mis-lowered. Changes are mostly additive and exercised by a new example, but they touch core compilation plumbing.
> 
> **Overview**
> Extends `verity_contract` pure-expression lowering to support additional Uint256 operations: `mul`/`div`/`mod`, bitwise ops (`bitAnd`/`bitOr`/`bitXor`/`bitNot`) plus `shl`/`shr`, richer comparisons (`>`, `<`, `<=`, `!=`), and convenience aliases (`and`/`or`/`xor`/`not`).
> 
> Adds lowering for common math helpers (`mulDivDown`, `mulDivUp`, `wMulDown`, `wDivUp`, `min`, `max`) and an expression-level conditional `ite`, and updates the unsupported-expression error to point to planned expansions (#1003). A new `Counter.previewOps` example plus local helper defs in `MacroContracts.lean` smoke-test the new lowering paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1fc769fc073a928511530b8d815605eab1d1f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->