### PR TITLE
docs: sync Layer-1 verification table with ERC20/ERC721 counts

### DIFF
--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -148,7 +148,7 @@ See [`TRUST_ASSUMPTIONS.md`](../TRUST_ASSUMPTIONS.md) for the full trust-boundar
 
 ## Layer 1: EDSL ≡ CompilationModel (`CompilationModel`) ✅ **COMPLETE**
 
-**Status**: 8 contracts verified (7 with full spec proofs, 1 with inline proofs); CryptoHash is an unverified linker demo (0 specs)
+**Status**: 10 contracts with non-stdlib theorem coverage (including ERC20/ERC721 foundation baselines); CryptoHash is an unverified linker demo (0 specs)
 
 **What This Layer Proves**: User-facing EDSL contracts satisfy their human-readable specifications.
 
@@ -165,6 +165,8 @@ See [`TRUST_ASSUMPTIONS.md`](../TRUST_ASSUMPTIONS.md) for the full trust-boundar
 | OwnedCounter | 48 | ✅ Complete | `Verity/Proofs/OwnedCounter/` |
 | Ledger | 33 | ✅ Complete | `Verity/Proofs/Ledger/` |
 | SimpleToken | 61 | ✅ Complete | `Verity/Proofs/SimpleToken/` |
+| ERC20 | 19 | 🟡 Baseline | `Verity/Proofs/ERC20/` |
+| ERC721 | 11 | 🟡 Baseline | `Verity/Proofs/ERC721/` |
 | CryptoHash | 0 | ⬜ No specs | `Verity/Examples/CryptoHash.lean` |
 | ReentrancyExample | 4 | ✅ Complete | `Verity/Examples/ReentrancyExample.lean` |
 | **Total** | **272** | **✅ 100%** | — |


### PR DESCRIPTION
## Summary
- add missing `ERC20` and `ERC721` rows in `docs/VERIFICATION_STATUS.md` Layer-1 contract table
- keep total aligned with `artifacts/verification_status.json` (`non_stdlib_total = 272`)
- update status line to reflect 10 non-stdlib contracts with theorem coverage

## Why
The table previously omitted ERC20/ERC721 while still reporting a total that implicitly included them, creating an internal inconsistency in the public verification-status artifact.

## Validation
- manual table/value consistency review against `artifacts/verification_status.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update; no code, proofs, or build logic changed.
> 
> **Overview**
> Updates `docs/VERIFICATION_STATUS.md` Layer-1 status text and the verified-contracts table to include missing `ERC20` and `ERC721` baseline rows, and to state that **10** non-stdlib contracts contribute to the **272** non-stdlib theorem total (aligning the table with `artifacts/verification_status.json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c62e200b191826643f14990d659d89f236300a5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->