### PR TITLE
ci: split build into proofs and compiler jobs with separate caches

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -195,7 +195,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:
@@ -334,10 +334,84 @@ jobs:
           lake env lean PrintAxioms.lean 2>&1 | tee axiom-report-raw.log
           AXIOM_REPORT_FILE=axiom-report.md python3 scripts/check_axiom_report.py --log axiom-report-raw.log | tee -a "$GITHUB_STEP_SUMMARY"
 
+      - name: Generate proof length report
+        run: python3 scripts/check_proof_length.py --format=markdown >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate property coverage report
+        run: python3 scripts/report_property_coverage.py --format=markdown >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate storage layout report
+        run: python3 scripts/check_storage_layout.py --format=markdown >> $GITHUB_STEP_SUMMARY
+
+      - name: Save Lake packages cache
+        if: always() && steps.cache-lake.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .lake
+          key: lake-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('Verity/**/*.lean', 'Compiler/**/*.lean') }}
+
+      - name: Upload axiom dependency report
+        uses: actions/upload-artifact@v4
+        with:
+          name: axiom-dependency-report
+          path: |
+            axiom-report.md
+            axiom-report-raw.log
+
+  # Compiler executable + Yul generation + solc validation.
+  # Cached separately from proofs: only rebuilds when Compiler/ sources,
+  # lean-toolchain, or lake-manifest.json change.  Proof-only changes
+  # (Verity/**) never invalidate this cache.
+  build-compiler:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache elan + Lean toolchain
+        id: cache-elan
+        uses: actions/cache@v4
+        with:
+          path: ~/.elan
+          key: elan-${{ hashFiles('lean-toolchain') }}
+
+      - name: Install elan
+        if: steps.cache-elan.outputs.cache-hit != 'true'
+        env:
+          ELAN_VERSION: "v4.1.2"
+          ELAN_INIT_SHA256: "4bacca9502cb89736fe63d2685abc2947cfbf34dc87673504f1bb4c43eda9264"
+        run: |
+          curl -sSfL "https://raw.githubusercontent.com/leanprover/elan/${ELAN_VERSION}/elan-init.sh" -o elan-init.sh
+          echo "${ELAN_INIT_SHA256}  elan-init.sh" | sha256sum -c -
+          bash elan-init.sh -y --default-toolchain none
+          rm elan-init.sh
+
+      - name: Add elan to PATH
+        run: echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: Restore Lake compiler cache
+        id: cache-lake-compiler
+        uses: actions/cache/restore@v4
+        with:
+          path: .lake
+          key: lake-compiler-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('Compiler/**/*.lean') }}
+          restore-keys: |
+            lake-compiler-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-
+            lake-compiler-${{ hashFiles('lean-toolchain') }}-
+
+      - name: Fetch mathlib compiled cache
+        run: lake exe cache get
+
       - name: Build compiler
+        env:
+          LEAN_NUM_THREADS: 4
         run: lake build verity-compiler
 
       - name: Build difftest interpreter
+        env:
+          LEAN_NUM_THREADS: 4
         run: lake build difftest-interpreter
 
       - name: Generate Yul (all contracts + CryptoHash with linked libraries)
@@ -423,21 +497,12 @@ jobs:
               print(f"| `{patch}` | {total} | {contracts[patch]} |")
           PY
 
-      - name: Generate proof length report
-        run: python3 scripts/check_proof_length.py --format=markdown >> $GITHUB_STEP_SUMMARY
-
-      - name: Generate property coverage report
-        run: python3 scripts/report_property_coverage.py --format=markdown >> $GITHUB_STEP_SUMMARY
-
-      - name: Generate storage layout report
-        run: python3 scripts/check_storage_layout.py --format=markdown >> $GITHUB_STEP_SUMMARY
-
-      - name: Save Lake packages cache
-        if: always() && steps.cache-lake.outputs.cache-hit != 'true'
+      - name: Save Lake compiler cache
+        if: always() && steps.cache-lake-compiler.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: .lake
-          key: lake-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('Verity/**/*.lean', 'Compiler/**/*.lean') }}
+          key: lake-compiler-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('Compiler/**/*.lean') }}
 
       - name: Upload generated Yul
         uses: actions/upload-artifact@v4
@@ -475,18 +540,10 @@ jobs:
           name: patch-coverage-report
           path: compiler/patch-report.tsv
 
-      - name: Upload axiom dependency report
-        uses: actions/upload-artifact@v4
-        with:
-          name: axiom-dependency-report
-          path: |
-            axiom-report.md
-            axiom-report-raw.log
-
   foundry-gas-calibration:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [changes, build]
+    needs: [changes, build, build-compiler]
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
@@ -509,7 +566,7 @@ jobs:
   foundry:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [changes, build]
+    needs: [changes, build, build-compiler]
     if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
@@ -546,7 +603,7 @@ jobs:
   foundry-patched:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [changes, build]
+    needs: [changes, build, build-compiler]
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v4
@@ -580,7 +637,7 @@ jobs:
   foundry-multi-seed:
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: [changes, build]
+    needs: [changes, build, build-compiler]
     if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false  # Test all seeds even if one fails

