### PR TITLE
Enforce deterministic macro property-test artifact generation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Check property manifest sync
         run: python3 scripts/check_property_manifest_sync.py
 
+      - name: Check macro property-test artifact generation
+        run: python3 scripts/check_macro_property_test_generation.py --check
+
       - name: Check storage layout consistency
         run: python3 scripts/check_storage_layout.py
 

--- a/artifacts/macro_property_tests/PropertyCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertyCounter.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyCounterTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertyCounterTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("Counter");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: increment has no unexpected revert
+    function testAuto_Increment_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("increment()"));
+        require(ok, "increment reverted unexpectedly");
+    }
+    // Property 2: decrement has no unexpected revert
+    function testAuto_Decrement_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("decrement()"));
+        require(ok, "decrement reverted unexpectedly");
+    }
+    // Property 3: TODO decode and assert `getCount` result
+    function testTODO_GetCount_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCount()"));
+        require(ok, "getCount reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 4: TODO decode and assert `previewAddTwice` result
+    function testTODO_PreviewAddTwice_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("previewAddTwice(uint256)", uint256(1)));
+        require(ok, "previewAddTwice reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 5: TODO decode and assert `previewOps` result
+    function testTODO_PreviewOps_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("previewOps(uint256,uint256,uint256)", uint256(1), uint256(1), uint256(1)));
+        require(ok, "previewOps reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 6: TODO decode and assert `previewEnvOps` result
+    function testTODO_PreviewEnvOps_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("previewEnvOps(uint256,uint256)", uint256(1), uint256(1)));
+        require(ok, "previewEnvOps reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 7: TODO decode and assert `previewLowLevel` result
+    function testTODO_PreviewLowLevel_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("previewLowLevel(uint256,uint256)", uint256(1), uint256(1)));
+        require(ok, "previewLowLevel reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/macro_property_tests/PropertyERC20.t.sol
+++ b/artifacts/macro_property_tests/PropertyERC20.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyERC20Test
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertyERC20Test is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("ERC20");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: mint has no unexpected revert
+    function testAuto_Mint_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("mint(address,uint256)", alice, uint256(1)));
+        require(ok, "mint reverted unexpectedly");
+    }
+    // Property 2: transfer has no unexpected revert
+    function testAuto_Transfer_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("transfer(address,uint256)", alice, uint256(1)));
+        require(ok, "transfer reverted unexpectedly");
+    }
+    // Property 3: approve has no unexpected revert
+    function testAuto_Approve_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("approve(address,uint256)", alice, uint256(1)));
+        require(ok, "approve reverted unexpectedly");
+    }
+    // Property 4: transferFrom has no unexpected revert
+    function testAuto_TransferFrom_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("transferFrom(address,address,uint256)", alice, alice, uint256(1)));
+        require(ok, "transferFrom reverted unexpectedly");
+    }
+    // Property 5: TODO decode and assert `balanceOf` result
+    function testTODO_BalanceOf_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("balanceOf(address)", alice));
+        require(ok, "balanceOf reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 6: TODO decode and assert `allowanceOf` result
+    function testTODO_AllowanceOf_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("allowanceOf(address,address)", alice, alice));
+        require(ok, "allowanceOf reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 7: TODO decode and assert `totalSupply` result
+    function testTODO_TotalSupply_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("totalSupply()"));
+        require(ok, "totalSupply reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 8: TODO decode and assert `owner` result
+    function testTODO_Owner_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("owner()"));
+        require(ok, "owner reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/macro_property_tests/PropertyLedger.t.sol
+++ b/artifacts/macro_property_tests/PropertyLedger.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyLedgerTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertyLedgerTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("Ledger");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: deposit has no unexpected revert
+    function testAuto_Deposit_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("deposit(uint256)", uint256(1)));
+        require(ok, "deposit reverted unexpectedly");
+    }
+    // Property 2: withdraw has no unexpected revert
+    function testAuto_Withdraw_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("withdraw(uint256)", uint256(1)));
+        require(ok, "withdraw reverted unexpectedly");
+    }
+    // Property 3: transfer has no unexpected revert
+    function testAuto_Transfer_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("transfer(address,uint256)", alice, uint256(1)));
+        require(ok, "transfer reverted unexpectedly");
+    }
+    // Property 4: TODO decode and assert `getBalance` result
+    function testTODO_GetBalance_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getBalance(address)", alice));
+        require(ok, "getBalance reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/macro_property_tests/PropertyOwned.t.sol
+++ b/artifacts/macro_property_tests/PropertyOwned.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyOwnedTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertyOwnedTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("Owned");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: transferOwnership has no unexpected revert
+    function testAuto_TransferOwnership_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("transferOwnership(address)", alice));
+        require(ok, "transferOwnership reverted unexpectedly");
+    }
+    // Property 2: TODO decode and assert `getOwner` result
+    function testTODO_GetOwner_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getOwner()"));
+        require(ok, "getOwner reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/macro_property_tests/PropertyOwnedCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertyOwnedCounter.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyOwnedCounterTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertyOwnedCounterTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("OwnedCounter");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: increment has no unexpected revert
+    function testAuto_Increment_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("increment()"));
+        require(ok, "increment reverted unexpectedly");
+    }
+    // Property 2: decrement has no unexpected revert
+    function testAuto_Decrement_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("decrement()"));
+        require(ok, "decrement reverted unexpectedly");
+    }
+    // Property 3: TODO decode and assert `getCount` result
+    function testTODO_GetCount_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCount()"));
+        require(ok, "getCount reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 4: TODO decode and assert `getOwner` result
+    function testTODO_GetOwner_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getOwner()"));
+        require(ok, "getOwner reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 5: transferOwnership has no unexpected revert
+    function testAuto_TransferOwnership_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("transferOwnership(address)", alice));
+        require(ok, "transferOwnership reverted unexpectedly");
+    }
+}

