### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,4 +27,57 @@ Compiler/Interpreter.lean @Th0rgal
 
 # CI pipeline — governs what gets checked
 .github/workflows/ @Th0rgal
-scripts/ @Th0rgal
+scripts/ @Th0rgalimport torch
+import torch.nn as nn
+import torch.optim as optim
+
+# XOR dataset
+X = torch.tensor([[0.,0.],
+                  [0.,1.],
+                  [1.,0.],
+                  [1.,1.]])
+
+y = torch.tensor([[0.],
+                  [1.],
+                  [1.],
+                  [0.]])
+
+# Deep Neural Network
+class DeepXORNet(nn.Module):
+    def __init__(self):
+        super(DeepXORNet, self).__init__()
+        self.model = nn.Sequential(
+            nn.Linear(2, 8),
+            nn.ReLU(),
+            nn.Linear(8, 8),
+            nn.ReLU(),
+            nn.Linear(8, 4),
+            nn.ReLU(),
+            nn.Linear(4, 1),
+            nn.Sigmoid()
+        )
+
+    def forward(self, x):
+        return self.model(x)
+
+# Initialize model
+model = DeepXORNet()
+
+# Loss and optimizer
+criterion = nn.BCELoss()
+optimizer = optim.Adam(model.parameters(), lr=0.01)
+
+# Training
+epochs = 5000
+for epoch in range(epochs):
+    optimizer.zero_grad()
+    outputs = model(X)
+    loss = criterion(outputs, y)
+    loss.backward()
+    optimizer.step()
+
+# Test
+with torch.no_grad():
+    predictions = model(X)
+    print("Final Output:")
+    print(torch.round(predictions))


### PR DESCRIPTION
import torch
import torch.nn as nn
import torch.optim as optim

# XOR dataset
X = torch.tensor([[0.,0.],
                  [0.,1.],
                  [1.,0.],
                  [1.,1.]])

y = torch.tensor([[0.],
                  [1.],
                  [1.],
                  [0.]])

# Deep Neural Network
class DeepXORNet(nn.Module):
    def __init__(self):
        super(DeepXORNet, self).__init__()
        self.model = nn.Sequential(
            nn.Linear(2, 8),
            nn.ReLU(),
            nn.Linear(8, 8),
            nn.ReLU(),
            nn.Linear(8, 4),
            nn.ReLU(),
            nn.Linear(4, 1),
            nn.Sigmoid()
        )

    def forward(self, x):
        return self.model(x)

# Initialize model
model = DeepXORNet()

# Loss and optimizer
criterion = nn.BCELoss()
optimizer = optim.Adam(model.parameters(), lr=0.01)

# Training
epochs = 5000
for epoch in range(epochs):
    optimizer.zero_grad()
    outputs = model(X)
    loss = criterion(outputs, y)
    loss.backward()
    optimizer.step()

# Test
with torch.no_grad():
    predictions = model(X)
    print("Final Output:")
    print(torch.round(predictions))2026-03-04T16:26:36.0017766Z Current runner version: '2.331.0'