--- a/scripts/check_verify_build_docs_sync.py
+++ b/scripts/check_verify_build_docs_sync.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Ensure verify.yml build-job script list matches scripts/README.md docs."""
+"""Ensure verify.yml build/build-compiler job script lists match scripts/README.md docs."""
 
 from __future__ import annotations
 
@@ -18,32 +18,38 @@ ROOT = Path(__file__).resolve().parents[1]
 VERIFY_YML = ROOT / ".github" / "workflows" / "verify.yml"
 SCRIPTS_README = ROOT / "scripts" / "README.md"
 
+# Each entry: (workflow job name, README heading pattern, label for messages)
+_JOBS = [
+    ("build", r"^\*\*`build` job\*\*", "build"),
+    ("build-compiler", r"^\*\*`build-compiler` job\*\*", "build-compiler"),
+]
+
 
 def _normalize_spaces(text: str) -> str:
     return " ".join(text.split())
 
 
-def _extract_workflow_build_commands(text: str) -> list[str]:
-    job_body = extract_job_body(text, "build", VERIFY_YML)
+def _extract_workflow_job_commands(text: str, job_name: str) -> list[str]:
+    job_body = extract_job_body(text, job_name, VERIFY_YML)
     run_commands = extract_run_commands_from_job_body(
-        job_body, source=VERIFY_YML, context="build"
+        job_body, source=VERIFY_YML, context=job_name
     )
     commands = extract_python_script_commands(
         run_commands, source=VERIFY_YML, include_args=False
     )
     if not commands:
-        raise ValueError(f"No python3 scripts/* run commands found in build job in {VERIFY_YML}")
+        raise ValueError(f"No python3 scripts/* run commands found in {job_name} job in {VERIFY_YML}")
     return commands
 
 
-def _extract_readme_build_commands(text: str) -> list[str]:
+def _extract_readme_job_commands(text: str, heading_pattern: str, label: str) -> list[str]:
     section = re.search(
-        r"^\*\*`build` job\*\*.*?\n(?P<body>(?:^\d+\.\s.*\n)+)",
+        heading_pattern + r".*?\n(?P<body>(?:^\d+\.\s.*\n)+)",
         text,
         flags=re.MULTILINE,
     )
     if not section:
-        raise ValueError(f"Could not locate '**`build` job**' numbered list in {SCRIPTS_README}")
+        raise ValueError(f"Could not locate '**`{label}` job**' numbered list in {SCRIPTS_README}")
 
     commands: list[str] = []
     for line in section.group("body").splitlines():
@@ -57,7 +63,7 @@ def _extract_readme_build_commands(text: str) -> list[str]:
             commands.append(_normalize_spaces(cmd).split()[0])
 
     if not commands:
-        raise ValueError(f"No documented build script commands found in {SCRIPTS_README}")
+        raise ValueError(f"No documented {label} script commands found in {SCRIPTS_README}")
     return commands
 
 
@@ -65,24 +71,34 @@ def main() -> int:
     workflow_text = VERIFY_YML.read_text(encoding="utf-8")
     readme_text = SCRIPTS_README.read_text(encoding="utf-8")
 
-    workflow_commands = _extract_workflow_build_commands(workflow_text)
-    readme_commands = _extract_readme_build_commands(readme_text)
+    all_errors: list[str] = []
+    total_commands = 0
 
-    errors = compare_lists("workflow build job", workflow_commands, "README build list", readme_commands)
-    if errors:
+    for job_name, heading_pattern, label in _JOBS:
+        workflow_commands = _extract_workflow_job_commands(workflow_text, job_name)
+        readme_commands = _extract_readme_job_commands(readme_text, heading_pattern, label)
+
+        errors = compare_lists(
+            f"workflow {label} job", workflow_commands,
+            f"README {label} list", readme_commands,
+        )
+        all_errors.extend(errors)
+        total_commands += len(workflow_commands)
+
+    if all_errors:
         print("verify build/docs sync check failed:", file=sys.stderr)
-        for error in errors:
+        for error in all_errors:
             print(error, file=sys.stderr)
         print(
-            "\nUpdate scripts/README.md '**`build` job**' command list to match "
-            ".github/workflows/verify.yml build job.",
+            "\nUpdate scripts/README.md '**`build` job**' and '**`build-compiler` job**' "
+            "command lists to match .github/workflows/verify.yml.",
             file=sys.stderr,
         )
         return 1
 
     print(
         "verify build/docs command list is synchronized "
-        f"({len(workflow_commands)} script commands)."
+        f"({total_commands} script commands across {len(_JOBS)} jobs)."
     )
     return 0
 

--- a/scripts/test_check_verify_build_docs_sync.py
+++ b/scripts/test_check_verify_build_docs_sync.py
@@ -10,7 +10,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from check_verify_build_docs_sync import _extract_workflow_build_commands
+from check_verify_build_docs_sync import _extract_workflow_job_commands
 
 
 class VerifyBuildDocsSyncTests(unittest.TestCase):
@@ -30,7 +30,7 @@ class VerifyBuildDocsSyncTests(unittest.TestCase):
             """
         )
 
