### PR TITLE
refactor: deduplicate require-family tail bridge simpa pattern

### DIFF
--- a/Verity/Core/Free/TypedIRCompilerCorrectness.lean
+++ b/Verity/Core/Free/TypedIRCompilerCorrectness.lean
@@ -4362,6 +4362,12 @@ def execCompiledRequireFamilyClausesThenTail
 
 /-- Generic sequencing semantic-preservation theorem over the supported tail
 family after unified `require` guard-family clause lists. -/
+syntax "simpa_require_family_tail" " using " term : tactic
+
+macro_rules
+  | `(tactic| simpa_require_family_tail using $h) =>
+      `(tactic| simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail] using $h)
+
 theorem compile_require_family_clauses_then_tail_semantics
     (fields : List Field) (init : TExecState)
     (clauses : List RequireLiteralGuardFamilyClause)
@@ -4370,162 +4376,126 @@ theorem compile_require_family_clauses_then_tail_semantics
       execSourceRequireFamilyClausesThenTail fields init clauses tail := by
   cases tail with
   | noOp =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_noop_semantics fields init clauses
+      simpa_require_family_tail using compile_require_family_clauses_then_noop_semantics fields init clauses
   | setStorageLiteral fieldName slot writeVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_setStorage_literal_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_setStorage_literal_semantics
           fields fieldName slot init clauses writeVal hfind
   | iteEqSetStorageLiterals fieldName slot n m thenVal elseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_ite_eq_setStorage_literals_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_ite_eq_setStorage_literals_semantics
           fields fieldName slot init clauses n m thenVal elseVal hfind
   | iteEqSetStorageThenReturnLiteral fieldName slot n m thenVal elseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_ite_eq_setStorage_then_return_literal_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_ite_eq_setStorage_then_return_literal_semantics
           fields fieldName slot init clauses n m thenVal elseVal hfind
   | iteEqReturnThenSetStorageLiteral fieldName slot n m thenVal elseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_ite_eq_return_then_setStorage_literal_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_ite_eq_return_then_setStorage_literal_semantics
           fields fieldName slot init clauses n m thenVal elseVal hfind
   | iteEqReturnLiterals n m thenVal elseVal =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_ite_eq_return_literals_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_ite_eq_return_literals_semantics
           fields init clauses n m thenVal elseVal
   | iteEqThenIteEqReturnLiterals n m p q thenVal elseVal outerElseVal =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_ite_eq_then_ite_eq_return_literals_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_ite_eq_then_ite_eq_return_literals_semantics
           fields init clauses n m p q thenVal elseVal outerElseVal
   | iteEqThenIteEqSetStorageLiteralsThenReturnLiteral
       fieldName slot n m p q thenVal elseVal outerElseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using
+      simpa_require_family_tail using
           compile_require_family_clauses_then_ite_eq_then_ite_eq_setStorage_literals_then_return_literal_semantics
             fields fieldName slot init clauses n m p q thenVal elseVal outerElseVal hfind
   | iteEqThenIteEqReturnLiteralsThenSetStorageLiteral
       fieldName slot n m p q thenVal elseVal outerElseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using
+      simpa_require_family_tail using
           compile_require_family_clauses_then_ite_eq_then_ite_eq_return_literals_then_setStorage_literal_semantics
             fields fieldName slot init clauses n m p q thenVal elseVal outerElseVal hfind
   | iteEqThenIteEqReturnLiteralsThenSetStorageLiteralThenReturnLiteral
       fieldName slot n m p q thenVal elseVal outerElseWriteVal outerElseRetVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using
+      simpa_require_family_tail using
           compile_require_family_clauses_then_ite_eq_then_ite_eq_return_literals_then_setStorage_literal_then_return_literal_semantics
             fields fieldName slot init clauses n m p q thenVal elseVal outerElseWriteVal outerElseRetVal hfind
   | iteEqThenIteEqSetStorageLiteralsThenSetStorageLiteral
       fieldName slot n m p q thenVal elseVal outerElseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using
+      simpa_require_family_tail using
           compile_require_family_clauses_then_ite_eq_then_ite_eq_setStorage_literals_then_setStorage_literal_semantics
             fields fieldName slot init clauses n m p q thenVal elseVal outerElseVal hfind
   | iteEqThenIteEqSetStorageThenReturnLiteralThenReturnLiteral
       fieldName slot n m p q thenVal elseVal outerElseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using
+      simpa_require_family_tail using
           compile_require_family_clauses_then_ite_eq_then_ite_eq_setStorage_then_return_literal_then_return_literal_semantics
             fields fieldName slot init clauses n m p q thenVal elseVal outerElseVal hfind
   | iteEqThenIteEqSetStorageThenReturnLiteralThenSetStorageLiteral
       fieldName slot n m p q thenVal elseVal outerElseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using
