### PR TITLE
WIP: #997 migrate proofs to generated macro artifacts

### DIFF
--- a/Compiler/Proofs/SpecCorrectness/Counter.lean
+++ b/Compiler/Proofs/SpecCorrectness/Counter.lean
@@ -14,7 +14,7 @@
 
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
-import Verity.Examples.Counter
+import Verity.Examples.MacroContracts
 
 namespace Compiler.Proofs.SpecCorrectness
 
@@ -22,9 +22,11 @@ open Compiler.CompilationModel
 open Compiler.Specs
 open Verity.Proofs.Stdlib.SpecInterpreter
 open Verity
-open Verity.Examples.Counter
+open Verity.Examples.MacroContracts.Counter
 open Verity.EVM.Uint256 (add sub)
 open Verity.Core.Uint256 (modulus val_ofNat)
+
+local abbrev counterSpec : CompilationModel := Verity.Examples.MacroContracts.Counter.spec
 
 /- State Conversion -/
 

--- a/Compiler/Proofs/SpecCorrectness/ERC20.lean
+++ b/Compiler/Proofs/SpecCorrectness/ERC20.lean
@@ -5,7 +5,7 @@
 -/
 
 import Verity.Specs.ERC20.Spec
-import Verity.Examples.ERC20
+import Verity.Examples.MacroContracts
 import Verity.Proofs.ERC20.Basic
 import Verity.Proofs.ERC20.Correctness
 import Verity.Stdlib.Math
@@ -14,7 +14,12 @@ namespace Compiler.Proofs.SpecCorrectness
 
 open Verity
 open Verity.Specs.ERC20
-open Verity.Examples.ERC20
+open Verity.Examples.MacroContracts.ERC20
+
+local abbrev owner : StorageSlot Address := Verity.Examples.MacroContracts.ERC20.ownerSlot
+local abbrev totalSupply : StorageSlot Uint256 := Verity.Examples.MacroContracts.ERC20.totalSupplySlot
+local abbrev balances : StorageSlot (Address → Uint256) := Verity.Examples.MacroContracts.ERC20.balancesSlot
+local abbrev allowances : StorageSlot (Address → Address → Uint256) := Verity.Examples.MacroContracts.ERC20.allowancesSlot
 
 /-- Spec/EDSL agreement for `constructor`. -/
 theorem erc20_constructor_spec_correct (s : ContractState) (initialOwner : Address) :

--- a/Compiler/Proofs/SpecCorrectness/Ledger.lean
+++ b/Compiler/Proofs/SpecCorrectness/Ledger.lean
@@ -18,7 +18,7 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
-import Verity.Examples.Ledger
+import Verity.Examples.MacroContracts
 import Verity.Proofs.Ledger.Basic
 
 -- Increased heartbeats due to additional struct fields (mappings2, events, etc.)
@@ -32,7 +32,9 @@ open Verity.Proofs.Stdlib.SpecInterpreter
 open Verity.Proofs.Stdlib.Automation
 open Verity
 open Verity.Stdlib.Math (MAX_UINT256)
-open Verity.Examples.Ledger
+open Verity.Examples.MacroContracts.Ledger
+
+local abbrev ledgerSpec : CompilationModel := Verity.Examples.MacroContracts.Ledger.spec
 
 -- Address encoding lemmas are provided by Automation.
 

--- a/Compiler/Proofs/SpecCorrectness/Owned.lean
+++ b/Compiler/Proofs/SpecCorrectness/Owned.lean
@@ -17,7 +17,7 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
-import Verity.Examples.Owned
+import Verity.Examples.MacroContracts
 import Verity.Proofs.Owned.Basic
 import Verity.Proofs.Owned.Correctness
 
@@ -28,7 +28,9 @@ open Compiler.Specs
 open Verity.Proofs.Stdlib.SpecInterpreter
 open Verity.Proofs.Stdlib.Automation
 open Verity
-open Verity.Examples.Owned
+open Verity.Examples.MacroContracts.Owned
+
+local abbrev ownedSpec : CompilationModel := Verity.Examples.MacroContracts.Owned.spec
 
 /- State Conversion -/
 
@@ -45,7 +47,7 @@ def ownedEdslToSpecStorage (state : ContractState) : SpecStorage :=
 
 /-- The `constructor` correctly initializes the owner -/
 theorem owned_constructor_correct (state : ContractState) (initialOwner : Address) (sender : Address) :