-        self.assertEqual(_extract_workflow_build_commands(workflow), ["check_a.py"])
+        self.assertEqual(_extract_workflow_job_commands(workflow, "build"), ["check_a.py"])
 
     def test_extracts_folded_block_run_commands(self) -> None:
         workflow = textwrap.dedent(
@@ -52,7 +52,7 @@ class VerifyBuildDocsSyncTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            _extract_workflow_build_commands(workflow),
+            _extract_workflow_job_commands(workflow, "build"),
             ["check_b.py", "check_c.py"],
         )
 
@@ -75,7 +75,7 @@ class VerifyBuildDocsSyncTests(unittest.TestCase):
             """
         )
 
-        self.assertEqual(_extract_workflow_build_commands(workflow), ["check_d.py"])
+        self.assertEqual(_extract_workflow_job_commands(workflow, "build"), ["check_d.py"])
 
     def test_extracts_with_inline_comments(self) -> None:
         workflow = textwrap.dedent(
@@ -96,7 +96,28 @@ class VerifyBuildDocsSyncTests(unittest.TestCase):
             """
         )
 
-        self.assertEqual(_extract_workflow_build_commands(workflow), ["check_e.py"])
+        self.assertEqual(_extract_workflow_job_commands(workflow, "build"), ["check_e.py"])
+
+    def test_extracts_build_compiler_job(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              build-compiler:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: python3 scripts/check_gas.py
+                  - run: python3 scripts/check_yul.py
+              other:
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+        self.assertEqual(
+            _extract_workflow_job_commands(workflow, "build-compiler"),
+            ["check_gas.py", "check_yul.py"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Splits the monolithic `build` job into two parallel jobs: `build` (proofs) and `build-compiler` (compiler exe + Yul)
- Compiler cache key excludes `Verity/**/*.lean` — proof changes never trigger an 88-minute relink
- Supersedes #1044 (simple timeout bump)

## Problem
The `lake build verity-compiler` step takes **88+ minutes** on GH Actions runners when the Lake cache is cold, due to single-threaded native linking of the EVMYulLean FFI. The old monolithic `build` job had a single cache key that included both `Verity/**/*.lean` and `Compiler/**/*.lean`, meaning **every proof change** invalidated the compiler cache and forced a cold relink.

Combined with `cancel-in-progress: true` concurrency groups, builds were routinely cancelled before the cache could be saved — creating a self-perpetuating cold-cache cycle. Looking at the last ~30 CI runs: almost all were cancelled, and no code-changing run has successfully completed recently.

## Solution
Split into two parallel jobs with separate cache keys:

| Job | Timeout | Cache key | Invalidated by |
|-----|---------|-----------|----------------|
| `build` | 30 min | `lake-{toolchain}-{manifest}-{Verity+Compiler/**}` | Any Lean source change |
| `build-compiler` | 120 min | `lake-compiler-{toolchain}-{manifest}-{Compiler/**}` | Only `Compiler/` changes or dep bumps |

Once the compiler cache is warm, it stays warm indefinitely across proof-only changes. The 120-minute timeout gives cold-cache builds enough headroom to complete and save the cache.

Downstream foundry jobs depend on both: `needs: [changes, build, build-compiler]` — Foundry tests still gate on proof correctness.

## Files changed
- `.github/workflows/verify.yml` — split build job, separate cache keys, updated downstream deps
- `scripts/check_verify_artifact_sync.py` — supports multiple producer jobs (`build` + `build-compiler`)
- `scripts/check_verify_build_docs_sync.py` — validates both jobs' script lists
- `scripts/README.md` — documents the new 8-job layout
- `scripts/test_check_verify_artifact_sync.py` — new tests for split-producer scenarios
- `scripts/test_check_verify_build_docs_sync.py` — new test for `build-compiler` extraction

## Test plan
- [x] All 10 `check_verify_*.py` sync-check scripts pass locally
- [x] 180/181 Python unit tests pass (1 pre-existing failure: stale `verification_status.json`)
- [ ] CI `build-compiler` job completes and saves compiler cache
- [ ] Subsequent proof-only PRs hit compiler cache and skip the 88-min link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reworks the CI workflow DAG, caching, and artifact production/consumption; mistakes here could cause CI to skip required validations or fail downstream jobs even though runtime code is unchanged.
> 
> **Overview**
> Splits the previous monolithic CI `build` into two jobs: `build` focused on proofs/axiom audit (now a 30‑minute timeout) and a new `build-compiler` job that builds the compiler, generates/validates Yul, and produces gas/Yul artifacts with a separate `lake-compiler-*` cache key that is not invalidated by `Verity/**` proof-only changes.
> 
> Moves report generation/axiom-report upload to the proofs `build` job, keeps Yul/gas artifacts produced by `build-compiler`, and updates downstream Foundry jobs to `needs: [changes, build, build-compiler]`.
> 
> Updates CI sync tooling and docs to match the new split: artifact sync now treats `build` + `build-compiler` as producer jobs, build/docs sync validates both job sections in `scripts/README.md`, and unit tests are expanded to cover the split-job scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 454d847148af2443beead6ebf5b45f360b1bbbb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->