+      simpa_require_family_tail using
           compile_require_family_clauses_then_ite_eq_then_ite_eq_setStorage_then_return_literal_then_setStorage_literal_semantics
             fields fieldName slot init clauses n m p q thenVal elseVal outerElseVal hfind
   | iteEqThenIteEqReturnThenSetStorageLiteralThenReturnLiteral
       fieldName slot n m p q thenVal elseVal outerElseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using
+      simpa_require_family_tail using
           compile_require_family_clauses_then_ite_eq_then_ite_eq_return_then_setStorage_literal_then_return_literal_semantics
             fields fieldName slot init clauses n m p q thenVal elseVal outerElseVal hfind
   | iteEqThenIteEqReturnThenSetStorageLiteralThenSetStorageLiteral
       fieldName slot n m p q thenVal elseVal outerElseVal hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using
+      simpa_require_family_tail using
           compile_require_family_clauses_then_ite_eq_then_ite_eq_return_then_setStorage_literal_then_setStorage_literal_semantics
             fields fieldName slot init clauses n m p q thenVal elseVal outerElseVal hfind
   | returnLiteral retVal =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_return_literal_semantics fields init clauses retVal
+      simpa_require_family_tail using compile_require_family_clauses_then_return_literal_semantics fields init clauses retVal
   | letReturnLocalLiteral tmp retVal =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_return_local_literal_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_return_local_literal_semantics
           fields tmp init clauses retVal
   | letSetStorageLocalLiteral fieldName tmp slot n hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_setStorage_local_literal_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_setStorage_local_literal_semantics
           fields fieldName tmp slot init clauses n hfind
   | letAssignSetStorageLocalLiteral fieldName tmp slot n m hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_assign_setStorage_local_literal_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_assign_setStorage_local_literal_semantics
           fields fieldName tmp slot init clauses n m hfind
   | letAssignAddSetStorageLocalLiteral fieldName tmp slot n m hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_assign_add_setStorage_local_literal_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_assign_add_setStorage_local_literal_semantics
           fields fieldName tmp slot init clauses n m hfind
   | letAssignSubSetStorageLocalLiteral fieldName tmp slot n m hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_assign_sub_setStorage_local_literal_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_assign_sub_setStorage_local_literal_semantics
           fields fieldName tmp slot init clauses n m hfind
   | letAssignMulSetStorageLocalLiteral fieldName tmp slot n m hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_assign_mul_setStorage_local_literal_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_assign_mul_setStorage_local_literal_semantics
           fields fieldName tmp slot init clauses n m hfind
   | letStorageSetStorageAddLocalStop fieldName tmp slot m hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_storage_setStorage_add_local_stop_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_storage_setStorage_add_local_stop_semantics
           fields fieldName tmp slot init clauses m hfind
   | letStorageSetStorageSubLocalStop fieldName tmp slot m hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_storage_setStorage_sub_local_stop_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_storage_setStorage_sub_local_stop_semantics
           fields fieldName tmp slot init clauses m hfind
   | letStorageReturnLocal fieldName tmp slot hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_storage_return_local_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_storage_return_local_semantics
           fields fieldName tmp slot init clauses hfind
   | returnStorage fieldName slot hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_return_storage_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_return_storage_semantics
           fields fieldName slot init clauses hfind
   | returnStorageAddr fieldName slot hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_return_storage_addr_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_return_storage_addr_semantics
           fields fieldName slot init clauses hfind
   | requireCallerEqStorageAddrSetStorageAddStop ownerField countField msg ownerSlot countSlot n hOwner hCount =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_require_caller_eq_storage_addr_setStorage_add_stop_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_require_caller_eq_storage_addr_setStorage_add_stop_semantics
           fields ownerField countField ownerSlot countSlot init clauses n msg hOwner hCount
   | requireCallerEqStorageAddrSetStorageSubStop ownerField countField msg ownerSlot countSlot n hOwner hCount =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_require_caller_eq_storage_addr_setStorage_sub_stop_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_require_caller_eq_storage_addr_setStorage_sub_stop_semantics
           fields ownerField countField ownerSlot countSlot init clauses n msg hOwner hCount
   | returnMappingCaller fieldName slot hSlot =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_return_mapping_caller_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_return_mapping_caller_semantics
           fields fieldName slot init clauses hSlot
   | letStorageAddrReturnLocal fieldName tmp slot hfind =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_storage_addr_return_local_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_storage_addr_return_local_semantics
           fields fieldName tmp slot init clauses hfind
   | letMappingParamReturnLocal fieldName paramName tmp slot hSlot =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_mapping_param_return_local_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_mapping_param_return_local_semantics
           fields fieldName paramName tmp slot init clauses hSlot
   | letMapping2ParamsReturnLocal fieldName p1 p2 tmp slot hSlot hp =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_mapping2_params_return_local_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_mapping2_params_return_local_semantics
           fields fieldName p1 p2 tmp slot init clauses hSlot hp
   | letCallerSetMapping2Stop fieldName senderVar p1 p2 slot hSlot h1 h2 h3 h4 h5 h6 =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_caller_setMapping2_stop_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_caller_setMapping2_stop_semantics
           fields fieldName senderVar p1 p2 slot init clauses hSlot h1 h2 h3 h4 h5 h6
   | letMappingUintParamReturnLocal fieldName paramName tmp slot hSlot =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_let_mappingUint_param_return_local_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_let_mappingUint_param_return_local_semantics
           fields fieldName paramName tmp slot init clauses hSlot
   | setMappingUintParamsStop fieldName p1 p2 slot hSlot hp =>
