### PR TITLE
refactor(specs): alias SimpleStorage manual spec to macro canonical

### DIFF
--- a/Compiler/Specs.lean
+++ b/Compiler/Specs.lean
@@ -52,30 +52,8 @@ def requireOwner : Stmt :=
 ## SimpleStorage Specification
 -/
 
-def simpleStorageSpec : CompilationModel := {
-  name := "SimpleStorage"
-  fields := [
-    { name := "storedData", ty := FieldType.uint256 }
-  ]
-  «constructor» := none  -- No initialization needed
-  functions := [
-    { name := "store"
-      params := [{ name := "value", ty := ParamType.uint256 }]
-      returnType := none
-      body := [
-        Stmt.setStorage "storedData" (Expr.param "value"),
-        Stmt.stop
-      ]
-    },
-    { name := "retrieve"
-      params := []
-      returnType := some FieldType.uint256
-      body := [
-        Stmt.return (Expr.storage "storedData")
-      ]
-    }
-  ]
-}
+/-- Legacy compatibility alias. Canonical source is macro-generated. -/
+def simpleStorageSpec : CompilationModel := Verity.Examples.MacroContracts.SimpleStorage.spec
 
 
 /-!


### PR DESCRIPTION
## Summary
- replace the hand-written `Compiler.Specs.simpleStorageSpec` body with a compatibility alias to `Verity.Examples.MacroContracts.SimpleStorage.spec`
- keep the existing `simpleStorageSpec` symbol intact so downstream tests/proofs/imports do not need churn
- mark the alias as legacy compatibility and establish macro-generated spec as canonical source of truth

## Why
This is an incremental migration step for #999 (manual spec quarantine). It removes one duplicated manual spec definition without changing public call sites.

## Validation
- `lake build Compiler.Specs Compiler.CompilationModelFeatureTest`
- `make check`

Refs #999

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily removes duplicated spec code while keeping the `simpleStorageSpec` symbol stable. Main risk is behavioral drift if the macro-generated spec differs from the removed manual definition.
> 
> **Overview**
> Switches `Compiler.Specs.simpleStorageSpec` from a hand-written `CompilationModel` definition to a **legacy compatibility alias** of the macro-generated `Verity.Examples.MacroContracts.SimpleStorage.spec`, keeping downstream imports/tests unchanged while making the macro output the canonical source of truth.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0bede30435344084c3e66768c555bfbba73bc00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->