### PR TITLE
ci: fail-close legacy proof refs outside #997 allowlist

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -160,6 +160,9 @@ jobs:
       - name: Check manual-spec quarantine boundary
         run: python3 scripts/check_manual_spec_quarantine.py
 
+      - name: Check SpecCorrectness migration boundary
+        run: python3 scripts/check_spec_proof_migration_boundary.py
+
       - name: Check Lean hygiene
         run: python3 scripts/check_lean_hygiene.py
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,6 +80,7 @@ These CI-critical scripts validate cross-layer consistency:
 - **`check_property_manifest_sync.py`** - Ensures `property_manifest.json` stays in sync with actual Lean theorems (detects added/removed theorems)
 - **`check_storage_layout.py`** - Validates storage slot consistency across EDSL, Spec, and Compiler layers; strips Lean comments/docstrings with a shared string-aware parser (so `--` and `/- -/` inside string literals are preserved), detects intra-contract slot collisions, derives Spec slot usage from `Verity/Specs/*/Spec.lean` literal state accesses, and enforces Spec↔EDSL slot/type parity for compiled non-external contracts
 - **`check_manual_spec_quarantine.py`** - Enforces issue #999 quarantine boundaries: canonical compiler/lowering/gas/CLI paths must not reference manual `Compiler.Specs.*Spec` symbols (except explicit compatibility allowlist entries such as `cryptoHashSpec`); Lean source checks are comment/string-aware so comment-only or string-literal decoys cannot satisfy checks
+- **`check_spec_proof_migration_boundary.py`** - Enforces issue #997 anti-regression boundary: legacy proof references (`Verity.Examples.{Counter,SimpleStorage,Owned,Ledger,OwnedCounter,SimpleToken,SafeCounter}` and manual `Compiler.Specs.*Spec` names) are allowed only in an explicit temporary allowlist, and stale allowlist entries fail closed once migrated
 - **`check_mapping_slot_boundary.py`** - Enforces the mapping-slot abstraction boundary for proof interpreters: no proof semantics file may import `MappingEncoding`; builtin dispatch in `Compiler/Proofs/YulGeneration/Builtins.lean` must route through `abstractMappingSlot`/`abstractLoadStorageOrMapping`; runtime interpreters must import `MappingSlot`, use `abstractStoreStorageOrMapping`/`abstractStoreMappingEntry`, avoid legacy mapping internals (`mappingTag`/`encodeMappingSlot`/`decodeMappingSlot`/`encodeNestedMappingSlot`/`normalizeMappingBaseSlot`) including local aliases, and must not define a separate execution-state `mappings` table (`IRState`/`YulState` remain flat-storage only); also enforces explicit backend-scope markers (`activeMappingSlotBackend := .keccak`), presence of keccak helpers (`abiEncodeMappingSlot`, `solidityMappingSlot`), keccak routing through `solidityMappingSlot`, flat-storage keccak routing in `abstractLoadMappingEntry`/`abstractStoreMappingEntry`, smoke-test avoidance of legacy tagged helpers, and matching trust-boundary documentation in `TRUST_ASSUMPTIONS.md`; Lean source checks are comment/string-aware so comment-only or string-literal decoys cannot satisfy required markers
 - **`check_yul_builtin_boundary.py`** - Enforces a centralized Yul builtin semantics boundary: runtime interpreters must import `Compiler/Proofs/YulGeneration/Builtins.lean`, call `evalBuiltinCall` or `evalBuiltinCallWithBackend`, and avoid inline builtin dispatch branches (`func = "add"`, `func = "sload"`, etc.); Lean source checks are comment/string-aware so comment-only or string-literal decoys cannot satisfy required call markers
 - **`check_builtin_list_sync.py`** - Ensures `Compiler/Linker.lean` `yulBuiltins` stays synchronized with `Compiler/CompilationModel.lean` (`interopBuiltinCallNames ∪ isLowLevelCallName`) while allowing expected Linker-only Yul-object builtins (`datasize`, `dataoffset`, `datacopy`); Lean source checks are comment-aware so commented decoy `def` lines cannot satisfy extraction
@@ -125,6 +126,7 @@ python3 scripts/check_verify_artifact_sync.py
 # Run locally after modifying storage slots or adding contracts
 python3 scripts/check_storage_layout.py
 python3 scripts/check_manual_spec_quarantine.py
+python3 scripts/check_spec_proof_migration_boundary.py
 
 # After a lake build, enforce warning non-regression
 python3 scripts/check_lean_warning_regression.py --log lake-build.log
@@ -259,16 +261,17 @@ Scripts run automatically in GitHub Actions (`verify.yml`) across 8 jobs:
 21. Macro property-test artifact generation (`check_macro_property_test_generation.py --check`)
 22. Storage layout consistency (`check_storage_layout.py`)
 23. Manual-spec quarantine boundary (`check_manual_spec_quarantine.py`)