-      simpa [execCompiledRequireFamilyClausesThenTail, execSourceRequireFamilyClausesThenTail]
-        using compile_require_family_clauses_then_setMappingUint_params_stop_semantics
+      simpa_require_family_tail using compile_require_family_clauses_then_setMappingUint_params_stop_semantics
           fields fieldName p1 p2 slot init clauses hSlot hp
   -- Morpho admin tails
   | letCallerLetStorageAddrReqEqReqNeqSetStorageAddrParamStop


### PR DESCRIPTION
## Summary
This refactor removes repeated unfold boilerplate in  by introducing a local tactic macro:
- 

It encapsulates the repeated pattern:
- 

and replaces all repetitive constructor branches in that theorem.

This is a focused proof-refactor for #1090 (abstraction/boilerplate reduction in ).

## Validation
- Build completed successfully.
- Running CI-equivalent checks job...
python3 scripts/check_property_manifest.py
Property manifest check passed.
python3 scripts/check_property_coverage.py
Property coverage check passed.
python3 scripts/check_contract_structure.py
Checking 9 contracts for complete file structure...
  (Excluding: CryptoHash, MacroContracts, ReentrancyExample)

  OK Counter
  OK ERC20
  OK ERC721
  OK Ledger
  OK Owned
  OK OwnedCounter
  OK SafeCounter
  OK SimpleStorage
  OK SimpleToken

OK: All 9 contracts have complete file structure
python3 scripts/check_case_insensitive_path_conflicts.py
python3 scripts/check_axiom_locations.py
  OK keccak256_first_4_bytes at Compiler/Selectors.lean:41

OK: All 1 axiom locations in AXIOMS.md are accurate
python3 scripts/generate_verification_status.py --check
Verification artifact is up to date: /workspaces/mission-1bbccca0/temp/verity/artifacts/verification_status.json
python3 scripts/check_doc_counts.py
Documentation count check passed (425 theorems, 11 categories, 1 axioms, 475 tests, 38 suites, 19 sorry, 250/425 covered, 175 exclusions).
python3 scripts/check_interop_matrix_sync.py
Interop matrix is synchronized across docs (6 feature rows checked).
python3 scripts/check_verify_sync.py
[PASS] paths
[PASS] jobs
[PASS] python-commands
[PASS] multiseed
[PASS] foundry
[PASS] artifacts
[PASS] makefile
verify sync passed: 7 invariant groups
python3 scripts/check_solc_pin.py
✓ solc pin is consistent (0.8.33+commit.64118f21)
python3 scripts/check_property_manifest_sync.py
Property manifest sync check passed.
python3 scripts/check_macro_property_test_generation.py --check
macro property-test artifacts are up to date: artifacts/macro_property_tests
python3 scripts/check_storage_layout.py
Storage layout validation passed.

============================================================
STORAGE LAYOUT REPORT
============================================================

  Counter
    Slot 0: count (Uint256)

  CryptoHash
    Slot 0: lastHash (Uint256)

  ERC20
    Slot 0: owner (Address)
    Slot 1: totalSupply (Uint256)
    Slot 2: balances ((Address → Uint256))
    Slot 3: allowances ((Address → Address → Uint256))

  ERC721
    Slot 0: owner (Address)
    Slot 1: totalSupply (Uint256)
    Slot 2: nextTokenId (Uint256)
    Slot 3: balances ((Address → Uint256))
    Slot 4: owners ((Uint256 → Uint256))
    Slot 5: tokenApprovals ((Uint256 → Uint256))
    Slot 6: operatorApprovals ((Address → Address → Uint256))

  Ledger
    Slot 0: balances ((Address → Uint256))

  Owned
    Slot 0: owner (Address)

  OwnedCounter
    Slot 0: owner (Address)
    Slot 1: count (Uint256)

  ReentrancyExample
    Slot 0: reentrancyLock (Uint256)
    Slot 1: totalSupply (Uint256)
    Slot 2: balances ((Address → Uint256))

  SafeCounter
    Slot 0: count (Uint256)

  SimpleStorage
    Slot 0: storedData (Uint256)

  SimpleToken
    Slot 0: owner (Address)
    Slot 1: balances ((Address → Uint256))
    Slot 2: totalSupply (Uint256)
