### PR TITLE
Add macro-driven property test stub generator

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -178,6 +178,7 @@ python3 scripts/check_patch_gas_delta.py \
 ## Contract Scaffold Generator
 
 - **`generate_contract.py`** - Generates all boilerplate files for a new contract
+- **`generate_macro_property_tests.py`** - Generates baseline `Property*.t.sol` suites from `verity_contract` declarations
 
 ```bash
 # Simple contract
@@ -190,6 +191,17 @@ python3 scripts/generate_contract.py MyToken \
 
 # Preview without creating files
 python3 scripts/generate_contract.py MyContract --dry-run
+
+# Generate baseline property stubs from macro contracts
+python3 scripts/generate_macro_property_tests.py \
+  --source Verity/Examples/MacroContracts.lean \
+  --output-dir test/generated
+
+# Generate only one contract to stdout (for review)
+python3 scripts/generate_macro_property_tests.py \
+  --source Verity/Examples/MacroContracts.lean \
+  --contract Counter \
+  --stdout
 ```
 
 Creates 8 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic proofs, Correctness proofs, SpecCorrectness scaffold, and Property tests. Prints instructions for manual steps (All.lean imports, Compiler/Specs.lean entry).

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import generate_macro_property_tests as gen
+
+
+class ParseContractsTests(unittest.TestCase):
+    def test_parse_two_contracts(self) -> None:
+        src = textwrap.dedent(
+            """
+            verity_contract Counter where
+              storage
+                count : Uint256 := slot 0
+
+              function increment () : Unit := do
+                pure ()
+
+              function getCount () : Uint256 := do
+                return 0
+
+            verity_contract Owned where
+              storage
+                owner : Address := slot 0
+
+              function getOwner () : Address := do
+                return 0
+            """
+        )
+        parsed = gen.parse_contracts(src, Path("dummy.lean"))
+        self.assertEqual(sorted(parsed.keys()), ["Counter", "Owned"])
+        self.assertEqual([f.name for f in parsed["Counter"].functions], ["increment", "getCount"])
+        self.assertEqual(parsed["Counter"].functions[1].return_type, "Uint256")
+
+    def test_parse_params(self) -> None:
+        out = gen._split_params("to : Address, amount : Uint256")
+        self.assertEqual([(p.name, p.lean_type) for p in out], [("to", "Address"), ("amount", "Uint256")])
+
+
+class RenderTests(unittest.TestCase):
+    def test_render_unit_and_non_unit_tests(self) -> None:
+        contract = gen.ContractDecl(
+            name="Sample",
+            source=gen.ROOT / "Verity/Examples/MacroContracts.lean",
+            functions=(
+                gen.FunctionDecl("touch", (), "Unit"),
+                gen.FunctionDecl("read", (gen.ParamDecl("who", "Address"),), "Uint256"),
+            ),
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_Touch_NoUnexpectedRevert()", rendered)
+        self.assertIn("function testTODO_Read_DecodeAndAssert()", rendered)
+        self.assertIn('abi.encodeWithSignature("read(address)", alice)', rendered)
+
+    def test_render_array_param_adds_helper(self) -> None:
+        contract = gen.ContractDecl(
+            name="ArrayConsumer",
+            source=gen.ROOT / "Verity/Examples/MacroContracts.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "consume",
+                    (gen.ParamDecl("values", "Array Uint256"),),
+                    "Unit",
+                ),
+            ),
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("_singletonUintArray", rendered)
+        self.assertIn('abi.encodeWithSignature("consume(uint256[])", _singletonUintArray(1))', rendered)
+
+
+class CollectContractsTests(unittest.TestCase):
+    def test_duplicate_contract_name_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            a = root / "A.lean"
+            b = root / "B.lean"
+            a.write_text("verity_contract X where\n  storage\n    a : Uint256 := slot 0\n", encoding="utf-8")
+            b.write_text("verity_contract X where\n  storage\n    b : Uint256 := slot 0\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "duplicate contract 'X'"):
+                gen.collect_contracts([a, b])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements a concrete `#1011` slice by adding an automated baseline property-test generator for `verity_contract` declarations.

### What this adds
- `scripts/generate_macro_property_tests.py`
  - scans Lean source files for `verity_contract` blocks
  - extracts contract/function signatures
  - generates `Property<Contract>.t.sol` baseline suites with one test stub per function
  - emits runnable no-unexpected-revert tests for `Unit` functions
  - emits explicit TODO decode/assert stubs for non-`Unit` functions
  - supports filtering by `--contract` and review mode via `--stdout`
- `scripts/test_generate_macro_property_tests.py`
  - parser coverage for contracts/functions/params
  - output-shape checks (Unit vs non-Unit tests)
  - array helper generation check
  - duplicate-contract fail-closed behavior check
- `scripts/README.md`
  - new usage docs for generator commands

## Why
`#1011` asks for systematic property-test generation from macro declarations. This lands a deterministic baseline generator so every macro contract can get immediate Foundry stubs without manual boilerplate.

## Validation
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/generate_macro_property_tests.py --source Verity/Examples/MacroContracts.lean --contract Counter --stdout | head -n 80`

Closes part of #1011.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new standalone codegen script plus unit tests and documentation; it doesn’t change runtime contracts or existing verification logic. Risk is mainly around incorrect parsing/type mapping producing misleading generated test scaffolds.
> 
> **Overview**
> Adds `scripts/generate_macro_property_tests.py` to scan Lean `verity_contract` declarations and generate baseline Foundry suites (`Property<Contract>.t.sol`) with per-function stubs, emitting runnable *no-unexpected-revert* tests for `Unit` functions and explicit `TODO` decode/assert placeholders for non-`Unit` functions.
> 
> Includes a small `unittest` suite covering contract/function parsing, rendering shape (including array-param helper emission), and fail-closed duplicate contract detection, and updates `scripts/README.md` with usage examples for the new generator.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79f514ec92d4a88b9bc1983c6ae4dbbe8b3d9dbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->