### PR TITLE
Constructor-aware macro property-test stubs

### DIFF
--- a/artifacts/macro_property_tests/PropertyERC20.t.sol
+++ b/artifacts/macro_property_tests/PropertyERC20.t.sol
@@ -13,7 +13,7 @@ contract PropertyERC20Test is YulTestBase {
     address alice = address(0x1111);
 
     function setUp() public {
-        target = deployYul("ERC20");
+        target = deployYulWithArgs("ERC20", abi.encode(alice));
         require(target != address(0), "Deploy failed");
     }
 

--- a/artifacts/macro_property_tests/PropertyOwned.t.sol
+++ b/artifacts/macro_property_tests/PropertyOwned.t.sol
@@ -13,7 +13,7 @@ contract PropertyOwnedTest is YulTestBase {
     address alice = address(0x1111);
 
     function setUp() public {
-        target = deployYul("Owned");
+        target = deployYulWithArgs("Owned", abi.encode(alice));
         require(target != address(0), "Deploy failed");
     }
 

--- a/artifacts/macro_property_tests/PropertyOwnedCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertyOwnedCounter.t.sol
@@ -13,7 +13,7 @@ contract PropertyOwnedCounterTest is YulTestBase {
     address alice = address(0x1111);
 
     function setUp() public {
-        target = deployYul("OwnedCounter");
+        target = deployYulWithArgs("OwnedCounter", abi.encode(alice));
         require(target != address(0), "Deploy failed");
     }
 

--- a/artifacts/macro_property_tests/PropertySimpleToken.t.sol
+++ b/artifacts/macro_property_tests/PropertySimpleToken.t.sol
@@ -13,7 +13,7 @@ contract PropertySimpleTokenTest is YulTestBase {
     address alice = address(0x1111);
 
     function setUp() public {
-        target = deployYul("SimpleToken");
+        target = deployYulWithArgs("SimpleToken", abi.encode(alice));
         require(target != address(0), "Deploy failed");
     }
 


### PR DESCRIPTION
## Summary
- parse `constructor (...) :=` declarations in macro contracts
- generate `deployYulWithArgs(..., abi.encode(...))` in setUp when constructor parameters exist
- keep fail-closed behavior for unsupported constructor parameter types via existing `_example_value` mapping
- regenerate macro-property artifacts for constructor-based contracts (ERC20, Owned, OwnedCounter, SimpleToken)
- add parser/render regression tests for constructor handling

## Validation
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py --check`
- `python3 scripts/test_check_macro_property_test_generation.py`

Refs #1011

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test-stub generation and regenerated artifacts; main risk is producing incorrect constructor encodings that could make generated Foundry tests fail or mis-initialize contracts.
> 
> **Overview**
> Updates the macro property-test generator to **parse `constructor(...)` declarations** from `verity_contract` Lean sources and carry them through the `ContractDecl` model.
> 
> Generated Foundry stubs now **deploy contracts with constructor parameters** via `deployYulWithArgs(..., abi.encode(...))` (including array-helper support when needed), and the checked-in artifacts for `ERC20`, `Owned`, `OwnedCounter`, and `SimpleToken` are regenerated accordingly. Adds unit tests to cover constructor parsing and rendering behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39c783826cc89b5ce3048f6769f5a4ee90661170. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->