### PR TITLE
Fix semantic-bridge IR fixture to preserve prior event log

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -94,6 +94,7 @@ def mkIRState
   returnValue := none
   sender := sender.val
   selector := selector
+  events := encodeEvents state.events
 }
 
 /-! ## Layer 2 Generic Theorem Spine -/


### PR DESCRIPTION
## Summary
- fix `mkIRState` to carry forward encoded pre-state events (`events := encodeEvents state.events`)
- this aligns IR initial state with semantic-bridge theorem obligations that compare `encodeEvents s'.events` against `irResult.events`

## Diagnosis for long elaboration
- the previous `simpleStorage_retrieve_semantic_bridge` attempt used theorem-level `set_option maxHeartbeats 1000000000` with broad unfolding/simplification
- this caused very long elaboration behavior (appearing stalled) on `lake build Compiler.Proofs.SemanticBridge`
- reproducing without the override yields deterministic timeout (`maxHeartbeats 200000`) at `whnf`, confirming the issue is proof-search explosion rather than a compiler deadlock

## Validation
- `lake build Compiler.Proofs.SemanticBridge`
- `make check`

Both pass on this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-field change to the semantic-bridge IR state fixture; main risk is shifting expectations in proofs/tests that previously assumed an empty initial event log.
> 
> **Overview**
> Updates `Compiler/Proofs/SemanticBridge.lean` so `mkIRState` initializes the IR `events` field from the EDSL pre-state (`encodeEvents state.events`) instead of implicitly dropping the prior event log.
> 
> This aligns semantic-bridge statements that compare post-state event logs against IR execution results, ensuring IR interpretation starts from the same append-only event history as the EDSL state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35dad944b0ed0c6fed488339f824789517fcd2d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->