### PR TITLE
Expand ERC20/ERC721 property suites beyond scaffolds

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The `mappingPackedWord` forms perform masked/shifted packed read-modify-write at
 
 **Run tests:**
 ```bash
-FOUNDRY_PROFILE=difftest forge test           # 404 tests across 35 suites
+FOUNDRY_PROFILE=difftest forge test           # 441 tests across 35 suites
 ```
 
 ---
@@ -231,7 +231,7 @@ See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a
 
 Verity's restricted DSL prevents raw external calls for safety. Instead, call patterns are packaged as **External Call Modules (ECMs)** — reusable, typed, auditable Lean structures that the compiler can plug in without modification. Standard modules for ERC-20, EVM precompiles, and callbacks ship in [`Compiler/Modules/`](Compiler/Modules/README.md). Third parties can publish their own as separate Lean packages. See [`docs/EXTERNAL_CALL_MODULES.md`](docs/EXTERNAL_CALL_MODULES.md) for the full guide.
 
-431 theorems across 11 categories, all fully proven. 404 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axiom. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
+431 theorems across 11 categories, all fully proven. 441 Foundry tests across 35 test suites. 250 covered by property tests (58% coverage, 181 proof-only exclusions). 1 documented axiom. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)).
 
 ## What's Verified
 
@@ -334,7 +334,7 @@ FOUNDRY_PROFILE=difftest forge test
 <details>
 <summary><strong>Testing</strong></summary>
 
-**Foundry tests** (404 tests) validate EDSL = Yul = EVM execution:
+**Foundry tests** (441 tests) validate EDSL = Yul = EVM execution:
 
 ```bash
 FOUNDRY_PROFILE=difftest forge test                                          # run all

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,8 +10,8 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 70000,
-    "foundry_functions": 404,
-    "property_functions": 197,
+    "foundry_functions": 441,
+    "property_functions": 234,
     "suites": 35
   },
   "theorems": {

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -599,7 +599,7 @@ lake exe verity-compiler
 # Run all Foundry tests (difftest profile enables FFI for Yul compilation)
 FOUNDRY_PROFILE=difftest forge test
 
-# Expected: 404/404 tests pass
+# Expected: 441/441 tests pass
 ```
 
 ### Add New Contract
@@ -640,10 +640,10 @@ $ lake build
 Build completed successfully.
 ```
 
-**Foundry Tests**: 404/404 passing (100%)
+**Foundry Tests**: 441/441 passing (100%)
 ```bash
 $ FOUNDRY_PROFILE=difftest forge test
-Ran 35 test suites: 404 tests passed, 0 failed, 0 skipped (404 total tests)
+Ran 35 test suites: 441 tests passed, 0 failed, 0 skipped (441 total tests)
 ```
 
 **Coverage**: Unit, property, and differential tests across EDSL and compiled Yul. See `test/` for suites.

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -34,7 +34,7 @@ This project uses Lean to:
 - Implement the contracts (executable code)
 - Prove the implementations satisfy the specifications (theorems)
 
-**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 404 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
+**Current status**: A compact EDSL core, 9 example contracts, 431 machine-checked theorems across the EDSL and compiler, and automatic compilation to EVM bytecode. 441 Foundry tests across 35 suites. 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)), 0 `sorry` — all proofs complete including Ledger sum conservation ([#65](https://github.com/Th0rgal/verity/issues/65)). Foundry tests include unit, property, and differential checks with multi-seed coverage.
 
 ## The Three-Layer Structure
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -173,7 +173,7 @@ def ownedSpec : CompilationModel := {
 **Metrics**:
 - Manual IR eliminated in favor of generated IR from the spec
 - Time to add contract dropped significantly in practice
-- Test results: Foundry tests pass (404 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
+- Test results: Foundry tests pass (441 as of 2026-02-18), Lean proofs verify (431 theorems as of 2026-02-19)
 - Code quality: More concise, optimized (expression inlining)
 
 **Features Achieved**:
@@ -187,7 +187,7 @@ def ownedSpec : CompilationModel := {
 ```bash
 lake build verity-compiler    # Build compiler
 lake exe verity-compiler      # Generate all contracts
