### PR TITLE
CI: increase build job timeout from 45 to 90 minutes

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -192,7 +192,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:


### PR DESCRIPTION
## Summary
- Increase build job `timeout-minutes` from 45 to 90 to accommodate cold-cache EVMYulLean native linking
- The clang linking step for the EVMYulLean FFI (SHA-2, Keccak256, EthereumTests) takes 50+ minutes on GitHub Actions 2-core runners when the Lake cache is cold
- When the build exceeds 45 minutes, it gets cancelled before the `cache/save` step can run, preventing the cache from ever being populated — creating a perpetual cold-cache failure cycle

## Context
The same issue was fixed in morpho-verity (PR #47, merged) where the verity-proofs job was increased to 90 minutes. This PR applies the same fix to verity's build job.

Recent main branch builds have been consistently cancelled at the concurrency group level before completion, which means the Lake cache hasn't been refreshed. The current main build (run 22533150470) has been running for 35+ minutes and is likely to hit the same 45-minute wall.

## Test plan
- [ ] All 158 Python unit tests pass locally
- [ ] Build job completes within 90 minutes on a cold-cache run
- [ ] Cache save step executes after successful build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a GitHub Actions job timeout with no impact on runtime code or test logic; the main effect is longer waits before CI cancels stuck builds.
> 
> **Overview**
> In `verify.yml`, increases the `build` job timeout from **45** to **90 minutes** to reduce premature cancellations on cold-cache runs and allow the workflow to reach its cache-save and artifact upload steps reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d98590dd2362bd3d78d2d567c26ca3cf23a6c1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->