### PR TITLE
macro: support array params/returns in verity_contract

### DIFF
--- a/Verity/Examples/MacroContracts.lean
+++ b/Verity/Examples/MacroContracts.lean
@@ -41,6 +41,7 @@ def delegatecall (gas target inOffset inSize outOffset outSize : Uint256) : Uint
 def calldatacopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def returndataCopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def revertReturndata : Contract Unit := pure ()
+def returnStorageWords (_slots : Array Uint256) : Contract (Array Uint256) := pure #[]
 def mstore (_offset _value : Uint256) : Contract Unit := pure ()
 def getMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset : Uint256) :
     Contract Uint256 := pure 0
@@ -393,9 +394,17 @@ verity_contract MappingWordSmoke where
     let word ← getMappingWord words key 1
     return (word != 0)
 
+verity_contract StorageWordsSmoke where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function extSloadsLike (slots : Array Bytes32) : Array Uint256 := do
+    returnStorageWords slots
+
 #check_contract Counter
 #check_contract UintMapSmoke
 #check_contract Bytes32Smoke
 #check_contract MappingWordSmoke
+#check_contract StorageWordsSmoke
 
 end Verity.Examples.MacroContracts

--- a/artifacts/macro_property_tests/PropertyStorageWordsSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyStorageWordsSmoke.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyStorageWordsSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Verity/Examples/MacroContracts.lean
+ */
+contract PropertyStorageWordsSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("StorageWordsSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `extSloadsLike` result
+    function testTODO_ExtSloadsLike_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("extSloadsLike(bytes32[])", _singletonBytes32Array(bytes32(uint256(0xBEEF)))));
+        require(ok, "extSloadsLike reverted unexpectedly");
+        require(ret.length >= 64, "extSloadsLike ABI dynamic return payload unexpectedly short");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+
+    function _singletonBytes32Array(bytes32 x) internal pure returns (bytes32[] memory arr) {
+        arr = new bytes32[](1);
+        arr[0] = x;
+    }
+}

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -99,6 +99,26 @@ class RenderTests(unittest.TestCase):
         self.assertIn("_singletonUintArray", rendered)
         self.assertIn('abi.encodeWithSignature("consume(uint256[])", _singletonUintArray(1))', rendered)
 
+    def test_render_bytes32_array_param_adds_helper(self) -> None:
+        contract = gen.ContractDecl(
+            name="ArrayConsumer",
+            constructor=None,
+            source=gen.ROOT / "Verity/Examples/MacroContracts.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "consume",
+                    (gen.ParamDecl("values", "Array Bytes32"),),
+                    "Unit",
+                ),
+            ),
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("_singletonBytes32Array", rendered)
+        self.assertIn(
+            'abi.encodeWithSignature("consume(bytes32[])", _singletonBytes32Array(bytes32(uint256(0xBEEF))))',
+            rendered,
+        )
+
     def test_render_unknown_type_fails_closed(self) -> None:
         contract = gen.ContractDecl(
             name="UnknownType",


### PR DESCRIPTION
## Summary
- extend `Verity/Macro/Translate.lean` type parsing to support `Bytes` and `Array <type>` in `verity_contract` function params/returns (fail-closed on nested arrays and `Array Unit`)
- keep storage-field typing strict (`Bytes`/`Array` storage fields remain rejected with explicit diagnostics)
- add macro smoke coverage via `StorageWordsSmoke.extSloadsLike(slots : Array Bytes32) : Array Uint256` using `returnStorageWords`
- update macro property-test generator to synthesize example values for `Array Bytes32` and emit a helper for bytes32[] args
- regenerate canonical artifact for the new smoke contract

## Why
This closes a macro front-end gap where `CompilationModel` already supports array ABI parameter/return types but `verity_contract` declarations were still scalar-only. It directly unlocks migration of array-parameter selectors (notably `extSloads(bytes32[])` in morpho-verity #38).

## Validation
- `lake build Verity.Examples.MacroContracts Compiler.MainTest`
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py`
- `python3 scripts/check_macro_property_test_generation.py --check`
- `python3 scripts/test_check_macro_property_test_generation.py`
- `python3 scripts/check_doc_counts.py`
- `python3 scripts/check_axiom_locations.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it extends the macro’s type parser and ABI model generation for dynamic types (`Bytes`/`Array`), which can affect selector/ABI encoding and generated artifacts; storage typing remains fail-closed.
> 
> **Overview**
> **`verity_contract` now accepts dynamic ABI types in function signatures.** The macro translation layer adds support for `Bytes` and `Array <elem>` in params/returns, including compilation-model mapping (`ParamType.array`) and contract-level Lean type generation, while explicitly rejecting `Array Unit` and nested arrays.
> 
> **Storage typing stays strict.** `Bytes`/`Array` remain disallowed for storage fields with clearer diagnostics.
> 
> **Adds smoke + generated test coverage for array params/returns.** Introduces `StorageWordsSmoke.extSloadsLike(slots : Array Bytes32) : Array Uint256` using `returnStorageWords`, regenerates the corresponding Foundry property-test artifact, and updates the property-test generator (plus unit tests) to emit example values and helpers for `bytes32[]` arguments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb767860656a2b29c8945cbfdb846f711390a6a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->