### PR TITLE
wip: checkpoint current step-0.2 changes

### DIFF
--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -84,8 +84,9 @@ The gap between these two Yul execution entry points needs a bridging lemma.
 We capture this composition with the documented gap below.
 -/
 
-/-- Explicit bridge hypothesis for the param-load erasure step. -/
-def ParamLoadErasure (fn : IRFunction) (tx : IRTransaction) (state : IRState) : Prop :=
+/-- Explicit bridge hypothesis for the param-load erasure step.
+Scoped to this module because it is an internal bridge assumption. -/
+private def ParamLoadErasure (fn : IRFunction) (tx : IRTransaction) (state : IRState) : Prop :=
   let paramState := fn.params.zip tx.args |>.foldl
     (fun s (p, v) => s.setVar p.name v) state
   let yulTx : YulTransaction := {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scope-only change: `ParamLoadErasure` is now `private`, reducing its visibility without altering proof logic or runtime behavior. Risk is low unless downstream modules relied on importing this definition.
> 
> **Overview**
> Makes the `ParamLoadErasure` bridge assumption in `Compiler/Proofs/EndToEnd.lean` `private`, explicitly scoping this internal hypothesis to the module.
> 
> No semantic/proof behavior changes are introduced; this just tightens visibility and may require updates only if other modules referenced `ParamLoadErasure` directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a22c3b6534d44b2d8f3f30c45dc677b6c572dcb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->