### PR TITLE
ci: bump build job timeout to 120 min for cold-cache linking

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -195,7 +195,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:


### PR DESCRIPTION
## Summary
- Bumps the `build` job timeout from 90 → 120 minutes to break the cold-cache cycle

## Problem
The `lake build verity-compiler` step takes 88+ minutes on GH Actions runners when the Lake cache is cold, due to single-threaded native linking of the EVMYulLean FFI (thousands of `.o` files for SHA-2 + Keccak256 C objects). With the previous 90-minute timeout, the job times out before the cache can be saved (`Save Lake packages cache` step never runs), creating a self-perpetuating cold-cache cycle:

1. Cold cache → linking takes 88+ min → job times out at 90 min
2. Cache never saved → next run also cold cache → repeat

This is visible on the current `main` branch run and was blocking PR #1042.

## Fix
Bump timeout from 90 → 120 minutes. This gives ~30 min of headroom for the cold-cache linking to complete and save the Lake cache, after which subsequent builds take ~2 minutes with a warm cache.

## Test plan
- [x] All 10 `check_verify_*.py` sync-check scripts pass locally
- [ ] CI build job completes within 120 minutes and saves cache
- [ ] Subsequent CI runs on same toolchain/manifest hit cache and complete in <5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that increases the GitHub Actions `build` job timeout; no production code or test logic is modified.
> 
> **Overview**
> Increases the GitHub Actions `verify.yml` `build` job timeout from **90** to **120 minutes** to reduce CI failures on cold caches and allow long linking/build steps to complete and save caches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f634bc820129d8f6a78db1300457f1e6120f35c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->