### PR TITLE
fix: add missing --output compiler/yul to CI Yul generation step

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -400,6 +400,7 @@ jobs:
       - name: Generate Yul (all contracts + CryptoHash with linked libraries)
         run: |
           ./.lake/build/bin/verity-compiler \
+            --output compiler/yul \
             --link examples/external-libs/PoseidonT3.yul \
             --link examples/external-libs/PoseidonT4.yul
 


### PR DESCRIPTION
## Summary
- The `build-compiler` job's "Generate Yul" step invokes `verity-compiler` without `--output`, so it writes to the default `artifacts/yul`
- But **all** subsequent steps reference `compiler/yul`: `check_yul_compiles.py`, `check_gas_model_coverage.py`, `check_selectors.py`, artifact uploads, `DIFFTEST_YUL_DIR`, and Foundry tests
- The patched Yul step already had `--output compiler/yul-patched` — this was missing only for the baseline

This is a latent bug: `build-compiler` takes ~2h and often gets cancelled by newer pushes before reaching the post-compilation validation steps. When it does run to completion, `check_yul_compiles.py --dir compiler/yul` would fail because the directory doesn't exist.

## Fix
Add `--output compiler/yul` to the Generate Yul step, matching the directory all downstream steps expect.

## Test plan
- [x] `check_verify_sync.py` passes all 6 invariant groups (no spec change needed)
- [ ] CI `checks` job passes
- [ ] CI `build-compiler` job completes successfully (validates the fix end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just aligns the baseline Yul generation output directory with what downstream validation and artifact steps already consume; main risk is unexpected reliance on the previous default output path.
> 
> **Overview**
> Fixes the `build-compiler` job’s baseline “Generate Yul” step to pass `--output compiler/yul`, matching the directory used by downstream Yul validation (`check_yul_compiles.py`, gas coverage, Foundry) and artifact uploads.
> 
> This brings the baseline generation step in line with the already-explicit patched-Yul output (`compiler/yul-patched`) and prevents failures from missing `compiler/yul` in CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fba3de46242453e3b64659fc8ecd1a0a27d7dc18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->