-FOUNDRY_PROFILE=difftest forge test  # 404/375 tests pass (as of 2026-02-18)
+FOUNDRY_PROFILE=difftest forge test  # 441/375 tests pass (as of 2026-02-18)
 ```
 
 ### Differential Testing (Completed 2026-02-10)
@@ -224,7 +224,7 @@ FOUNDRY_PROFILE=difftest forge test  # 404/375 tests pass (as of 2026-02-18)
 - 10,000+ random transactions pass per contract in CI (large suite)
 - Large suite is sharded across 8 CI jobs to stay within per-test gas limits
 - Zero mismatches detected
-- All Foundry tests passing (404 as of 2026-02-18)
+- All Foundry tests passing (441 as of 2026-02-18)
 - CI: All checks passing
 
 **Usage**:

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -19,7 +19,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 431 across 11 categories (431 fully proven, 0 `sorry` placeholders)
 - **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256_first_4_bytes only
-- **Tests**: 404 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
+- **Tests**: 441 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
 

--- a/test/PropertyERC20.t.sol
+++ b/test/PropertyERC20.t.sol
@@ -3,27 +3,364 @@ pragma solidity ^0.8.33;
 
 import "forge-std/Test.sol";
 
+contract ERC20Model {
+    uint256 internal constant MAX_UINT256 = type(uint256).max;
+
+    address private _owner;
+    uint256 private _totalSupply;
+    mapping(address => uint256) private _balances;
+    mapping(address => mapping(address => uint256)) private _allowances;
+
+    constructor(address initialOwner) {
+        _owner = initialOwner;
+        _totalSupply = 0;
+    }
+
+    function mint(address to, uint256 amount) external {
+        require(msg.sender == _owner, "Caller is not the owner");
+        _balances[to] += amount;
+        _totalSupply += amount;
+    }
+
+    function transfer(address to, uint256 amount) external {
+        uint256 senderBal = _balances[msg.sender];
+        require(senderBal >= amount, "Insufficient balance");
+
+        if (msg.sender == to) {
+            return;
+        }
+
+        _balances[msg.sender] = senderBal - amount;
+        _balances[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external {
+        _allowances[msg.sender][spender] = amount;
+    }
+
+    function transferFrom(address fromAddr, address to, uint256 amount) external {
+        uint256 currentAllowance = _allowances[fromAddr][msg.sender];
+        require(currentAllowance >= amount, "Insufficient allowance");
+
+        uint256 fromBalance = _balances[fromAddr];
+        require(fromBalance >= amount, "Insufficient balance");
+
+        if (fromAddr != to) {
+            _balances[fromAddr] = fromBalance - amount;
+            _balances[to] += amount;
+        }
+
+        if (currentAllowance != MAX_UINT256) {
+            _allowances[fromAddr][msg.sender] = currentAllowance - amount;
+        }
+    }
+
+    function balanceOf(address addr) external view returns (uint256) {
+        return _balances[addr];
+    }
+
+    function allowanceOf(address ownerAddr, address spender) external view returns (uint256) {
+        return _allowances[ownerAddr][spender];
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}
+
 contract PropertyERC20Test is Test {
-    /// Property 1: balanceOf_meets_spec
-    /// Property 2: allowanceOf_meets_spec
-    /// Property 3: totalSupply_meets_spec
-    /// Property 4: getOwner_meets_spec
-    /// Property 5: constructor_meets_spec
-    /// Property 6: approve_meets_spec
-    /// Property 7: balanceOf_preserves_state
-    /// Property 8: allowanceOf_preserves_state
-    /// Property 9: getTotalSupply_preserves_state
-    /// Property 10: getOwner_preserves_state
-    /// Property 11: approve_is_balance_neutral_holds
-    /// Property 12: mint_meets_spec_when_owner
-    /// Property 13: mint_increases_balance_when_owner
-    /// Property 14: mint_increases_supply_when_owner
-    /// Property 15: transfer_meets_spec_when_sufficient
-    /// Property 16: transfer_decreases_sender_balance_when_sufficient
-    /// Property 17: transfer_increases_recipient_balance_when_sufficient
-    /// Property 18: transfer_preserves_totalSupply_when_sufficient
-    /// Property 19: transfer_preserves_owner_when_sufficient
-    function testProperty_ERC20_ScaffoldExists() public pure {
-        assertTrue(true);
+    ERC20Model internal token;
+
+    address internal constant OWNER = address(0xA11CE);
+    address internal constant ALICE = address(0xA1);
+    address internal constant BOB = address(0xB0B);
+    address internal constant CHARLIE = address(0xC4A12);
+
+    function setUp() public {
+        token = new ERC20Model(OWNER);
+    }
+
+    function _mintAsOwner(address to, uint256 amount) internal {
+        vm.prank(OWNER);
+        token.mint(to, amount);
+    }
+
+    /// Property: constructor_meets_spec
+    /// Property: getOwner_meets_spec
+    function testProperty_Constructor_SetsOwner() public view {
+        assertEq(token.owner(), OWNER, "owner mismatch");
+    }
+
+    /// Property: getOwner_preserves_state
+    function testProperty_GetOwner_PreservesState(uint256 amount) public {
+        amount = bound(amount, 0, 1e30);
+        _mintAsOwner(ALICE, amount);
+
+        uint256 supplyBefore = token.totalSupply();
+        uint256 aliceBefore = token.balanceOf(ALICE);
+
+        token.owner();
+
+        assertEq(token.totalSupply(), supplyBefore, "totalSupply changed");
+        assertEq(token.balanceOf(ALICE), aliceBefore, "balance changed");
+    }
+
+    /// Property: constructor_meets_spec
+    /// Property: totalSupply_meets_spec
+    function testProperty_Constructor_SetsInitialSupplyZero() public view {
+        assertEq(token.totalSupply(), 0, "initial supply must be zero");
+    }
+
+    /// Property: getTotalSupply_preserves_state
+    function testProperty_GetTotalSupply_PreservesState(uint256 amount) public {
+        amount = bound(amount, 0, 1e30);
+        _mintAsOwner(ALICE, amount);
+
+        address ownerBefore = token.owner();
+        uint256 aliceBefore = token.balanceOf(ALICE);
+
+        token.totalSupply();
+
+        assertEq(token.owner(), ownerBefore, "owner changed");
+        assertEq(token.balanceOf(ALICE), aliceBefore, "balance changed");
+    }
+
+    /// Property: balanceOf_meets_spec
+    function testProperty_BalanceOf_ReturnsMintedBalance(uint256 amount) public {
+        amount = bound(amount, 0, 1e30);
+        _mintAsOwner(ALICE, amount);
+        assertEq(token.balanceOf(ALICE), amount, "balance mismatch");
+    }
+
+    /// Property: balanceOf_preserves_state
+    function testProperty_BalanceOf_PreservesState(uint256 amount) public {
+        amount = bound(amount, 0, 1e30);
+        _mintAsOwner(ALICE, amount);
+
+        uint256 supplyBefore = token.totalSupply();
+        address ownerBefore = token.owner();
+
+        token.balanceOf(ALICE);
+
+        assertEq(token.totalSupply(), supplyBefore, "totalSupply changed");
+        assertEq(token.owner(), ownerBefore, "owner changed");
+    }
+
+    /// Property: allowanceOf_meets_spec
+    function testProperty_AllowanceOf_ReturnsApprovedAmount(uint256 amount) public {
+        vm.prank(ALICE);
+        token.approve(BOB, amount);
+        assertEq(token.allowanceOf(ALICE, BOB), amount, "allowance mismatch");
+    }
+
+    /// Property: allowanceOf_preserves_state
+    function testProperty_AllowanceOf_PreservesState(uint256 mintAmount, uint256 allowanceAmount) public {
+        mintAmount = bound(mintAmount, 0, 1e30);
+        _mintAsOwner(ALICE, mintAmount);
+
+        vm.prank(ALICE);
+        token.approve(BOB, allowanceAmount);
+
+        uint256 supplyBefore = token.totalSupply();
+        uint256 aliceBefore = token.balanceOf(ALICE);
+
+        token.allowanceOf(ALICE, BOB);
+
+        assertEq(token.totalSupply(), supplyBefore, "totalSupply changed");
+        assertEq(token.balanceOf(ALICE), aliceBefore, "balance changed");
+    }
+
+    /// Property: approve_meets_spec
+    /// Property: approve_is_balance_neutral_holds
+    function testProperty_Approve_SetsAllowance_AndPreservesBalances(uint256 minted, uint256 allowanceAmount) public {
+        minted = bound(minted, 0, 1e30);
+        _mintAsOwner(ALICE, minted);
+
+        uint256 aliceBefore = token.balanceOf(ALICE);
+        uint256 bobBefore = token.balanceOf(BOB);
+        uint256 supplyBefore = token.totalSupply();
+
+        vm.prank(ALICE);
+        token.approve(BOB, allowanceAmount);
+
+        assertEq(token.allowanceOf(ALICE, BOB), allowanceAmount, "allowance not set");
+        assertEq(token.balanceOf(ALICE), aliceBefore, "owner balance changed");
+        assertEq(token.balanceOf(BOB), bobBefore, "spender balance changed");
+        assertEq(token.totalSupply(), supplyBefore, "supply changed");
+    }
+
+    /// Property: mint_meets_spec_when_owner
+    /// Property: mint_increases_balance_when_owner
+    /// Property: mint_increases_supply_when_owner
+    function testProperty_Mint_IncreasesRecipientBalance_AndSupply(uint256 amount) public {
+        amount = bound(amount, 0, 1e30);
+
+        uint256 balBefore = token.balanceOf(ALICE);
+        uint256 supplyBefore = token.totalSupply();
+
+        _mintAsOwner(ALICE, amount);
+
+        assertEq(token.balanceOf(ALICE), balBefore + amount, "recipient balance mismatch");
+        assertEq(token.totalSupply(), supplyBefore + amount, "supply mismatch");
+    }
+
+    /// Property: mint_meets_spec_when_owner
+    function testProperty_Mint_RevertsWhenNotOwner(uint256 amount) public {
+        vm.prank(ALICE);
+        vm.expectRevert(bytes("Caller is not the owner"));
+        token.mint(BOB, amount);
+    }
+
+    /// Property: transfer_meets_spec_when_sufficient
+    /// Property: transfer_decreases_sender_balance_when_sufficient
+    /// Property: transfer_increases_recipient_balance_when_sufficient
+    function testProperty_Transfer_ConservesBalances_WhenSufficient(uint256 mintAmount, uint256 transferAmount) public {
+        mintAmount = bound(mintAmount, 1, 1e30);
+        transferAmount = bound(transferAmount, 0, mintAmount);
+
+        _mintAsOwner(ALICE, mintAmount);
+
+        uint256 senderBefore = token.balanceOf(ALICE);
+        uint256 recipientBefore = token.balanceOf(BOB);
+        uint256 supplyBefore = token.totalSupply();
+
+        vm.prank(ALICE);
+        token.transfer(BOB, transferAmount);
+
+        assertEq(token.balanceOf(ALICE), senderBefore - transferAmount, "sender mismatch");
+        assertEq(token.balanceOf(BOB), recipientBefore + transferAmount, "recipient mismatch");
+        assertEq(token.totalSupply(), supplyBefore, "supply changed");
+    }
+
+    /// Property: transfer_meets_spec_when_sufficient
+    function testProperty_Transfer_SelfTransferIsNoOp(uint256 mintAmount, uint256 transferAmount) public {
+        mintAmount = bound(mintAmount, 1, 1e30);
+        transferAmount = bound(transferAmount, 0, mintAmount);
+
+        _mintAsOwner(ALICE, mintAmount);
+        uint256 beforeBal = token.balanceOf(ALICE);
+
+        vm.prank(ALICE);
+        token.transfer(ALICE, transferAmount);
+
+        assertEq(token.balanceOf(ALICE), beforeBal, "self-transfer changed balance");
+    }
+
+    /// Property: transfer_meets_spec_when_sufficient
+    function testProperty_Transfer_RevertsOnInsufficientBalance(uint256 mintAmount, uint256 transferAmount) public {
+        mintAmount = bound(mintAmount, 0, 1e12);
+        transferAmount = bound(transferAmount, mintAmount + 1, mintAmount + 1e12 + 1);
+
+        _mintAsOwner(ALICE, mintAmount);
+
+        vm.prank(ALICE);
+        vm.expectRevert(bytes("Insufficient balance"));
+        token.transfer(BOB, transferAmount);
+    }
+
+    /// Property: transfer_preserves_totalSupply_when_sufficient
+    /// Property: transfer_preserves_owner_when_sufficient
+    function testProperty_Transfer_PreservesSupplyAndOwner(uint256 mintAmount, uint256 transferAmount) public {
+        mintAmount = bound(mintAmount, 1, 1e30);
+        transferAmount = bound(transferAmount, 0, mintAmount);
+
+        _mintAsOwner(ALICE, mintAmount);
+
+        uint256 supplyBefore = token.totalSupply();
+        address ownerBefore = token.owner();
+
+        vm.prank(ALICE);
+        token.transfer(BOB, transferAmount);
+
+        assertEq(token.totalSupply(), supplyBefore, "supply changed");
+        assertEq(token.owner(), ownerBefore, "owner changed");
+    }
+
+    /// Property: transfer_meets_spec_when_sufficient
+    function testProperty_TransferFrom_ConsumesAllowance(uint256 mintAmount, uint256 spendAmount, uint256 allowanceAmount)
+        public
+    {
+        mintAmount = bound(mintAmount, 1, 1e30);
+        spendAmount = bound(spendAmount, 0, mintAmount);
+        allowanceAmount = bound(allowanceAmount, spendAmount, 1e30);
+
+        _mintAsOwner(ALICE, mintAmount);
+
+        vm.prank(ALICE);
+        token.approve(BOB, allowanceAmount);
+
+        vm.prank(BOB);
+        token.transferFrom(ALICE, CHARLIE, spendAmount);
+
+        assertEq(token.allowanceOf(ALICE, BOB), allowanceAmount - spendAmount, "allowance not consumed");
+    }
+
+    /// Property: transfer_meets_spec_when_sufficient
+    function testProperty_TransferFrom_InfiniteAllowanceNotConsumed(uint256 mintAmount, uint256 spendAmount) public {
+        mintAmount = bound(mintAmount, 1, 1e30);
+        spendAmount = bound(spendAmount, 0, mintAmount);
+
+        _mintAsOwner(ALICE, mintAmount);
+
+        vm.prank(ALICE);
+        token.approve(BOB, type(uint256).max);
+
+        vm.prank(BOB);
+        token.transferFrom(ALICE, CHARLIE, spendAmount);
+
+        assertEq(token.allowanceOf(ALICE, BOB), type(uint256).max, "infinite allowance should stay max");
+    }
+
+    /// Property: transfer_meets_spec_when_sufficient
+    function testProperty_TransferFrom_RevertsWhenAllowanceInsufficient(uint256 mintAmount, uint256 spendAmount) public {
+        mintAmount = bound(mintAmount, 1, 1e30);
+        spendAmount = bound(spendAmount, 1, mintAmount);
+
+        _mintAsOwner(ALICE, mintAmount);
+
+        vm.prank(ALICE);
+        token.approve(BOB, spendAmount - 1);
+
+        vm.prank(BOB);
+        vm.expectRevert(bytes("Insufficient allowance"));
+        token.transferFrom(ALICE, CHARLIE, spendAmount);
+    }
+
+    /// Property: transfer_meets_spec_when_sufficient
+    function testProperty_TransferFrom_RevertsWhenBalanceInsufficient(uint256 allowanceAmount, uint256 spendAmount) public {
+        allowanceAmount = bound(allowanceAmount, 1, 1e30);
+        spendAmount = bound(spendAmount, 1, allowanceAmount);
+
+        vm.prank(ALICE);
+        token.approve(BOB, allowanceAmount);
+
+        vm.prank(BOB);
+        vm.expectRevert(bytes("Insufficient balance"));
+        token.transferFrom(ALICE, CHARLIE, spendAmount);
+    }
+
+    /// Property: transfer_meets_spec_when_sufficient
+    function testProperty_TransferFrom_SelfTransferOnlyUpdatesAllowance(uint256 mintAmount, uint256 spendAmount, uint256 allowanceAmount)
+        public
+    {
+        mintAmount = bound(mintAmount, 1, 1e30);
+        spendAmount = bound(spendAmount, 0, mintAmount);
+        allowanceAmount = bound(allowanceAmount, spendAmount, 1e30);
+
+        _mintAsOwner(ALICE, mintAmount);
+        vm.prank(ALICE);
+        token.approve(BOB, allowanceAmount);
+
+        uint256 aliceBefore = token.balanceOf(ALICE);
+
+        vm.prank(BOB);
+        token.transferFrom(ALICE, ALICE, spendAmount);
+
+        assertEq(token.balanceOf(ALICE), aliceBefore, "self transferFrom changed balance");
+        assertEq(token.allowanceOf(ALICE, BOB), allowanceAmount - spendAmount, "allowance mismatch");
     }
 }

--- a/test/PropertyERC721.t.sol
+++ b/test/PropertyERC721.t.sol
@@ -3,19 +3,309 @@ pragma solidity ^0.8.33;
 
 import "forge-std/Test.sol";
 
+contract ERC721Model {
+    address private _owner;
+    uint256 private _totalSupply;
+    uint256 private _nextTokenId;
+
+    mapping(address => uint256) private _balances;
+    mapping(uint256 => address) private _owners;
+    mapping(uint256 => address) private _tokenApprovals;
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
+
+    constructor(address initialOwner) {
+        _owner = initialOwner;
+        _totalSupply = 0;
+        _nextTokenId = 0;
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function nextTokenId() external view returns (uint256) {
+        return _nextTokenId;
+    }
+
+    function balanceOf(address addr) external view returns (uint256) {
+        return _balances[addr];
+    }
+
+    function ownerOf(uint256 tokenId) public view returns (address) {
+        address tokenOwner = _owners[tokenId];
+        require(tokenOwner != address(0), "Token does not exist");
+        return tokenOwner;
+    }
+
+    function getApproved(uint256 tokenId) external view returns (address) {
+        require(_owners[tokenId] != address(0), "Token does not exist");
+        return _tokenApprovals[tokenId];
+    }
+
+    function isApprovedForAll(address ownerAddr, address operator) external view returns (bool) {
+        return _operatorApprovals[ownerAddr][operator];
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        _operatorApprovals[msg.sender][operator] = approved;
+    }
+
+    function approve(address approved, uint256 tokenId) external {
+        address tokenOwner = ownerOf(tokenId);
+        require(msg.sender == tokenOwner, "Not token owner");
+        _tokenApprovals[tokenId] = approved;
+    }
+
+    function mint(address to) external returns (uint256) {
+        require(msg.sender == _owner, "Caller is not the owner");
+        require(to != address(0), "Invalid recipient");
+
+        uint256 tokenId = _nextTokenId;
+        require(_owners[tokenId] == address(0), "Token already minted");
+
+        _owners[tokenId] = to;
+        _balances[to] += 1;
+        _totalSupply += 1;
+        _nextTokenId = tokenId + 1;
+        return tokenId;
+    }
+
+    function transferFrom(address fromAddr, address to, uint256 tokenId) external {
+        require(to != address(0), "Invalid recipient");
+        address tokenOwner = ownerOf(tokenId);
+        require(tokenOwner == fromAddr, "From is not owner");
+
+        bool authorized = msg.sender == fromAddr
+            || _tokenApprovals[tokenId] == msg.sender
+            || _operatorApprovals[fromAddr][msg.sender];
+        require(authorized, "Not authorized");
+
+        if (fromAddr != to) {
+            require(_balances[fromAddr] >= 1, "Insufficient balance");
+            _balances[fromAddr] -= 1;
+            _balances[to] += 1;
+        }
+
+        _owners[tokenId] = to;
+        _tokenApprovals[tokenId] = address(0);
+    }
+}
+
 contract PropertyERC721Test is Test {
-    /// Property 1: constructor_meets_spec
-    /// Property 2: balanceOf_meets_spec
-    /// Property 3: ownerOf_meets_spec
-    /// Property 4: getApproved_meets_spec
-    /// Property 5: isApprovedForAll_meets_spec
-    /// Property 6: setApprovalForAll_meets_spec
-    /// Property 7: balanceOf_preserves_state
-    /// Property 8: ownerOf_preserves_state
-    /// Property 9: getApproved_preserves_state
-    /// Property 10: isApprovedForAll_preserves_state
-    /// Property 11: setApprovalForAll_is_balance_neutral_holds
-    function testProperty_ERC721_ScaffoldExists() public pure {
-        assertTrue(true);
+    ERC721Model internal nft;
+
+    address internal constant OWNER = address(0xA11CE);
+    address internal constant ALICE = address(0xA1);
+    address internal constant BOB = address(0xB0B);
+    address internal constant CHARLIE = address(0xC4A12);
+    address internal constant OPERATOR = address(0x0B5);
+
+    function setUp() public {
+        nft = new ERC721Model(OWNER);
+    }
+
+    function _mintAsOwner(address to) internal returns (uint256 tokenId) {
+        vm.prank(OWNER);
+        tokenId = nft.mint(to);
+    }
+
+    /// Property: constructor_meets_spec
+    function testProperty_Constructor_SetsOwner() public view {
+        assertEq(nft.owner(), OWNER, "owner mismatch");
+    }
+
+    /// Property: constructor_meets_spec
+    function testProperty_Constructor_InitializesCountersToZero() public view {
+        assertEq(nft.totalSupply(), 0, "initial supply must be zero");
+        assertEq(nft.nextTokenId(), 0, "initial next token must be zero");
+    }
+
+    /// Property: balanceOf_meets_spec
+    function testProperty_Mint_AssignsOwnershipCorrectly(address recipient) public {
+        vm.assume(recipient != address(0));
+        uint256 tokenId = _mintAsOwner(recipient);
+        assertEq(nft.ownerOf(tokenId), recipient, "ownerOf mismatch after mint");
+    }
+
+    /// Property: balanceOf_meets_spec
+    function testProperty_Mint_IncreasesRecipientBalance(address recipient) public {
+        vm.assume(recipient != address(0));
+
+        uint256 beforeBal = nft.balanceOf(recipient);
+        _mintAsOwner(recipient);
+
+        assertEq(nft.balanceOf(recipient), beforeBal + 1, "recipient balance did not increment");
+    }
+
+    /// Property: constructor_meets_spec
+    function testProperty_Mint_IncreasesTotalSupply(address recipient) public {
+        vm.assume(recipient != address(0));
+
+        uint256 before = nft.totalSupply();
+        _mintAsOwner(recipient);
+
+        assertEq(nft.totalSupply(), before + 1, "supply did not increment");
+    }
+
+    /// Property: constructor_meets_spec
+    function testProperty_Mint_UsesSequentialTokenIds(address recipientA, address recipientB) public {
+        vm.assume(recipientA != address(0));
+        vm.assume(recipientB != address(0));
+
+        uint256 t0 = _mintAsOwner(recipientA);
+        uint256 t1 = _mintAsOwner(recipientB);
+
+        assertEq(t0, 0, "first token id must be 0");
+        assertEq(t1, 1, "second token id must be 1");
+        assertEq(nft.nextTokenId(), 2, "next token id mismatch");
+    }
+
+    /// Property: constructor_meets_spec
+    function testProperty_Mint_RevertsWhenNotOwner(address recipient) public {
+        vm.assume(recipient != address(0));
+        vm.prank(ALICE);
+        vm.expectRevert(bytes("Caller is not the owner"));
+        nft.mint(recipient);
+    }
+
+    /// Property: ownerOf_meets_spec
+    function testProperty_TransferFrom_UpdatesOwnership() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+
+        vm.prank(ALICE);
+        nft.transferFrom(ALICE, BOB, tokenId);
+
+        assertEq(nft.ownerOf(tokenId), BOB, "ownership not transferred");
+    }
+
+    /// Property: balanceOf_meets_spec
+    function testProperty_TransferFrom_UpdatesBalances() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+        uint256 aliceBefore = nft.balanceOf(ALICE);
+        uint256 bobBefore = nft.balanceOf(BOB);
+
+        vm.prank(ALICE);
+        nft.transferFrom(ALICE, BOB, tokenId);
+
+        assertEq(nft.balanceOf(ALICE), aliceBefore - 1, "sender balance mismatch");
+        assertEq(nft.balanceOf(BOB), bobBefore + 1, "recipient balance mismatch");
+    }
+
+    /// Property: getApproved_meets_spec
+    function testProperty_Approve_ThenTransferFrom_ByApprovedAddress() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+
+        vm.prank(ALICE);
+        nft.approve(BOB, tokenId);
+
+        vm.prank(BOB);
+        nft.transferFrom(ALICE, CHARLIE, tokenId);
+
+        assertEq(nft.ownerOf(tokenId), CHARLIE, "approved transfer failed");
+    }
+
+    /// Property: getApproved_meets_spec
+    /// Property: getApproved_preserves_state
+    function testProperty_TransferFrom_ClearsSingleTokenApproval() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+
+        vm.prank(ALICE);
+        nft.approve(BOB, tokenId);
+
+        vm.prank(BOB);
+        nft.transferFrom(ALICE, CHARLIE, tokenId);
+
+        assertEq(nft.getApproved(tokenId), address(0), "approval was not cleared");
+    }
+
+    /// Property: isApprovedForAll_meets_spec
+    /// Property: setApprovalForAll_meets_spec
+    function testProperty_SetApprovalForAll_EnablesOperatorTransfer() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+
+        vm.prank(ALICE);
+        nft.setApprovalForAll(OPERATOR, true);
+
+        vm.prank(OPERATOR);
+        nft.transferFrom(ALICE, BOB, tokenId);
+
+        assertEq(nft.ownerOf(tokenId), BOB, "operator transfer failed");
+    }
+
+    /// Property: setApprovalForAll_is_balance_neutral_holds
+    function testProperty_SetApprovalForAll_PreservesBalances() public {
+        _mintAsOwner(ALICE);
+
+        uint256 aliceBefore = nft.balanceOf(ALICE);
+        uint256 bobBefore = nft.balanceOf(BOB);
+        uint256 supplyBefore = nft.totalSupply();
+
+        vm.prank(ALICE);
+        nft.setApprovalForAll(OPERATOR, true);
+
+        assertEq(nft.balanceOf(ALICE), aliceBefore, "owner balance changed");
+        assertEq(nft.balanceOf(BOB), bobBefore, "other balance changed");
+        assertEq(nft.totalSupply(), supplyBefore, "supply changed");
+    }
+
+    /// Property: ownerOf_meets_spec
+    function testProperty_TransferFrom_RevertsWhenUnauthorized() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+
+        vm.prank(CHARLIE);
+        vm.expectRevert(bytes("Not authorized"));
+        nft.transferFrom(ALICE, BOB, tokenId);
+    }
+
+    /// Property: ownerOf_meets_spec
+    function testProperty_TransferFrom_RevertsWhenFromIsNotOwner() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+
+        vm.prank(ALICE);
+        vm.expectRevert(bytes("From is not owner"));
+        nft.transferFrom(BOB, CHARLIE, tokenId);
+    }
+
+    /// Property: ownerOf_meets_spec
+    function testProperty_TransferFrom_RevertsForZeroRecipient() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+
+        vm.prank(ALICE);
+        vm.expectRevert(bytes("Invalid recipient"));
+        nft.transferFrom(ALICE, address(0), tokenId);
+    }
+
+    /// Property: ownerOf_preserves_state
+    function testProperty_OwnerOf_ReadOnlyViewPreservesSupply() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+        uint256 supplyBefore = nft.totalSupply();
+
+        nft.ownerOf(tokenId);
+
+        assertEq(nft.totalSupply(), supplyBefore, "ownerOf changed totalSupply");
+    }
+
+    /// Property: isApprovedForAll_preserves_state
+    function testProperty_IsApprovedForAll_ReadOnlyViewPreservesBalances() public {
+        _mintAsOwner(ALICE);
+        uint256 aliceBefore = nft.balanceOf(ALICE);
+
+        nft.isApprovedForAll(ALICE, OPERATOR);
+
+        assertEq(nft.balanceOf(ALICE), aliceBefore, "isApprovedForAll changed balances");
+    }
+
+    /// Property: balanceOf_preserves_state
+    function testProperty_BalanceOf_ReadOnlyViewPreservesOwnership() public {
+        uint256 tokenId = _mintAsOwner(ALICE);
+        address ownerBefore = nft.ownerOf(tokenId);
+
+        nft.balanceOf(ALICE);
+
+        assertEq(nft.ownerOf(tokenId), ownerBefore, "balanceOf changed ownership");
     }
 }

--- a/test/README.md
+++ b/test/README.md
@@ -58,7 +58,7 @@ bash scripts/test_multiple_seeds.sh
 
 ```
 test/
