### PR TITLE
docs: align canonical compile flow with macro-generated specs

### DIFF
--- a/Compiler/Specs.lean
+++ b/Compiler/Specs.lean
@@ -445,10 +445,13 @@ def safeCounterSpec : CompilationModel := {
 Yul libraries (PoseidonT3/T4). Use `lake exe verity-compiler --link ...` to
 compile it separately.
 
-**Adding a new contract**: After adding `myCompilationModel` here, also ensure
-each function's selector is pre-computed in `Compiler/Selectors.lean` via
-`computeSelectors`. The compiler will fail at runtime if a function has no
-matching selector.
+**Adding a new contract (canonical path)**: add a `verity_contract` declaration
+in `Verity/Examples/MacroContracts.lean`. `allSpecs` is derived from those
+macro declarations.
+
+Manual `Compiler.Specs.*Spec` definitions remain only for legacy proof migration
+and special cases (for example, linked-library workflows like `cryptoHashSpec`).
+Selectors are still auto-computed by `computeSelectors`.
 -/
 
 def allSpecs : List CompilationModel := [

--- a/README.md
+++ b/README.md
@@ -192,8 +192,6 @@ One logical spec can have many implementations, and one implementation can have 
 
 **Unverified examples**:
 - [CryptoHash](Verity/Examples/CryptoHash.lean) demonstrates external library linking via the [Linker](Compiler/Linker.lean) but has no specs or proofs.
-- [ERC20](Verity/Examples/ERC20.lean) is a new foundation scaffold with executable logic plus formal spec/invariant modules in `Verity/Specs/ERC20/`, with proof development tracked in [#69](https://github.com/Th0rgal/verity/issues/69).
-- [ERC721](Verity/Examples/ERC721.lean) is a new foundation scaffold with executable logic plus formal spec/invariant modules in `Verity/Specs/ERC721/`, with proof development tracked in [#73](https://github.com/Th0rgal/verity/issues/73).
 
 ### Using External Libraries (Linker)
 
@@ -201,7 +199,7 @@ Verity supports linking external Yul libraries (e.g., cryptographic libraries) t
 
 **The pattern:**
 1. Write a simple Lean placeholder (e.g., `add a b` for a hash function)
-2. Add an `externalCall` in your compilation model (`CompilationModel`/`CompilationModel`)
+2. Add an `externalCall` in your compilation model (`CompilationModel`)
 3. Link your production Yul library at compile time
 
 ```bash
@@ -219,7 +217,7 @@ lake exe verity-compiler \
 def myHash (a b : Uint256) : Contract Uint256 := do
   return (a + b)  -- simple placeholder
 
--- 2. CompilationModel/CompilationModel calls the real library
+-- 2. CompilationModel calls the real library
 Stmt.letVar "h" (Expr.externalCall "myHash" [Expr.param "a", Expr.param "b"])
 
 -- 3. Compile with: lake exe verity-compiler --link examples/external-libs/MyHash.yul
@@ -235,7 +233,7 @@ Verity's restricted DSL prevents raw external calls for safety. Instead, call pa
 
 ## What's Verified
 
-- **Layer 1 (per contract)**: EDSL behavior matches its compilation model (`CompilationModel`/`CompilationModel`).
+- **Layer 1 (per contract)**: EDSL behavior matches its compilation model (`CompilationModel`).
 - **Layer 2 (framework)**: compilation model → `IR` preserves behavior.
 - **Layer 3 (framework)**: `IR -> Yul` preserves behavior.
 - **Proof-chain note**: Layer 1 equivalence is proven per contract/spec today, and the CLI compiles through the EDSL/macro lowering boundary with optional `--edsl-contract` selection. Fully automatic verified EDSL reification/lowering remains in progress. Layers 2 and 3 (`CompilationModel -> IR -> Yul`) are verified with 1 axiom.

--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -29,7 +29,7 @@ python3 scripts/generate_contract.py MyRegistry --fields "data:mapping(uint256)"
 python3 scripts/generate_contract.py MyContract --dry-run
 ```
 
-This creates 7 scaffold files (EDSL, Spec, Invariants, Proofs re-export shim, Basic proofs, Correctness proofs, Property tests) and prints the manual steps for `All.lean` and `Compiler/Specs.lean`.
+This creates 7 scaffold files (EDSL, Spec, Invariants, Proofs re-export shim, Basic proofs, Correctness proofs, Property tests) and prints follow-up steps for `All.lean` plus canonical macro registration.
 
 ## Checklist
 
@@ -46,8 +46,9 @@ This creates 7 scaffold files (EDSL, Spec, Invariants, Proofs re-export shim, Ba
    - Prove correctness in `Verity/Proofs/<Name>/Basic.lean` and `Correctness.lean`
    - Each theorem states observable behavior (return values + storage deltas)
 
-4. **Compiler Spec + Layer 2 Proofs**
-   - Add compiler-level spec in `Compiler/Specs.lean`
+4. **Compiler Integration + Layer 2 Proofs**
+   - Add canonical `verity_contract` declaration in `Verity/Examples/MacroContracts.lean`
+   - Handwritten `Compiler.Specs.*Spec` definitions are legacy/migration scaffolding only
    - Prove `CompilationModel → IR` preservation in `Compiler/Proofs/SpecCorrectness/<Name>.lean`
    - `Verity/Specs/<Name>/Proofs.lean` is a re-export shim (imports from `Compiler/Proofs/SpecCorrectness/`)
 
@@ -81,7 +82,7 @@ test/Property<Name>.t.sol              # Property tests
 ## Common Pitfalls
 
 - **Storage slot mismatches** between spec, EDSL, and compiler
-- **Missing function entries** in `Compiler/Specs.lean` (selectors are auto-computed from function signatures)
+- **Missing macro declaration** in `Verity/Examples/MacroContracts.lean` (canonical `allSpecs` derives from these declarations)
 - **Mapping conversions** not mirrored between spec and proofs
 - **Property tag drift** — test tags must match lemma names exactly
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -604,20 +604,12 @@ FOUNDRY_PROFILE=difftest forge test
 
 ### Add New Contract
 
-1. **Define specification** in `Compiler/Specs.lean`:
+1. **Add a macro contract declaration** in `Verity/Examples/MacroContracts.lean`:
 ```lean
-def myCompilationModel : CompilationModel := {
-  name := "MyContract"
+verity_contract MyContract where
   fields := [/* ... */]
   constructor := /* ... */
   functions := [/* ... */]
-}
-
--- Add to allSpecs (selectors are auto-computed from function signatures)
-def allSpecs : List CompilationModel := [
-  /* ... */,
-  myCompilationModel
-]
 ```
 
 2. **Recompile**:
@@ -627,6 +619,9 @@ lake exe verity-compiler
 ```
 
 3. **Done!** Contract generated in `artifacts/yul/MyContract.yul`
+
+Legacy note: handwritten `Compiler.Specs.*Spec` definitions are retained only for
+migration/special workflows and are not the canonical CLI compile path.
 
 Time: **~5 minutes** (vs ~30 minutes manual IR)
 

--- a/docs-site/content/examples.mdx
+++ b/docs-site/content/examples.mdx
@@ -219,7 +219,7 @@ Source: [`Verity/Examples/CryptoHash.lean`](https://github.com/Th0rgal/verity/bl
 
 ## ERC20 (Foundation Scaffold)
 
-Unverified ERC20 foundation scaffold with executable logic (`mint`, `transfer`, `approve`, `transferFrom`) and formal spec/invariant modules for incremental proof work tracked in issue #69.
+Baseline-verified ERC20 foundation scaffold with executable logic (`mint`, `transfer`, `approve`, `transferFrom`) and formal spec/invariant modules.
 
 Source:
 - Implementation: [`Verity/Examples/ERC20.lean`](https://github.com/Th0rgal/verity/blob/main/Verity/Examples/ERC20.lean)
@@ -237,7 +237,7 @@ Source:
 7. **SimpleToken**: full composition (Owned + Ledger + supply tracking)
 8. **ReentrancyExample**: vulnerability modeling and safety proofs
 9. **CryptoHash**: external library linking (unverified)
-10. **ERC20**: standards-oriented token scaffold with specs/invariants (proofs pending)
+10. **ERC20**: standards-oriented token scaffold with baseline proofs and specs/invariants
 
 ## Source
 

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -355,13 +355,13 @@ grep -r "sorry" Verity/Specs/TipJar/ Verity/Proofs/TipJar/
 
 ## Phase 5: Add to Compiler (15 minutes)
 
-### 5.1 Add Compiler Spec
+### 5.1 Add Canonical Compiler Declaration
 
-Add your contract to `Compiler/Specs.lean`:
+Add your contract to `Verity/Examples/MacroContracts.lean` with `verity_contract`.
+`Compiler.Specs.allSpecs` is derived from these macro declarations:
 
 ```lean
-def tipJarSpec : CompilationModel := {
-  name := "TipJar"
+verity_contract TipJar where
   fields := [
     { name := "tips", ty := FieldType.mappingTyped (.simple .address) }
   ]
@@ -384,21 +384,14 @@ def tipJarSpec : CompilationModel := {
       ]
     }
   ]
-}
 ```
 
-### 5.2 Register Your Contract
+### 5.2 Legacy Note
 
-Add your contract to the `allSpecs` list in `Compiler/Specs.lean`:
+Handwritten `Compiler.Specs.*Spec` definitions are retained for proof-migration and
+special workflows only; they are not the canonical CLI compile path.
 
-```lean
-def allSpecs : List CompilationModel := [
-  -- ... existing contracts ...,
-  tipJarSpec
-]
-```
-
-Function selectors (the first 4 bytes of `keccak256("functionName(paramTypes)")`) are computed automatically by `computeSelectors` during compilation — you do not need to list them manually.
+Function selectors (the first 4 bytes of `keccak256("functionName(paramTypes)")`) are computed automatically by `computeSelectors` during compilation.
 
 > **Tip**: Run `python3 scripts/check_selectors.py` to verify that the auto-computed selectors match `solc --hashes` output. You can also compute selectors manually with `python3 scripts/keccak256.py "tip(uint256)" "getBalance(address)"`.
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -351,8 +351,8 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 ### Verified Components (Zero Trust)
 
-1. **EDSL → CompilationModel/CompilationModel**: Proven correct in Lean (Layer 1)
-2. **CompilationModel/CompilationModel → IR**: Proven correct in Lean (Layer 2)
+1. **EDSL → CompilationModel**: Proven correct in Lean (Layer 1)
+2. **CompilationModel → IR**: Proven correct in Lean (Layer 2)
 3. **IR → Yul**: Proven correct in Lean (Layer 3, 1 axiom)
 4. **IR Interpreter**: Used for differential testing, verified against specs
 5. **Property Tests**: Extracted from proven theorems, tested in Foundry

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -211,7 +211,7 @@ python3 scripts/check_macro_property_test_generation.py
 python3 scripts/check_macro_property_test_generation.py --check
 ```
 
-Creates 8 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic proofs, Correctness proofs, SpecCorrectness scaffold, and Property tests. Prints instructions for manual steps (All.lean imports, Compiler/Specs.lean entry).
+Creates 8 files: EDSL implementation, Spec, Invariants, Proofs re-export, Basic proofs, Correctness proofs, SpecCorrectness scaffold, and Property tests. Prints instructions for manual follow-up (All.lean imports, canonical macro registration in `Verity/Examples/MacroContracts.lean`).
 
 Identifier rules (fail-fast validation):
 - Contract name: PascalCase alphanumeric (existing rule), e.g. `MyToken`

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -937,7 +937,7 @@ def _gen_test_helpers(cfg: ContractConfig) -> str:
 
 
 def gen_compiler_spec(cfg: ContractConfig) -> str:
-    """Generate Compiler/Specs.lean entry (printed for manual insertion)."""
+    """Generate a legacy Compiler/Specs.lean entry for migration/special workflows."""
     fields_str = ",\n    ".join(
         f'{{ name := "{f.name}", ty := {f.compiler_field_type} }}'
         for f in cfg.fields
@@ -1161,14 +1161,14 @@ Examples:
     print(gen_all_lean_imports(cfg))
     print()
 
-    name_lower = cfg.name[0].lower() + cfg.name[1:]
-    print("2. Add compiler spec to Compiler/Specs.lean:")
+    print("2. Legacy bridge (optional): add compiler spec to Compiler/Specs.lean if needed:")
     print(gen_compiler_spec(cfg))
     print()
 
-    print(f"3. Register in allSpecs (Compiler/Specs.lean):")
-    print(f"   Find 'def allSpecs' and add '{name_lower}Spec' to the list.")
-    print(f"   Selectors are computed automatically by computeSelectors during compilation.")
+    print("3. Canonical registration:")
+    print("   Add a `verity_contract` declaration in Verity/Examples/MacroContracts.lean.")
+    print("   `Compiler.Specs.allSpecs` is derived from macro declarations (no manual allSpecs edit).")
+    print("   Manual `Compiler.Specs.*Spec` entries are legacy migration scaffolding only.")
     print()
 
     print(f"4. Create differential tests (not scaffolded):")


### PR DESCRIPTION
## Summary
This PR updates stale docs/scaffold guidance so the canonical contract compile path matches the current macro-driven architecture.

It fixes the outdated items identified in the migration review:

1. Remove stale `allSpecs` manual-registration instructions from scaffolding/docs and replace with canonical `verity_contract` guidance.
2. Mark handwritten `Compiler.Specs.*Spec` as legacy/migration-only (not canonical CLI flow).
3. Update stale `Compiler/Specs.lean` comment that implied manual `myCompilationModel` registration.
4. Resolve README verification-status contradiction for ERC20/ERC721.
5. Fix `CompilationModel/CompilationModel` typo/legacy naming artifacts.
6. Keep trust-boundary references anchored to `TRUST_ASSUMPTIONS.md` (no `verity-paper/sections/limitations.tex` references remain in-repo).

## Files changed
- `Compiler/Specs.lean`
- `scripts/generate_contract.py`
- `scripts/README.md`
- `README.md`
- `docs/VERIFICATION_STATUS.md`
- `docs-site/content/compiler.mdx`
- `docs-site/content/guides/first-contract.mdx`
- `docs-site/content/add-contract.mdx`
- `docs-site/content/examples.mdx`

## Validation
- `python3 -m py_compile scripts/generate_contract.py`
- `python3 scripts/check_doc_counts.py`

## Notes
- Manual `Compiler.Specs.*Spec` definitions are still documented as legacy scaffolding for migration/special cases.
- Canonical compile path documentation now points to macro declarations in `Verity/Examples/MacroContracts.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only and scaffolding output changes that clarify the canonical `verity_contract`-based registration path; no compiler/proof logic is modified, but misleading guidance could still impact onboarding if reviewers miss a spot.
> 
> **Overview**
> Updates docs and scaffolding guidance to treat `verity_contract` declarations in `Verity/Examples/MacroContracts.lean` as the **canonical** way to register compilable contracts, and explicitly frames handwritten `Compiler.Specs.*Spec` entries as *legacy/migration or special workflows* (e.g., linked-library `CryptoHash`).
> 
> Cleans up stale terminology/instructions (removing `CompilationModel/CompilationModel` typos, dropping manual `allSpecs`-edit steps across guides/scripts) and resolves a verification-status messaging inconsistency by describing ERC20 as baseline-verified in the docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0b949dcf395dcbc48928298c66fe91fe2bf74bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->