python3 scripts/check_manual_spec_quarantine.py
Manual-spec quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
python3 scripts/check_spec_proof_migration_boundary.py
Spec-proof migration boundary check passed (18 allowlisted files; no out-of-bound legacy references).
python3 scripts/check_layer2_universality.py
Layer-2 universality check passed (15 semantic bridge theorem headers validated).
python3 scripts/check_lean_hygiene.py
Lean hygiene check passed (0 debug commands in proofs, 1 allowUnsafeReducibility, 19 sorry (expected 19), 0 native_decide in proofs).
python3 scripts/check_gas_model_coverage.py
OK: static gas model covers all emitted Yul calls (26 names) across: artifacts/yul
python3 scripts/check_mapping_slot_boundary.py
✓ Mapping slot boundary is enforced
python3 scripts/check_yul_builtin_boundary.py
✓ Yul builtin boundary is enforced
python3 scripts/check_builtin_list_sync.py
✓ Builtin lists in sync (85 Linker, 78+4 CompilationModel)
python3 scripts/check_evmyullean_capability_boundary.py
✓ EVMYulLean capability boundary is enforced
python3 scripts/generate_evmyullean_capability_report.py --check
EVMYulLean capability report is up to date: /workspaces/mission-1bbccca0/temp/verity/artifacts/evmyullean_capability_report.json
EVMYulLean unsupported-node report is up to date: /workspaces/mission-1bbccca0/temp/verity/artifacts/evmyullean_unsupported_nodes.json
python3 scripts/generate_evmyullean_adapter_report.py --check
EVMYulLean adapter report is up to date: /workspaces/mission-1bbccca0/temp/verity/artifacts/evmyullean_adapter_report.json
python3 scripts/generate_print_axioms.py --check
OK: /workspaces/mission-1bbccca0/temp/verity/PrintAxioms.lean is up to date.
python3 scripts/check_proof_length.py
Proof length check: 894 proofs scanned.
  838 under 30 lines (good)
  42 between 30-50 lines (acceptable)
  14 over 50 lines (allowlisted)

Proof length check passed. No new proofs exceed the 50-line hard limit.
python3 scripts/check_issue_1060_integrity.py
issue #1060 integrity check passed
python3 -m unittest discover -s scripts -p 'test_*.py' -v
✓ Builtin lists in sync (3 Linker, 1+1 CompilationModel)
Documentation count check passed (425 theorems, 11 categories, 1 axioms, 475 tests, 38 suites, 19 sorry, 250/425 covered, 175 exclusions).
Interop matrix is synchronized across docs (1 feature rows checked).
issue #1060 integrity check passed
wrote macro property-test artifacts (1 file(s)): tmpzrybuoip/artifacts
wrote macro property-test artifacts (1 file(s)): tmpbz25u5im/artifacts
macro property-test artifacts are up to date: tmpbz25u5im/artifacts
Manual-spec quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Manual-spec quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Spec-proof migration boundary check passed (1 allowlisted files; no out-of-bound legacy references).
Spec-proof migration boundary check passed (0 allowlisted files; no out-of-bound legacy references).
✓ Yul builtin boundary is enforced
Wrote Lean warning baseline to /tmp/tmptmnll9fk/baseline.json
All checks passed.

## Notes
- No semantic changes; this is proof-script deduplication only.
- Morpho admin-tail branches that require additional simp lemmas remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-script-only refactor introducing a small tactic macro to reduce repeated `simpa`/unfold patterns; semantics and executable code are unchanged. Risk is limited to potential proof fragility if the macro’s simp set needs future adjustment.
> 
> **Overview**
> Refactors `compile_require_family_clauses_then_tail_semantics` in `TypedIRCompilerCorrectness.lean` by introducing a local tactic macro, `simpa_require_family_tail`, that encapsulates the repeated `simpa` unfolding of `execCompiledRequireFamilyClausesThenTail`/`execSourceRequireFamilyClausesThenTail`.
> 
> All non-*Morpho admin tail* constructor branches are rewritten to use this macro, reducing boilerplate while keeping the underlying semantic-preservation lemmas and proof structure the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b734795d52e3cf8f51c2ef2f5a2c7885d4c1746. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->