### PR TITLE
Compiler: remove partial recursion in ABI/Codegen helpers

### DIFF
--- a/Compiler/ABI.lean
+++ b/Compiler/ABI.lean
@@ -23,7 +23,7 @@ private def jsonString (s : String) : String :=
 private def joinJsonFields (fields : List String) : String :=
   String.intercalate ", " fields
 
-private partial def abiTypeString : ParamType → String
+private def abiTypeString : ParamType → String
   | .uint256 => "uint256"
   | .address => "address"
   | .bool => "bool"
@@ -52,7 +52,6 @@ mutual
     | .array t => abiComponents? t
     | .fixedArray t _ => abiComponents? t
     | _ => none
-
   private partial def renderParam (name : String) (ty : ParamType) (indexed : Option Bool) : String :=
     let base := [
       s!"\"name\": {jsonString name}",


### PR DESCRIPTION
## Summary
This is a focused `#1008` hardening slice that removes easy compiler `partial def` usage without changing behavior.

Changes:
- `Compiler/ABI.lean`
  - convert `abiTypeString` from `partial def` to total `def` (structural recursion)
- `Compiler/Codegen.lean`
  - convert `stmtContainsSwitchCaseCall` from `partial def` to total mutual recursion with explicit `termination_by`
  - add list helper `stmtListContainsSwitchCaseCall` to keep recursion structural and proof-visible

## Why
`#1008` tracks reducing opaque recursion in compiler/codegen paths. This PR removes two low-risk `partial` declarations in core output-generation logic.

## Validation
- `lake build Compiler.ABI Compiler.Codegen Compiler.MainTest`

## Risk
Low. This is a refactor of recursion shape only; no semantic changes to emitted ABI strings or switch-case call detection behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes recursion/termination structure in helper functions; behavior should be unchanged but touches ABI rendering and Yul switch-case analysis utilities used in codegen tests.
> 
> **Overview**
> Removes `partial` recursion from two compiler helpers to make termination explicit and proof-visible.
> 
> In `Compiler/ABI.lean`, `abiTypeString` is now a total `def` (structural recursion) with the same ABI type string rendering. In `Compiler/Codegen.lean`, `stmtContainsSwitchCaseCall` is rewritten as a mutual recursion with a new `stmtListContainsSwitchCaseCall` helper and explicit `termination_by`, preserving the existing switch-case call detection logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0fd764769e8e4392cdaef3eecc835aba79afcba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->