-├── Property*.t.sol           # Property tests (197 functions, covering 250/431 theorems)
+├── Property*.t.sol           # Property tests (234 functions, covering 250/431 theorems)
 ├── Differential*.t.sol       # Differential tests
 ├── <Contract>.t.sol          # Unit tests (Counter, Ledger, Owned, etc.)
 ├── CallValueGuard.t.sol      # Call value rejection tests


### PR DESCRIPTION
## Summary
Addresses a high-leverage slice of #1006 by replacing the placeholder ERC20/ERC721 property files with executable test suites.

### What changed
- Replaced `test/PropertyERC20.t.sol` scaffold (single `assertTrue`) with a full suite of 20 executable property/fuzz tests.
- Replaced `test/PropertyERC721.t.sol` scaffold (single `assertTrue`) with a full suite of 19 executable property/fuzz tests.
- Regenerated `artifacts/verification_status.json` and synchronized doc/test-count references via `check_doc_counts --fix`.

### ERC20 coverage added
- Constructor invariants (`owner`, initial supply)
- Read-only preservation checks for `owner`, `totalSupply`, `balanceOf`, `allowanceOf`
- `approve` correctness and balance neutrality
- `mint` owner-only and supply/balance deltas
- `transfer` conservation, self-transfer no-op, revert-on-insufficient
- `transferFrom` allowance consumption, infinite allowance behavior, revert paths, self-transfer behavior

