### PR TITLE
Layer 2: add generic compile-to-IR theorem spine

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -73,6 +73,35 @@ def encodeEvent (ev : Event) : List Nat :=
 def encodeEvents (events : List Event) : List (List Nat) :=
   events.map encodeEvent
 
+/-! ## Layer 2 Generic Theorem Spine -/
+
+/-- Generic Layer-2 bridge theorem: once a contract-specific postcondition is
+established for the compiled IR contract, the same postcondition is available
+through the `compile` entrypoint for all states and senders. This enforces the
+universal quantification shape at Layer 2 and avoids fixed test fixtures. -/
+theorem spec_to_ir_preserves_semantics
+    {α : Type}
+    (spec : CompilationModel.CompilationModel)
+    (selectors : List Nat)
+    (compiled : IRContract)
+    (runSpec : ContractState → Address → α)
+    (mkTx : Address → IRTransaction)
+    (mkIRState : ContractState → Address → IRState)
+    (post : α → IRResult → Prop)
+    (hcompile : CompilationModel.compile spec selectors = Except.ok compiled)
+    (hpost : ∀ (state : ContractState) (sender : Address),
+      post (runSpec state sender)
+        (interpretIR compiled (mkTx sender) (mkIRState state sender))) :
+    ∀ (state : ContractState) (sender : Address),
+      let compiledResult := CompilationModel.compile spec selectors
+      match compiledResult with
+      | Except.ok irContract =>
+          post (runSpec state sender)
+            (interpretIR irContract (mkTx sender) (mkIRState state sender))
+      | Except.error _ => False := by
+  intro state sender
+  simpa [hcompile] using hpost state sender
+
 /-! ## Target Theorems: SimpleStorage -/
 
 theorem simpleStorage_store_semantic_bridge

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -609,6 +609,7 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.abstractStoreStorageOrMapping_eq
 
 -- Compiler/Proofs/SemanticBridge.lean
+#print axioms Compiler.Proofs.SemanticBridge.spec_to_ir_preserves_semantics
 #print axioms Compiler.Proofs.SemanticBridge.simpleStorage_store_semantic_bridge
 #print axioms Compiler.Proofs.SemanticBridge.simpleStorage_retrieve_semantic_bridge
 #print axioms Compiler.Proofs.SemanticBridge.counter_increment_semantic_bridge
@@ -645,4 +646,4 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy
--- Total: 550 theorems/lemmas (529 public, 21 private)
+-- Total: 551 theorems/lemmas (530 public, 21 private)


### PR DESCRIPTION
## Summary
- add `spec_to_ir_preserves_semantics` in `Compiler/Proofs/SemanticBridge.lean`
- make Layer-2 quantification explicit over all `state` and `sender` while routing through `CompilationModel.compile`
- regenerate `PrintAxioms.lean` to keep verification artifacts in sync

## Why
Issue #1101 requests a generic Layer-2 theorem shape instead of ad-hoc per-contract theorem forms. This PR introduces that reusable theorem spine and enforces universal quantification through the compile entrypoint.

Closes #1101

## Validation
- `lake build Compiler.Proofs.SemanticBridge`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new reusable Lean theorem and updates generated axiom-print artifacts; no runtime/compiler logic changes, but may affect downstream proof/CI expectations that reference theorem lists.
> 
> **Overview**
> Introduces a **generic Layer-2 semantic bridge theorem** (`spec_to_ir_preserves_semantics`) that lifts any contract-specific IR postcondition proven for a known compiled contract to the same postcondition phrased through the `CompilationModel.compile` entrypoint, universally quantified over all `state`/`sender`.
> 
> Regenerates `PrintAxioms.lean` to include the new theorem in axiom reporting and updates the printed theorem count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea4a94c86d7854848fbc8d5e86bb463ff559cad3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->