### PR TITLE
refactor: tighten API surface — 15 private helpers + deduplicate MAX_UINT256

### DIFF
--- a/Compiler/Codegen.lean
+++ b/Compiler/Codegen.lean
@@ -26,7 +26,7 @@ structure YulEmitOptions where
   mappingSlotScratchBase : Nat := 0
 
 /-- Runtime emission output plus patch audit report for tool/CI consumption. -/
-structure RuntimeEmitReport where
+private structure RuntimeEmitReport where
   runtimeCode : List YulStmt
   patchReport : Yul.PatchPassReport
 
@@ -43,7 +43,7 @@ private def yulReturnRuntime : YulStmt :=
     YulExpr.call "datasize" [YulExpr.str "runtime"]
   ])
 
-def mappingSlotFuncAt (scratchBase : Nat) : YulStmt :=
+private def mappingSlotFuncAt (scratchBase : Nat) : YulStmt :=
   let keyPtr := scratchBase
   let slotPtr := scratchBase + 32
   YulStmt.funcDef "mappingSlot" ["baseSlot", "key"] ["slot"] [
@@ -52,7 +52,7 @@ def mappingSlotFuncAt (scratchBase : Nat) : YulStmt :=
     YulStmt.assign "slot" (YulExpr.call "keccak256" [YulExpr.lit keyPtr, YulExpr.lit 64])
   ]
 
-def mappingSlotFunc : YulStmt :=
+private def mappingSlotFunc : YulStmt :=
   mappingSlotFuncAt 0
 
 /-- Revert if ETH is sent to a non-payable function. -/
@@ -105,7 +105,7 @@ private def insertBy [LT β] [DecidableRel (α := β) (· < ·)] (key : α → �
 private def insertionSortBy [LT β] [DecidableRel (α := β) (· < ·)] (key : α → β) (xs : List α) : List α :=
   xs.foldl (fun acc x => insertBy key x acc) []
 
-def buildSwitch
+private def buildSwitch
     (funcs : List IRFunction)
     (fallback : Option IREntrypoint := none)
     (receive : Option IREntrypoint := none)
@@ -167,7 +167,7 @@ private def internalHelpersForProfile (profile : BackendProfile) (helpers : List
   else
     helpers
 
-def runtimeCodeWithEmitOptions (contract : IRContract) (options : YulEmitOptions) : List YulStmt :=
+private def runtimeCodeWithEmitOptions (contract : IRContract) (options : YulEmitOptions) : List YulStmt :=
   let mapping := if contract.usesMapping then [mappingSlotFuncAt options.mappingSlotScratchBase] else []
   let internals := internalHelpersForProfile options.backendProfile contract.internalFunctions
   let sortCases := profileSortsDispatchCases options.backendProfile
@@ -232,12 +232,12 @@ private def emitYulWithOptionsInternal
     patchReport := mergedPatchReport }
 
 /-- Emit runtime code and keep the patch pass report (manifest + iteration count). -/
-def runtimeCodeWithOptionsReport (contract : IRContract) (options : YulEmitOptions) : RuntimeEmitReport :=
+private def runtimeCodeWithOptionsReport (contract : IRContract) (options : YulEmitOptions) : RuntimeEmitReport :=
   let report := emitYulWithOptionsInternal contract options
   { runtimeCode := report.patched.runtimeCode
     patchReport := report.patchReport }
 
-def runtimeCodeWithOptions (contract : IRContract) (options : YulEmitOptions) : List YulStmt :=
+private def runtimeCodeWithOptions (contract : IRContract) (options : YulEmitOptions) : List YulStmt :=
   (runtimeCodeWithOptionsReport contract options).runtimeCode
 
 def emitYul (contract : IRContract) : YulObject :=

--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -475,7 +475,7 @@ def findStructMember (members : List StructMember) (memberName : String) : Optio
   members.find? (·.name == memberName)
 
 -- Keep compiler literals aligned with Uint256 semantics (mod 2^256).
-def uint256Modulus : Nat := 2 ^ 256
+private def uint256Modulus : Nat := 2 ^ 256
 
 private def packedMaskNat (packed : PackedBits) : Nat :=
   if packed.width >= 256 then

--- a/Compiler/Proofs/YulGeneration/Codegen.lean
+++ b/Compiler/Proofs/YulGeneration/Codegen.lean
@@ -23,7 +23,7 @@ theorem emitYul_runtimeCode_eq (contract : IRContract) :
 
 /-- Selector extraction via `selectorExpr` yields the 4-byte selector. -/
 @[simp]
-theorem evalYulExpr_selectorExpr (state : YulState) :
+private theorem evalYulExpr_selectorExpr (state : YulState) :
     evalYulExpr state selectorExpr = some (state.selector % selectorModulus) :=
 by
   simpa using (Compiler.Proofs.YulGeneration.evalYulExpr_selectorExpr_semantics state)
@@ -46,7 +46,7 @@ def switchCases (fns : List IRFunction) : List (Prod Nat (List YulStmt)) :=
   fns.map (fun f => (f.selector, switchCaseBody f))
 
 /-- Default dispatch body used by `buildSwitch`. -/
-def switchDefaultCase
+private def switchDefaultCase
     (fallback : Option IREntrypoint)
     (receive : Option IREntrypoint) : List YulStmt :=
   match receive, fallback with
@@ -76,7 +76,7 @@ def switchDefaultCase
       ]]
 
 /-- If the selector matches a case, the switch executes that case body (fueled). -/
