### PR TITLE
docs: fix stale counts, reorder TRUST_ASSUMPTIONS sections, add missing coverage rows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ setup-foundry: ## Install Foundry (forge, cast, anvil)
 verify: ## Verify all proofs (lake build)
 	lake build
 
-axiom-report: ## Generate axiom dependency report for all 569 theorems
+axiom-report: ## Generate axiom dependency report for all 556 theorems
 	lake env lean PrintAxioms.lean 2>&1 | tee axiom-report-raw.log
 	python3 scripts/check_axiom_report.py --log axiom-report-raw.log
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Every claim below is enforced by CI on every commit. Each one can be independent
 | Proven theorems | 425 | `make verify` |
 | Incomplete proofs (`sorry`) | 0 | `make verify` (Lean rejects sorry) |
 | Project-specific axioms | 1 ([documented](AXIOMS.md)) | `make axiom-report` |
-| Axiom dependency audit | 613 theorems checked | `make axiom-report` |
-| Foundry runtime tests | 445 across 37 suites | `make test-foundry` |
+| Axiom dependency audit | 556 theorems checked | `make axiom-report` |
+| Foundry runtime tests | 447 across 37 suites | `make test-foundry` |
 | Property test coverage | 250/425 (59%) | `python3 scripts/check_property_coverage.py` |
 | CI validation scripts | 30 | `make check` |
 | Proof length enforcement | 92% under 30 lines | `python3 scripts/check_proof_length.py` |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -158,26 +158,6 @@ See [`docs/REVERT_STATE_MODEL.md`](docs/REVERT_STATE_MODEL.md) for the precise m
 7. Review ECM axiom report (`--verbose`) and confirm all module trust assumptions are acceptable.
 8. If third-party ECMs are used, audit their `AXIOMS.md` and `compile` implementations.
 
-## Change Control Requirement
-
-Any source change that affects architecture, semantics, trust boundary, or CI safeguards must update this file in the same change set.
-
-If this file is stale, audit conclusions may be invalid.
-
-## Related Documents
-
-- [AUDIT.md](AUDIT.md)
-- [AXIOMS.md](AXIOMS.md)
-- [docs/ARITHMETIC_PROFILE.md](docs/ARITHMETIC_PROFILE.md)
-- [docs/REVERT_STATE_MODEL.md](docs/REVERT_STATE_MODEL.md)
-- [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md)
-- [docs/SOLIDITY_PARITY_PROFILE.md](docs/SOLIDITY_PARITY_PROFILE.md)
-- [docs/PARITY_PACKS.md](docs/PARITY_PACKS.md)
-- [docs/REWRITE_RULES.md](docs/REWRITE_RULES.md)
-- [docs/IDENTITY_CHECKER.md](docs/IDENTITY_CHECKER.md)
-- [docs/ROADMAP.md](docs/ROADMAP.md)
-- [docs/VERIFICATION_STATUS.md](docs/VERIFICATION_STATUS.md)
-
 ### 9. Macro Elaborator (`verity_contract`)
 
 - Role: generates both the EDSL `Contract` monad value and the `CompilationModel`
@@ -230,5 +210,25 @@ Roadmap:
    `interpretSpec` in the TCB.
 4. 🔲 Expand DSL coverage (dynamic arrays, structs, try/catch, create/create2).
 
-**Last Updated**: 2026-03-02
+## Change Control Requirement
+
+Any source change that affects architecture, semantics, trust boundary, or CI safeguards must update this file in the same change set.
+
+If this file is stale, audit conclusions may be invalid.
+
+## Related Documents
+
+- [AUDIT.md](AUDIT.md)
+- [AXIOMS.md](AXIOMS.md)
+- [docs/ARITHMETIC_PROFILE.md](docs/ARITHMETIC_PROFILE.md)
+- [docs/REVERT_STATE_MODEL.md](docs/REVERT_STATE_MODEL.md)
+- [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md)
+- [docs/SOLIDITY_PARITY_PROFILE.md](docs/SOLIDITY_PARITY_PROFILE.md)
+- [docs/PARITY_PACKS.md](docs/PARITY_PACKS.md)
+- [docs/REWRITE_RULES.md](docs/REWRITE_RULES.md)
+- [docs/IDENTITY_CHECKER.md](docs/IDENTITY_CHECKER.md)
+- [docs/ROADMAP.md](docs/ROADMAP.md)
+- [docs/VERIFICATION_STATUS.md](docs/VERIFICATION_STATUS.md)
+
+**Last Updated**: 2026-03-03
 **Maintainer Rule**: Update on every trust-boundary-relevant code change.

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -291,7 +291,7 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 ### Current Coverage
 
 - **Total Properties**: 425