2026-03-04T16:26:36.0043219Z ##[group]Runner Image Provisioner
2026-03-04T16:26:36.0044172Z Hosted Compute Agent
2026-03-04T16:26:36.0044759Z Version: 20260213.493
2026-03-04T16:26:36.0045355Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
2026-03-04T16:26:36.0046146Z Build Date: 2026-02-13T00:28:41Z
2026-03-04T16:26:36.0046813Z Worker ID: {3eb89991-4aff-4776-ab59-ea62d4e29930}
2026-03-04T16:26:36.0047681Z Azure Region: northcentralus
2026-03-04T16:26:36.0048472Z ##[endgroup]
2026-03-04T16:26:36.0049944Z ##[group]Operating System
2026-03-04T16:26:36.0050526Z Ubuntu
2026-03-04T16:26:36.0051138Z 24.04.3
2026-03-04T16:26:36.0051592Z LTS
2026-03-04T16:26:36.0052282Z ##[endgroup]
2026-03-04T16:26:36.0052877Z ##[group]Runner Image
2026-03-04T16:26:36.0053470Z Image: ubuntu-24.04
2026-03-04T16:26:36.0053959Z Version: 20260224.36.1
2026-03-04T16:26:36.0055249Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260224.36/images/ubuntu/Ubuntu2404-Readme.md
2026-03-04T16:26:36.0056677Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260224.36
2026-03-04T16:26:36.0057675Z ##[endgroup]
2026-03-04T16:26:36.0058695Z ##[group]GITHUB_TOKEN Permissions
2026-03-04T16:26:36.0060636Z Contents: read
2026-03-04T16:26:36.0061197Z Metadata: read
2026-03-04T16:26:36.0061758Z ##[endgroup]
2026-03-04T16:26:36.0064132Z Secret source: Actions
2026-03-04T16:26:36.0065031Z Prepare workflow directory
2026-03-04T16:26:36.0475227Z Prepare all required actions
2026-03-04T16:26:36.0513167Z Getting action download info
2026-03-04T16:26:36.4434329Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
2026-03-04T16:26:36.5817134Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
2026-03-04T16:26:36.6963399Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)
2026-03-04T16:26:36.9178646Z Complete job name: build
2026-03-04T16:26:37.0044298Z ##[group]Run actions/checkout@v4
2026-03-04T16:26:37.0045199Z with:
2026-03-04T16:26:37.0045634Z   repository: Th0rgal/verity
2026-03-04T16:26:37.0046308Z   token: ***
2026-03-04T16:26:37.0046710Z   ssh-strict: true
2026-03-04T16:26:37.0047120Z   ssh-user: git
2026-03-04T16:26:37.0047533Z   persist-credentials: true
2026-03-04T16:26:37.0047997Z   clean: true
2026-03-04T16:26:37.0048406Z   sparse-checkout-cone-mode: true
2026-03-04T16:26:37.0048910Z   fetch-depth: 1
2026-03-04T16:26:37.0049331Z   fetch-tags: false
2026-03-04T16:26:37.0049773Z   show-progress: true
2026-03-04T16:26:37.0050208Z   lfs: false
2026-03-04T16:26:37.0050596Z   submodules: false
2026-03-04T16:26:37.0051017Z   set-safe-directory: true
2026-03-04T16:26:37.0051724Z env:
2026-03-04T16:26:37.0052285Z   SOLC_VERSION: 0.8.33
2026-03-04T16:26:37.0053111Z   SOLC_URL: https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21
2026-03-04T16:26:37.0054260Z   SOLC_SHA256: 1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468
2026-03-04T16:26:37.0055015Z ##[endgroup]
2026-03-04T16:26:37.1296613Z Syncing repository: Th0rgal/verity
2026-03-04T16:26:37.1298415Z ##[group]Getting Git version info
2026-03-04T16:26:37.1299457Z Working directory is '/home/runner/work/verity/verity'
2026-03-04T16:26:37.1301318Z [command]/usr/bin/git version
2026-03-04T16:26:37.1395914Z git version 2.53.0
2026-03-04T16:26:37.1425691Z ##[endgroup]
2026-03-04T16:26:37.1443335Z Temporarily overriding HOME='/home/runner/work/_temp/67bf6648-5cff-4e6d-9a24-240ca710f4fe' before making global git config changes
2026-03-04T16:26:37.1445175Z Adding repository directory to the temporary git global config as a safe directory
2026-03-04T16:26:37.1450164Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/verity/verity
2026-03-04T16:26:37.1505343Z Deleting the contents of '/home/runner/work/verity/verity'
2026-03-04T16:26:37.1511973Z ##[group]Initializing the repository
2026-03-04T16:26:37.1518037Z [command]/usr/bin/git init /home/runner/work/verity/verity
2026-03-04T16:26:37.1650920Z hint: Using 'master' as the name for the initial branch. This default branch name
2026-03-04T16:26:37.1652923Z hint: will change to "main" in Git 3.0. To configure the initial branch name
2026-03-04T16:26:37.1654368Z hint: to use in all of your new repositories, which will suppress this warning,
2026-03-04T16:26:37.1656273Z hint: call:
2026-03-04T16:26:37.1657163Z hint:
2026-03-04T16:26:37.1658007Z hint: 	git config --global init.defaultBranch <name>
2026-03-04T16:26:37.1658827Z hint:
2026-03-04T16:26:37.1659598Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2026-03-04T16:26:37.1660898Z hint: 'development'. The just-created branch can be renamed via this command:
2026-03-04T16:26:37.1662465Z hint:
2026-03-04T16:26:37.1663022Z hint: 	git branch -m <name>
2026-03-04T16:26:37.1663655Z hint:
2026-03-04T16:26:37.1664414Z hint: Disable this message with "git config set advice.defaultBranchName false"
2026-03-04T16:26:37.1665457Z Initialized empty Git repository in /home/runner/work/verity/verity/.git/
2026-03-04T16:26:37.1669151Z [command]/usr/bin/git remote add origin https://github.com/Th0rgal/verity
2026-03-04T16:26:37.1708349Z ##[endgroup]
2026-03-04T16:26:37.1709104Z ##[group]Disabling automatic garbage collection
2026-03-04T16:26:37.1713044Z [command]/usr/bin/git config --local gc.auto 0
2026-03-04T16:26:37.1744730Z ##[endgroup]
2026-03-04T16:26:37.1746130Z ##[group]Setting up auth
2026-03-04T16:26:37.1753233Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2026-03-04T16:26:37.1796384Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2026-03-04T16:26:37.2201824Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2026-03-04T16:26:37.2234892Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2026-03-04T16:26:37.2478112Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
2026-03-04T16:26:37.2598911Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
2026-03-04T16:26:37.2773481Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
2026-03-04T16:26:37.2811065Z ##[endgroup]
2026-03-04T16:26:37.2812430Z ##[group]Fetching the repository
2026-03-04T16:26:37.2820609Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +966b4c884295faee5454b56842fa25c5852a85a4:refs/remotes/pull/1126/merge
2026-03-04T16:26:37.7561457Z From https://github.com/Th0rgal/verity
2026-03-04T16:26:37.7565045Z  * [new ref]         966b4c884295faee5454b56842fa25c5852a85a4 -> pull/1126/merge
2026-03-04T16:26:37.7588785Z ##[endgroup]
2026-03-04T16:26:37.7589838Z ##[group]Determining the checkout info
2026-03-04T16:26:37.7591755Z ##[endgroup]
2026-03-04T16:26:37.7596671Z [command]/usr/bin/git sparse-checkout disable
2026-03-04T16:26:37.7641677Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
2026-03-04T16:26:37.7668740Z ##[group]Checking out the ref
2026-03-04T16:26:37.7672901Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/1126/merge
2026-03-04T16:26:37.7987843Z Note: switching to 'refs/remotes/pull/1126/merge'.
2026-03-04T16:26:37.7989498Z 
2026-03-04T16:26:37.7990749Z You are in 'detached HEAD' state. You can look around, make experimental
2026-03-04T16:26:37.7993631Z changes and commit them, and you can discard any commits you make in this
2026-03-04T16:26:37.7996040Z state without impacting any branches by switching back to a branch.
2026-03-04T16:26:37.7997688Z 
2026-03-04T16:26:37.7998529Z If you want to create a new branch to retain commits you create, you may
2026-03-04T16:26:37.8000506Z do so (now or later) by using -c with the switch command. Example:
2026-03-04T16:26:37.8001466Z 
2026-03-04T16:26:37.8001870Z   git switch -c <new-branch-name>
2026-03-04T16:26:37.8002662Z 
2026-03-04T16:26:37.8003032Z Or undo this operation with:
2026-03-04T16:26:37.8003624Z 
2026-03-04T16:26:37.8003953Z   git switch -
2026-03-04T16:26:37.8004409Z 
2026-03-04T16:26:37.8005219Z Turn off this advice by setting config variable advice.detachedHead to false
2026-03-04T16:26:37.8006391Z 
2026-03-04T16:26:37.8007640Z HEAD is now at 966b4c8 Merge 4e512ca8f28799d15e7b270f715ae36b9fb209e8 into 08d942a51b798128c04f00998992ac160dd10dcd
2026-03-04T16:26:37.8011881Z ##[endgroup]
2026-03-04T16:26:37.8043374Z [command]/usr/bin/git log -1 --format=%H
2026-03-04T16:26:37.8070397Z 966b4c884295faee5454b56842fa25c5852a85a4
2026-03-04T16:26:37.8934228Z ##[group]Run actions/cache@v4
2026-03-04T16:26:37.8935310Z with:
2026-03-04T16:26:37.8936081Z   path: ~/.elan
2026-03-04T16:26:37.8937528Z   key: elan-dc397be7564abee074b314671cf89faede145e9510db8c01a5e956d5cb5d7713
2026-03-04T16:26:37.8939352Z   enableCrossOsArchive: false
2026-03-04T16:26:37.8940421Z   fail-on-cache-miss: false
2026-03-04T16:26:37.8941420Z   lookup-only: false
2026-03-04T16:26:37.8942484Z   save-always: false
2026-03-04T16:26:37.8943348Z env:
2026-03-04T16:26:37.8944103Z   SOLC_VERSION: 0.8.33
2026-03-04T16:26:37.8945910Z   SOLC_URL: https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21
2026-03-04T16:26:37.8948503Z   SOLC_SHA256: 1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468
2026-03-04T16:26:37.8950191Z ##[endgroup]
2026-03-04T16:26:38.2189757Z Cache hit for: elan-dc397be7564abee074b314671cf89faede145e9510db8c01a5e956d5cb5d7713
2026-03-04T16:26:39.3268405Z Received 134217728 of 509805613 (26.3%), 127.9 MBs/sec
2026-03-04T16:26:40.3268625Z Received 369098752 of 509805613 (72.4%), 175.9 MBs/sec
2026-03-04T16:26:40.9786772Z Received 509805613 of 509805613 (100.0%), 183.3 MBs/sec
2026-03-04T16:26:40.9790558Z Cache Size: ~486 MB (509805613 B)
2026-03-04T16:26:40.9910409Z [command]/usr/bin/tar -xf /home/runner/work/_temp/09b36c1e-3622-4021-954b-69948e135743/cache.tzst -P -C /home/runner/work/verity/verity --use-compress-program unzstd
2026-03-04T16:26:44.5950123Z Cache restored successfully
2026-03-04T16:26:44.7038873Z Cache restored from key: elan-dc397be7564abee074b314671cf89faede145e9510db8c01a5e956d5cb5d7713
2026-03-04T16:26:44.7311604Z ##[group]Run echo "$HOME/.elan/bin" >> $GITHUB_PATH
2026-03-04T16:26:44.7312482Z [36;1mecho "$HOME/.elan/bin" >> $GITHUB_PATH[0m
2026-03-04T16:26:44.7386321Z shell: /usr/bin/bash -e {0}
2026-03-04T16:26:44.7386733Z env:
2026-03-04T16:26:44.7387032Z   SOLC_VERSION: 0.8.33
2026-03-04T16:26:44.7387799Z   SOLC_URL: https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21
2026-03-04T16:26:44.7388873Z   SOLC_SHA256: 1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468
2026-03-04T16:26:44.7389629Z ##[endgroup]
2026-03-04T16:26:45.0685903Z ##[group]Run actions/cache/restore@v4
2026-03-04T16:26:45.0686437Z with:
2026-03-04T16:26:45.0686757Z   path: .lake
2026-03-04T16:26:45.0688536Z   key: lake-Linux-dc397be7564abee074b314671cf89faede145e9510db8c01a5e956d5cb5d7713-2da17007afff62a1cc094445f845c8e26bd3b9a7cfbf8456ec34d1ff652e275b-987bf5dc9ec497172abe68cbaa0b10009a47a00c35155cc123eddbd69944f49b
2026-03-04T16:26:45.0691468Z   restore-keys: lake-Linux-dc397be7564abee074b314671cf89faede145e9510db8c01a5e956d5cb5d7713-2da17007afff62a1cc094445f845c8e26bd3b9a7cfbf8456ec34d1ff652e275b-

2026-03-04T16:26:45.0693225Z   enableCrossOsArchive: false
2026-03-04T16:26:45.0693677Z   fail-on-cache-miss: false
2026-03-04T16:26:45.0694083Z   lookup-only: false
2026-03-04T16:26:45.0694435Z env:
2026-03-04T16:26:45.0694730Z   SOLC_VERSION: 0.8.33
2026-03-04T16:26:45.0695793Z   SOLC_URL: https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21
2026-03-04T16:26:45.0697033Z   SOLC_SHA256: 1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468
2026-03-04T16:26:45.0698133Z ##[endgroup]
2026-03-04T16:26:45.3308787Z Cache not found for input keys: lake-Linux-dc397be7564abee074b314671cf89faede145e9510db8c01a5e956d5cb5d7713-2da17007afff62a1cc094445f845c8e26bd3b9a7cfbf8456ec34d1ff652e275b-987bf5dc9ec497172abe68cbaa0b10009a47a00c35155cc123eddbd69944f49b, lake-Linux-dc397be7564abee074b314671cf89faede145e9510db8c01a5e956d5cb5d7713-2da17007afff62a1cc094445f845c8e26bd3b9a7cfbf8456ec34d1ff652e275b-
2026-03-04T16:26:45.3394029Z ##[group]Run lake exe cache get
2026-03-04T16:26:45.3394577Z [36;1mlake exe cache get[0m
2026-03-04T16:26:45.3462334Z shell: /usr/bin/bash -e {0}
2026-03-04T16:26:45.3462737Z env:
2026-03-04T16:26:45.3463038Z   SOLC_VERSION: 0.8.33
2026-03-04T16:26:45.3463790Z   SOLC_URL: https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21
2026-03-04T16:26:45.3464840Z   SOLC_SHA256: 1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468
2026-03-04T16:26:45.3465514Z ##[endgroup]
2026-03-04T16:26:46.5133627Z info: evmyul: cloning https://github.com/NethermindEth/EVMYulLean.git
2026-03-04T16:26:46.5134715Z info: evmyul: checking out revision '047f63070309f436b66c61e276ab3b6d1169265a'
2026-03-04T16:26:48.3807616Z warning: /home/runner/work/verity/verity/.lake/packages/evmyul/lakefile.lean:64:18: `Lake.Package.nativeLibDir` has been deprecated: Use staticLibDir or sharedLibDir instead.
2026-03-04T16:27:23.9357338Z info: mathlib: cloning https://github.com/leanprover-community/mathlib4.git
2026-03-04T16:27:23.9358836Z info: mathlib: checking out revision '79e94a093aff4a60fb1b1f92d9681e407124c2ca'
2026-03-04T16:27:24.9620923Z info: plausible: cloning https://github.com/leanprover-community/plausible
2026-03-04T16:27:24.9621795Z info: plausible: checking out revision 'b100ad4c5d74a464f497aaa8e7c74d86bf39a56f'
2026-03-04T16:27:25.2035090Z info: LeanSearchClient: cloning https://github.com/leanprover-community/LeanSearchClient
2026-03-04T16:27:25.2036222Z info: LeanSearchClient: checking out revision '99657ad92e23804e279f77ea6dbdeebaa1317b98'
2026-03-04T16:27:25.5165919Z info: importGraph: cloning https://github.com/leanprover-community/import-graph
2026-03-04T16:27:25.5166837Z info: importGraph: checking out revision 'eb164a46de87078f27640ee71e6c3841defc2484'
2026-03-04T16:27:25.9745442Z info: proofwidgets: cloning https://github.com/leanprover-community/ProofWidgets4
2026-03-04T16:27:25.9746761Z info: proofwidgets: checking out revision '1253a071e6939b0faf5c09d2b30b0bfc79dae407'
2026-03-04T16:27:27.4418801Z info: aesop: cloning https://github.com/leanprover-community/aesop
2026-03-04T16:27:27.4419839Z info: aesop: checking out revision '1256a18522728c2eeed6109b02dd2b8f207a2a3c'
2026-03-04T16:27:27.7303380Z info: Qq: cloning https://github.com/leanprover-community/quote4
2026-03-04T16:27:27.7304318Z info: Qq: checking out revision '917bfa5064b812b7fbd7112d018ea0b4def25ab3'
2026-03-04T16:27:33.1587617Z info: batteries: cloning https://github.com/leanprover-community/batteries
2026-03-04T16:27:33.1588238Z info: batteries: checking out revision '240676e9568c254a69be94801889d4b13f3b249f'
2026-03-04T16:27:33.4255111Z info: Cli: cloning https://github.com/leanprover/lean4-cli
2026-03-04T16:27:33.4255644Z info: Cli: checking out revision 'c682c91d2d4dd59a7187e2ab977ac25bd1f87329'
2026-03-04T16:27:33.8273073Z ✔ [2/20] Built Cache.Lean
2026-03-04T16:27:33.9275199Z ✔ [3/20] Built Cache.Lean:c.o
2026-03-04T16:27:34.5304330Z ✔ [6/20] Built Batteries.Data.String.Basic
2026-03-04T16:27:34.6299091Z ✔ [7/20] Built Batteries.Data.String.Basic:c.o
2026-03-04T16:27:35.1324107Z ✔ [8/20] Built Batteries.Data.Array.Match
2026-03-04T16:27:35.4319258Z ✔ [9/20] Built Batteries.Data.Array.Match:c.o
2026-03-04T16:27:35.5325999Z ✔ [10/20] Built Batteries.Data.String.Matcher
2026-03-04T16:27:35.7333687Z ✔ [11/20] Built Cache.IO
2026-03-04T16:27:35.8324721Z ✔ [12/20] Built Batteries.Data.String.Matcher:c.o
2026-03-04T16:27:36.6338955Z ✔ [13/20] Built Cache.Hashing
2026-03-04T16:27:37.7356460Z ✔ [14/20] Built Cache.Hashing:c.o
2026-03-04T16:27:38.5369086Z ✔ [15/20] Built Cache.Requests
2026-03-04T16:27:38.5369877Z ✔ [16/20] Built Cache.IO:c.o
2026-03-04T16:27:39.2377321Z ✔ [17/20] Built Cache.Main
2026-03-04T16:27:40.0387375Z ✔ [18/20] Built Cache.Main:c.o
2026-03-04T16:27:40.2390151Z ✔ [19/20] Built Cache.Requests:c.o
2026-03-04T16:27:40.6397258Z ✔ [20/20] Built cache:exe
2026-03-04T16:27:42.9814107Z   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
2026-03-04T16:27:42.9815567Z                                  Dload  Upload   Total   Spent    Left  Speed
2026-03-04T16:27:42.9816107Z 
2026-03-04T16:27:42.9816408Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
2026-03-04T16:27:42.9817138Z   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
2026-03-04T16:27:42.9817623Z 
2026-03-04T16:27:42.9817941Z 100 1075k  100 1075k    0     0  6903k      0 --:--:-- --:--:-- --:--:-- 6903k
2026-03-04T16:27:42.9818443Z 
2026-03-04T16:27:43.0216006Z installing leantar 0.1.15
2026-03-04T16:27:44.4029316Z Current branch: HEAD
2026-03-04T16:27:44.4029849Z Using cache from origin: leanprover-community/mathlib4
2026-03-04T16:27:44.4030580Z Attempting to download 7067 file(s) from leanprover-community/mathlib4 cache
2026-03-04T16:27:45.7606211Z 
2026-03-04T16:27:45.8608072Z Downloaded: 1 file(s) [attempted 1/7067 = 0%]
2026-03-04T16:27:45.9614801Z Downloaded: 245 file(s) [attempted 245/7067 = 3%]
2026-03-04T16:27:46.0621221Z Downloaded: 546 file(s) [attempted 546/7067 = 7%]
2026-03-04T16:27:46.1614939Z Downloaded: 842 file(s) [attempted 842/7067 = 11%]
2026-03-04T16:27:46.2614868Z Downloaded: 1123 file(s) [attempted 1123/7067 = 15%]
2026-03-04T16:27:46.3619305Z Downloaded: 1437 file(s) [attempted 1437/7067 = 20%]
2026-03-04T16:27:46.4616499Z Downloaded: 1721 file(s) [attempted 1721/7067 = 24%]
2026-03-04T16:27:46.5631660Z Downloaded: 2017 file(s) [attempted 2017/7067 = 28%]
2026-03-04T16:27:46.6635455Z Downloaded: 2313 file(s) [attempted 2313/7067 = 32%]
2026-03-04T16:27:46.7635157Z Downloaded: 2616 file(s) [attempted 2616/7067 = 37%]
2026-03-04T16:27:46.8649283Z Downloaded: 2912 file(s) [attempted 2912/7067 = 41%]
2026-03-04T16:27:46.9644705Z Downloaded: 3220 file(s) [attempted 3220/7067 = 45%]
2026-03-04T16:27:47.0650396Z Downloaded: 3527 file(s) [attempted 3527/7067 = 49%]
2026-03-04T16:27:47.1645255Z Downloaded: 3815 file(s) [attempted 3815/7067 = 53%]
2026-03-04T16:27:47.2646574Z Downloaded: 4103 file(s) [attempted 4103/7067 = 58%]
2026-03-04T16:27:47.3645157Z Downloaded: 4367 file(s) [attempted 4367/7067 = 61%]
2026-03-04T16:27:47.4659724Z Downloaded: 4639 file(s) [attempted 4639/7067 = 65%]
2026-03-04T16:27:47.5659263Z Downloaded: 4912 file(s) [attempted 4912/7067 = 69%]
2026-03-04T16:27:47.6654857Z Downloaded: 5212 file(s) [attempted 5212/7067 = 73%]
2026-03-04T16:27:47.7656379Z Downloaded: 5462 file(s) [attempted 5462/7067 = 77%]
2026-03-04T16:27:47.8655967Z Downloaded: 5733 file(s) [attempted 5733/7067 = 81%]
2026-03-04T16:27:47.9666946Z Downloaded: 6020 file(s) [attempted 6020/7067 = 85%]
2026-03-04T16:27:48.0664702Z Downloaded: 6307 file(s) [attempted 6307/7067 = 89%]
2026-03-04T16:27:48.1678222Z Downloaded: 6582 file(s) [attempted 6582/7067 = 93%]
2026-03-04T16:27:48.2889386Z Downloaded: 6880 file(s) [attempted 6880/7067 = 97%]
2026-03-04T16:27:48.2931046Z Downloaded: 7067 file(s) [attempted 7067/7067 = 100%]
2026-03-04T16:27:48.2931898Z Downloaded: 7067 file(s) [attempted 7067/7067 = 100%] (100% success)
2026-03-04T16:28:03.557