-    let edslResult := (Verity.Examples.Owned.constructor initialOwner).run { state with sender := sender }
+    let edslResult := (Verity.Examples.MacroContracts.Owned.constructor initialOwner).run { state with sender := sender }
     let specTx : DiffTestTypes.Transaction := {
       sender := sender
       functionName := ""  -- constructor has no name
@@ -55,8 +57,8 @@ theorem owned_constructor_correct (state : ContractState) (initialOwner : Addres
     edslResult.isSuccess = true ∧
     specResult.success = true ∧
     specResult.finalStorage.getSlot 0 = Verity.Core.Address.val (edslResult.getState.storageAddr 0) := by
-  simp [Verity.Examples.Owned.constructor, Contract.run, ownedSpec, interpretSpec,
-    setStorageAddr, Verity.Examples.Owned.owner,
+  simp [Verity.Examples.MacroContracts.Owned.constructor, Contract.run, ownedSpec, interpretSpec,
+    setStorageAddr, Verity.Examples.MacroContracts.Owned.owner,
     execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
 
 /-- The `transferOwnership` function correctly transfers ownership when called by owner -/
@@ -119,8 +121,8 @@ theorem owned_getOwner_correct (state : ContractState) (sender : Address) :
     let specResult := interpretSpec ownedSpec (ownedEdslToSpecStorage state) specTx
     specResult.success = true ∧
     specResult.returnValue = some (Verity.Core.Address.val edslAddr) := by
-  simp [Verity.Examples.Owned.getOwner, Contract.runValue, ownedSpec, interpretSpec, ownedEdslToSpecStorage,
-    getStorageAddr, Verity.Examples.Owned.owner, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot]
+  simp [Verity.Examples.MacroContracts.Owned.getOwner, Contract.runValue, ownedSpec, interpretSpec, ownedEdslToSpecStorage,
+    getStorageAddr, Verity.Examples.MacroContracts.Owned.owner, execFunction, execStmts, execStmt, evalExpr, SpecStorage.getSlot]
 
 /- Helper Properties -/
 
@@ -128,7 +130,7 @@ theorem owned_getOwner_correct (state : ContractState) (sender : Address) :
 theorem owned_getOwner_preserves_state (state : ContractState) (sender : Address) :
     let finalState := getOwner.runState { state with sender := sender }
     finalState.storageAddr 0 = state.storageAddr 0 := by
-  simp [Verity.Examples.Owned.getOwner, Contract.runState, getStorageAddr, Verity.Examples.Owned.owner]
+  simp [Verity.Examples.MacroContracts.Owned.getOwner, Contract.runState, getStorageAddr, Verity.Examples.MacroContracts.Owned.owner]
 
 /-- Only owner can transfer ownership -/
 theorem owned_only_owner_can_transfer (state : ContractState) (newOwner : Address) (sender : Address) :
@@ -152,14 +154,14 @@ theorem owned_only_owner_can_transfer (state : ContractState) (newOwner : Addres
 
 /-- Constructor sets initial owner correctly -/
 theorem owned_constructor_sets_owner (state : ContractState) (initialOwner : Address) (sender : Address) :
-    let finalState := (Verity.Examples.Owned.constructor initialOwner).runState { state with sender := sender }
+    let finalState := (Verity.Examples.MacroContracts.Owned.constructor initialOwner).runState { state with sender := sender }
     finalState.storageAddr 0 = initialOwner := by
-  simp [Verity.Examples.Owned.constructor, Contract.runState, setStorageAddr, Verity.Examples.Owned.owner]
+  simp [Verity.Examples.MacroContracts.Owned.constructor, Contract.runState, setStorageAddr, Verity.Examples.MacroContracts.Owned.owner]
 
 /-- TransferOwnership updates owner when authorized -/
 theorem owned_transferOwnership_updates_owner (state : ContractState) (newOwner : Address) (sender : Address)
     (h : state.storageAddr 0 = sender) :
-    let finalState := (Verity.Examples.Owned.transferOwnership newOwner).runState { state with sender := sender }
+    let finalState := (Verity.Examples.MacroContracts.Owned.transferOwnership newOwner).runState { state with sender := sender }
     finalState.storageAddr 0 = newOwner := by
   have h_owner' : ({ state with sender := sender }).sender =
       ({ state with sender := sender }).storageAddr 0 := by simp [h]

--- a/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/OwnedCounter.lean
@@ -18,7 +18,7 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
-import Verity.Examples.OwnedCounter
+import Verity.Examples.MacroContracts
 import Verity.Proofs.OwnedCounter.Basic
 
 namespace Compiler.Proofs.SpecCorrectness
@@ -28,8 +28,10 @@ open Compiler.Specs
 open Verity.Proofs.Stdlib.SpecInterpreter
 open Verity.Proofs.Stdlib.Automation
 open Verity
-open Verity.Examples.OwnedCounter
+open Verity.Examples.MacroContracts.OwnedCounter
 open Verity.Proofs.OwnedCounter
+
+local abbrev ownedCounterSpec : CompilationModel := Verity.Examples.MacroContracts.OwnedCounter.spec
 
 -- Address encoding lemmas are provided by Automation.
 
@@ -54,7 +56,7 @@ def ownedCounterEdslToSpecStorage (state : ContractState) : SpecStorage :=
 
 /-- The `constructor` correctly initializes the owner -/
 theorem ownedCounter_constructor_correct (state : ContractState) (initialOwner : Address) (sender : Address) :
-    let edslResult := (Verity.Examples.OwnedCounter.constructor initialOwner).run { state with sender := sender }
+    let edslResult := (Verity.Examples.MacroContracts.OwnedCounter.constructor initialOwner).run { state with sender := sender }
     let specTx : DiffTestTypes.Transaction := {
       sender := sender
       functionName := ""
@@ -64,8 +66,8 @@ theorem ownedCounter_constructor_correct (state : ContractState) (initialOwner :
     edslResult.isSuccess = true ∧
     specResult.success = true ∧
     specResult.finalStorage.getSlot 0 = (edslResult.getState.storageAddr 0).val := by
-  simp [Verity.Examples.OwnedCounter.constructor, Contract.run, ownedCounterSpec, interpretSpec,
-    setStorageAddr, Verity.Examples.OwnedCounter.owner,
+  simp [Verity.Examples.MacroContracts.OwnedCounter.constructor, Contract.run, ownedCounterSpec, interpretSpec,
+    setStorageAddr, Verity.Examples.MacroContracts.OwnedCounter.owner,
     execConstructor, execStmts, execStmt, evalExpr, SpecStorage.setSlot, SpecStorage.getSlot, SpecStorage.empty]
 
 /-- The `increment` function correctly increments when called by owner -/
@@ -191,8 +193,8 @@ theorem ownedCounter_getCount_correct (state : ContractState) (sender : Address)
     let specResult := interpretSpec ownedCounterSpec (ownedCounterEdslToSpecStorage state) specTx
     specResult.success = true ∧
     specResult.returnValue = some edslValue := by
-  simp [Verity.Examples.OwnedCounter.getCount, Contract.runValue, ownedCounterSpec, interpretSpec,
-    ownedCounterEdslToSpecStorage, getStorage, Verity.Examples.OwnedCounter.count, execFunction,
+  simp [Verity.Examples.MacroContracts.OwnedCounter.getCount, Contract.runValue, ownedCounterSpec, interpretSpec,
+    ownedCounterEdslToSpecStorage, getStorage, Verity.Examples.MacroContracts.OwnedCounter.count, execFunction,
     execStmts, execStmt, evalExpr, SpecStorage.getSlot]
 
 /-- The `getOwner` function correctly retrieves the owner address -/
@@ -206,8 +208,8 @@ theorem ownedCounter_getOwner_correct (state : ContractState) (sender : Address)
     let specResult := interpretSpec ownedCounterSpec (ownedCounterEdslToSpecStorage state) specTx
     specResult.success = true ∧
     specResult.returnValue = some edslAddr.val := by
-  simp [Verity.Examples.OwnedCounter.getOwner, Contract.runValue, ownedCounterSpec, interpretSpec,
-    ownedCounterEdslToSpecStorage, getStorageAddr, Verity.Examples.OwnedCounter.owner, execFunction,
+  simp [Verity.Examples.MacroContracts.OwnedCounter.getOwner, Contract.runValue, ownedCounterSpec, interpretSpec,
+    ownedCounterEdslToSpecStorage, getStorageAddr, Verity.Examples.MacroContracts.OwnedCounter.owner, execFunction,
     execStmts, execStmt, evalExpr, SpecStorage.getSlot]
 
 /-- The `transferOwnership` function correctly transfers ownership when called by owner -/
@@ -266,8 +268,8 @@ theorem ownedCounter_getters_preserve_state (state : ContractState) (sender : Ad
     let ownerState := getOwner.runState { state with sender := sender }
     countState.storage 1 = state.storage 1 ∧
     ownerState.storageAddr 0 = state.storageAddr 0 := by
-  simp [Verity.Examples.OwnedCounter.getCount, Verity.Examples.OwnedCounter.getOwner, Contract.runState,
-    getStorage, getStorageAddr, Verity.Examples.OwnedCounter.count, Verity.Examples.OwnedCounter.owner]
+  simp [Verity.Examples.MacroContracts.OwnedCounter.getCount, Verity.Examples.MacroContracts.OwnedCounter.getOwner, Contract.runState,
+    getStorage, getStorageAddr, Verity.Examples.MacroContracts.OwnedCounter.count, Verity.Examples.MacroContracts.OwnedCounter.owner]
 
 /-- Only owner can modify counter -/
 theorem ownedCounter_only_owner_modifies (state : ContractState) (sender : Address) :

--- a/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
+++ b/Compiler/Proofs/SpecCorrectness/SafeCounter.lean
@@ -16,7 +16,7 @@
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
 import Verity.Proofs.Stdlib.Automation
-import Verity.Examples.SafeCounter
+import Verity.Examples.MacroContracts
 import Verity.Proofs.SafeCounter.Basic
 
 namespace Compiler.Proofs.SpecCorrectness
@@ -25,9 +25,11 @@ open Compiler.CompilationModel
 open Compiler.Specs
 open Verity.Proofs.Stdlib.SpecInterpreter
 open Verity
-open Verity.Examples.SafeCounter
+open Verity.Examples.MacroContracts.SafeCounter
 open Verity.Stdlib.Math
 open Verity.Proofs.Stdlib.Automation
+
+local abbrev safeCounterSpec : CompilationModel := Verity.Examples.MacroContracts.SafeCounter.spec
 
 /- State Conversion -/
 

--- a/Compiler/Proofs/SpecCorrectness/SimpleStorage.lean
+++ b/Compiler/Proofs/SpecCorrectness/SimpleStorage.lean
@@ -14,7 +14,7 @@
 
 import Compiler.Specs
 import Verity.Proofs.Stdlib.SpecInterpreter
-import Verity.Examples.SimpleStorage
+import Verity.Examples.MacroContracts
 
 namespace Compiler.Proofs.SpecCorrectness
 
@@ -24,6 +24,8 @@ open Verity.Proofs.Stdlib.SpecInterpreter
 open Verity
 open Verity.Examples
 open Verity.Core.Uint256
+
+local abbrev simpleStorageSpec : CompilationModel := Verity.Examples.MacroContracts.SimpleStorage.spec
 
 /-!
 ## State Conversion

--- a/Verity/Examples/MacroContracts.lean
+++ b/Verity/Examples/MacroContracts.lean
@@ -151,6 +151,19 @@ verity_contract Owned where
     let currentOwner ← getStorageAddr owner
     return currentOwner
 
+namespace Owned
+
+def isOwner : Contract Bool := do
+  let sender ← msgSender
+  let currentOwner ← getStorageAddr owner
+  return sender == currentOwner
+
+def onlyOwner : Contract Unit := do
+  let ownerCheck ← isOwner
+  require ownerCheck "Caller is not the owner"
+
+end Owned
+
 verity_contract Ledger where
   storage
     balances : Address → Uint256 := slot 0
@@ -235,6 +248,19 @@ verity_contract OwnedCounter where
     let currentOwner ← getStorageAddr owner
     require (sender == currentOwner) "Caller is not the owner"
     setStorageAddr owner newOwner
+
+namespace OwnedCounter
+
+def isOwner : Contract Bool := do
+  let sender ← msgSender
+  let currentOwner ← getStorageAddr owner
+  return sender == currentOwner
+
+def onlyOwner : Contract Unit := do
+  let ownerCheck ← isOwner
+  require ownerCheck "Caller is not the owner"
+
+end OwnedCounter
 
 verity_contract SimpleToken where
   storage
@@ -357,6 +383,38 @@ verity_contract ERC20 where
   function owner () : Address := do
     let currentOwner ← getStorageAddr ownerSlot
     return currentOwner
+
+namespace SimpleToken
+
+abbrev getTotalSupply : Contract Uint256 := totalSupply
+abbrev getOwner : Contract Address := owner
+
+def isOwner : Contract Bool := do
+  let sender ← msgSender
+  let currentOwner ← getStorageAddr ownerSlot
+  return sender == currentOwner
+
+def onlyOwner : Contract Unit := do
+  let ownerCheck ← isOwner
+  require ownerCheck "Caller is not the owner"
+
+end SimpleToken
+
+namespace ERC20
+
+abbrev getTotalSupply : Contract Uint256 := totalSupply
+abbrev getOwner : Contract Address := owner
+
+def isOwner : Contract Bool := do
+  let sender ← msgSender
+  let currentOwner ← getStorageAddr ownerSlot
+  return sender == currentOwner
+
+def onlyOwner : Contract Unit := do
+  let ownerCheck ← isOwner
+  require ownerCheck "Caller is not the owner"
+
+end ERC20
 
 verity_contract UintMapSmoke where
   storage

--- a/Verity/Proofs/Counter/Basic.lean
+++ b/Verity/Proofs/Counter/Basic.lean
@@ -6,11 +6,12 @@
 
 import Verity.Specs.Counter.Spec
 import Verity.Specs.Counter.Invariants
+import Verity.Examples.MacroContracts
 
 namespace Verity.Proofs.Counter
 
 open Verity
-open Verity.Examples.Counter
+open Verity.Examples.MacroContracts.Counter
 open Verity.Specs.Counter
 
 /-! ## Basic Lemmas about setStorage and getStorage

--- a/Verity/Proofs/Counter/Correctness.lean
+++ b/Verity/Proofs/Counter/Correctness.lean
@@ -13,7 +13,7 @@ import Verity.Proofs.Stdlib.Automation
 namespace Verity.Proofs.Counter.Correctness
 
 open Verity
-open Verity.Examples.Counter
+open Verity.Examples.MacroContracts.Counter
 open Verity.Specs.Counter
 open Verity.Proofs.Counter
 open Verity.Proofs.Stdlib.Automation (wf_of_state_eq)

--- a/Verity/Proofs/ERC20/Basic.lean
+++ b/Verity/Proofs/ERC20/Basic.lean
@@ -3,7 +3,7 @@
 -/
 
 import Verity.Specs.ERC20.Spec
-import Verity.Examples.ERC20
+import Verity.Examples.MacroContracts
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.Automation
 
@@ -11,10 +11,15 @@ namespace Verity.Proofs.ERC20
 
 open Verity
 open Verity.Specs.ERC20
-open Verity.Examples.ERC20
+open Verity.Examples.MacroContracts.ERC20
 open Verity.Stdlib.Math (MAX_UINT256 requireSomeUint)
 open Verity.Proofs.Stdlib.Math (safeAdd_some)
 open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne uint256_ge_val_le)
+
+local abbrev owner : StorageSlot Address := Verity.Examples.MacroContracts.ERC20.ownerSlot
+local abbrev totalSupply : StorageSlot Uint256 := Verity.Examples.MacroContracts.ERC20.totalSupplySlot
+local abbrev balances : StorageSlot (Address → Uint256) := Verity.Examples.MacroContracts.ERC20.balancesSlot
+local abbrev allowances : StorageSlot (Address → Address → Uint256) := Verity.Examples.MacroContracts.ERC20.allowancesSlot
 
 /-- `constructor` sets owner slot 0 and initializes supply slot 1. -/
 theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :

--- a/Verity/Proofs/ERC20/Correctness.lean
+++ b/Verity/Proofs/ERC20/Correctness.lean
@@ -12,27 +12,27 @@ open Verity.Specs.ERC20
 
 /-- Read-only `balanceOf` preserves state. -/
 theorem balanceOf_preserves_state (s : ContractState) (addr : Address) :
-    ((Verity.Examples.ERC20.balanceOf addr).runState s) = s := by
-  simp [Verity.Examples.ERC20.balanceOf, getMapping, Contract.runState]
+    ((Verity.Examples.MacroContracts.ERC20.balanceOf addr).runState s) = s := by
+  simp [Verity.Examples.MacroContracts.ERC20.balanceOf, getMapping, Contract.runState]
 
 /-- Read-only `allowanceOf` preserves state. -/
 theorem allowanceOf_preserves_state (s : ContractState) (ownerAddr spender : Address) :
-    ((Verity.Examples.ERC20.allowanceOf ownerAddr spender).runState s) = s := by
-  simp [Verity.Examples.ERC20.allowanceOf, getMapping2, Contract.runState]
+    ((Verity.Examples.MacroContracts.ERC20.allowanceOf ownerAddr spender).runState s) = s := by
+  simp [Verity.Examples.MacroContracts.ERC20.allowanceOf, getMapping2, Contract.runState]
 
 /-- Read-only `getTotalSupply` preserves state. -/
 theorem getTotalSupply_preserves_state (s : ContractState) :
-    ((Verity.Examples.ERC20.getTotalSupply).runState s) = s := by
-  simp [Verity.Examples.ERC20.getTotalSupply, getStorage, Contract.runState]
+    ((Verity.Examples.MacroContracts.ERC20.getTotalSupply).runState s) = s := by
+  simp [Verity.Examples.MacroContracts.ERC20.getTotalSupply, getStorage, Contract.runState]
 
 /-- Read-only `getOwner` preserves state. -/
 theorem getOwner_preserves_state (s : ContractState) :
-    ((Verity.Examples.ERC20.getOwner).runState s) = s := by
-  simp [Verity.Examples.ERC20.getOwner, getStorageAddr, Contract.runState]
+    ((Verity.Examples.MacroContracts.ERC20.getOwner).runState s) = s := by
+  simp [Verity.Examples.MacroContracts.ERC20.getOwner, getStorageAddr, Contract.runState]
 
 /-- `approve` satisfies the balance-neutral invariant helper. -/
 theorem approve_is_balance_neutral_holds (s : ContractState) (spender : Address) (amount : Uint256) :
-    approve_is_balance_neutral s ((Verity.Examples.ERC20.approve spender amount).runState s) := by
+    approve_is_balance_neutral s ((Verity.Examples.MacroContracts.ERC20.approve spender amount).runState s) := by
   have h := approve_meets_spec s spender amount
   rcases h with ⟨_, _, _, h_storage, _, h_storageMap, _⟩
   exact ⟨h_storage, h_storageMap⟩
@@ -43,7 +43,7 @@ theorem transfer_preserves_totalSupply_when_sufficient
     (h_balance : s.storageMap 2 s.sender ≥ amount)
     (h_no_overflow : s.sender ≠ to →
       (s.storageMap 2 to : Nat) + (amount : Nat) ≤ Verity.Stdlib.Math.MAX_UINT256) :
-    ((Verity.Examples.ERC20.transfer to amount).runState s).storage 1 = s.storage 1 := by
+    ((Verity.Examples.MacroContracts.ERC20.transfer to amount).runState s).storage 1 = s.storage 1 := by
   have h := transfer_meets_spec_when_sufficient s to amount h_balance h_no_overflow
   exact h.2.2.2.2.1
 
@@ -53,7 +53,7 @@ theorem transfer_preserves_owner_when_sufficient
     (h_balance : s.storageMap 2 s.sender ≥ amount)
     (h_no_overflow : s.sender ≠ to →
       (s.storageMap 2 to : Nat) + (amount : Nat) ≤ Verity.Stdlib.Math.MAX_UINT256) :
-    ((Verity.Examples.ERC20.transfer to amount).runState s).storageAddr 0 = s.storageAddr 0 := by
+    ((Verity.Examples.MacroContracts.ERC20.transfer to amount).runState s).storageAddr 0 = s.storageAddr 0 := by
   have h := transfer_meets_spec_when_sufficient s to amount h_balance h_no_overflow
   exact h.2.2.2.2.2.1
 

--- a/Verity/Proofs/Ledger/Basic.lean
+++ b/Verity/Proofs/Ledger/Basic.lean
@@ -13,11 +13,12 @@ import Verity.Specs.Ledger.Spec
 import Verity.Specs.Ledger.Invariants
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.Automation
+import Verity.Examples.MacroContracts
 
 namespace Verity.Proofs.Ledger
 
 open Verity
-open Verity.Examples.Ledger
+open Verity.Examples.MacroContracts.Ledger
 open Verity.Specs.Ledger
 open Verity.Stdlib.Math (safeAdd requireSomeUint MAX_UINT256)
 open Verity.Proofs.Stdlib.Math (safeAdd_some safeAdd_none)
@@ -174,7 +175,7 @@ private theorem transfer_unfold_other (s : ContractState) (to : Address) (amount
         if slot == 0 then ((s.knownAddresses slot).insert s.sender).insert to
         else s.knownAddresses slot,
       events := s.events } := by
-  simp only [transfer, Examples.Ledger.balances,
+  simp only [transfer, Examples.MacroContracts.Ledger.balances,
     msgSender, getMapping, setMapping,
     requireSomeUint,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
@@ -255,7 +256,7 @@ theorem transfer_reverts_recipient_overflow (s : ContractState) (to : Address) (
   (h_ne : s.sender ≠ to)
   (h_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) > MAX_UINT256) :
   ∃ msg, (transfer to amount).run s = ContractResult.revert msg s := by
-  simp [transfer, requireSomeUint, Examples.Ledger.balances,
+  simp [transfer, requireSomeUint, Examples.MacroContracts.Ledger.balances,
     msgSender, getMapping,
     Verity.require, Verity.bind, Bind.bind, Contract.run,
     uint256_ge_val_le h_balance, h_ne, beq_iff_eq,

--- a/Verity/Proofs/Ledger/Conservation.lean
+++ b/Verity/Proofs/Ledger/Conservation.lean
@@ -17,7 +17,7 @@ import Verity.Proofs.Stdlib.ListSum
 namespace Verity.Proofs.Ledger.Conservation
 
 open Verity
-open Verity.Examples.Ledger
+open Verity.Examples.MacroContracts.Ledger
 open Verity.Specs.Ledger
 open Verity.Proofs.Ledger
 open Verity.Proofs.Stdlib.ListSum (countOcc countOccU countOcc_cons_eq countOcc_cons_ne

--- a/Verity/Proofs/Ledger/Correctness.lean
+++ b/Verity/Proofs/Ledger/Correctness.lean
@@ -12,7 +12,7 @@ import Verity.Proofs.Ledger.Basic
 namespace Verity.Proofs.Ledger.Correctness
 
 open Verity
-open Verity.Examples.Ledger
+open Verity.Examples.MacroContracts.Ledger
 open Verity.Specs.Ledger
 open Verity.Proofs.Ledger
 open Verity.Stdlib.Math (MAX_UINT256)

--- a/Verity/Proofs/Owned/Basic.lean
+++ b/Verity/Proofs/Owned/Basic.lean
@@ -10,11 +10,12 @@
 import Verity.Specs.Owned.Spec
 import Verity.Specs.Owned.Invariants
 import Verity.Proofs.Stdlib.Automation
+import Verity.Examples.MacroContracts
 
 namespace Verity.Proofs.Owned
 
 open Verity
-open Verity.Examples.Owned
+open Verity.Examples.MacroContracts.Owned
 open Verity.Specs.Owned
 open Verity.Proofs.Stdlib.Automation (wf_of_state_eq)
 

--- a/Verity/Proofs/Owned/Correctness.lean
+++ b/Verity/Proofs/Owned/Correctness.lean
@@ -12,7 +12,7 @@ import Verity.Proofs.Owned.Basic
 namespace Verity.Proofs.Owned.Correctness
 
 open Verity
-open Verity.Examples.Owned
+open Verity.Examples.MacroContracts.Owned
 open Verity.Specs.Owned
 open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne)
 open Verity.Proofs.Owned

--- a/Verity/Proofs/OwnedCounter/Basic.lean
+++ b/Verity/Proofs/OwnedCounter/Basic.lean
@@ -12,11 +12,12 @@
 import Verity.Specs.OwnedCounter.Spec
 import Verity.Specs.OwnedCounter.Invariants
 import Verity.Proofs.Stdlib.Automation
+import Verity.Examples.MacroContracts
 
 namespace Verity.Proofs.OwnedCounter
 
 open Verity
-open Verity.Examples.OwnedCounter
+open Verity.Examples.MacroContracts.OwnedCounter
 open Verity.Specs.OwnedCounter
 open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne)
 

--- a/Verity/Proofs/OwnedCounter/Correctness.lean
+++ b/Verity/Proofs/OwnedCounter/Correctness.lean
@@ -12,7 +12,7 @@ import Verity.Proofs.OwnedCounter.Basic
 namespace Verity.Proofs.OwnedCounter.Correctness
 
 open Verity
-open Verity.Examples.OwnedCounter
+open Verity.Examples.MacroContracts.OwnedCounter
 open Verity.Specs.OwnedCounter
 open Verity.Proofs.OwnedCounter
 

--- a/Verity/Proofs/OwnedCounter/Isolation.lean
+++ b/Verity/Proofs/OwnedCounter/Isolation.lean
@@ -16,7 +16,7 @@ import Verity.Proofs.OwnedCounter.Basic
 namespace Verity.Proofs.OwnedCounter.Isolation
 
 open Verity
-open Verity.Examples.OwnedCounter
+open Verity.Examples.MacroContracts.OwnedCounter
 open Verity.Specs.OwnedCounter
 open Verity.Proofs.OwnedCounter
 

--- a/Verity/Proofs/SafeCounter/Basic.lean
+++ b/Verity/Proofs/SafeCounter/Basic.lean
@@ -11,6 +11,7 @@
 import Verity.Proofs.Stdlib.Math
 import Verity.Specs.SafeCounter.Spec
 import Verity.Specs.SafeCounter.Invariants
+import Verity.Examples.MacroContracts
 
 namespace Verity.Proofs.SafeCounter
 
@@ -18,7 +19,7 @@ open Verity
 open Verity.Stdlib.Math
 open Verity.Proofs.Stdlib.Math (safeAdd_some safeAdd_none safeSub_some safeSub_none)
 open Verity.EVM.Uint256
-open Verity.Examples.SafeCounter
+open Verity.Examples.MacroContracts.SafeCounter
 open Verity.Specs.SafeCounter
 
 /-! ## getCount Correctness -/

--- a/Verity/Proofs/SafeCounter/Correctness.lean
+++ b/Verity/Proofs/SafeCounter/Correctness.lean
@@ -15,7 +15,7 @@ namespace Verity.Proofs.SafeCounter.Correctness
 open Verity
 open Verity.Stdlib.Math
 open Verity.EVM.Uint256
-open Verity.Examples.SafeCounter
+open Verity.Examples.MacroContracts.SafeCounter
 open Verity.Specs.SafeCounter
 open Verity.Proofs.SafeCounter
 open Verity.Proofs.Stdlib.Automation

--- a/Verity/Proofs/SimpleStorage/Basic.lean
+++ b/Verity/Proofs/SimpleStorage/Basic.lean
@@ -6,7 +6,7 @@
   Status: Complete — all 13 proofs proven with zero axioms and zero sorry.
 -/
 
-import Verity.Examples.SimpleStorage
+import Verity.Examples.MacroContracts
 import Verity.Specs.SimpleStorage.Spec
 import Verity.Specs.SimpleStorage.Invariants
 

--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -9,7 +9,7 @@
   - Invariant preservation
 -/
 
-import Verity.Examples.SimpleToken
+import Verity.Examples.MacroContracts
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.Automation
 import Verity.Specs.SimpleToken.Spec
@@ -24,52 +24,56 @@ open Verity
 open Verity.Stdlib.Math
 open Verity.Proofs.Stdlib.Math (safeAdd_some safeAdd_none)
 open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne uint256_ge_val_le wf_of_state_eq)
-open Verity.Examples.SimpleToken (constructor mint transfer balanceOf getTotalSupply getOwner isOwner)
+open Verity.Examples.MacroContracts.SimpleToken (constructor mint transfer balanceOf getTotalSupply getOwner isOwner)
 open Verity.Specs.SimpleToken
+
+local abbrev owner : StorageSlot Address := Verity.Examples.MacroContracts.SimpleToken.ownerSlot
+local abbrev balances : StorageSlot (Address → Uint256) := Verity.Examples.MacroContracts.SimpleToken.balancesSlot
+local abbrev totalSupply : StorageSlot Uint256 := Verity.Examples.MacroContracts.SimpleToken.totalSupplySlot
 
 /-! ## Basic Lemmas for Storage Operations -/
 
 /-- setStorageAddr updates the owner address -/
 theorem setStorageAddr_updates_owner (s : ContractState) (addr : Address) :
-  let slot : StorageSlot Address := Examples.SimpleToken.owner
+  let slot : StorageSlot Address := Examples.MacroContracts.SimpleToken.ownerSlot
   let s' := ((setStorageAddr slot addr).run s).snd
   s'.storageAddr 0 = addr := by
-  simp [setStorageAddr, Examples.SimpleToken.owner]
+  simp [setStorageAddr, Examples.MacroContracts.SimpleToken.ownerSlot]
 
 /-- setStorage updates the total supply -/
 theorem setStorage_updates_supply (s : ContractState) (value : Uint256) :
-  let slot : StorageSlot Uint256 := Examples.SimpleToken.totalSupply
+  let slot : StorageSlot Uint256 := Examples.MacroContracts.SimpleToken.totalSupplySlot
   let s' := ((setStorage slot value).run s).snd
   s'.storage 2 = value := by
-  simp [setStorage, Examples.SimpleToken.totalSupply]
+  simp [setStorage, Examples.MacroContracts.SimpleToken.totalSupplySlot]
 
 /-- setMapping updates a balance -/
 theorem setMapping_updates_balance (s : ContractState) (addr : Address) (value : Uint256) :
-  let slot : StorageSlot (Address → Uint256) := Examples.SimpleToken.balances
+  let slot : StorageSlot (Address → Uint256) := Examples.MacroContracts.SimpleToken.balancesSlot
   let s' := ((setMapping slot addr value).run s).snd
   s'.storageMap 1 addr = value := by
-  simp [setMapping, Examples.SimpleToken.balances]
+  simp [setMapping, Examples.MacroContracts.SimpleToken.balancesSlot]
 
 /-- getMapping reads a balance -/
 theorem getMapping_reads_balance (s : ContractState) (addr : Address) :
-  let slot : StorageSlot (Address → Uint256) := Examples.SimpleToken.balances
+  let slot : StorageSlot (Address → Uint256) := Examples.MacroContracts.SimpleToken.balancesSlot
   let result := ((getMapping slot addr).run s).fst
   result = s.storageMap 1 addr := by
-  simp [getMapping, Examples.SimpleToken.balances]
+  simp [getMapping, Examples.MacroContracts.SimpleToken.balancesSlot]
 
 /-- getStorage reads total supply -/
 theorem getStorage_reads_supply (s : ContractState) :
-  let slot : StorageSlot Uint256 := Examples.SimpleToken.totalSupply
+  let slot : StorageSlot Uint256 := Examples.MacroContracts.SimpleToken.totalSupplySlot
   let result := ((getStorage slot).run s).fst
   result = s.storage 2 := by
-  simp [getStorage, Examples.SimpleToken.totalSupply]
+  simp [getStorage, Examples.MacroContracts.SimpleToken.totalSupplySlot]
 
 /-- getStorageAddr reads owner -/
 theorem getStorageAddr_reads_owner (s : ContractState) :
-  let slot : StorageSlot Address := Examples.SimpleToken.owner
+  let slot : StorageSlot Address := Examples.MacroContracts.SimpleToken.ownerSlot
   let result := ((getStorageAddr slot).run s).fst
   result = s.storageAddr 0 := by
-  simp [getStorageAddr, Examples.SimpleToken.owner]
+  simp [getStorageAddr, Examples.MacroContracts.SimpleToken.ownerSlot]
 
 /-- setMapping preserves other addresses -/
 theorem setMapping_preserves_other_addresses (s : ContractState) (slot_val : StorageSlot (Address → Uint256))
@@ -87,16 +91,16 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   · rfl
   · rfl
   · intro slot h_neq
-    simp only [constructor, setStorageAddr, setStorage, Examples.SimpleToken.owner,
-      Examples.SimpleToken.totalSupply, bind, Bind.bind, Contract.run, ContractResult.snd]
+    simp only [constructor, setStorageAddr, setStorage, Examples.MacroContracts.SimpleToken.ownerSlot,
+      Examples.MacroContracts.SimpleToken.totalSupplySlot, bind, Bind.bind, Contract.run, ContractResult.snd]
     split
     · next h =>
       have : slot = 0 := beq_iff_eq.mp h
       exact absurd this h_neq
     · rfl
   · intro slot h_neq
-    simp only [constructor, setStorageAddr, setStorage, Examples.SimpleToken.owner,
-      Examples.SimpleToken.totalSupply, bind, Bind.bind, Contract.run, ContractResult.snd]
+    simp only [constructor, setStorageAddr, setStorage, Examples.MacroContracts.SimpleToken.ownerSlot,
+      Examples.MacroContracts.SimpleToken.totalSupplySlot, bind, Bind.bind, Contract.run, ContractResult.snd]
     split
     · next h =>
       have : slot = 2 := beq_iff_eq.mp h
@@ -104,8 +108,8 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
     · rfl
   · rfl
   ·
-    simp [Specs.sameContext, constructor, setStorageAddr, setStorage, Examples.SimpleToken.owner,
-      Examples.SimpleToken.totalSupply, bind, Bind.bind, Contract.run, ContractResult.snd]
+    simp [Specs.sameContext, constructor, setStorageAddr, setStorage, Examples.MacroContracts.SimpleToken.ownerSlot,
+      Examples.MacroContracts.SimpleToken.totalSupplySlot, bind, Bind.bind, Contract.run, ContractResult.snd]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((constructor initialOwner).run s).snd
@@ -129,7 +133,7 @@ on overflow, matching Solidity ^0.8 checked arithmetic semantics.
 -- Helper: isOwner returns true when sender is owner
 theorem isOwner_true_when_owner (s : ContractState) (h : s.sender = s.storageAddr 0) :
   ((isOwner).run s).fst = true := by
-  simp [isOwner, msgSender, getStorageAddr, Examples.SimpleToken.owner, bind, Bind.bind, Contract.run, pure, Pure.pure, ContractResult.fst, h]
+  simp [isOwner, msgSender, getStorageAddr, Examples.MacroContracts.SimpleToken.ownerSlot, bind, Bind.bind, Contract.run, pure, Pure.pure, ContractResult.fst, h]
 
 -- Helper: unfold mint when owner guard passes and no overflow
 private theorem mint_unfold (s : ContractState) (to : Address) (amount : Uint256)
@@ -155,8 +159,8 @@ private theorem mint_unfold (s : ContractState) (to : Address) (amount : Uint256
   have h_safe_bal := safeAdd_some (s.storageMap 1 to) amount h_no_bal_overflow
   have h_safe_sup := safeAdd_some (s.storage 2) amount h_no_sup_overflow
   -- Unfold mint (checks-before-effects ordering: both requireSomeUint before mutations)
-  simp only [mint, Verity.Examples.SimpleToken.onlyOwner, isOwner,
-    Examples.SimpleToken.owner, Examples.SimpleToken.balances, Examples.SimpleToken.totalSupply,
+  simp only [mint, Verity.Examples.MacroContracts.SimpleToken.onlyOwner, isOwner,
+    Examples.MacroContracts.SimpleToken.ownerSlot, Examples.MacroContracts.SimpleToken.balancesSlot, Examples.MacroContracts.SimpleToken.totalSupplySlot,
     msgSender, getStorageAddr, setStorageAddr, getStorage, setStorage, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
@@ -218,8 +222,8 @@ theorem mint_reverts_balance_overflow (s : ContractState) (to : Address) (amount
   (h_overflow : (s.storageMap 1 to : Nat) + (amount : Nat) > MAX_UINT256) :
   ∃ msg, (mint to amount).run s = ContractResult.revert msg s := by
   have h_none := safeAdd_none (s.storageMap 1 to) amount h_overflow
-  simp [mint, Verity.Examples.SimpleToken.onlyOwner, isOwner, requireSomeUint,
-    Examples.SimpleToken.owner, Examples.SimpleToken.balances, Examples.SimpleToken.totalSupply,
+  simp [mint, Verity.Examples.MacroContracts.SimpleToken.onlyOwner, isOwner, requireSomeUint,
+    Examples.MacroContracts.SimpleToken.ownerSlot, Examples.MacroContracts.SimpleToken.balancesSlot, Examples.MacroContracts.SimpleToken.totalSupplySlot,
     msgSender, getStorageAddr, setStorageAddr, getStorage, setStorage, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
@@ -235,8 +239,8 @@ theorem mint_reverts_supply_overflow (s : ContractState) (to : Address) (amount 
   ∃ msg, (mint to amount).run s = ContractResult.revert msg s := by
   have h_safe_bal := safeAdd_some (s.storageMap 1 to) amount h_no_bal_overflow
   have h_none := safeAdd_none (s.storage 2) amount h_overflow
-  simp only [mint, Verity.Examples.SimpleToken.onlyOwner, isOwner, requireSomeUint,
-    Examples.SimpleToken.owner, Examples.SimpleToken.balances, Examples.SimpleToken.totalSupply,
+  simp only [mint, Verity.Examples.MacroContracts.SimpleToken.onlyOwner, isOwner, requireSomeUint,
+    Examples.MacroContracts.SimpleToken.ownerSlot, Examples.MacroContracts.SimpleToken.balancesSlot, Examples.MacroContracts.SimpleToken.totalSupplySlot,
     msgSender, getStorageAddr, setStorageAddr, getStorage, setStorage, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
@@ -258,7 +262,7 @@ private theorem transfer_unfold_self (s : ContractState) (to : Address) (amount 
   (h_eq : s.sender = to) :
   (transfer to amount).run s = ContractResult.success () s := by
   have h_balance' := uint256_ge_val_le (h_eq ▸ h_balance)
-  simp [transfer, Examples.SimpleToken.balances,
+  simp [transfer, Examples.MacroContracts.SimpleToken.balancesSlot,
     msgSender, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
@@ -288,7 +292,7 @@ private theorem transfer_unfold_other (s : ContractState) (to : Address) (amount
       events := s.events } := by
   have h_balance' := uint256_ge_val_le h_balance
   have h_safe := safeAdd_some (s.storageMap 1 to) amount h_no_overflow
-  simp only [transfer, Examples.SimpleToken.balances,
+  simp only [transfer, Examples.MacroContracts.SimpleToken.balancesSlot,
     msgSender, getMapping, setMapping,
     requireSomeUint,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
@@ -378,7 +382,7 @@ theorem transfer_reverts_recipient_overflow (s : ContractState) (to : Address) (
   ∃ msg, (transfer to amount).run s = ContractResult.revert msg s := by
   have h_balance' := uint256_ge_val_le h_balance
   have h_none := safeAdd_none (s.storageMap 1 to) amount h_overflow
-  simp [transfer, requireSomeUint, Examples.SimpleToken.balances,
+  simp [transfer, requireSomeUint, Examples.MacroContracts.SimpleToken.balancesSlot,
     msgSender, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
@@ -389,7 +393,7 @@ theorem transfer_reverts_recipient_overflow (s : ContractState) (to : Address) (
 theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :
   let result := ((balanceOf addr).run s).fst
   balanceOf_spec addr result s := by
-  simp [balanceOf, balanceOf_spec, getMapping, Examples.SimpleToken.balances]
+  simp [balanceOf, balanceOf_spec, getMapping, Examples.MacroContracts.SimpleToken.balancesSlot]
 
 theorem balanceOf_returns_balance (s : ContractState) (addr : Address) :
   let result := ((balanceOf addr).run s).fst
@@ -404,7 +408,7 @@ theorem balanceOf_preserves_state (s : ContractState) (addr : Address) :
 theorem getTotalSupply_meets_spec (s : ContractState) :
   let result := ((getTotalSupply).run s).fst
   getTotalSupply_spec result s := by
-  simp [getTotalSupply, getTotalSupply_spec, getStorage, Examples.SimpleToken.totalSupply]
+  simp [getTotalSupply, getTotalSupply_spec, getStorage, Examples.MacroContracts.SimpleToken.totalSupplySlot]
 
 theorem getTotalSupply_returns_supply (s : ContractState) :
   let result := ((getTotalSupply).run s).fst
@@ -419,7 +423,7 @@ theorem getTotalSupply_preserves_state (s : ContractState) :
 theorem getOwner_meets_spec (s : ContractState) :
   let result := ((getOwner).run s).fst
   getOwner_spec result s := by
-  simp [getOwner, getOwner_spec, getStorageAddr, Examples.SimpleToken.owner]
+  simp [getOwner, getOwner_spec, getStorageAddr, Examples.MacroContracts.SimpleToken.ownerSlot]
 
 theorem getOwner_returns_owner (s : ContractState) :
   let result := ((getOwner).run s).fst
@@ -446,7 +450,7 @@ theorem constructor_getOwner_correct (s : ContractState) (initialOwner : Address
   let s' := ((constructor initialOwner).run s).snd
   let result := ((getOwner).run s').fst
   result = initialOwner := by
-  simp only [constructor, getOwner, setStorageAddr, setStorage, getStorageAddr, Examples.SimpleToken.owner, Examples.SimpleToken.totalSupply, bind, Bind.bind, Contract.run, ContractResult.snd, ContractResult.fst]
+  simp only [constructor, getOwner, setStorageAddr, setStorage, getStorageAddr, Examples.MacroContracts.SimpleToken.ownerSlot, Examples.MacroContracts.SimpleToken.totalSupplySlot, bind, Bind.bind, Contract.run, ContractResult.snd, ContractResult.fst]
   rfl
 
 /-! ## Invariant Preservation -/

--- a/Verity/Proofs/SimpleToken/Correctness.lean
+++ b/Verity/Proofs/SimpleToken/Correctness.lean
@@ -16,10 +16,14 @@ namespace Verity.Proofs.SimpleToken.Correctness
 
 open Verity
 open Verity.Stdlib.Math (MAX_UINT256 safeAdd requireSomeUint)
-open Verity.Examples.SimpleToken (constructor mint transfer balanceOf getTotalSupply getOwner isOwner)
+open Verity.Examples.MacroContracts.SimpleToken (constructor mint transfer balanceOf getTotalSupply getOwner isOwner)
 open Verity.Specs.SimpleToken
 open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne)
 open Verity.Proofs.SimpleToken
+
+local abbrev owner : StorageSlot Address := Verity.Examples.MacroContracts.SimpleToken.ownerSlot
+local abbrev balances : StorageSlot (Address → Uint256) := Verity.Examples.MacroContracts.SimpleToken.balancesSlot
+local abbrev totalSupply : StorageSlot Uint256 := Verity.Examples.MacroContracts.SimpleToken.totalSupplySlot
 
 /-! ## Guard Revert Proofs
 
@@ -32,8 +36,8 @@ This is critical for safety: unauthorized or invalid operations must fail.
 theorem mint_reverts_when_not_owner (s : ContractState) (to : Address) (amount : Uint256)
   (h_not_owner : s.sender ≠ s.storageAddr 0) :
   ∃ msg, (mint to amount).run s = ContractResult.revert msg s := by
-  simp only [mint, Verity.Examples.SimpleToken.onlyOwner, isOwner,
-    Examples.SimpleToken.owner, Examples.SimpleToken.balances, Examples.SimpleToken.totalSupply,
+  simp only [mint, Verity.Examples.MacroContracts.SimpleToken.onlyOwner, isOwner,
+    Examples.MacroContracts.SimpleToken.ownerSlot, Examples.MacroContracts.SimpleToken.balancesSlot, Examples.MacroContracts.SimpleToken.totalSupplySlot,
     msgSender, getStorageAddr, getStorage, setStorage, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run]
@@ -44,7 +48,7 @@ theorem mint_reverts_when_not_owner (s : ContractState) (to : Address) (amount :
 theorem transfer_reverts_insufficient_balance (s : ContractState) (to : Address) (amount : Uint256)
   (h_insufficient : s.storageMap 1 s.sender < amount) :
   ∃ msg, (transfer to amount).run s = ContractResult.revert msg s := by
-  simp only [transfer, Examples.SimpleToken.balances,
+  simp only [transfer, Examples.MacroContracts.SimpleToken.balancesSlot,
     msgSender, getMapping,
     Verity.require, Verity.bind, Bind.bind,
     Contract.run]

--- a/Verity/Proofs/SimpleToken/Isolation.lean
+++ b/Verity/Proofs/SimpleToken/Isolation.lean
@@ -16,10 +16,14 @@ namespace Verity.Proofs.SimpleToken.Isolation
 
 open Verity
 open Verity.Stdlib.Math (safeAdd requireSomeUint)
-open Verity.Examples.SimpleToken (constructor mint transfer balanceOf getTotalSupply getOwner isOwner)
+open Verity.Examples.MacroContracts.SimpleToken (constructor mint transfer balanceOf getTotalSupply getOwner isOwner)
 open Verity.Specs.SimpleToken
 open Verity.Proofs.Stdlib.Automation (uint256_ge_val_le)
 open Verity.Proofs.SimpleToken
+
+local abbrev owner : StorageSlot Address := Verity.Examples.MacroContracts.SimpleToken.ownerSlot
+local abbrev balances : StorageSlot (Address → Uint256) := Verity.Examples.MacroContracts.SimpleToken.balancesSlot
+local abbrev totalSupply : StorageSlot Uint256 := Verity.Examples.MacroContracts.SimpleToken.totalSupplySlot
 
 /-! ## Constructor Isolation -/
 
@@ -30,7 +34,7 @@ private theorem constructor_isolation (s : ContractState) (initialOwner : Addres
   (∀ addr, ((constructor initialOwner).run s).snd.storageMap slot addr = s.storageMap slot addr) ∧
   (slot ≠ 0 → ((constructor initialOwner).run s).snd.storageAddr slot = s.storageAddr slot) := by
   simp only [constructor, setStorageAddr, setStorage,
-    Examples.SimpleToken.owner, Examples.SimpleToken.totalSupply,
+    Examples.MacroContracts.SimpleToken.ownerSlot, Examples.MacroContracts.SimpleToken.totalSupplySlot,
     Verity.bind, Bind.bind, Contract.run, ContractResult.snd]
   refine ⟨fun h_ne => ?_, fun _ => trivial, fun h_ne => ?_⟩ <;>
     simp [beq_iff_eq, h_ne]
@@ -62,8 +66,8 @@ private theorem mint_isolation (s : ContractState) (to : Address) (amount : Uint
   (slot ≠ 2 → ((mint to amount).run s).snd.storage slot = s.storage slot) ∧
   (slot ≠ 1 → ∀ addr, ((mint to amount).run s).snd.storageMap slot addr = s.storageMap slot addr) ∧
   (slot ≠ 0 → ((mint to amount).run s).snd.storageAddr slot = s.storageAddr slot) := by
-  simp only [mint, Verity.Examples.SimpleToken.onlyOwner, isOwner,
-    Examples.SimpleToken.owner, Examples.SimpleToken.balances, Examples.SimpleToken.totalSupply,
+  simp only [mint, Verity.Examples.MacroContracts.SimpleToken.onlyOwner, isOwner,
+    Examples.MacroContracts.SimpleToken.ownerSlot, Examples.MacroContracts.SimpleToken.balancesSlot, Examples.MacroContracts.SimpleToken.totalSupplySlot,
     msgSender, getStorageAddr, getStorage, setStorage, getMapping, setMapping,
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd,
@@ -103,12 +107,12 @@ private theorem transfer_isolation (s : ContractState) (to : Address) (amount : 
   (((transfer to amount).run s).snd.storageAddr slot = s.storageAddr slot) := by
   by_cases h_eq : s.sender = to
   · have h_balance' := uint256_ge_val_le (h_eq ▸ h_balance)
-    simp [transfer, Examples.SimpleToken.balances,
+    simp [transfer, Examples.MacroContracts.SimpleToken.balancesSlot,
       msgSender, getMapping,
       Verity.require, Verity.pure, Verity.bind, Bind.bind,
       Contract.run, ContractResult.snd, h_balance', h_eq]
   · refine ⟨?_, fun h_ne_slot addr => ?_, ?_⟩
-    all_goals simp [transfer, Examples.SimpleToken.balances,
+    all_goals simp [transfer, Examples.MacroContracts.SimpleToken.balancesSlot,
         msgSender, getMapping, setMapping, requireSomeUint,
         Verity.require, Verity.bind, Bind.bind, Pure.pure,
         Contract.run, ContractResult.snd,

--- a/Verity/Proofs/SimpleToken/Supply.lean
+++ b/Verity/Proofs/SimpleToken/Supply.lean
@@ -21,7 +21,7 @@ namespace Verity.Proofs.SimpleToken.Supply
 
 open Verity
 open Verity.Stdlib.Math (MAX_UINT256)
-open Verity.Examples.SimpleToken (constructor mint transfer balanceOf getTotalSupply getOwner isOwner)
+open Verity.Examples.MacroContracts.SimpleToken (constructor mint transfer balanceOf getTotalSupply getOwner isOwner)
 open Verity.Specs.SimpleToken
 open Verity.Proofs.SimpleToken
 open Verity.Proofs.Stdlib.ListSum (countOcc countOccU countOccU_cons_eq countOccU_cons_ne


### PR DESCRIPTION
## Summary
- ports current proof/spec files to generated macro artifact module layout
- updates imports/namespaces across Compiler/Proofs/SpecCorrectness/* and Verity/Proofs/*
- keeps the pre-existing local migration edits that were already present in this workspace and relevant to #997
- includes the Verity/Examples/MacroContracts.lean alias cleanup/update used by migrated proofs

## Verification
- Verified these edits are still unique vs origin/main before opening PR (git diff --name-only origin/main -- ... listed all 28 touched files), so this is not already merged there.
- This PR is intentionally opened with work-in-progress state, as requested, to capture progress so far.

## Follow-up
- continue patching remaining Lean build/proof breakages on this branch until green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large-scale namespace/import rewrites across many Lean proof files can easily cause build/proof breakages even though the underlying contract semantics are largely unchanged. Adds new helper aliases (`isOwner`/`onlyOwner`, getter abbrevs) in `Verity/Examples/MacroContracts.lean`, which could affect downstream name resolution.
> 
> **Overview**
> Migrates the `Compiler.Proofs.SpecCorrectness.*` theorems and multiple `Verity.Proofs.*` modules from the old `Verity.Examples.*` contract definitions to the generated `Verity.Examples.MacroContracts.*` layout, updating imports/opens and adding local abbrevs for `spec` values and key storage slots.
> 
> Extends `Verity/Examples/MacroContracts.lean` with helper namespaces for `Owned`, `OwnedCounter`, `SimpleToken`, and `ERC20` (adding `isOwner`/`onlyOwner` and `getOwner`/`getTotalSupply` abbrevs) so migrated proofs can reference a consistent API surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b20ef682150b42b1d37ca5d995e07f4f5fae91a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->