### PR TITLE
fix: correct sorry count across all docs (1 → 19) and fix stale artifact

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -112,8 +112,10 @@ Wrapping modular arithmetic at 2^256 is **proven**, not assumed. All 15 pure bui
 - The semantic bridge and typed-IR migration work (Issues #998 and #1060:
   `Compiler/Proofs/EndToEnd.lean`, `Compiler/Proofs/SemanticBridge.lean`,
   `Verity/Macro/Bridge.lean`, and the `Verity/Core/Free/TypedIR*` pipeline)
-  does not add, remove, or modify Lean axioms. The bridge layer and active
-  typed compilation path carry zero executable `sorry` placeholders.
+  does not add, remove, or modify Lean axioms. `SemanticBridge.lean` contains
+  18 `sorry` placeholders in proof terms (theorem statements are preserved;
+  proofs are blocked by heartbeat limits after the `evalBuiltinCall` refactor).
+  The typed-IR compilation path (`TypedIRCompiler*.lean`) carries zero `sorry`.
 
 ## Maintenance Rule
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ EVM Bytecode
 
 | Layer | What it proves | Key file |
 |-------|---------------|----------|
-| 1 | EDSL execution = CompilationModel interpretation | [SemanticBridge.lean](Compiler/Proofs/SemanticBridge.lean) |
-| 2 | CompilationModel compilation preserves behavior | [EndToEnd.lean](Compiler/Proofs/EndToEnd.lean) |
+| 1 | EDSL execution = CompilationModel interpretation | [TypedIRCompilerCorrectness.lean](Verity/Core/Free/TypedIRCompilerCorrectness.lean) |
+| 2 | CompilationModel → IR preserves behavior | [IRInterpreter.lean](Compiler/Proofs/IRGeneration/IRInterpreter.lean) |
 | 3 | IR → Yul codegen preserves behavior | [Preservation.lean](Compiler/Proofs/YulGeneration/Preservation.lean) |
 
 Layers 2 and 3 (`CompilationModel → IR → Yul`) are verified with 1 axiom: [`keccak256_first_4_bytes`](Compiler/Selectors.lean) for function selector computation, validated by CI against `solc --hashes`. See [AXIOMS.md](AXIOMS.md).
@@ -137,7 +137,7 @@ FOUNDRY_PROFILE=difftest forge test    # 447 tests across 37 suites
 | ReentrancyExample | 4 | Reentrancy vulnerability vs safe pattern |
 | CryptoHash | — | External library linking demo (no proofs) |
 
-425 theorems across 11 categories (424 proven, 1 `sorry`). 447 Foundry tests across 37 test suites. 250 covered by property tests (59% coverage, 175 proof-only exclusions). 1 documented axiom.
+425 theorems across 11 categories. 447 Foundry tests across 37 test suites. 250 covered by property tests (59% coverage, 175 proof-only exclusions). 1 documented axiom. 19 `sorry` placeholders (18 in cross-layer bridge proofs, 1 in Yul preservation — see [VERIFICATION_STATUS.md](docs/VERIFICATION_STATUS.md)).
 
 ---
 
@@ -190,8 +190,8 @@ Every claim is enforced by CI on every commit:
 
 | Claim | Value | Verify locally |
 |-------|-------|----------------|
