### PR TITLE
fix: correct sorry count in README and rename ContractSpec to CompilationModel in ROADMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Every claim below is enforced by CI on every commit. Each one can be independent
 | Claim | Value | Verify locally |
 |-------|-------|----------------|
 | Proven theorems | 431 | `make verify` |
-| Incomplete proofs (`sorry`) | 2 | `make verify` (Lean rejects sorry) |
+| Incomplete proofs (`sorry`) | 51 (2 hand-written + ~49 macro-generated) | `make verify` (Lean rejects sorry) |
 | Project-specific axioms | 1 ([documented](AXIOMS.md)) | `make axiom-report` |
 | Axiom dependency audit | 613 theorems checked | `make axiom-report` |
 | Foundry runtime tests | 404 across 35 suites | `make test-foundry` |
@@ -229,7 +229,7 @@ See [`examples/external-libs/README.md`](examples/external-libs/README.md) for a
 
 Verity's restricted DSL prevents raw external calls for safety. Instead, call patterns are packaged as **External Call Modules (ECMs)** — reusable, typed, auditable Lean structures that the compiler can plug in without modification. Standard modules for ERC-20, EVM precompiles, and callbacks ship in [`Compiler/Modules/`](Compiler/Modules/README.md). Third parties can publish their own as separate Lean packages. See [`docs/EXTERNAL_CALL_MODULES.md`](docs/EXTERNAL_CALL_MODULES.md) for the full guide.
 
-469 theorems across 11 categories (429 proven, 2 `sorry` in macro-generated semantic preservation placeholders). 441 Foundry tests across 35 test suites. 250 covered by property tests (53% coverage, 219 proof-only exclusions). 1 documented axiom.
+469 theorems across 11 categories (429 proven, 51 `sorry`: 2 hand-written in EndToEnd.lean bridging lemmas + ~49 macro-generated via Bridge.lean, one per function in verity_contract blocks). 441 Foundry tests across 35 test suites. 250 covered by property tests (53% coverage, 219 proof-only exclusions). 1 documented axiom.
 
 ## What's Verified
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,13 +7,13 @@
 ## Current Status
 
 - ✅ **Layer 1 Complete**: 469 theorems across 11 categories (8 contracts + Stdlib math library)