-- **Covered**: 220 (55%)
+- **Covered**: 250 (59%)
 - **Excluded**: 175 (all proof-only)
 - **Missing**: 0
 
@@ -299,14 +299,16 @@ All 8 statement types (assign, storage load/store, mapping load/store, condition
 
 | Contract | Coverage | Exclusions | Status |
 |----------|----------|------------|--------|
+| ERC20 | 100% (19/19) | 0 | ✅ Complete |
+| ERC721 | 100% (11/11) | 0 | ✅ Complete |
 | SafeCounter | 100% (25/25) | 0 | ✅ Complete |
 | ReentrancyExample | 100% (4/4) | 0 | ✅ Complete |
+| Ledger | 100% (33/33) | 0 | ✅ Complete |
 | SimpleStorage | 95% (19/20) | 1 proof-only | ✅ Near-complete |
-| Owned | 87% (20/23) | 3 proof-only | ✅ Near-complete |
 | OwnedCounter | 92% (44/48) | 4 proof-only | ✅ Near-complete |
+| Owned | 87% (20/23) | 3 proof-only | ✅ Near-complete |
 | SimpleToken | 85% (52/61) | 9 proof-only | ✅ High coverage |
 | Counter | 82% (23/28) | 5 proof-only | ✅ High coverage |
-| Ledger | 100% (33/33) | 0 | ✅ Complete |
 | Stdlib | 0% (0/153) | 153 proof-only | — Internal |
 
 ### Exclusion Categories


### PR DESCRIPTION
## Summary

Documentation accuracy fixes discovered by automated audit (Priority 7: Documentation).

### Stale numeric claims fixed

| Location | Old Value | New Value | Source of Truth |
|----------|-----------|-----------|-----------------|
| README line 123 (axiom audit) | 613 theorems | 556 theorems | `PrintAxioms.lean` has 556 `#print axioms` |
| README line 124 (Foundry tests) | 445 across 37 | 447 across 37 | `grep -rn "function test" test/*.t.sol` |
| Makefile line 70 | 569 theorems | 556 theorems | Same as above |
| VERIFICATION_STATUS.md line 294 | 220 (55%) | 250 (59%) | `artifacts/verification_status.json` |

### Structural fix: TRUST_ASSUMPTIONS.md

Section 9 (Macro Elaborator) and "Planned Trust-Boundary Hardening" were appended *after* the "Related Documents" section, which should be terminal. Moved them before Related Documents where they logically belong — Section 9 is a trusted component (alongside sections 1-8), and planned hardening is a body section.

### Missing coverage rows: VERIFICATION_STATUS.md

ERC20 (19/19, 100%) and ERC721 (11/11, 100%) were missing from the per-contract coverage table. Added them and re-sorted by coverage descending.

## Test plan

- [x] `python3 scripts/check_doc_counts.py` passes
- [x] `python3 scripts/check_verify_sync.py` passes (6/6 invariant groups)
- [ ] CI verify workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates (counts, table rows, and section ordering) with no impact to code, proofs, or CI behavior.
> 
> **Overview**
> Refreshes reported verification metrics to match current artifacts: updates the `axiom-report` theorem count in the `Makefile`, and corrects README claims for axiom-audit coverage and Foundry test totals.
> 
> Reorders `TRUST_ASSUMPTIONS.md` so the change-control and related-docs sections are placed at the end again and bumps its **Last Updated** date.
> 
> Fixes `docs/VERIFICATION_STATUS.md` property-test coverage reporting (covered %/count) and completes the per-contract coverage table by adding missing `ERC20`/`ERC721` rows and re-sorting entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ee2298d9270309e314e8c73f6b75a1c3b4d9988. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->