### PR TITLE
docs: follow-up fixes after #1043

### DIFF
--- a/Compiler/Specs.lean
+++ b/Compiler/Specs.lean
@@ -446,8 +446,8 @@ Yul libraries (PoseidonT3/T4). Use `lake exe verity-compiler --link ...` to
 compile it separately.
 
 **Adding a new contract (canonical path)**: add a `verity_contract` declaration
-in `Verity/Examples/MacroContracts.lean`. `allSpecs` is derived from those
-macro declarations.
+in `Verity/Examples/MacroContracts.lean`, then add the generated `<Name>.spec`
+to `allSpecs` below.
 
 Manual `Compiler.Specs.*Spec` definitions remain only for legacy proof migration
 and special cases (for example, linked-library workflows like `cryptoHashSpec`).

--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -82,7 +82,9 @@ test/Property<Name>.t.sol              # Property tests
 ## Common Pitfalls
 
 - **Storage slot mismatches** between spec, EDSL, and compiler
-- **Missing macro declaration** in `Verity/Examples/MacroContracts.lean` (canonical `allSpecs` derives from these declarations)
+- **Missing canonical registration**:
+  - Add macro declaration in `Verity/Examples/MacroContracts.lean`
+  - Add `<Name>.spec` entry to `Compiler.Specs.allSpecs` in `Compiler/Specs.lean`
 - **Mapping conversions** not mirrored between spec and proofs
 - **Property tag drift** — test tags must match lemma names exactly
 

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -607,18 +607,26 @@ FOUNDRY_PROFILE=difftest forge test
 1. **Add a macro contract declaration** in `Verity/Examples/MacroContracts.lean`:
 ```lean
 verity_contract MyContract where
-  fields := [/* ... */]
-  constructor := /* ... */
-  functions := [/* ... */]
+  storage
+    value : Uint256 := slot 0
+  function setValue (x : Uint256) : Unit := do
+    setStorage value x
+  function getValue () : Uint256 := do
+    return (← getStorage value)
 ```
 
-2. **Recompile**:
+2. **Register it in** `Compiler/Specs.lean` **under** `allSpecs`:
+```lean
+Verity.Examples.MacroContracts.MyContract.spec
+```
+
+3. **Recompile**:
 ```bash
 lake build verity-compiler
 lake exe verity-compiler
 ```
 
-3. **Done!** Contract generated in `artifacts/yul/MyContract.yul`
+4. **Done!** Contract generated in `artifacts/yul/MyContract.yul`
 
 Legacy note: handwritten `Compiler.Specs.*Spec` definitions are retained only for
 migration/special workflows and are not the canonical CLI compile path.

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -358,32 +358,20 @@ grep -r "sorry" Verity/Specs/TipJar/ Verity/Proofs/TipJar/
 ### 5.1 Add Canonical Compiler Declaration
 
 Add your contract to `Verity/Examples/MacroContracts.lean` with `verity_contract`.
-`Compiler.Specs.allSpecs` is derived from these macro declarations:
+Then register `<Name>.spec` in `Compiler/Specs.lean` under `allSpecs`:
 
 ```lean
 verity_contract TipJar where
-  fields := [
-    { name := "tips", ty := FieldType.mappingTyped (.simple .address) }
-  ]
-  constructor := none
-  functions := [
-    { name := "tip"
-      params := [{ name := "amount", ty := ParamType.uint256 }]
-      returnType := none
-      body := [
-        Stmt.setMapping "tips" Expr.caller
-          (Expr.add (Expr.mapping "tips" Expr.caller) (Expr.param "amount")),
-        Stmt.stop
-      ]
-    },
-    { name := "getBalance"
-      params := [{ name := "addr", ty := ParamType.address }]
-      returnType := some FieldType.uint256
-      body := [
-        Stmt.return (Expr.mapping "tips" (Expr.param "addr"))
-      ]
-    }
-  ]
+  storage
+    tips : Uint256 -> Uint256 := slot 0
+
+  function tip (amount : Uint256) : Unit := do
+    let sender := caller
+    let current ← getMapping tips sender
+    setMapping tips sender (add current amount)
+
+  function getBalance (addr : Uint256) : Uint256 := do
+    return (← getMapping tips addr)
 ```
 
 ### 5.2 Legacy Note
@@ -397,7 +385,7 @@ Function selectors (the first 4 bytes of `keccak256("functionName(paramTypes)")`
 
 ### 5.3 Write Layer 2 Proofs
 
-Layer 2 proofs show that the `CompilationModel` you just wrote faithfully represents the EDSL implementation. Create `Compiler/Proofs/SpecCorrectness/TipJar.lean` (Lake discovers all `.lean` files under `Compiler/` automatically via `globs := #[.andSubmodules `Compiler]` in `lakefile.lean`, so no registration is needed):
+Layer 1 bridge proofs show that the `CompilationModel` faithfully represents the EDSL implementation. Create `Compiler/Proofs/SpecCorrectness/TipJar.lean` (Lake discovers all `.lean` files under `Compiler/` automatically via `globs := #[.andSubmodules `Compiler]` in `lakefile.lean`, so no registration is needed):
 
 ```lean
 /-

--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -1167,7 +1167,8 @@ Examples:
 
     print("3. Canonical registration:")
     print("   Add a `verity_contract` declaration in Verity/Examples/MacroContracts.lean.")
-    print("   `Compiler.Specs.allSpecs` is derived from macro declarations (no manual allSpecs edit).")
+    print("   Then add `<Name>.spec` from MacroContracts to `Compiler.Specs.allSpecs`.")
+    print("   (Automatic allSpecs derivation is planned but not implemented yet.)")
     print("   Manual `Compiler.Specs.*Spec` entries are legacy migration scaffolding only.")
     print()
 


### PR DESCRIPTION
## Summary
Fixes the follow-up issues identified after #1043:

- Correct docs/scaffold wording: `allSpecs` is still manually maintained today (macro declaration + manual `allSpecs` entry required).
- Replace invalid `verity_contract` examples (`fields := / constructor := / functions :=`) with valid macro syntax (`storage` / `function`).
- Fix layer wording in first-contract guide (`CompilationModel <-> EDSL` is Layer 1 bridge proof).
- Align `Compiler/Specs.lean` canonical-path comment with current implementation.

## Files changed
- `scripts/generate_contract.py`
- `docs-site/content/guides/first-contract.mdx`
- `docs-site/content/compiler.mdx`
- `docs-site/content/add-contract.mdx`
- `Compiler/Specs.lean`

## Validation
- `python3 -m py_compile scripts/generate_contract.py`
- `python3 scripts/check_doc_counts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation, comments, and scaffold-generator messaging; no compiler or contract logic is modified.
> 
> **Overview**
> Clarifies the *canonical* “add a contract” workflow: after adding a `verity_contract` in `Verity/Examples/MacroContracts.lean`, you must also manually register `Verity.Examples.MacroContracts.<Name>.spec` in `Compiler/Specs.lean` under `allSpecs` (docs + generator output now match current behavior).
> 
> Updates documentation examples to use valid `verity_contract` syntax (`storage`/`function` blocks) and corrects wording in the first-contract guide (bridge proof layering), plus aligns the `Compiler/Specs.lean` comment with the manual `allSpecs` maintenance reality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d0aee1061e0613a33f1c08c5a0beb1a8015d9fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->