### PR TITLE
Macro: support Bytes32-typed verity_contract params/returns

### DIFF
--- a/Verity/Examples/MacroContracts.lean
+++ b/Verity/Examples/MacroContracts.lean
@@ -363,7 +363,19 @@ verity_contract UintMapSmoke where
     let current ← getMappingUint values key
     return current
 
+verity_contract Bytes32Smoke where
+  storage
+    value : Uint256 := slot 0
+
+  function setDigest (digest : Bytes32) : Unit := do
+    setStorage value digest
+
+  function getDigest () : Bytes32 := do
+    let digest ← getStorage value
+    return digest
+
 #check_contract Counter
 #check_contract UintMapSmoke
+#check_contract Bytes32Smoke
 
 end Verity.Examples.MacroContracts

--- a/artifacts/macro_property_tests/PropertyBytes32Smoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyBytes32Smoke.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyBytes32SmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertyBytes32SmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("Bytes32Smoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: setDigest has no unexpected revert
+    function testAuto_SetDigest_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("setDigest(bytes32)", bytes32(uint256(0xBEEF))));
+        require(ok, "setDigest reverted unexpectedly");
+    }
+    // Property 2: TODO decode and assert `getDigest` result
+    function testTODO_GetDigest_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getDigest()"));
+        require(ok, "getDigest reverted unexpectedly");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}


### PR DESCRIPTION
## Summary
- add `Bytes32` support to `verity_contract` type translation
  - accept `Bytes32` in macro type parser
  - map `Bytes32` params to `ParamType.bytes32`
  - represent `Bytes32` contract-level values as `Uint256`
  - emit explicit `returns := [...]` in generated `FunctionSpec` so `Bytes32` return signatures are ABI-correct
- add a macro smoke contract (`Bytes32Smoke`) in `Verity/Examples/MacroContracts.lean`
- regenerate macro property-test artifacts with `PropertyBytes32Smoke.t.sol`

## Why
`morpho-verity#38` migration is blocked on selectors involving `bytes32` ABI types. This patch extends the macro-native path with first-class `Bytes32` surface support so those selectors can be migrated incrementally.

## Validation
- `lake build Verity.Examples.MacroContracts Compiler.MainTest`
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py --check`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_axiom_locations.py`

Refs #1003

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes macro translation and ABI metadata (`FunctionSpec.returns`) which can affect generated selectors and call/return encoding for all macro-compiled contracts.
> 
> **Overview**
> Adds `Bytes32` as a supported surface type in `verity_contract` macros, mapping it to `ParamType.bytes32` for ABI signatures while representing contract-level values as `Uint256` and explicitly rejecting `Bytes32` storage fields.
> 
> Updates function spec generation to always emit an explicit `returns := [...]` list (including `bytes32`) to keep ABI return signatures correct.
> 
> Adds a `Bytes32Smoke` example contract and a regenerated Solidity property-test stub (`PropertyBytes32Smoke.t.sol`) to exercise `bytes32` call/return wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93192945e472fd89a4bc3feb93ef48f0f6dfd46c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->