-24. Lean hygiene (`check_lean_hygiene.py`)
-25. Static gas model builtin coverage (`check_gas_model_coverage.py`)
-26. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
-27. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
-28. Builtin list sync (Linker ↔ CompilationModel) (`check_builtin_list_sync.py`)
-29. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
-30. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
-30. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
-31. PrintAxioms.lean freshness (`generate_print_axioms.py --check`)
-32. Proof length limits (`check_proof_length.py`)
+24. SpecCorrectness migration boundary (`check_spec_proof_migration_boundary.py`)
+25. Lean hygiene (`check_lean_hygiene.py`)
+26. Static gas model builtin coverage (`check_gas_model_coverage.py`)
+27. Mapping-slot abstraction boundary (`check_mapping_slot_boundary.py`)
+28. Yul builtin abstraction boundary (`check_yul_builtin_boundary.py`)
+29. Builtin list sync (Linker ↔ CompilationModel) (`check_builtin_list_sync.py`)
+30. EVMYulLean capability boundary (`check_evmyullean_capability_boundary.py`)
+31. EVMYulLean capability + unsupported-node report freshness (`generate_evmyullean_capability_report.py --check`)
+32. EVMYulLean adapter report freshness (`generate_evmyullean_adapter_report.py --check`)
+33. PrintAxioms.lean freshness (`generate_print_axioms.py --check`)
+34. Proof length limits (`check_proof_length.py`)
 
 **`build` job** (proofs + axiom audit, ~30 min timeout):
 1. Lean warning non-regression (`check_lean_warning_regression.py` over `lake-build.log`)

--- a/scripts/test_check_spec_proof_migration_boundary.py
+++ b/scripts/test_check_spec_proof_migration_boundary.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_spec_proof_migration_boundary as guard
+
+
+class SpecProofMigrationBoundaryTests(unittest.TestCase):
+    def _run_check(self, files: dict[str, str], allowlist: set[str]) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as tmpdir:
+            root = Path(tmpdir)
+            compiler_proofs = root / "Compiler" / "Proofs"
+            verity_proofs = root / "Verity" / "Proofs"
+            compiler_proofs.mkdir(parents=True, exist_ok=True)
+            verity_proofs.mkdir(parents=True, exist_ok=True)
+
+            for rel, content in files.items():
+                path = root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+
+            old_root = guard.ROOT
+            old_roots = guard.PROOF_ROOTS
+            old_allowlist = guard.ALLOWLIST
+            guard.ROOT = root
+            guard.PROOF_ROOTS = [compiler_proofs, verity_proofs]
+            guard.ALLOWLIST = {Path(p) for p in allowlist}
+            try:
+                stderr = io.StringIO()
+                with redirect_stderr(stderr):
+                    rc = guard.main()
+                return rc, stderr.getvalue()
+            finally:
+                guard.ROOT = old_root
+                guard.PROOF_ROOTS = old_roots
+                guard.ALLOWLIST = old_allowlist
+
+    def test_rejects_non_allowlisted_legacy_reference(self) -> None:
+        rc, stderr = self._run_check(
+            {
+                "Verity/Proofs/NewContract/Basic.lean": (
+                    "import Verity.Examples.Counter\n"
+                    "def x := 1\n"
+                )
+            },
+            allowlist=set(),
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("unexpected legacy proof reference", stderr)
+
+    def test_accepts_allowlisted_legacy_reference(self) -> None:
+        rc, stderr = self._run_check(
+            {
+                "Compiler/Proofs/SpecCorrectness/Counter.lean": (
+                    "def x := Compiler.Specs.counterSpec\n"
+                )
+            },
+            allowlist={"Compiler/Proofs/SpecCorrectness/Counter.lean"},
+        )
+        self.assertEqual(rc, 0, stderr)
+
+    def test_fails_on_stale_allowlist_entry(self) -> None:
+        rc, stderr = self._run_check(
+            {"Verity/Proofs/Counter/Basic.lean": "def ok := 42\n"},
+            allowlist={"Verity/Proofs/Counter/Basic.lean"},
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("stale allowlist entry", stderr)
+
+    def test_ignores_comment_and_string_decoys(self) -> None:
+        rc, stderr = self._run_check(
+            {
+                "Verity/Proofs/Counter/Basic.lean": (
+                    "-- Verity.Examples.Counter\n"
+                    "def msg := \"Compiler.Specs.counterSpec\"\n"
+                )
+            },
+            allowlist=set(),
+        )
+        self.assertEqual(rc, 0, stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/check_spec_proof_migration_boundary.py` to enforce issue #997 anti-regression boundary
- allow legacy proof references only in explicit temporary allowlist (24 files)
- fail on stale allowlist entries once a file is migrated
- add regression tests in `scripts/test_check_spec_proof_migration_boundary.py`
- wire check into `verify.yml` `checks` job and sync `scripts/README.md`

## Why
Proof migration to macro-generated artifacts is incremental. This guard prevents new legacy references from spreading while providing a deterministic burn-down mechanism: each migrated file must be removed from the allowlist.

## Validation
- `python3 scripts/test_check_spec_proof_migration_boundary.py`
- `python3 scripts/check_spec_proof_migration_boundary.py`
- `python3 scripts/check_verify_checks_docs_sync.py`
- `python3 scripts/test_check_verify_checks_docs_sync.py`
- `python3 scripts/check_doc_counts.py`

Refs #997

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new fail-closed CI boundary check that can block merges if it flags unexpected or stale legacy references, so false positives/allowlist drift could interrupt developer workflow.
> 
> **Overview**
> Adds a new CI guard (`scripts/check_spec_proof_migration_boundary.py`) to *fail closed* if Lean proof files introduce legacy references (`Verity.Examples.*` or `Compiler.Specs.*Spec`) outside an explicit temporary allowlist, and to also fail when an allowlisted file no longer contains such references (stale entry burn-down).
> 
> Wires the check into the `verify.yml` `checks` job, documents it in `scripts/README.md`, and adds Python unit tests covering non-allowlisted hits, allowlisted acceptance, stale-allowlist failures, and comment/string-literal decoy avoidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f399d3f5a3418c0040a0c76ac1646016614c0794. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->