### PR TITLE
step 0.1: lock semantic contract types

### DIFF
--- a/Verity/All.lean
+++ b/Verity/All.lean
@@ -12,6 +12,7 @@
 
 -- Core & Stdlib
 import Verity.Core
+import Verity.Core.Semantics
 import Verity.Core.Uint256
 import Verity.Core.FiniteSet
 import Verity.EVM.Uint256

--- a/Verity/Core/Semantics.lean
+++ b/Verity/Core/Semantics.lean
@@ -1,0 +1,29 @@
+import Verity.Core
+
+namespace Verity
+
+abbrev World := ContractState
+abbrev Exit (α : Type) := ContractResult α
+
+structure Env where
+  sender : Address
+  thisAddress : Address
+  msgValue : Uint256
+  blockTimestamp : Uint256
+  deriving Repr
+
+def Env.ofWorld (w : World) : Env where
+  sender := w.sender
+  thisAddress := w.thisAddress
+  msgValue := w.msgValue
+  blockTimestamp := w.blockTimestamp
+
+def World.withEnv (w : World) (env : Env) : World :=
+  { w with
+    sender := env.sender
+    thisAddress := env.thisAddress
+    msgValue := env.msgValue
+    blockTimestamp := env.blockTimestamp
+  }
+
+end Verity


### PR DESCRIPTION
Part of #1060. Completes step 0.1.

- [x] Lock the semantic contract types (Exit, World, Env in Verity/Core/Semantics.lean)

Verify: ran \ (pass)
Sorry count: 24
Max heartbeats: default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, isolated module that re-exports existing core types and simple conversion helpers, plus a new import in `Verity/All.lean`.
> 
> **Overview**
> Introduces `Verity/Core/Semantics.lean` to *lock in* canonical semantic contract types by defining `World` and `Exit` abbreviations and an `Env` record for call context.
> 
> Adds helpers `Env.ofWorld` and `World.withEnv` to convert between `ContractState` and the new environment type, and exports the module via `Verity/All.lean` so downstream users get these definitions by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd32149fe638e7f458801e231cb11cfafb59333c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->