### PR TITLE
docs: fix remaining first-contract snippet issues after #1048

### DIFF
--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -363,10 +363,10 @@ Then register `<Name>.spec` in `Compiler/Specs.lean` under `allSpecs`:
 ```lean
 verity_contract TipJar where
   storage
-    tips : Uint256 -> Uint256 := slot 0
+    tips : Address -> Uint256 := slot 0
 
   function tip (amount : Uint256) : Unit := do
-    let sender := msgSender
+    let sender <- msgSender
     let current ← getMapping tips sender
     setMapping tips sender (add current amount)
 


### PR DESCRIPTION
## Summary
- fix TipJar storage mapping key type in Phase 5 snippet to `Address -> Uint256`
- fix `msgSender` binding in `verity_contract` snippet to use monadic bind (`<-`)

## Why
These were reported as follow-up review issues on #1048. The previous snippet was not copy/paste-compilable and was inconsistent with earlier phases.

## Validation
- `python3 scripts/check_doc_counts.py`
- grep check for legacy bad patterns in the updated snippet

## Related
- follow-up to #1048

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc-only change that updates a code snippet to be copy/paste-compilable; no runtime or proof logic changes.
> 
> **Overview**
> Fixes the Phase 5 `TipJar` compiler-declaration snippet in `first-contract.mdx` to match the earlier tutorial phases and compile correctly.
> 
> Specifically, it changes the `tips` storage mapping key from `Uint256` to `Address`, and updates `msgSender` to use monadic bind (`let sender <- msgSender`) instead of a plain `let`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b1fd279bdf55583d2dd39033f22b0b14e0c194f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->