### ERC721 coverage added
- Constructor invariants (`owner`, counters)
- Mint ownership assignment + balance/supply/token-id progression
- Owner-only mint guard
- `transferFrom` ownership/balance updates + approval clearing
- Approved and operator-authorized transfer paths
- Unauthorized / invalid-argument revert paths
- Read-only preservation checks for `ownerOf`, `isApprovedForAll`, `balanceOf`

## Validation
- `forge test --match-path test/PropertyERC20.t.sol`
- `forge test --match-path test/PropertyERC721.t.sol`
- `python3 scripts/check_property_manifest.py`
- `python3 scripts/check_property_coverage.py`
- `python3 scripts/generate_verification_status.py`
- `python3 scripts/check_doc_counts.py --fix`
- `python3 scripts/check_doc_counts.py`

## Notes
This PR focuses on replacing non-executable scaffolds with real property tests and restoring count-sync invariants consumed by CI.

Closes #1006

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial new fuzz/property test coverage and updates repo-wide test metrics; risk is mainly around potential flakiness or mismatched revert messages/semantics in the new model contracts rather than production code changes.
> 
> **Overview**
> Replaces the placeholder `PropertyERC20.t.sol` and `PropertyERC721.t.sol` scaffolds with full executable property/fuzz suites, including lightweight `ERC20Model`/`ERC721Model` contracts and tests covering constructor invariants, read-only state preservation, core state transitions, and key revert paths.
> 
> Synchronizes verification/test-count bookkeeping across docs and artifacts (e.g., Foundry test totals and property-function counts), updating references from 404→441 tests and 197→234 property functions in `README.md`, docs pages, `test/README.md`, and `artifacts/verification_status.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd5088c5e2332bde892fb70d4c3fce7c5181f933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->