-| Proven theorems | 425 | `make verify` |
-| Incomplete proofs (`sorry`) | 1 | `make verify` |
+| Tracked theorems | 425 across 11 categories | `make verify` |
+| Incomplete proofs (`sorry`) | 19 (18 bridge + 1 Yul) | `python3 scripts/check_lean_hygiene.py` |
 | Project-specific axioms | 1 ([documented](AXIOMS.md)) | `make axiom-report` |
 | Foundry runtime tests | 447 across 37 suites | `make test-foundry` |
 | Property test coverage | 250/425 (59%) | `python3 scripts/check_property_coverage.py` |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -23,7 +23,7 @@ All three layers are proven in Lean. The single axiom is `keccak256_first_4_byte
 - **Layer 1**: EDSL behavior matches its CompilationModel. For supported contracts, a generic typed-IR compilation-correctness theorem eliminates per-contract manual proofs.
 - **Layer 2**: CompilationModel → IR preserves behavior.
 - **Layer 3**: IR → Yul preserves behavior (1 axiom for keccak-based selectors).
-- **Cross-layer**: `Compiler/Proofs/SemanticBridge.lean` states per-function EDSL ≡ IR equivalence. `Compiler/Proofs/EndToEnd.lean` composes Layers 2+3.
+- **Cross-layer**: `Compiler/Proofs/SemanticBridge.lean` *states* per-function EDSL ≡ IR equivalence theorems (18 theorems, all currently `sorry` — blocked by heartbeat limits after `evalBuiltinCall` refactor). `Compiler/Proofs/EndToEnd.lean` composes Layers 2+3.
 
 425 theorems across 11 categories. 250 theorems have corresponding Foundry property tests. 59% runtime test coverage.
 

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -5,7 +5,7 @@
   },
   "proofs": {
     "axioms": 1,
-    "sorry": 1
+    "sorry": 19
   },
   "schema_version": 1,
   "tests": {
@@ -33,7 +33,7 @@
       "SimpleToken": 61,
       "Stdlib": 153
     },
-    "proven": 424,
+    "proven": 406,
     "stdlib": 153,
     "total": 425
   },

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -26,7 +26,7 @@ Important: Verity has two different "spec" concepts.
 - **Layer 1 per contract**: EDSL behavior is proven equivalent to its `CompilationModel`.
 - **Layer 2 framework proof**: `CompilationModel -> IR` preserves semantics.
 - **Layer 3 framework proof**: `IR -> Yul` preserves semantics.
-- **Machine-checked proofs**: 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)) — `keccak256_first_4_bytes` only, 0 sorry.
+- **Machine-checked proofs**: 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)) — `keccak256_first_4_bytes` only, 19 sorry (18 SemanticBridge + 1 Preservation).
 - **Interpreter semantics**: Spec, IR, and Yul semantics defined and linked in Lean
 
 ### What's Tested (High Confidence)
@@ -751,5 +751,5 @@ def ownedSpec : CompilationModel := {
 
 - [Research & Development](/research) — Design decisions and proof techniques
 - [Examples](/examples) — 12 example contracts
-- [Verification](/verification) — 425 proven theorems
+- [Verification](/verification) — 425 tracked theorems (406 proven, 19 sorry)
 - [GitHub Repository](https://github.com/Th0rgal/verity) — Source code

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -387,7 +387,7 @@ Function selectors (the first 4 bytes of `keccak256("functionName(paramTypes)")`
 
 When you define a contract using the `verity_contract` macro (in `Verity/Examples/MacroContracts.lean`), the framework automatically provides compilation correctness via the generic typed-IR theorem in `Verity/Core/Free/TypedIRCompilerCorrectness.lean`. This theorem covers a grammar of 36+ supported statement fragments, so no per-contract compilation proofs are needed for standard patterns.
 
-The bridge between EDSL semantics and the compilation model is maintained in `Compiler/Proofs/SemanticBridge.lean`. For contracts using only supported patterns (storage reads/writes, mappings, require guards, arithmetic, conditionals), compilation correctness is fully automatic with zero `sorry`.
+The bridge between EDSL semantics and the compilation model is maintained in `Compiler/Proofs/SemanticBridge.lean`. The bridge theorem *statements* are fully defined for all supported patterns (storage reads/writes, mappings, require guards, arithmetic, conditionals), but 18 proof terms currently use `sorry` (blocked by heartbeat limits after the `evalBuiltinCall` refactor). The typed-IR compilation path (`TypedIRCompilerCorrectness.lean`) carries zero `sorry`.
 
 > **Tip**: Study `Verity/Core/Free/TypedIRCompilerCorrectness.lean` to see the supported statement fragment grammar and bridge theorem examples for Counter, SimpleStorage, ERC20, and ERC721.
 

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -126,7 +126,7 @@ See [/verification](/verification) for the complete, always-current theorem list
 
 **What's a proof?** A step-by-step logical argument that shows why a theorem must be true. Lean checks every step.
 
-**What's `sorry`?** A placeholder in Lean that says "I'll prove this later." It's how incomplete proofs compile. This project has 0 `sorry` — all proofs are fully complete.
+**What's `sorry`?** A placeholder in Lean that says "I'll prove this later." It's how incomplete proofs compile. This project has 19 `sorry` — 18 in SemanticBridge cross-layer bridge proofs and 1 in Yul Preservation (theorem statements preserved; proofs blocked by heartbeat limits).
 
 **What are axioms?** Statements assumed true without proof. This project uses 1 documented axiom: `keccak256_first_4_bytes` for selector hashing (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)).
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -5,7 +5,7 @@ description: Design decisions, iterations, and proof techniques
 
 # Research & Development
 
-**Compact core, built across 7 iterations. 425 theorems, all fully proven. 1 documented axiom, 0 sorry.**
+**Compact core, built across 7 iterations. 425 theorems, 406 fully proven, 19 sorry (18 SemanticBridge + 1 Preservation). 1 documented axiom.**
 
 ## Evolution
 

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -7,7 +7,7 @@ description: EDSL proofs plus compiler correctness proofs (IR + Yul)
 
 The compiler is verified with IR preservation proofs and Yul equivalence proofs in `Compiler/Proofs/`. All three layers are complete and checked by `lake build`.
 
-**Status**: 425 theorems across 11 categories, all fully proven. 0 `sorry` — Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 1 axiom documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
+**Status**: 425 theorems across 11 categories, 406 fully proven. 19 `sorry` placeholders (18 in SemanticBridge cross-layer bridge proofs, 1 in Yul Preservation — theorem statements preserved, proofs blocked by heartbeat limits). Ledger sum proofs completed in Conservation.lean ([#65](https://github.com/Th0rgal/verity/issues/65)). 1 axiom documented in [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md).
 
 ## Snapshot (2026-02-17)
 

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -14,10 +14,10 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 
 ## Quick Facts
 
-- **Language**: Lean 4.15.0
+- **Language**: Lean 4.22.0
 - **Core Size**: 376 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
-- **Theorems**: 425 across 11 categories (424 fully proven, 1 `sorry` placeholders)
+- **Theorems**: 425 across 11 categories, 406 fully proven, 19 `sorry` placeholders (18 in SemanticBridge cross-layer proofs, 1 in Yul Preservation)
 - **Axioms**: 1 documented axiom (see AXIOMS.md) — keccak256_first_4_bytes only
 - **Tests**: 447 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
@@ -77,7 +77,7 @@ def bind (x : Contract α) (f : α → Contract β) : Contract β :=
 
 The GitHub Actions workflow validates:
 - All Lean proofs compile (`lake build`)
-- No `sorry` in any proof files (all proofs complete)
+- Expected `sorry` count matches baseline (19: 18 SemanticBridge + 1 Preservation)
 - All axioms documented in AXIOMS.md
 - Property manifest in sync with Lean proofs
 - All manifest theorems have tests (or documented exclusions)
@@ -122,13 +122,14 @@ Add `.md` to any URL for raw markdown (saves tokens).
 
 See TRUST_ASSUMPTIONS.md for full analysis. Key trust boundaries:
 - **Verified**: EDSL -> CompilationModel -> IR -> Yul
-- **Trusted**: Yul -> Bytecode (via solc, validated by 70k+ differential tests)
+- **Trusted**: Yul -> Bytecode (via solc, validated by 90,000+ differential tests)
 - **Axioms**: 1 documented, with soundness justification
 - **External**: Lean 4 kernel, EVM specification alignment
 
 ## Known Limitations
 
-- All proofs complete — Ledger sum properties proven in Conservation.lean (issue #65 resolved)
+- 19 `sorry` placeholders remain (18 SemanticBridge cross-layer bridge proofs, 1 Yul preservation — theorem statements preserved, only proof terms incomplete)
+- Ledger sum properties proven in Conservation.lean (issue #65 resolved)
 - No gas modeling
 - Self-transfer handled via delta-zero pattern (not separate logic)
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -18,7 +18,7 @@ EVM Bytecode
 
 ## Layer 1: EDSL ≡ CompilationModel — COMPLETE
 
-**What it proves**: User-facing EDSL contracts satisfy their human-readable specifications.
+**What it proves**: The EDSL `Contract` monad execution is equivalent to `CompilationModel` interpretation for all supported contracts. Per-contract proofs under `Verity/Proofs/` then show these contracts satisfy their human-readable specifications.
 
 ### Verified Contracts
 
@@ -104,7 +104,7 @@ Key files: [`StatementEquivalence.lean`](../Compiler/Proofs/YulGeneration/Statem
 
 **Proof-Only Properties (175 exclusions)**: Internal proof machinery that cannot be tested in Foundry.
 
-1 `sorry` remaining (macro-generated semantic preservation placeholders).
+19 `sorry` remaining: 18 in `Compiler/Proofs/SemanticBridge.lean` (EDSL ≡ IR bridge theorem proofs, blocked by `evalBuiltinCall` heartbeat limit after callvalue/calldatasize refactor) and 1 in `Compiler/Proofs/YulGeneration/Preservation.lean` (switchCaseBody connection). The theorem *statements* are preserved; only the proof terms use placeholders.
 
 ## Differential Testing
 

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -85,8 +85,22 @@ def get_core_line_count() -> int:
 
 
 def get_sorry_count() -> int:
-    """Count sorry statements in Lean proof files."""
-    return _count_lean_lines(r"^\s*(·\s*)?sorry\b")
+    """Count sorry statements in Lean proof files.
+
+    Uses ``search`` (not the ``match`` used by ``_count_lean_lines``) so that
+    ``by sorry`` at end-of-line is detected, matching ``check_lean_hygiene.py``.
+    """
+    matcher = re.compile(r"\bsorry\b")
+    count = 0
+    for d in [ROOT / "Compiler", ROOT / "Verity"]:
+        if not d.exists():
+            continue
+        for lean in d.rglob("*.lean"):
+            text = strip_lean_comments(lean.read_text(encoding="utf-8"))
+            for line in text.splitlines():
+                if matcher.search(line):
+                    count += 1
+    return count
 
 
 def get_contract_count() -> int:
@@ -691,7 +705,7 @@ def main(argv: list[str] | None = None) -> None:
                 ),
                 (
                     "theorem count in links",
-                    re.compile(r"Verification.+ — (\d+) proven theorems"),
+                    re.compile(r"Verification.+ — (\d+) tracked theorems"),
                     str(total_theorems),
                 ),
                 (
@@ -742,7 +756,7 @@ def main(argv: list[str] | None = None) -> None:
         check_required_and_forbidden_substrings(
             compiler_mdx,
             required=[
-                "- **Machine-checked proofs**: 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)) — `keccak256_first_4_bytes` only, 0 sorry."
+                "- **Machine-checked proofs**: 1 documented axiom (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)) — `keccak256_first_4_bytes` only, 19 sorry (18 SemanticBridge + 1 Preservation)."
             ],
             forbidden=["address injectivity"],
         )
@@ -1043,7 +1057,7 @@ def main(argv: list[str] | None = None) -> None:
                 ),
                 (
                     "theorem count in header",
-                    re.compile(r"(\d+) theorems, all fully proven"),
+                    re.compile(r"(\d+) theorems, \d+ fully proven"),
                     str(total_theorems),
                 ),
                 (


### PR DESCRIPTION
## Summary

- **Root cause**: `check_doc_counts.py` used `re.match()` with a start-of-line regex (`^\s*(·\s*)?sorry\b`) that missed `by sorry` at end-of-line in SemanticBridge.lean, so `get_sorry_count()` returned 1 instead of 19
- **Fix**: rewrite `get_sorry_count()` to use `re.search()` with `\bsorry\b`, matching `check_lean_hygiene.py` which correctly found 19
- **Impact**: 12 files updated across docs, artifact, CI script, and docs-site

### What changed

| File | Change |
|------|--------|
| `scripts/check_doc_counts.py` | Fix sorry regex (match→search), update CI validation patterns |
| `artifacts/verification_status.json` | Regenerated: sorry 1→19, proven 424→406 |
| `README.md` | Fix sorry count, layer table key files, verification guarantees table |
| `docs/VERIFICATION_STATUS.md` | Full sorry breakdown, precise Layer 1 description |
| `TRUST_ASSUMPTIONS.md` | Make SemanticBridge sorry status explicit (18 theorems, all sorry) |
| `AXIOMS.md` | Replace false "zero sorry in bridge" with accurate status |
| `docs-site/public/llms.txt` | Fix Lean version 4.15.0→4.22.0, sorry count, diff test count 70k→90k, remove false "No sorry" claim |
| `docs-site/content/verification.mdx` | "0 sorry" → "19 sorry placeholders" with breakdown |
| `docs-site/content/research.mdx` | "all fully proven, 0 sorry" → "406 fully proven, 19 sorry" |
| `docs-site/content/compiler.mdx` | "0 sorry" → "19 sorry", "425 proven theorems" → "425 tracked theorems (406 proven, 19 sorry)" |
| `docs-site/content/index.mdx` | "This project has 0 sorry" → accurate count with explanation |
| `docs-site/content/guides/first-contract.mdx` | "zero sorry" → accurate SemanticBridge status |

### Local CI verification

```
✓ check_doc_counts.py         — 425 theorems, 19 sorry, 250/425 covered
✓ check_lean_hygiene.py       — 19 sorry (expected 19)
✓ generate_verification_status.py --check  — artifact up to date
✓ check_verify_artifact_sync.py
✓ check_contract_structure.py
✓ check_axiom_locations.py
✓ check_mapping_slot_boundary.py
✓ check_solc_pin.py
✓ check_interop_matrix_sync.py
✓ check_verify_sync.py
✓ check_proof_length.py
✓ check_issue_1060_integrity.py
✓ check_property_coverage.py
✓ check_property_manifest.py
```

## Test plan

- [ ] CI passes (all check scripts, `lake build`, Foundry tests)
- [ ] Verify `python3 scripts/check_doc_counts.py` passes
- [ ] Verify `python3 scripts/check_lean_hygiene.py` passes
- [ ] Verify `python3 scripts/generate_verification_status.py --check` passes
- [ ] Spot-check docs-site renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates are limited to documentation/metrics and a CI counting script; no compiler/runtime logic changes, but incorrect counts could still cause CI/doc drift if the new `sorry` matcher is overly broad.
> 
> **Overview**
> Updates the project’s published verification metrics to reflect the current Lean proof state: `sorry` placeholders are now reported as 19 (18 in `SemanticBridge` + 1 in Yul `Preservation`), and derived stats like proven theorem count are refreshed in `README`, trust docs, and docs-site pages.
> 
> Fixes `scripts/check_doc_counts.py` to count `sorry` tokens more reliably (detecting `by sorry` mid-line) and adjusts related doc validation patterns, then regenerates `artifacts/verification_status.json` to match the corrected metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4b2f87df94d77c5230b9d75644c1002c9ceb22d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->