### PR TITLE
docs: address #1047 review bugs in first-contract guide

### DIFF
--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -366,11 +366,11 @@ verity_contract TipJar where
     tips : Uint256 -> Uint256 := slot 0
 
   function tip (amount : Uint256) : Unit := do
-    let sender := caller
+    let sender := msgSender
     let current ← getMapping tips sender
     setMapping tips sender (add current amount)
 
-  function getBalance (addr : Uint256) : Uint256 := do
+  function getBalance (addr : Address) : Uint256 := do
     return (← getMapping tips addr)
 ```
 


### PR DESCRIPTION
## Summary
- replace `caller` with `msgSender` in the `verity_contract` tutorial snippet
- restore `getBalance` argument type to `Address` to match selector/test flow (`getBalance(address)`)

## Why
PR #1047 review reported two P1 tutorial regressions that break copy/paste build and desynchronize function selectors.

## Validation
- `python3 scripts/check_doc_counts.py`
- `rg -n "let sender := caller|getBalance \(addr : Uint256\)" docs-site/content/guides/first-contract.mdx` (no matches)

Refs:
- https://github.com/Th0rgal/verity/pull/1047#discussion_r2868695737
- https://github.com/Th0rgal/verity/pull/1047#discussion_r2868695738

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it corrects copy/paste tutorial code to use the current API and avoids selector mismatches in examples/tests.
> 
> **Overview**
> Fixes two tutorial regressions in `docs-site/content/guides/first-contract.mdx`.
> 
> The `verity_contract` snippet now uses `msgSender` instead of the legacy `caller`, and updates `getBalance` to take an `Address` parameter (matching the intended `getBalance(address)` selector flow).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d6a323704f51081158f35a65039b70fbd846369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->