### PR TITLE
Enforce Layer-2 universality guard in checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Check SpecCorrectness migration boundary
         run: python3 scripts/check_spec_proof_migration_boundary.py
 
+      - name: Check Layer-2 sender/storage universality
+        run: python3 scripts/check_layer2_universality.py
+
       - name: Check Lean hygiene
         run: python3 scripts/check_lean_hygiene.py
 

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/check_storage_layout.py
 	python3 scripts/check_manual_spec_quarantine.py
 	python3 scripts/check_spec_proof_migration_boundary.py
+	python3 scripts/check_layer2_universality.py
 	python3 scripts/check_lean_hygiene.py
 	python3 scripts/check_gas_model_coverage.py
 	python3 scripts/check_mapping_slot_boundary.py

--- a/scripts/check_layer2_universality.py
+++ b/scripts/check_layer2_universality.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Enforce universal sender/storage quantification in Layer-2 bridge theorems.
+
+Guards against regressions from Issue #1103 where Layer-2 proofs were written for
+fixed test values (e.g., concrete sender or empty initial storage) instead of
+universally quantifying over inputs.
+
+Checks:
+1. Every `*_semantic_bridge` theorem in `Compiler/Proofs/SemanticBridge.lean`
+   quantifies both `(state : ContractState)` and `(sender : Address)`.
+2. Legacy fixed-value anti-patterns are absent from the Layer-2 bridge file.
+
+Usage:
+    python3 scripts/check_layer2_universality.py
+"""
+
+from __future__ import annotations
+
+import re
+
+from property_utils import ROOT, report_errors, strip_lean_comments
+
+TARGET = ROOT / "Compiler" / "Proofs" / "SemanticBridge.lean"
+
+THEOREM_RE = re.compile(
+    r"^\s*(?:@\[[^\]]*\]\s*)*(?:(?:private|protected|noncomputable|unsafe)\s+)*"
+    r"(?:theorem|lemma)\s+(?P<name>[A-Za-z_][A-Za-z0-9_']*)\b"
+)
+STATE_PARAM_RE = re.compile(r"\(\s*state\s*:\s*ContractState\s*\)")
+SENDER_PARAM_RE = re.compile(r"\(\s*sender\s*:\s*Address\s*\)")
+
+LEGACY_ANTI_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("SpecStorage.empty", "fixed empty initial storage"),
+    ("test_sender", "fixed concrete sender"),
+    ("let initialStorage :=", "local fixed-storage theorem pattern"),
+)
+
+
+def _collect_semantic_bridge_headers(lines: list[str]) -> list[tuple[str, int, str]]:
+    """Return `(name, start_line_1indexed, header_text)` for bridge theorems."""
+    out: list[tuple[str, int, str]] = []
+    i = 0
+    while i < len(lines):
+        match = THEOREM_RE.match(lines[i])
+        if match is None:
+            i += 1
+            continue
+
+        name = match.group("name")
+        if not name.endswith("_semantic_bridge"):
+            i += 1
+            continue
+
+        start = i
+        header_lines = [lines[i]]
+        i += 1
+        while i < len(lines):
+            header_lines.append(lines[i])
+            if re.search(r":\s*$", lines[i]):
+                break
+            i += 1
+
+        out.append((name, start + 1, "\n".join(header_lines)))
+        i += 1
+
+    return out
+
+
+def main() -> None:
+    errors: list[str] = []
+
+    text = strip_lean_comments(TARGET.read_text(encoding="utf-8"))
+    lines = text.splitlines()
+
+    theorem_headers = _collect_semantic_bridge_headers(lines)
+    if not theorem_headers:
+        errors.append(
+            f"{TARGET.relative_to(ROOT)}: no *_semantic_bridge theorem headers found"
+        )
+
+    for name, line_no, header in theorem_headers:
+        if STATE_PARAM_RE.search(header) is None:
+            errors.append(
+                f"{TARGET.relative_to(ROOT)}:{line_no}: {name} is missing "
+                "`(state : ContractState)` quantification"
+            )
+        if SENDER_PARAM_RE.search(header) is None:
+            errors.append(
+                f"{TARGET.relative_to(ROOT)}:{line_no}: {name} is missing "
+                "`(sender : Address)` quantification"
+            )
+
+    for needle, reason in LEGACY_ANTI_PATTERNS:
+        for idx, line in enumerate(lines, 1):
+            if needle in line:
+                errors.append(
+                    f"{TARGET.relative_to(ROOT)}:{idx}: found `{needle}` "
+                    f"(legacy non-universal pattern: {reason})"
+                )
+
+    report_errors(errors, "Layer-2 universality check failed")
+    print(
+        "Layer-2 universality check passed "
+        f"({len(theorem_headers)} semantic bridge theorem headers validated)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -33,6 +33,7 @@
     "check_storage_layout.py",
     "check_manual_spec_quarantine.py",
     "check_spec_proof_migration_boundary.py",
+    "check_layer2_universality.py",
     "check_lean_hygiene.py",
     "check_gas_model_coverage.py",
     "check_mapping_slot_boundary.py",


### PR DESCRIPTION
## Summary
- add a dedicated CI guard (`scripts/check_layer2_universality.py`) enforcing that every Layer-2 `*_semantic_bridge` theorem in `Compiler/Proofs/SemanticBridge.lean` quantifies both `(state : ContractState)` and `(sender : Address)`
- fail closed on known legacy non-universal proof patterns (`SpecStorage.empty`, `test_sender`, `let initialStorage :=`)
- wire the check into both local and CI check pipelines:
  - `Makefile` `check` target
  - `.github/workflows/verify.yml` checks job
  - `scripts/verify_sync_spec.json` expected checks list

## Why
Issue #1103 tracks a proof-architecture risk: proving correctness only for fixed sender/storage test values. The current codebase already uses universally-quantified Layer-2 bridge theorem signatures; this PR adds an explicit regression guard so the invariant is enforced continuously by CI.

## Validation
- `python3 scripts/check_layer2_universality.py`
- `make check`

Closes #1103

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI gate based on regex-parsing Lean sources; mis-parsing or future theorem signature changes could cause unexpected CI failures, but no runtime/proof logic is modified.
> 
> **Overview**
> Introduces `scripts/check_layer2_universality.py`, a new Python validator that scans `Compiler/Proofs/SemanticBridge.lean` to ensure every `*_semantic_bridge` theorem header includes universal parameters `(state : ContractState)` and `(sender : Address)`, and rejects legacy fixed-value patterns like `SpecStorage.empty` and `test_sender`.
> 
> Wires this guard into the standard verification pipelines by adding it to the GitHub `verify.yml` *checks* job, the `Makefile` `check` target, and `scripts/verify_sync_spec.json` so workflow-sync enforcement includes the new command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cacec28ea81c335333d10cabc47dc3e187e8d25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->