### PR TITLE
Quarantine legacy manual artifacts in canonical compiler paths

### DIFF
--- a/scripts/check_manual_spec_quarantine.py
+++ b/scripts/check_manual_spec_quarantine.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Fail closed if canonical compiler paths reference quarantined manual specs.
+"""Fail closed if canonical compiler paths reference quarantined manual artifacts.
 
-Issue #999 keeps legacy/manual specs available for compatibility and proof migration,
-but canonical compile/lowering/gas/CLI paths must not depend on manual `*Spec`
-artifacts (except explicit compatibility allowlist entries).
+Issue #999 keeps legacy/manual artifacts available for compatibility and proof
+migration, but canonical compile/lowering/gas/CLI paths must not depend on
+manual `*Spec` artifacts or legacy hand-written `Verity.Examples.*` contracts
+(except explicit compatibility allowlist entries).
 """
 
 from __future__ import annotations
@@ -31,6 +32,23 @@ QUALIFIED_SPEC_RE = re.compile(
     r"\b(?P<qual>(?:Compiler\.)?Specs\.(?P<name>[A-Za-z_][A-Za-z0-9_']*Spec))\b"
 )
 
+LEGACY_EXAMPLE_MODULES = {
+    "Counter",
+    "SimpleStorage",
+    "SafeCounter",
+    "Owned",
+    "OwnedCounter",
+    "Ledger",
+    "SimpleToken",
+}
+
+LEGACY_IMPORT_RE = re.compile(
+    r"\bimport\s+Verity\.Examples\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)\b"
+)
+LEGACY_QUALIFIED_RE = re.compile(
+    r"\bVerity\.Examples\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)\."
+)
+
 
 def find_disallowed_references(content: str) -> list[str]:
     disallowed: list[str] = []
@@ -39,6 +57,14 @@ def find_disallowed_references(content: str) -> list[str]:
         if qualified in ALLOWED_QUALIFIED_SPEC_REFERENCES:
             continue
         disallowed.append(qualified)
+    for match in LEGACY_IMPORT_RE.finditer(content):
+        name = match.group("name")
+        if name in LEGACY_EXAMPLE_MODULES:
+            disallowed.append(f"import Verity.Examples.{name}")
+    for match in LEGACY_QUALIFIED_RE.finditer(content):
+        name = match.group("name")
+        if name in LEGACY_EXAMPLE_MODULES:
+            disallowed.append(f"Verity.Examples.{name}.*")
     return disallowed
 
 
@@ -61,14 +87,15 @@ def main() -> int:
         for err in errors:
             print(f"- {err}", file=sys.stderr)
         print(
-            "\nCanonical compiler paths must not reference manual Compiler.Specs.*Spec symbols. "
-            "Route canonical flows through generated EDSL contracts and Specs.allSpecs.",
+            "\nCanonical compiler paths must not reference manual Compiler.Specs.*Spec symbols "
+            "or legacy Verity.Examples contract modules. Route canonical flows through generated "
+            "EDSL contracts and Specs.allSpecs.",
             file=sys.stderr,
         )
         return 1
 
     print(
-        "Manual-spec quarantine check passed "
+        "Manual-artifact quarantine check passed "
         f"({len(CANONICAL_FILES)} canonical files; only allowlisted compatibility specs used)."
     )
     return 0

--- a/scripts/test_check_manual_spec_quarantine.py
+++ b/scripts/test_check_manual_spec_quarantine.py
@@ -68,6 +68,32 @@ class ManualSpecQuarantineTests(unittest.TestCase):
         )
         self.assertEqual(rc, 0, stderr)
 
+    def test_fails_on_legacy_example_import(self) -> None:
+        rc, stderr = self._run_check(
+            {
+                "Compiler/Main.lean": "import Verity.Examples.Counter\n",
+            }
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("import Verity.Examples.Counter", stderr)
+
+    def test_fails_on_legacy_example_qualified_reference(self) -> None:
+        rc, stderr = self._run_check(
+            {
+                "Compiler/Main.lean": "def bad := Verity.Examples.Owned.transferOwnership\n",
+            }
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("Verity.Examples.Owned.*", stderr)
+
+    def test_allows_macro_example_import(self) -> None:
+        rc, stderr = self._run_check(
+            {
+                "Compiler/Main.lean": "import Verity.Examples.MacroContracts\n",
+            }
+        )
+        self.assertEqual(rc, 0, stderr)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `check_manual_spec_quarantine.py` to also detect legacy `Verity.Examples.<Contract>` imports/references in canonical compiler files
- keep existing compatibility allowlist for `cryptoHashSpec` untouched
- update diagnostics to reflect manual-artifact quarantine scope
- add unit tests covering legacy imports, qualified references, and macro import allow-case

## Why
Issue #999 tracks quarantining manual artifacts to prevent drift from the generated path. This hardens the existing guard so canonical compiler entry points cannot regress back to legacy hand-written example modules while migration continues.

## Validation
- `python3 -m unittest -v scripts/test_check_manual_spec_quarantine.py`
- `python3 scripts/check_manual_spec_quarantine.py`
- `make check`

Closes #999

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a Python guard script and its unit tests, tightening static reference detection and error messaging without impacting compiler runtime behavior.
> 
> **Overview**
> Tightens the canonical-path quarantine gate by expanding `scripts/check_manual_spec_quarantine.py` to also flag imports and qualified references to a set of legacy hand-written `Verity.Examples.*` contract modules (while keeping the existing `*Spec` allowlist).
> 
> Updates user-facing diagnostics to reflect the broader *manual-artifact* scope, and adds unit tests covering legacy imports, qualified references, and an allow-case for `Verity.Examples.MacroContracts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19fcb51f04fae6d1e7d27e0198ffd38386f55976. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->