-- ✅ **Layer 2 Complete**: All IR generation with preservation proofs (ContractSpec → IR)
+- ✅ **Layer 2 Complete**: All IR generation with preservation proofs (CompilationModel → IR)
 - ✅ **Layer 3 Complete**: All 8 statement equivalence proofs + universal dispatcher (PR #42)
 - ✅ **Property Testing**: 53% coverage (250/469), all testable properties covered
 - ✅ **Differential Testing**: Production-ready with 70k+ tests
 - ✅ **Trust Reduction Phase 1**: keccak256 axiom + CI validation (PR #43, #46)
 - ✅ **External Linking**: Cryptographic library support (PR #49)
-- ✅ **ContractSpec Real-World Support**: Loops, branching, arrays, events, multi-mappings, internal calls, verified extern linking (#153, #154, #179, #180, #181, #184)
+- ✅ **CompilationModel Real-World Support**: Loops, branching, arrays, events, multi-mappings, internal calls, verified extern linking (#153, #154, #179, #180, #181, #184)
 
 ---
 
@@ -69,17 +69,17 @@ Status legend:
 | 6 | ABI JSON artifact generation | partial | partial | n/a | partial | partial |
 
 Recent progress for storage layout controls (`#623`):
-- `ContractSpec.Field` now supports optional explicit slot assignment (`slot := some <n>`), with backward-compatible positional slots when omitted.
+- `CompilationModel.Field` now supports optional explicit slot assignment (`slot := some <n>`), with backward-compatible positional slots when omitted.
 - Compiler now fails fast on conflicting effective slot assignments with an issue-linked diagnostic.
-- `ContractSpec.Field` now supports compatibility mirror-write slots (`aliasSlots := [...]`), so `setStorage`/`setMapping`/`setMapping2` write to canonical and alias slots in one declarative policy.
-- `ContractSpec` now supports slot remap policies (`slotAliasRanges := [{ sourceStart := a, sourceEnd := b, targetStart := c }, ...]`) so compatibility windows like `8..11 -> 20..23` can be declared once and applied automatically to canonical field writes.
-- `ContractSpec` now supports declarative reserved storage slot ranges (`reservedSlotRanges := [{ start := a, end_ := b }, ...]`) with compile-time overlap checks and fail-fast diagnostics when field canonical/alias write slots intersect reserved intervals.
-- `ContractSpec.Field` now supports packed subfield placement (`packedBits := some { offset := o, width := w }`) so multiple fields can share a slot with disjoint bit ranges; codegen performs masked read-modify-write updates and masked reads directly from layout metadata.
+- `CompilationModel.Field` now supports compatibility mirror-write slots (`aliasSlots := [...]`), so `setStorage`/`setMapping`/`setMapping2` write to canonical and alias slots in one declarative policy.
+- `CompilationModel` now supports slot remap policies (`slotAliasRanges := [{ sourceStart := a, sourceEnd := b, targetStart := c }, ...]`) so compatibility windows like `8..11 -> 20..23` can be declared once and applied automatically to canonical field writes.
+- `CompilationModel` now supports declarative reserved storage slot ranges (`reservedSlotRanges := [{ start := a, end_ := b }, ...]`) with compile-time overlap checks and fail-fast diagnostics when field canonical/alias write slots intersect reserved intervals.
+- `CompilationModel.Field` now supports packed subfield placement (`packedBits := some { offset := o, width := w }`) so multiple fields can share a slot with disjoint bit ranges; codegen performs masked read-modify-write updates and masked reads directly from layout metadata.
 
 Recent progress for low-level calls + returndata handling (`#622`):
-- `ContractSpec.Expr` now supports first-class low-level call primitives (`call`, `staticcall`, `delegatecall`) with explicit gas/value/target/input/output operands and deterministic Yul lowering.
-- `ContractSpec.Expr.returndataSize`, `Stmt.returndataCopy`, and `Stmt.revertReturndata` now provide first-class returndata access and revert-data forwarding without raw Yul builtin injection.
-- `ContractSpec.Expr.returndataOptionalBoolAt(outOffset)` now provides a first-class ERC20 compatibility helper for optional return-data bool decoding (`returndatasize()==0 || (returndatasize()==32 && mload(outOffset)==1)`), so low-level token call acceptance paths can be expressed without raw Yul builtins.
+- `CompilationModel.Expr` now supports first-class low-level call primitives (`call`, `staticcall`, `delegatecall`) with explicit gas/value/target/input/output operands and deterministic Yul lowering.
+- `CompilationModel.Expr.returndataSize`, `Stmt.returndataCopy`, and `Stmt.revertReturndata` now provide first-class returndata access and revert-data forwarding without raw Yul builtin injection.
+- `CompilationModel.Expr.returndataOptionalBoolAt(outOffset)` now provides a first-class ERC20 compatibility helper for optional return-data bool decoding (`returndatasize()==0 || (returndatasize()==32 && mload(outOffset)==1)`), so low-level token call acceptance paths can be expressed without raw Yul builtins.
 - Raw `Expr.externalCall` interop names for low-level/builtin opcodes remain fail-fast rejected, preserving explicit migration diagnostics while the first-class surface continues to expand.
 - ABI artifact emission now reflects explicit function mutability markers (`isView`, `isPure`) as `stateMutability: "view" | "pure"` in generated JSON.
 
@@ -88,7 +88,7 @@ Recent progress for custom errors (`#586`):
 - Static scalar payload args remain expression-friendly (`uint256`, `address`, `bool`, `bytes32`), while composite/dynamic payload args fail fast with issue-linked diagnostics when not provided as direct parameter references.
 
 Recent progress for ABI JSON artifact generation (`#688`):
-- `verity-compiler --abi-output <dir>` emits one `<Contract>.abi.json` file per compiled ContractSpec in the supported compilation path.
+- `verity-compiler --abi-output <dir>` emits one `<Contract>.abi.json` file per compiled CompilationModel in the supported compilation path.
 
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.
@@ -99,11 +99,11 @@ Delivery policy for unsupported features:
 
 ## Lessons from UnlinkPool (#185)
 
-[UnlinkPool](https://github.com/Th0rgal/unlink-contracts/pull/4) — a ZK privacy pool — was the first non-trivial contract built with Verity (37 theorems, 0 `sorry`, 64 Foundry tests). It exposed gaps in the ContractSpec compilation path that prevented real-world contracts from using the verified pipeline (Layers 2+3).
+[UnlinkPool](https://github.com/Th0rgal/unlink-contracts/pull/4) — a ZK privacy pool — was the first non-trivial contract built with Verity (37 theorems, 0 `sorry`, 64 Foundry tests). It exposed gaps in the CompilationModel compilation path that prevented real-world contracts from using the verified pipeline (Layers 2+3).
 
 ### What was added
 
-| Feature | Issue | ContractSpec | Core/Interpreter |
+| Feature | Issue | CompilationModel | Core/Interpreter |
 |---------|-------|-------------|-----------------|
 | If/else branching | #179 | `Stmt.ite` | `execStmt` mutual recursion |
 | ForEach loops | #179 | `Stmt.forEach` | `execStmtsFuel` + `expandForEach` desugaring |
@@ -115,11 +115,11 @@ Delivery policy for unsupported features:
 
 ### What this enables
 
-A developer can now write a `ContractSpec` for contracts with conditional logic, loops over arrays, nested mappings (`address → address → uint256` for ERC20 allowances), event emission, internal helper functions, and linked external libraries — and compile through the verified pipeline (Layers 2+3). Previously only simple counter/token contracts were supported.
+A developer can now write a `CompilationModel` for contracts with conditional logic, loops over arrays, nested mappings (`address → address → uint256` for ERC20 allowances), event emission, internal helper functions, and linked external libraries — and compile through the verified pipeline (Layers 2+3). Previously only simple counter/token contracts were supported.
 
 ### Remaining gap
 
-The EDSL path remains more expressive (supports arbitrary Lean, `List.foldl`, pattern matching). Contracts like UnlinkPool that use advanced Lean features still need the EDSL path. The ContractSpec path now covers the subset needed for standard DeFi contracts (ERC20, ERC721, governance, simple AMMs).
+The EDSL path remains more expressive (supports arbitrary Lean, `List.foldl`, pattern matching). Contracts like UnlinkPool that use advanced Lean features still need the EDSL path. The CompilationModel path now covers the subset needed for standard DeFi contracts (ERC20, ERC721, governance, simple AMMs).
 
 ### Interpreter feature-support contract
 
@@ -307,4 +307,4 @@ See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for contribution guidelines and [`VE
 ---
 
 **Last Updated**: 2026-02-20
-**Status**: Layers 1-3 complete. Trust reduction 1/3 done. Sum properties complete (7/7 proven). ContractSpec now supports real-world contracts (loops, branching, events, multi-mappings, internal calls, verified externs).
+**Status**: Layers 1-3 complete. Trust reduction 1/3 done. Sum properties complete (7/7 proven). CompilationModel now supports real-world contracts (loops, branching, events, multi-mappings, internal calls, verified externs).


### PR DESCRIPTION
## Summary

- **README.md**: The sorry count was listed as just 2, which only reflected the hand-written bridging lemmas in EndToEnd.lean. Updated to transparently report all 51 sorry instances (2 hand-written + ~49 macro-generated via Bridge.lean, one per function in verity_contract blocks). This affects both the Verification Guarantees table and the summary paragraph.
- **docs/ROADMAP.md**: Replaced all 16 occurrences of `ContractSpec` with `CompilationModel` to match the current codebase naming convention used in README.md and source code.

## Test plan

- [ ] Verify README.md sorry count line reads "51 (2 hand-written + ~49 macro-generated)"
- [ ] Verify README.md summary paragraph includes full sorry breakdown
- [ ] Verify zero occurrences of `ContractSpec` remain in docs/ROADMAP.md
- [ ] Verify all `CompilationModel` replacements are contextually correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust reported verification metrics and align terminology; no code, proofs, or compiler behavior changes.
> 
> **Overview**
> Updates `README.md` to accurately report **51 total `sorry` instances** (with a breakdown of hand-written vs macro-generated), including both the verification guarantees table and the high-level metrics sentence.
> 
> Rewords `docs/ROADMAP.md` to consistently use `CompilationModel` instead of `ContractSpec`, aligning roadmap status/progress descriptions and related examples with current naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ea3d8dca45cb6b56d714346f2fd151d14495ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->