### PR TITLE
Totalize exprContainsCallLike in CompilationModel

### DIFF
--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -1133,7 +1133,7 @@ def functionStateMutability (spec : FunctionSpec) : String :=
 private def findParamType (params : List Param) (name : String) : Option ParamType :=
   (params.find? (fun p => p.name == name)).map (·.ty)
 
-private partial def exprContainsCallLike (expr : Expr) : Bool :=
+private def exprContainsCallLike (expr : Expr) : Bool :=
   match expr with
   | Expr.call _ _ _ _ _ _ _ => true
   | Expr.staticcall _ _ _ _ _ _ => true


### PR DESCRIPTION
## Summary
- convert `exprContainsCallLike` in `Compiler/CompilationModel.lean` from `partial def` to total `def`
- keep behavior unchanged while removing one opaque recursive helper from the core compilation model path

## Validation
- `lake build Compiler.CompilationModel Compiler.MainTest`

Closes #1008

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes `exprContainsCallLike` from `partial def` to total `def`, with the same match cases and recursion structure. Main risk is any subtle Lean termination/compile-time behavior change, not runtime semantics.
> 
> **Overview**
> Removes the `partial` marker from `exprContainsCallLike` in `Compiler/CompilationModel.lean`, making the recursive call-detection helper a total definition while keeping the same pattern matches and recursion behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd878fcfe471acc4f188588249f4aad8bdebba5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->