### PR TITLE
Auto-generated macro property tests: assert ABI return shape

### DIFF
--- a/artifacts/macro_property_tests/PropertyBytes32Smoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyBytes32Smoke.t.sol
@@ -28,6 +28,7 @@ contract PropertyBytes32SmokeTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getDigest()"));
         require(ok, "getDigest reverted unexpectedly");
+        assertEq(ret.length, 32, "getDigest ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }

--- a/artifacts/macro_property_tests/PropertyCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertyCounter.t.sol
@@ -34,6 +34,7 @@ contract PropertyCounterTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCount()"));
         require(ok, "getCount reverted unexpectedly");
+        assertEq(ret.length, 32, "getCount ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -42,6 +43,7 @@ contract PropertyCounterTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("previewAddTwice(uint256)", uint256(1)));
         require(ok, "previewAddTwice reverted unexpectedly");
+        assertEq(ret.length, 32, "previewAddTwice ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -50,6 +52,7 @@ contract PropertyCounterTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("previewOps(uint256,uint256,uint256)", uint256(1), uint256(1), uint256(1)));
         require(ok, "previewOps reverted unexpectedly");
+        assertEq(ret.length, 32, "previewOps ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -58,6 +61,7 @@ contract PropertyCounterTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("previewEnvOps(uint256,uint256)", uint256(1), uint256(1)));
         require(ok, "previewEnvOps reverted unexpectedly");
+        assertEq(ret.length, 32, "previewEnvOps ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -66,6 +70,7 @@ contract PropertyCounterTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("previewLowLevel(uint256,uint256)", uint256(1), uint256(1)));
         require(ok, "previewLowLevel reverted unexpectedly");
+        assertEq(ret.length, 32, "previewLowLevel ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }

--- a/artifacts/macro_property_tests/PropertyERC20.t.sol
+++ b/artifacts/macro_property_tests/PropertyERC20.t.sol
@@ -46,6 +46,7 @@ contract PropertyERC20Test is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("balanceOf(address)", alice));
         require(ok, "balanceOf reverted unexpectedly");
+        assertEq(ret.length, 32, "balanceOf ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -54,6 +55,7 @@ contract PropertyERC20Test is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("allowanceOf(address,address)", alice, alice));
         require(ok, "allowanceOf reverted unexpectedly");
+        assertEq(ret.length, 32, "allowanceOf ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -62,6 +64,7 @@ contract PropertyERC20Test is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("totalSupply()"));
         require(ok, "totalSupply reverted unexpectedly");
+        assertEq(ret.length, 32, "totalSupply ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -70,6 +73,7 @@ contract PropertyERC20Test is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("owner()"));
         require(ok, "owner reverted unexpectedly");
+        assertEq(ret.length, 32, "owner ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }

--- a/artifacts/macro_property_tests/PropertyLedger.t.sol
+++ b/artifacts/macro_property_tests/PropertyLedger.t.sol
@@ -40,6 +40,7 @@ contract PropertyLedgerTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getBalance(address)", alice));
         require(ok, "getBalance reverted unexpectedly");
+        assertEq(ret.length, 32, "getBalance ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }

--- a/artifacts/macro_property_tests/PropertyOwned.t.sol
+++ b/artifacts/macro_property_tests/PropertyOwned.t.sol
@@ -28,6 +28,7 @@ contract PropertyOwnedTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getOwner()"));
         require(ok, "getOwner reverted unexpectedly");
+        assertEq(ret.length, 32, "getOwner ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }

--- a/artifacts/macro_property_tests/PropertyOwnedCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertyOwnedCounter.t.sol
@@ -34,6 +34,7 @@ contract PropertyOwnedCounterTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCount()"));
         require(ok, "getCount reverted unexpectedly");
+        assertEq(ret.length, 32, "getCount ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -42,6 +43,7 @@ contract PropertyOwnedCounterTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getOwner()"));
         require(ok, "getOwner reverted unexpectedly");
+        assertEq(ret.length, 32, "getOwner ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }

--- a/artifacts/macro_property_tests/PropertySafeCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertySafeCounter.t.sol
@@ -34,6 +34,7 @@ contract PropertySafeCounterTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCount()"));
         require(ok, "getCount reverted unexpectedly");
+        assertEq(ret.length, 32, "getCount ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }

--- a/artifacts/macro_property_tests/PropertySimpleStorage.t.sol
+++ b/artifacts/macro_property_tests/PropertySimpleStorage.t.sol
@@ -28,6 +28,7 @@ contract PropertySimpleStorageTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("retrieve()"));
         require(ok, "retrieve reverted unexpectedly");
+        assertEq(ret.length, 32, "retrieve ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }

--- a/artifacts/macro_property_tests/PropertySimpleToken.t.sol
+++ b/artifacts/macro_property_tests/PropertySimpleToken.t.sol
@@ -34,6 +34,7 @@ contract PropertySimpleTokenTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("balanceOf(address)", alice));
         require(ok, "balanceOf reverted unexpectedly");
+        assertEq(ret.length, 32, "balanceOf ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -42,6 +43,7 @@ contract PropertySimpleTokenTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("totalSupply()"));
         require(ok, "totalSupply reverted unexpectedly");
+        assertEq(ret.length, 32, "totalSupply ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
@@ -50,6 +52,7 @@ contract PropertySimpleTokenTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("owner()"));
         require(ok, "owner reverted unexpectedly");
+        assertEq(ret.length, 32, "owner ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }

--- a/artifacts/macro_property_tests/PropertyUintMapSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyUintMapSmoke.t.sol
@@ -28,6 +28,7 @@ contract PropertyUintMapSmokeTest is YulTestBase {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getValue(uint256)", uint256(1)));
         require(ok, "getValue reverted unexpectedly");
+        assertEq(ret.length, 32, "getValue ABI return length mismatch (expected 32 bytes)");
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }


### PR DESCRIPTION
## Summary
Addresses part of #1011 by replacing pure TODO placeholders for non-`Unit` functions with deterministic baseline assertions.

### What changed
- `scripts/generate_macro_property_tests.py`
  - Added `_return_shape_assertion` generator logic.
  - For non-`Unit` calls, generated tests now assert ABI return shape:
    - fixed-size returns (`Uint256`, `Address`, `Bool`, `Bytes32`) => `ret.length == 32`
    - dynamic returns (`Bytes`, `Array ...`) => `ret.length >= 64`
  - Keeps TODO decode/assert scaffolding for theorem-specific postconditions.
- `scripts/test_generate_macro_property_tests.py`
  - Added regression checks for fixed-size and dynamic return assertions.
  - Added fail-closed coverage for unsupported return types.
- Regenerated `artifacts/macro_property_tests/*.t.sol` to match generator output.

## Why this is high leverage
This turns generated non-`Unit` tests into concrete executable baseline properties (ABI-shape sanity + no-unexpected-revert), reducing "empty scaffold" surface while preserving the roadmap to theorem-derived semantic assertions.

## Validation
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py`
- `python3 scripts/check_macro_property_test_generation.py --check`
- `python3 scripts/test_check_macro_property_test_generation.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test generation and regenerated test artifacts, adding simple length checks without affecting production contracts.
> 
> **Overview**
> Generated macro property tests for non-`Unit` functions now include deterministic ABI *return-shape* assertions before the existing TODO decode/postcondition checks (fixed-size returns assert `ret.length == 32`; dynamic returns require `ret.length >= 64`).
> 
> The generator (`generate_macro_property_tests.py`) now fail-closes on unsupported return types, the Python unit tests add coverage for these new assertions and the fail-closed behavior, and the `artifacts/macro_property_tests/*.t.sol` files are regenerated to match the updated output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d48d2e09caa8b1b153b245f578c7597e4b9be277. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->