--- a/artifacts/macro_property_tests/PropertySafeCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertySafeCounter.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertySafeCounterTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertySafeCounterTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("SafeCounter");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: increment has no unexpected revert
+    function testAuto_Increment_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("increment()"));
+        require(ok, "increment reverted unexpectedly");
+    }
+    // Property 2: decrement has no unexpected revert
+    function testAuto_Decrement_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("decrement()"));
+        require(ok, "decrement reverted unexpectedly");
+    }
+    // Property 3: TODO decode and assert `getCount` result
+    function testTODO_GetCount_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCount()"));
+        require(ok, "getCount reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/macro_property_tests/PropertySimpleStorage.t.sol
+++ b/artifacts/macro_property_tests/PropertySimpleStorage.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertySimpleStorageTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertySimpleStorageTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("SimpleStorage");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: store has no unexpected revert
+    function testAuto_Store_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("store(uint256)", uint256(1)));
+        require(ok, "store reverted unexpectedly");
+    }
+    // Property 2: TODO decode and assert `retrieve` result
+    function testTODO_Retrieve_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("retrieve()"));
+        require(ok, "retrieve reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/artifacts/macro_property_tests/PropertySimpleToken.t.sol
+++ b/artifacts/macro_property_tests/PropertySimpleToken.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertySimpleTokenTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertySimpleTokenTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("SimpleToken");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: mint has no unexpected revert
+    function testAuto_Mint_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("mint(address,uint256)", alice, uint256(1)));
+        require(ok, "mint reverted unexpectedly");
+    }
+    // Property 2: transfer has no unexpected revert
+    function testAuto_Transfer_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("transfer(address,uint256)", alice, uint256(1)));
+        require(ok, "transfer reverted unexpectedly");
+    }
+    // Property 3: TODO decode and assert `balanceOf` result
+    function testTODO_BalanceOf_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("balanceOf(address)", alice));
+        require(ok, "balanceOf reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 4: TODO decode and assert `totalSupply` result
+    function testTODO_TotalSupply_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("totalSupply()"));
+        require(ok, "totalSupply reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 5: TODO decode and assert `owner` result
+    function testTODO_Owner_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("owner()"));
+        require(ok, "owner reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -179,6 +179,7 @@ python3 scripts/check_patch_gas_delta.py \
 
 - **`generate_contract.py`** - Generates all boilerplate files for a new contract
 - **`generate_macro_property_tests.py`** - Generates baseline `Property*.t.sol` suites from `verity_contract` declarations
+- **`check_macro_property_test_generation.py`** - Checks/regenerates deterministic macro-property stub artifacts in `artifacts/macro_property_tests`
 
 ```bash
 # Simple contract
@@ -202,6 +203,12 @@ python3 scripts/generate_macro_property_tests.py \
   --source Verity/Examples/MacroContracts.lean \
   --contract Counter \
   --stdout
+
+# Regenerate deterministic macro-property artifacts tracked in-repo
+python3 scripts/check_macro_property_test_generation.py
+
+# Fail-closed check for CI/local verification
+python3 scripts/check_macro_property_test_generation.py --check
 ```
 
 Creates 8 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic proofs, Correctness proofs, SpecCorrectness scaffold, and Property tests. Prints instructions for manual steps (All.lean imports, Compiler/Specs.lean entry).
@@ -249,15 +256,16 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 7 jobs:
 18. Verify artifact upload/download sync (`check_verify_artifact_sync.py`)
 19. Solc pin consistency (`check_solc_pin.py`)
 20. Property manifest sync (`check_property_manifest_sync.py`)
-21. Storage layout consistency (`check_storage_layout.py`)
-22. Manual-spec quarantine boundary (`check_manual_spec_quarantine.py`)
-23. Lean hygiene (`check_lean_hygiene.py`)
-24. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-25. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-26. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-27. Builtin list sync (Linker ↔ CompilationModel) (`check_builtin_list_sync.py`)
-28. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-29. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+21. Macro property-test artifact generation (`check_macro_property_test_generation.py --check`)
+22. Storage layout consistency (`check_storage_layout.py`)
+23. Manual-spec quarantine boundary (`check_manual_spec_quarantine.py`)
+24. Lean hygiene (`check_lean_hygiene.py`)
+25. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+26. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+27. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+28. Builtin list sync (Linker ↔ CompilationModel) (`check_builtin_list_sync.py`)
+29. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+30. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
 30. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
 31. PrintAxioms.lean freshness (`generate_print_axioms.py --check`)
 32. Proof length limits (`check_proof_length.py`)

--- a/scripts/check_macro_property_test_generation.py
+++ b/scripts/check_macro_property_test_generation.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Check/sync generated macro-property test stubs.
+
+Usage:
+  python3 scripts/check_macro_property_test_generation.py
+  python3 scripts/check_macro_property_test_generation.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import generate_macro_property_tests as generator
+from property_utils import ROOT
+
+DEFAULT_SOURCE = ROOT / "Verity" / "Examples" / "MacroContracts.lean"
+DEFAULT_OUTPUT_DIR = ROOT / "artifacts" / "macro_property_tests"
+
+
+def _expected_rendered(
+    sources: list[Path],
+    selected_contracts: list[str] | None,
+) -> dict[str, str]:
+    contracts = generator.collect_contracts(sources)
+    if not contracts:
+        raise SystemExit("no verity_contract declarations found")
+
+    names = selected_contracts or sorted(contracts.keys())
+    unknown = [name for name in names if name not in contracts]
+    if unknown:
+        known = ", ".join(sorted(contracts.keys()))
+        raise SystemExit(f"unknown contract(s): {', '.join(unknown)}; known: {known}")
+
+    rendered: dict[str, str] = {}
+    for name in names:
+        rendered[f"Property{name}.t.sol"] = generator.render_contract_test(contracts[name])
+    return rendered
+
+
+def _collect_existing(output_dir: Path) -> dict[str, str]:
+    if not output_dir.exists():
+        return {}
+    return {
+        path.name: path.read_text(encoding="utf-8")
+        for path in sorted(output_dir.glob("Property*.t.sol"))
+    }
+
+
+def _check(output_dir: Path, expected: dict[str, str]) -> int:
+    existing = _collect_existing(output_dir)
+    expected_names = set(expected.keys())
+    existing_names = set(existing.keys())
+
+    missing = sorted(expected_names - existing_names)
+    extra = sorted(existing_names - expected_names)
+    stale = sorted(name for name in expected_names & existing_names if existing[name] != expected[name])
+
+    if not missing and not extra and not stale:
+        print(f"macro property-test artifacts are up to date: {output_dir.relative_to(ROOT)}")
+        return 0
+
+    print("macro property-test artifact check failed:", file=sys.stderr)
+    for name in missing:
+        print(f"  missing: {name}", file=sys.stderr)
+    for name in extra:
+        print(f"  unexpected: {name}", file=sys.stderr)
+    for name in stale:
+        print(f"  stale: {name}", file=sys.stderr)
+    print(
+        "regenerate with:\n"
+        "  python3 scripts/check_macro_property_test_generation.py",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _write(output_dir: Path, expected: dict[str, str]) -> int:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for name, content in sorted(expected.items()):
+        (output_dir / name).write_text(content, encoding="utf-8")
+
+    for path in sorted(output_dir.glob("Property*.t.sol")):
+        if path.name not in expected:
+            path.unlink()
+
+    print(
+        "wrote macro property-test artifacts "
+        f"({len(expected)} file(s)): {output_dir.relative_to(ROOT)}"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        help=(
+            "Lean source path to scan (relative to repo root). "
+            "Repeat flag for multiple files. Defaults to Verity/Examples/MacroContracts.lean."
+        ),
+    )
+    parser.add_argument(
+        "--contract",
+        action="append",
+        default=[],
+        help="Only generate/check the named contract (repeatable). Defaults to all discovered contracts.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR.relative_to(ROOT)),
+        help="Output directory relative to repo root (default: artifacts/macro_property_tests).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if generated macro-property artifacts are missing/stale.",
+    )
+    args = parser.parse_args()
+
+    source_paths = [ROOT / p for p in (args.source or [str(DEFAULT_SOURCE.relative_to(ROOT))])]
+    missing_sources = [str(p.relative_to(ROOT)) for p in source_paths if not p.exists()]
+    if missing_sources:
+        print(
+            f"source file(s) not found: {', '.join(missing_sources)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    expected = _expected_rendered(source_paths, args.contract or None)
+    output_dir = ROOT / args.output_dir
+    if args.check:
+        return _check(output_dir, expected)
+    return _write(output_dir, expected)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_macro_property_test_generation.py
+++ b/scripts/test_check_macro_property_test_generation.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_macro_property_test_generation as check
+
+
+class MacroPropertyGenerationCheckTests(unittest.TestCase):
+    def test_check_fails_when_artifacts_missing(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            source = root / "MacroContracts.lean"
+            out_dir = root / "artifacts"
+            source.write_text(
+                "verity_contract Counter where\n"
+                "  function ping () : Unit := do\n"
+                "    pure ()\n",
+                encoding="utf-8",
+            )
+
+            expected = check._expected_rendered([source], None)
+            rc = check._check(out_dir, expected)
+            self.assertEqual(rc, 1)
+
+    def test_write_then_check_passes(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            source = root / "MacroContracts.lean"
+            out_dir = root / "artifacts"
+            source.write_text(
+                "verity_contract Counter where\n"
+                "  function ping () : Unit := do\n"
+                "    pure ()\n",
+                encoding="utf-8",
+            )
+
+            expected = check._expected_rendered([source], None)
+            self.assertEqual(check._write(out_dir, expected), 0)
+            self.assertEqual(check._check(out_dir, expected), 0)
+
+    def test_check_detects_stale_content(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            source = root / "MacroContracts.lean"
+            out_dir = root / "artifacts"
+            source.write_text(
+                "verity_contract Counter where\n"
+                "  function ping () : Unit := do\n"
+                "    pure ()\n",
+                encoding="utf-8",
+            )
+            expected = check._expected_rendered([source], None)
+            self.assertEqual(check._write(out_dir, expected), 0)
+
+            artifact = out_dir / "PropertyCounter.t.sol"
+            artifact.write_text(artifact.read_text(encoding="utf-8") + "\n// stale\n", encoding="utf-8")
+
+            self.assertEqual(check._check(out_dir, expected), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This advances #1011 from a standalone generator script to a fail-closed, CI-enforced workflow.

### What landed
- Added `scripts/check_macro_property_test_generation.py`:
  - deterministically renders macro-property stubs from `verity_contract` declarations
  - `--check` mode fails on missing/stale/extra artifacts
  - non-check mode rewrites canonical outputs in `artifacts/macro_property_tests`
- Added regression tests: `scripts/test_check_macro_property_test_generation.py`
- Added tracked artifact baseline (8 contracts from `Verity/Examples/MacroContracts.lean`):
  - `artifacts/macro_property_tests/Property*.t.sol`
- Wired CI check in `verify.yml`:
  - `python3 scripts/check_macro_property_test_generation.py --check`
- Updated `scripts/README.md` usage + checks job command list.

## Why
Previously, macro-property generation could silently drift as macro syntax/contracts evolved. This change makes the generator output auditable and fail-closed in CI, so #1011 progress is reproducible and regression-resistant.

## Validation
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/test_check_macro_property_test_generation.py`
- `python3 scripts/check_macro_property_test_generation.py --check`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/check_verify_build_docs_sync.py`
- `python3 scripts/check_verify_ci_jobs_docs_sync.py`
- `python3 scripts/check_verify_artifact_sync.py`

Part of #1011.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CI gate that will fail builds if the generator output drifts, which could cause unexpected CI failures if generation logic or inputs change. No production/runtime logic changes; impact is limited to tooling, tests, and tracked artifacts.
> 
> **Overview**
> Ensures macro-generated property-test stubs don’t silently drift by adding `scripts/check_macro_property_test_generation.py`, which deterministically renders `Property*.t.sol` outputs from `verity_contract` declarations and supports a fail-closed `--check` mode.
> 
> Wires this check into the `verify.yml` `checks` job, adds unit tests for the checker (`scripts/test_check_macro_property_test_generation.py`), and commits the canonical generated artifacts under `artifacts/macro_property_tests/` (with README updates documenting usage and the new check order).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2548162ec4ca9f9d8b180bd2c9a07a88c47a124d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->