### PR TITLE
fix: resolve 10 Lean warnings breaking CI on main

### DIFF
--- a/Verity/Core/Free/TypedIRCompiler.lean
+++ b/Verity/Core/Free/TypedIRCompiler.lean
@@ -1416,7 +1416,7 @@ theorem compileStmts_let_caller_setMapping2_stop_run
     (fields : List Field) (fieldName senderVar p1 p2 : String) (slot : Nat)
     (hSlot : findFieldSlot fields fieldName = some slot)
     (h1 : senderVar ≠ p2) (h2 : senderVar ≠ p1) (h3 : p2 ≠ p1)
-    (h4 : p1 ≠ p2) (h5 : p1 ≠ senderVar) (h6 : p2 ≠ senderVar) :
+    (_h4 : p1 ≠ p2) (_h5 : p1 ≠ senderVar) (_h6 : p2 ≠ senderVar) :
     (compileStmts fields
       [ Stmt.letVar senderVar Expr.caller
       , Stmt.setMapping2 fieldName (Expr.localVar senderVar) (Expr.param p1) (Expr.param p2)
@@ -1503,8 +1503,8 @@ theorem compileStmts_setMappingUint_params_stop_run
             TStmt.stop
           ] }) := by
   have hne : (p2 == p1) = false := beq_false_of_ne hp.symm
-  simp [compileStmts, compileStmt, compileExpr, emitSSABind, freshVar,
-    bindVar, pushLocal, lookupVar, asUInt256, liftExcept, hSlot, emit,
+  simp [compileStmts, compileStmt, compileExpr,
+    lookupVar, asUInt256, liftExcept, hSlot, emit,
     List.find?, hne]; rfl
 
 end Verity.Core.Free

--- a/Verity/Core/Free/TypedIRCompilerCorrectness.lean
+++ b/Verity/Core/Free/TypedIRCompilerCorrectness.lean
@@ -1204,7 +1204,7 @@ theorem compile_return_storage_semantics
   simp [execCompiledReturnStorage, execSourceReturnStorage,
     compileStmts_single_return_storage_run, hfind,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation theorem for `return (storage field)` (address). -/
 theorem compile_return_storage_addr_semantics
@@ -1217,7 +1217,7 @@ theorem compile_return_storage_addr_semantics
   simp [execCompiledReturnStorageAddr, execSourceReturnStorageAddr,
     compileStmts_single_return_storage_addr_run, hfind,
     evalTStmts, defaultEvalFuel]
-  simp [evalTStmtsFuel, evalTStmtFuel, evalTExpr]
+  simp [evalTStmtsFuel, evalTStmtFuel]
 
 /-- Semantic-preservation for `return (mapping fieldName caller)`:
 compiled execution matches direct source semantics (no state change). -/
@@ -4237,13 +4237,7 @@ theorem compile_require_family_clauses_tail_programs_append_semantics
           match execSourceRequireFamilyClausesTailPrograms fields init pre with
           | .ok st => execSourceRequireFamilyClausesTailPrograms fields st post
           | .revert reason => .revert reason := by
-            simpa [compile_require_family_clauses_tail_programs_semantics] using
-              congrArg
-                (fun r =>
-                  match r with
-                  | .ok st => execCompiledRequireFamilyClausesTailPrograms fields st post
-                  | .revert reason => .revert reason)
-                (compile_require_family_clauses_tail_programs_semantics fields init pre)
+            simp [compile_require_family_clauses_tail_programs_semantics]
     _ = execSourceRequireFamilyClausesTailPrograms fields init (pre ++ post) := by
           simpa using
             (execSourceRequireFamilyClausesTailPrograms_append_from fields init pre post).symm


### PR DESCRIPTION
## Summary
- Fixes #1092
- Resolves 10 Lean compiler warnings that break the `check_lean_warning_regression.py` CI check on `main` and all open PRs

## Changes (2 files, -12/+6 lines)

### TypedIRCompiler.lean
- Remove 4 unused simp args (`emitSSABind`, `freshVar`, `bindVar`, `pushLocal`) from `compileStmts_setMappingUint_params_stop_run`
- Prefix 3 unused params (`h4`, `h5`, `h6`) with `_` in `compileStmts_let_caller_setMapping2_stop_run` — these are derivable from h1/h2/h3 via `.symm` but kept in the signature for compatibility with the `SupportedContinuationTail` constructor

### TypedIRCompilerCorrectness.lean
- Remove unused `evalTExpr` from 2 simp calls (lines 1207, 1220)
- Replace `simpa [h] using congrArg ...` with `simp [h]` in `compile_require_family_clauses_tail_programs_append_semantics` — the `using` term was unnecessary

## Verification
- `lake build` passes with 0 warnings
- `check_lean_warning_regression.py` passes (0 observed vs 0 baseline)
- `check_proof_length.py` passes
- No proof semantics changed — only unused arguments removed

## Test plan
- [x] `lake build` succeeds locally with zero warnings
- [x] Warning regression check passes
- [x] Proof length check passes
- [ ] CI should go green once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to proof scripts and theorem signatures (unused arguments and simplifications) with no changes to compiler or execution semantics.
> 
> **Overview**
> Resolves Lean warning-regression failures by cleaning up unused arguments in proofs.
> 
> In `TypedIRCompiler.lean`, prefixes unused hypotheses in `compileStmts_let_caller_setMapping2_stop_run` and removes unused simp dependencies in `compileStmts_setMappingUint_params_stop_run`. In `TypedIRCompilerCorrectness.lean`, drops unused `evalTExpr` from simp steps and simplifies a proof rewrite from a `simpa … using congrArg …` pattern to a direct `simp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cba874898d55e7885b656c354ac16c69577474df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->