### PR TITLE
maint: fix CI sorry-check + review triage for #1060

### DIFF
--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -416,12 +416,12 @@ and the macro-generated proof skeleton.
 
 ### Other files:
 
-3. **`Verity/Macro/Bridge.lean` — `_semantic_preservation` theorems** (1 sorry per function)
+3. **`Verity/Macro/Bridge.lean` — `_semantic_preservation` theorems** (1 unfinished proof per function)
    - States: EDSL execution agrees with CM function spec (weak form)
    - Depends on: Phase 4 primitive bridge lemma composition
    - Impact: Medium — these are the macro-generated skeletons
 
-### Fully proven in this file (no `sorry`):
+### Fully proven in this file (zero sorry):
 
 - `interpretYulRuntime_eq_yulResultOfExec` — result wrapping equivalence
 - `yulStateOfIR_eq_initial` — state equivalence under entry-point conditions

--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -12,7 +12,7 @@
     ∀ slot, (edslFinalState.storage slot).val = irResult.finalStorage slot
 
   For SimpleStorage, Counter, Owned, and SafeCounter, the proofs attempt full
-  discharge (no sorry) via direct simp unfolding of both EDSL and IR execution.
+  discharge (zero sorry) via direct simp unfolding of both EDSL and IR execution.
   SafeCounter demonstrates the case-split approach for success/revert paths.
   For more complex contracts, the proofs compose:
   1. Primitive bridge lemmas (PrimitiveBridge.lean)


### PR DESCRIPTION
## Summary

- Fix 3 false-positive matches in the CI "Check for sorry" step that caused the `build` job to fail on PR #1059
- Doc-comment phrasings like `(no sorry)` and `(1 sorry per function)` bypassed the grep exclusion filters; rephrased to use filter-compatible wording

## Changes

**Compiler/Proofs/EndToEnd.lean**
- `(1 sorry per function)` → `(1 unfinished proof per function)` — avoids the keyword entirely
- `(no \`sorry\`)` → `(zero sorry)` — matches the `"zero sorry"` exclusion pattern

**Compiler/Proofs/SemanticBridge.lean**
- `(no sorry)` → `(zero sorry)` — matches the `"zero sorry"` exclusion pattern

## Verification

```
# CI sorry-check command (exact replica) — returns 0 matches after fix
grep -rn "sorry" Verity/ Compiler/ --include="*.lean" \
  | grep -v ":[[:space:]]*--" | grep -v "zero sorry" | grep -v "Summary" \
  | grep -v "SORRY" | grep -v "sorry_count" | grep -v "sorry placeholder" \
  | grep -v "No sorry" | grep -v "all proofs are complete" \
  | wc -l
# Result: 0

# Python hygiene check
python3 scripts/check_lean_hygiene.py
# Result: passed (0 sorry, expected 0)
```

## Review triage of Codex P1 comments on PR #1059

Assessed all 6 P1 inline review comments. Most were based on stale commit state:

| # | File | Valid? | Action |
|---|------|--------|--------|
| 1 | IRGeneration/Expr.lean (missing fixtures) | **No** — all fixtures exist on HEAD | None |
| 2 | SimpleStorage/Basic.lean (namespace) | **Unclear** — needs `lake build` to verify | Monitor |
| 3 | YulGeneration/Semantics.lean (callvalue) | **No** — `evalIRCall` handles both builtins | None |
| 4 | YulGeneration/Codegen.lean (runtimeCode_eq) | **Low risk** — referenced only in comments | Cosmetic; defer |
| 5 | Macro/Bridge.lean (True body) | **Valid, intentional** — roadmap step 3.2 | Tracked in #1060 |
| 6 | EndToEnd.lean (identity theorem) | **Valid, by design** — explicit assumption pattern | Documented |

## Test plan

- [ ] CI "Check for sorry" step passes (was failing)
- [ ] `lake build` still succeeds (no Lean code changed, only block comments)
- [ ] Python hygiene check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to doc-comment wording to satisfy CI grep filters, with no impact on Lean definitions or proofs.
> 
> **Overview**
> Updates documentation comments in `Compiler/Proofs/EndToEnd.lean` and `Compiler/Proofs/SemanticBridge.lean` to prevent the CI “check for sorry” grep from flagging phrases like `(no sorry)` / `(1 sorry per function)`.
> 
> Rephrases those lines to filter-compatible wording (e.g., `zero sorry`, `unfinished proof per function`) so CI hygiene checks pass without changing any proof code or semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29c2df9bb97cbf8f7b1bf2024a04a85ab296b767. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->