### PR TITLE
Add Bool return support in verity_contract macro

### DIFF
--- a/Verity/Examples/MacroContracts.lean
+++ b/Verity/Examples/MacroContracts.lean
@@ -389,6 +389,10 @@ verity_contract MappingWordSmoke where
     let word ← getMappingWord words key 1
     return word
 
+  function isWord1NonZero (key : Uint256) : Bool := do
+    let word ← getMappingWord words key 1
+    return (word != 0)
+
 #check_contract Counter
 #check_contract UintMapSmoke
 #check_contract Bytes32Smoke

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -108,7 +108,7 @@ private def modelReturnTypeTerm (ty : ValueType) : CommandElabM Term :=
   | .uint256 => `(some Compiler.CompilationModel.FieldType.uint256)
   | .address => `(some Compiler.CompilationModel.FieldType.address)
   | .bytes32 => `(none)
-  | .bool => throwError "function return type Bool is not yet supported; use Uint256 (0/1) encoding"
+  | .bool => `(none)
 
 private def modelReturnsTerm (ty : ValueType) : CommandElabM Term :=
   match ty with
@@ -116,7 +116,7 @@ private def modelReturnsTerm (ty : ValueType) : CommandElabM Term :=
   | .uint256 => `([Compiler.CompilationModel.ParamType.uint256])
   | .address => `([Compiler.CompilationModel.ParamType.address])
   | .bytes32 => `([Compiler.CompilationModel.ParamType.bytes32])
-  | .bool => throwError "function return type Bool is not yet supported; use Uint256 (0/1) encoding"
+  | .bool => `([Compiler.CompilationModel.ParamType.bool])
 
 private def contractValueTypeTerm (ty : ValueType) : CommandElabM Term :=
   match ty with

--- a/artifacts/macro_property_tests/PropertyMappingWordSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyMappingWordSmoke.t.sol
@@ -32,4 +32,13 @@ contract PropertyMappingWordSmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
+    // Property 3: TODO decode and assert `isWord1NonZero` result
+    function testTODO_IsWord1NonZero_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("isWord1NonZero(uint256)", uint256(1)));
+        require(ok, "isWord1NonZero reverted unexpectedly");
+        assertEq(ret.length, 32, "isWord1NonZero ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
 }

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -136,6 +136,19 @@ class RenderTests(unittest.TestCase):
             rendered,
         )
 
+    def test_render_bool_return_shape_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="ReturnsBool",
+            constructor=None,
+            source=gen.ROOT / "Verity/Examples/MacroContracts.lean",
+            functions=(gen.FunctionDecl("isReady", (), "Bool"),),
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn(
+            'assertEq(ret.length, 32, "isReady ABI return length mismatch (expected 32 bytes)");',
+            rendered,
+        )
+
     def test_render_unknown_return_type_fails_closed(self) -> None:
         contract = gen.ContractDecl(
             name="UnknownReturn",


### PR DESCRIPTION
## Summary
This PR removes an unnecessary macro front-end restriction: `verity_contract` functions can now return `Bool`.

### What changed
- `Verity/Macro/Translate.lean`
  - `modelReturnTypeTerm`: map `Bool` return to `none` (same compatibility path used for non-`FieldType` returns like `Bytes32`).
  - `modelReturnsTerm`: emit `returns := [ParamType.bool]` for `Bool` return functions.
- `Verity/Examples/MacroContracts.lean`
  - Added `MappingWordSmoke.isWord1NonZero(key : Uint256) : Bool` to exercise bool-return translation in the macro pipeline.
- `scripts/test_generate_macro_property_tests.py`
  - Added regression test ensuring generated property stubs treat `Bool` as a fixed-size ABI return (`ret.length == 32`).
- `artifacts/macro_property_tests/PropertyMappingWordSmoke.t.sol`
  - Regenerated to include the new bool-return smoke function.

## Why
`CompilationModel`/ABI already supports `ParamType.bool` returns, but the macro translator still hard-failed on `Bool` return types. This blocked valid macro declarations and created avoidable friction in the #1003 expansion lane.

## Validation
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py`
- `python3 scripts/check_macro_property_test_generation.py --check`
- `python3 scripts/test_check_macro_property_test_generation.py`
- `lake build Verity.Examples.MacroContracts Compiler.MainTest`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_axiom_locations.py`

Refs #1003

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only relaxes a previously-failing macro restriction by allowing `Bool` function returns, with added test coverage and regenerated artifacts; existing contracts that don’t return `Bool` should be unaffected.
> 
> **Overview**
> `verity_contract` functions can now return `Bool` instead of hard-failing in the macro translator. The macro now emits ABI/model metadata for boolean returns (`returns := [ParamType.bool]`) while keeping the same compatibility path for non-`FieldType` return types (`returnType := none`).
> 
> Adds a new `MappingWordSmoke.isWord1NonZero` example to exercise the pipeline, updates the generated Foundry property-test artifact to include a stub for it, and adds a Python regression test ensuring `Bool` returns are treated as fixed-size ABI returns (`ret.length == 32`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c9d250a5a92632e7d6edf3672ed3c9145a925fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->