-theorem execYulStmtFuel_switch_match
+private theorem execYulStmtFuel_switch_match
     (state : YulState) (expr : YulExpr) (cases' : List (Prod Nat (List YulStmt)))
     (defaultCase : Option (List YulStmt)) (fuel v : Nat) (body : List YulStmt)
     (hEval : evalYulExpr state expr = some v)
@@ -90,13 +90,13 @@ theorem execYulStmtFuel_switch_match
     state expr cases' defaultCase fuel v body hEval hFind')
 
 /-- If no selector case matches, the switch executes the default (or continues). -/
-def execYulStmtFuel_switch_miss_result (state : YulState) (fuel : Nat)
+private def execYulStmtFuel_switch_miss_result (state : YulState) (fuel : Nat)
     (defaultCase : Option (List YulStmt)) : YulExecResult :=
   match defaultCase with
   | some body => execYulStmtsFuel fuel state body
   | none => YulExecResult.continue state
 
-theorem execYulStmtFuel_switch_miss
+private theorem execYulStmtFuel_switch_miss
     (state : YulState) (expr : YulExpr) (cases' : List (Prod Nat (List YulStmt)))
     (defaultCase : Option (List YulStmt)) (fuel v : Nat)
     (hEval : evalYulExpr state expr = some v)

--- a/Compiler/Proofs/YulGeneration/Preservation.lean
+++ b/Compiler/Proofs/YulGeneration/Preservation.lean
@@ -19,7 +19,7 @@ executing an IR function body matches executing the same Yul statements.
 See `TRUST_ASSUMPTIONS.md` for the full trust-boundary description.
 -/
 
-@[simp] theorem interpretYulBody_eq_runtime (fn : IRFunction) (tx : IRTransaction) (state : IRState) :
+@[simp] private theorem interpretYulBody_eq_runtime (fn : IRFunction) (tx : IRTransaction) (state : IRState) :
     interpretYulBody fn tx state =
       interpretYulRuntime fn.body
         { sender := tx.sender, functionSelector := tx.functionSelector, args := tx.args }
@@ -27,11 +27,11 @@ See `TRUST_ASSUMPTIONS.md` for the full trust-boundary description.
   rfl
 
 /-- Helper: initial Yul state aligned with the IR transaction/state. -/
-def initialYulState (tx : YulTransaction) (state : IRState) : YulState :=
+private def initialYulState (tx : YulTransaction) (state : IRState) : YulState :=
   YulState.initial tx state.storage
 
 @[simp]
-theorem evalYulExpr_selectorExpr_initial
+private theorem evalYulExpr_selectorExpr_initial
     (tx : YulTransaction) (state : IRState)
     (hselector : tx.functionSelector < selectorModulus) :
     evalYulExpr (initialYulState tx state) selectorExpr = some tx.functionSelector := by

--- a/Verity/Stdlib/Math.lean
+++ b/Verity/Stdlib/Math.lean
@@ -16,8 +16,8 @@ namespace Verity.Stdlib.Math
 open Verity
 
 -- Maximum value for Uint256 (2^256 - 1)
--- For Lean's Nat, we define a practical upper bound
-def MAX_UINT256 : Nat := 2^256 - 1
+-- Alias of Verity.Core.MAX_UINT256 for backwards compatibility.
+abbrev MAX_UINT256 : Nat := Core.MAX_UINT256
 
 -- Safe addition: returns None on overflow
 def safeAdd (a b : Uint256) : Option Uint256 :=


### PR DESCRIPTION
## Summary

- Mark **15 internal helper definitions as `private`** across 3 core modules (Codegen.lean, proof Codegen.lean, Preservation.lean). All 15 have zero external references — they are consumed only within their defining file.
- Mark **`uint256Modulus` as `private`** in CompilationModel.lean (zero external callers, duplicates `evmModulus`)
- Change **`MAX_UINT256` in Stdlib/Math.lean** from independent definition to `abbrev` aliasing `Verity.Core.MAX_UINT256` (eliminates duplicate constant)

### Files changed

| File | Change | Count |
|------|--------|-------|
| `Compiler/Codegen.lean` | 7 defs → `private` | `RuntimeEmitReport`, `mappingSlotFuncAt`, `mappingSlotFunc`, `buildSwitch`, `runtimeCodeWithEmitOptions`, `runtimeCodeWithOptionsReport`, `runtimeCodeWithOptions` |
| `Compiler/Proofs/YulGeneration/Codegen.lean` | 5 defs → `private` | `evalYulExpr_selectorExpr`, `switchDefaultCase`, `execYulStmtFuel_switch_match`, `execYulStmtFuel_switch_miss_result`, `execYulStmtFuel_switch_miss` |
| `Compiler/Proofs/YulGeneration/Preservation.lean` | 3 defs → `private` | `interpretYulBody_eq_runtime`, `initialYulState`, `evalYulExpr_selectorExpr_initial` |
| `Compiler/CompilationModel.lean` | 1 def → `private` | `uint256Modulus` |
| `Verity/Stdlib/Math.lean` | `def` → `abbrev` alias | `MAX_UINT256` |

Refs: #1071, #1072, #1073

## Verification

`lake build` passes (1140 modules, zero errors).

## Test plan

- [x] `lake build` succeeds with zero errors
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to visibility/namespace hygiene (`private`/`abbrev`) with no functional logic changes, but may affect downstream code that relied on previously public helpers/constants.
> 
> **Overview**
> Tightens the public API surface by marking multiple internal helpers as `private` in codegen (`RuntimeEmitReport`, mapping-slot helpers, switch/runtime emission helpers), compilation model (`uint256Modulus`), and Yul-generation proofs (selector/switch/preservation lemmas).
> 
> Deduplicates the stdlib `MAX_UINT256` constant by replacing the local definition with an `abbrev` alias to `Verity.Core.MAX_UINT256` for backwards compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ff4e031e16001e34df2f4854695c34dcdae506e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->