### PR TITLE
Add #check_contract compile-time validation command

### DIFF
--- a/Verity/Examples/MacroContracts.lean
+++ b/Verity/Examples/MacroContracts.lean
@@ -352,4 +352,6 @@ verity_contract ERC20 where
     let currentOwner ← getStorageAddr ownerSlot
     return currentOwner
 
+#check_contract Counter
+
 end Verity.Examples.MacroContracts

--- a/Verity/Macro.lean
+++ b/Verity/Macro.lean
@@ -3,3 +3,4 @@ import Verity.Macro.Syntax
 import Verity.Macro.Translate
 import Verity.Macro.Bridge
 import Verity.Macro.Elaborate
+import Verity.Macro.Check

--- a/Verity/Macro/Check.lean
+++ b/Verity/Macro/Check.lean
@@ -1,0 +1,58 @@
+import Lean
+import Compiler.CompilationModel
+import Compiler.Selector
+import Verity.Macro.Syntax
+
+namespace Verity.Macro
+
+open Lean
+open Lean.Elab
+open Lean.Elab.Command
+
+private def formatCompileError (contractName : Name) (err : String) : String :=
+  s!"#check_contract failed for '{contractName}': {err}"
+
+@[command_elab checkContractCmd]
+def elabCheckContract : CommandElab := fun stx => do
+  match stx with
+  | `(#check_contract $contract:ident) => do
+      let env ← getEnv
+      let opts ← getOptions
+      let currentNs ← getCurrNamespace
+      let rawName := contract.getId
+      let contractCandidates : List Name :=
+        if currentNs == Name.anonymous then
+          [rawName]
+        else
+          [rawName, currentNs ++ rawName]
+      let mut resolvedContractName : Option Name := none
+      let mut resolvedSpec : Option Compiler.CompilationModel.CompilationModel := none
+      for contractName in contractCandidates do
+        let specName := contractName ++ `spec
+        if env.contains specName then
+          match unsafe env.evalConstCheck Compiler.CompilationModel.CompilationModel opts
+              ``Compiler.CompilationModel.CompilationModel specName with
+          | .ok spec =>
+              resolvedContractName := some contractName
+              resolvedSpec := some spec
+              break
+          | .error _ => pure ()
+      let contractName ←
+        match resolvedContractName with
+        | some name => pure name
+        | none =>
+            throwErrorAt contract s!"#check_contract expected a generated '<Contract>.spec' CompilationModel for '{contract.getId}'"
+      let spec ←
+        match resolvedSpec with
+        | some spec => pure spec
+        | none =>
+            throwErrorAt contract s!"#check_contract expected a generated '<Contract>.spec' CompilationModel for '{contract.getId}'"
+      let selectors ← liftIO <| Compiler.Selector.computeSelectors spec
+      match Compiler.CompilationModel.compile spec selectors with
+      | .ok _ =>
+          logInfo m!"#check_contract ok: {contractName}"
+      | .error err =>
+          throwErrorAt contract (formatCompileError contractName err)
+  | _ => throwErrorAt stx "invalid #check_contract command"
+
+end Verity.Macro

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -20,4 +20,7 @@ syntax (name := verityContractCmd)
   (verityConstructor)?
   verityFunction+ : command
 
+syntax (name := checkContractCmd)
+  "#check_contract " ident : command
+
 end Verity.Macro


### PR DESCRIPTION
## Summary
Implements `verity#1010` with a new Lean command:

- `#check_contract <ContractName>`

The command validates the macro-generated `<Contract>.spec` at elaboration time by:
1. deriving canonical selectors via `Compiler.Selector.computeSelectors`
2. invoking `Compiler.CompilationModel.compile spec selectors`
3. failing with a Lean error if compilation validation fails

This gives immediate editor/build-time feedback for contract authoring instead of waiting for CLI invocation.

## Changes
- Added command syntax in `Verity/Macro/Syntax.lean`.
- Added command elaborator in new file `Verity/Macro/Check.lean`.
- Wired command into `Verity/Macro.lean`.
- Added smoke usage in `Verity/Examples/MacroContracts.lean`:
  - `#check_contract Counter`

## Validation
- `lake build Verity.Macro.Check Verity.Examples.MacroContracts`
- `lake build Compiler.MainTest`

Closes #1010.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new elaboration-time command that executes selector derivation and compilation against macro-generated specs; failures now surface as Lean errors and it uses `unsafe` env evaluation, so it can affect build behavior and performance.
> 
> **Overview**
> Adds a new Lean command, `#check_contract <Contract>`, that validates a macro-generated `<Contract>.spec` during elaboration by resolving the spec from the environment, computing canonical selectors, and running `Compiler.CompilationModel.compile`, producing a targeted error on failure.
> 
> Wires the command into `Verity.Macro` via a new `Verity/Macro/Check.lean` module and extends `Verity/Macro/Syntax.lean` with the command syntax, with a smoke usage added to `Verity/Examples/MacroContracts.lean` (`#check_contract Counter`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eebb25e1dc756fbca0918c4274f5853e59d3529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->