### PR TITLE
Add env/logical/hash expression lowering to verity_contract macro

### DIFF
--- a/Verity/Examples/MacroContracts.lean
+++ b/Verity/Examples/MacroContracts.lean
@@ -23,6 +23,14 @@ def min (a b : Uint256) : Uint256 := if a <= b then a else b
 def max (a b : Uint256) : Uint256 := if a >= b then a else b
 def ite (cond : Prop) [Decidable cond] (thenVal elseVal : Uint256) : Uint256 :=
   if cond then thenVal else elseVal
+def logicalAnd (a b : Uint256) : Uint256 := if a != 0 && b != 0 then 1 else 0
+def logicalOr (a b : Uint256) : Uint256 := if a != 0 || b != 0 then 1 else 0
+def logicalNot (a : Uint256) : Uint256 := if a == 0 then 1 else 0
+def mload (offset : Uint256) : Uint256 := offset
+def keccak256 (offset size : Uint256) : Uint256 := add offset size
+def blockTimestamp : Uint256 := 0
+def contractAddress : Uint256 := 0
+def chainid : Uint256 := 0
 
 verity_contract SimpleStorage where
   storage
@@ -73,6 +81,18 @@ verity_contract Counter where
     let wadUp := wDivUp wadDown z
     let chosen := ite (x > y) wadUp (sub wadUp 1)
     return chosen
+
+  function previewEnvOps (x : Uint256, y : Uint256) : Uint256 := do
+    let ts := blockTimestamp
+    let self := contractAddress
+    let cid := chainid
+    let flagAnd := logicalAnd x y
+    let flagOr := logicalOr x y
+    let flagNot := logicalNot x
+    let hashInput := add (add ts self) cid
+    let memWord := mload hashInput
+    let digest := keccak256 memWord 64
+    return (add (add digest flagAnd) (add flagOr flagNot))
 
 verity_contract Owned where
   storage

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -177,6 +177,9 @@ partial def translatePureExpr
     (stx : Term) : CommandElabM Term := do
   let stx := stripParens stx
   match stx with
+  | `(term| blockTimestamp) => `(Compiler.CompilationModel.Expr.blockTimestamp)
+  | `(term| contractAddress) => `(Compiler.CompilationModel.Expr.contractAddress)
+  | `(term| chainid) => `(Compiler.CompilationModel.Expr.chainid)
   | `(term| $id:ident) => lookupVarExpr params locals (toString id.getId)
   | `(term| $n:num) => `(Compiler.CompilationModel.Expr.literal $n)
   | `(term| add $a $b) => `(Compiler.CompilationModel.Expr.add $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
@@ -200,10 +203,20 @@ partial def translatePureExpr
   | `(term| $a > $b) => `(Compiler.CompilationModel.Expr.gt $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
   | `(term| $a < $b) => `(Compiler.CompilationModel.Expr.lt $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
   | `(term| $a <= $b) => `(Compiler.CompilationModel.Expr.le $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| logicalAnd $a $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| logicalOr $a $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
+  | `(term| logicalNot $a) => `(Compiler.CompilationModel.Expr.logicalNot $(← translatePureExpr params locals a))
   | `(term| and $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
   | `(term| or $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
   | `(term| xor $a $b) => `(Compiler.CompilationModel.Expr.bitXor $(← translatePureExpr params locals a) $(← translatePureExpr params locals b))
   | `(term| not $a) => `(Compiler.CompilationModel.Expr.bitNot $(← translatePureExpr params locals a))
+  | `(term| mload $offset) =>
+      `(Compiler.CompilationModel.Expr.mload
+          $(← translatePureExpr params locals offset))
+  | `(term| keccak256 $offset $size) =>
+      `(Compiler.CompilationModel.Expr.keccak256
+          $(← translatePureExpr params locals offset)
+          $(← translatePureExpr params locals size))
   | `(term| mulDivDown $a $b $c) =>
       `(Compiler.CompilationModel.Expr.mulDivDown
           $(← translatePureExpr params locals a)


### PR DESCRIPTION
## Summary
Incremental `#1003` macro-support slice: adds environment/logical/hash expression lowering to `verity_contract`, with smoke coverage in `MacroContracts`.

### Added translation support
- Environment expressions:
  - `blockTimestamp` -> `Expr.blockTimestamp`
  - `contractAddress` -> `Expr.contractAddress`
  - `chainid` -> `Expr.chainid`
- Logical expressions:
  - `logicalAnd a b` -> `Expr.logicalAnd a b`
  - `logicalOr a b` -> `Expr.logicalOr a b`
  - `logicalNot a` -> `Expr.logicalNot a`
- Memory/hash expressions:
  - `mload offset` -> `Expr.mload offset`
  - `keccak256 offset size` -> `Expr.keccak256 offset size`

### Smoke coverage
- Added `Counter.previewEnvOps` in `Verity/Examples/MacroContracts.lean` to exercise all new paths through macro elaboration.

## Why this helps
- Reduces remaining expression-surface gap for Morpho migration (`morpho-verity#38`) by covering primitives that were previously blocked in macro lowering.
- Keeps fail-closed behavior intact for still-unsupported constructs.

## Validation
- `lake build Verity.Examples.MacroContracts Compiler.MainTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new expression forms to the `verity_contract` macro’s lowering logic, which can change elaboration/compilation behavior (and effectively reserves identifiers like `blockTimestamp`, `contractAddress`, and `chainid` in macro bodies). Overall scope is small and additive, but it touches core macro translation paths.
> 
> **Overview**
> Extends `verity_contract` expression lowering (`translatePureExpr`) to recognize **environment** terms (`blockTimestamp`, `contractAddress`, `chainid`), **logical** ops (`logicalAnd`, `logicalOr`, `logicalNot`), and **memory/hash** primitives (`mload`, `keccak256`), emitting the corresponding `Compiler.CompilationModel.Expr` variants.
> 
> Updates `Verity/Examples/MacroContracts.lean` with stub helpers/constants and adds `Counter.previewEnvOps` as smoke coverage to ensure the macro elaborates these newly-supported expressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3ea13bcbbf5af960ebc8489d8b15503acba9f1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->