### PR TITLE
Fail-close macro property-test generator type mapping

### DIFF
--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -137,12 +137,13 @@ def _sol_type(lean_ty: str) -> str:
     if ty.startswith("Array "):
         elem = ty[len("Array ") :].strip()
         return f"{_sol_type(elem)}[]"
-    # Fallback is deliberate: keep generator usable while making unknown mappings visible.
-    return "uint256"
+    raise ValueError(f"unsupported Lean type for Solidity signature mapping: {ty!r}")
 
 
 def _example_value(lean_ty: str) -> str:
     ty = _normalize_type(lean_ty)
+    if ty == "Uint256":
+        return "uint256(1)"
     if ty == "Address":
         return "alice"
     if ty == "Bool":
@@ -152,8 +153,14 @@ def _example_value(lean_ty: str) -> str:
     if ty == "Bytes":
         return "hex\"CAFE\""
     if ty.startswith("Array "):
+        elem = ty[len("Array ") :].strip()
+        if elem != "Uint256":
+            raise ValueError(
+                "unsupported Lean array element type for generated example value: "
+                f"{elem!r}"
+            )
         return "_singletonUintArray(1)"
-    return "uint256(1)"
+    raise ValueError(f"unsupported Lean type for generated example value: {ty!r}")
 
 
 def _sol_signature(fn: FunctionDecl) -> str:

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -73,6 +73,28 @@ class RenderTests(unittest.TestCase):
         self.assertIn("_singletonUintArray", rendered)
         self.assertIn('abi.encodeWithSignature("consume(uint256[])", _singletonUintArray(1))', rendered)
 
+    def test_render_unknown_type_fails_closed(self) -> None:
+        contract = gen.ContractDecl(
+            name="UnknownType",
+            source=gen.ROOT / "Verity/Examples/MacroContracts.lean",
+            functions=(
+                gen.FunctionDecl("mystery", (gen.ParamDecl("x", "String"),), "Unit"),
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "unsupported Lean type"):
+            gen.render_contract_test(contract)
+
+    def test_render_non_uint_array_fails_closed(self) -> None:
+        contract = gen.ContractDecl(
+            name="ArrayAddressConsumer",
+            source=gen.ROOT / "Verity/Examples/MacroContracts.lean",
+            functions=(
+                gen.FunctionDecl("consume", (gen.ParamDecl("values", "Array Address"),), "Unit"),
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "unsupported Lean array element type"):
+            gen.render_contract_test(contract)
+
 
 class CollectContractsTests(unittest.TestCase):
     def test_duplicate_contract_name_errors(self) -> None:


### PR DESCRIPTION
## Summary
This hardens issue #1011 tooling by making macro property-test generation fail closed on unsupported Lean parameter types.

## Changes
- `scripts/generate_macro_property_tests.py`
  - `_sol_type` now raises on unsupported Lean types instead of silently falling back to `uint256`.
  - `_example_value` now raises on unsupported Lean types.
  - Array example values are restricted to `Array Uint256`; non-`Uint256` arrays fail with explicit errors.
- `scripts/test_generate_macro_property_tests.py`
  - Added regression test that unknown Lean types fail generation.
  - Added regression test that non-`Uint256` array example generation fails.

## Why
Silent fallback to `uint256` can emit incorrect ABI signatures/call arguments and hide generator drift. Failing closed is safer and makes unsupported type work explicit.

## Validation
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py --check`

Refs #1011

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes code generation behavior to error out instead of emitting potentially incorrect Solidity ABI signatures and arguments, which could break existing automation if unsupported types were previously present. The scope is limited to dev tooling, but it hardens correctness checks around type mapping.
> 
> **Overview**
> Hardens the macro property-test generator to **fail closed** on unsupported Lean parameter types instead of silently mapping unknowns to `uint256`.
> 
> `_sol_type` and `_example_value` now raise `ValueError` for unknown Lean types, and array example generation is restricted to `Array Uint256` (other element types error). Adds tests asserting generation fails for an unknown type (e.g. `String`) and for `Array Address`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 852ed8d2de997ca0fd05f8e22cf5460f013480e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->