### PR TITLE
macro: support mappingWord operations in verity_contract

### DIFF
--- a/Verity/Examples/MacroContracts.lean
+++ b/Verity/Examples/MacroContracts.lean
@@ -42,6 +42,10 @@ def calldatacopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := 
 def returndataCopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def revertReturndata : Contract Unit := pure ()
 def mstore (_offset _value : Uint256) : Contract Unit := pure ()
+def getMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset : Uint256) :
+    Contract Uint256 := pure 0
+def setMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset _value : Uint256) :
+    Contract Unit := pure ()
 def forEach (_name : String) (_count : Uint256) (body : Contract Unit) : Contract Unit := body
 def blockTimestamp : Uint256 := 0
 def contractAddress : Uint256 := 0
@@ -374,8 +378,20 @@ verity_contract Bytes32Smoke where
     let digest ← getStorage value
     return digest
 
+verity_contract MappingWordSmoke where
+  storage
+    words : Uint256 → Uint256 := slot 0
+
+  function setWord1 (key : Uint256, value : Uint256) : Unit := do
+    setMappingWord words key 1 value
+
+  function getWord1 (key : Uint256) : Uint256 := do
+    let word ← getMappingWord words key 1
+    return word
+
 #check_contract Counter
 #check_contract UintMapSmoke
 #check_contract Bytes32Smoke
+#check_contract MappingWordSmoke
 
 end Verity.Examples.MacroContracts

--- a/artifacts/macro_property_tests/PropertyMappingWordSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyMappingWordSmoke.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyMappingWordSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertyMappingWordSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("MappingWordSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: setWord1 has no unexpected revert
+    function testAuto_SetWord1_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("setWord1(uint256,uint256)", uint256(1), uint256(1)));
+        require(ok, "setWord1 reverted unexpectedly");
+    }
+    // Property 2: TODO decode and assert `getWord1` result
+    function testTODO_GetWord1_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getWord1(uint256)", uint256(1)));
+        require(ok, "getWord1 reverted unexpectedly");
+        assertEq(ret.length, 32, "getWord1 ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}


### PR DESCRIPTION
## Summary
- add `verity_contract` translation support for `getMappingWord field key wordOffset` bind sources
- add `verity_contract` translation support for `setMappingWord field key wordOffset value` effect statements
- add `MappingWordSmoke` macro contract and generated property artifact coverage

## Why
`CompilationModel` already models `Expr.mappingWord`/`Stmt.setMappingWord`, but macro contracts could not emit them directly. This forces downstream migration slices to emulate multi-word mapping layout with incorrect base-slot splitting. Adding first-class macro support closes that gap and keeps migration code selector-exact and storage-layout-correct.

## Validation
- `lake build Verity.Macro.Translate Verity.Examples.MacroContracts Compiler.MainTest`
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py`
- `python3 scripts/check_macro_property_test_generation.py --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends macro-to-compilation-model translation for new storage access patterns, which can affect generated Yul and storage layout correctness. Risk is limited to macro contract translation paths and is covered by a new smoke contract/property test stub.
> 
> **Overview**
> Adds first-class `getMappingWord`/`setMappingWord` support to the `verity_contract` macro translator, emitting `CompilationModel.Expr.mappingWord` and `Stmt.setMappingWord` and updating related error messaging.
> 
> Introduces a new `MappingWordSmoke` example contract that exercises word-offset mapping access, and adds the corresponding auto-generated Solidity property test stub `PropertyMappingWordSmoke.t.sol`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1acb37f181ab6d524aa709c52b727717d56050e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->