### PR TITLE
Add CI guard against legacy migrated-contract imports

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -150,6 +150,9 @@ jobs:
       - name: Check SpecCorrectness migration boundary
         run: python3 scripts/check_spec_proof_migration_boundary.py
 
+      - name: Check migrated legacy-example import boundary
+        run: python3 scripts/check_legacy_example_imports.py
+
       - name: Check Layer-2 sender/storage universality
         run: python3 scripts/check_layer2_universality.py
 

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/check_storage_layout.py
 	python3 scripts/check_manual_spec_quarantine.py
 	python3 scripts/check_spec_proof_migration_boundary.py
+	python3 scripts/check_legacy_example_imports.py
 	python3 scripts/check_layer2_universality.py
 	python3 scripts/check_lean_hygiene.py
 	python3 scripts/check_gas_model_coverage.py

--- a/scripts/check_legacy_example_imports.py
+++ b/scripts/check_legacy_example_imports.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Fail closed on reintroduction of legacy migrated-contract imports.
+
+Issue #1143:
+- For migrated contracts, block `import Verity.Examples.<Contract>` in active code.
+- Allow explicit temporary exemptions through a documented allowlist.
+- Fail when allowlist entries become stale.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from property_utils import ROOT, scrub_lean_code
+
+MIGRATED_CONTRACTS = {
+    "SimpleStorage",
+    "Counter",
+    "SafeCounter",
+    "Owned",
+    "OwnedCounter",
+    "Ledger",
+    "SimpleToken",
+    "ERC20",
+    "ERC721",
+}
+
+IMPORT_RE = re.compile(
+    r"^\s*import\s+Verity\.Examples\.(?P<name>[A-Za-z_][A-Za-z0-9_]*)\b",
+    flags=re.MULTILINE,
+)
+
+ALLOWLIST_PATH = ROOT / "scripts" / "legacy_example_import_allowlist.txt"
+SCAN_ROOTS = [
+    ROOT / "Compiler",
+    ROOT / "Verity",
+]
+EXTRA_SCAN_FILES = [
+    ROOT / "Compiler.lean",
+    ROOT / "Verity.lean",
+]
+
+
+def discover_scan_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        files.extend(sorted(root.rglob("*.lean")))
+    files.extend(path for path in EXTRA_SCAN_FILES if path.exists())
+    return sorted(set(files))
+
+
+def parse_allowlist(path: Path) -> dict[Path, set[str]]:
+    if not path.exists():
+        raise SystemExit(f"Missing allowlist file: {path}")
+
+    entries: dict[Path, set[str]] = {}
+    for line_no, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            raise SystemExit(
+                f"Invalid allowlist entry at {path}:{line_no}: expected '<path>: <module>[, ...]'"
+            )
+        rel_raw, modules_raw = line.split(":", 1)
+        rel_text = rel_raw.strip()
+        modules = [token.strip() for token in modules_raw.split(",") if token.strip()]
+        if not rel_text or not modules:
+            raise SystemExit(
+                f"Invalid allowlist entry at {path}:{line_no}: expected non-empty path and module list"
+            )
+        rel_path = Path(rel_text)
+        if rel_path.is_absolute():
+            raise SystemExit(
+                f"Invalid allowlist entry at {path}:{line_no}: path must be repository-relative"
+            )
+        unknown = sorted(set(modules) - MIGRATED_CONTRACTS)
+        if unknown:
+            raise SystemExit(
+                f"Invalid allowlist entry at {path}:{line_no}: unknown migrated contract(s): {', '.join(unknown)}"
+            )
+        if rel_path in entries:
+            raise SystemExit(
+                f"Invalid allowlist entry at {path}:{line_no}: duplicate path {rel_path}"
+            )
+        entries[rel_path] = set(modules)
+    return entries
+
+
+def find_migrated_imports(text: str) -> list[str]:
+    imports: list[str] = []
+    for match in IMPORT_RE.finditer(text):
+        name = match.group("name")
+        if name in MIGRATED_CONTRACTS:
+            imports.append(name)
+    return imports
+
+
+def main() -> int:
+    allowlist = parse_allowlist(ALLOWLIST_PATH)
+    files = discover_scan_files()
+
+    used_allowlist: dict[Path, set[str]] = defaultdict(set)
+    errors: list[str] = []
+
+    for file_path in files:
+        rel = file_path.relative_to(ROOT)
+        imports = set(find_migrated_imports(scrub_lean_code(file_path.read_text(encoding="utf-8"))))
+        if not imports:
+            continue
+
+        allowed = allowlist.get(rel, set())
+        disallowed = sorted(imports - allowed)
+        if disallowed:
+            rendered = ", ".join(f"Verity.Examples.{name}" for name in disallowed)
+            errors.append(f"{rel}: unexpected legacy migrated-contract import(s): {rendered}")
+
+        used_allowlist[rel].update(imports & allowed)
+
+    for rel, allowed_modules in sorted(allowlist.items(), key=lambda kv: str(kv[0])):
+        file_path = ROOT / rel
+        if not file_path.exists():
+            errors.append(f"{rel}: stale allowlist entry (file does not exist)")
+            continue
+        stale_modules = sorted(allowed_modules - used_allowlist.get(rel, set()))
+        if stale_modules:
+            rendered = ", ".join(f"Verity.Examples.{name}" for name in stale_modules)
+            errors.append(
+                f"{rel}: stale allowlist module(s) with no matching import(s): {rendered}"
+            )
+
+    if errors:
+        print("Legacy migrated-contract import guard failed:", file=sys.stderr)
+        for err in errors:
+            print(f"- {err}", file=sys.stderr)
+        print(
+            "\nIssue #1143 guard: new imports of migrated legacy modules are blocked by default. "
+            "Use scripts/legacy_example_import_allowlist.txt only for explicit, temporary exemptions.",
+            file=sys.stderr,
+        )
+        return 1
+
+    allowlist_count = sum(len(mods) for mods in allowlist.values())
+    print(
+        "Legacy migrated-contract import guard passed "
+        f"({len(files)} Lean files scanned; {allowlist_count} explicit exemption module(s))."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legacy_example_import_allowlist.txt
+++ b/scripts/legacy_example_import_allowlist.txt
@@ -1,0 +1,7 @@
+# Explicit temporary exemptions for scripts/check_legacy_example_imports.py
+# Format:
+#   <repo-relative-lean-file>: <MigratedContract>[, <MigratedContract>...]
+#
+# Keep entries minimal and remove them as migration cleanup lands.
+
+Verity/All.lean: SimpleStorage, Counter, SafeCounter, Owned, OwnedCounter, Ledger, SimpleToken, ERC20, ERC721

--- a/scripts/test_check_legacy_example_imports.py
+++ b/scripts/test_check_legacy_example_imports.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_legacy_example_imports as guard
+
+
+class LegacyExampleImportGuardTests(unittest.TestCase):
+    def _run_check(
+        self,
+        *,
+        files: dict[str, str],
+        allowlist: str,
+    ) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as tmpdir:
+            root = Path(tmpdir)
+            (root / "Compiler").mkdir(parents=True, exist_ok=True)
+            (root / "Verity").mkdir(parents=True, exist_ok=True)
+            for rel, content in files.items():
+                path = root / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+
+            allowlist_path = root / "scripts" / "legacy_example_import_allowlist.txt"
+            allowlist_path.parent.mkdir(parents=True, exist_ok=True)
+            allowlist_path.write_text(allowlist, encoding="utf-8")
+
+            old_root = guard.ROOT
+            old_allowlist_path = guard.ALLOWLIST_PATH
+            old_scan_roots = guard.SCAN_ROOTS
+            old_extra_scan = guard.EXTRA_SCAN_FILES
+            guard.ROOT = root
+            guard.ALLOWLIST_PATH = allowlist_path
+            guard.SCAN_ROOTS = [root / "Compiler", root / "Verity"]
+            guard.EXTRA_SCAN_FILES = []
+            try:
+                stderr = io.StringIO()
+                with redirect_stderr(stderr):
+                    rc = guard.main()
+                return rc, stderr.getvalue()
+            finally:
+                guard.ROOT = old_root
+                guard.ALLOWLIST_PATH = old_allowlist_path
+                guard.SCAN_ROOTS = old_scan_roots
+                guard.EXTRA_SCAN_FILES = old_extra_scan
+
+    def test_rejects_non_allowlisted_import(self) -> None:
+        rc, stderr = self._run_check(
+            files={"Compiler/Main.lean": "import Verity.Examples.Counter\n"},
+            allowlist="",
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("unexpected legacy migrated-contract import", stderr)
+
+    def test_accepts_allowlisted_import(self) -> None:
+        rc, stderr = self._run_check(
+            files={"Verity/All.lean": "import Verity.Examples.Counter\n"},
+            allowlist="Verity/All.lean: Counter\n",
+        )
+        self.assertEqual(rc, 0, stderr)
+
+    def test_fails_on_stale_allowlist_module(self) -> None:
+        rc, stderr = self._run_check(
+            files={"Verity/All.lean": "def ok := 1\n"},
+            allowlist="Verity/All.lean: Counter\n",
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("stale allowlist module", stderr)
+
+    def test_ignores_comment_and_string_decoys(self) -> None:
+        rc, stderr = self._run_check(
+            files={
+                "Compiler/Main.lean": (
+                    "-- import Verity.Examples.Counter\n"
+                    'def msg := "import Verity.Examples.Counter"\n'
+                )
+            },
+            allowlist="",
+        )
+        self.assertEqual(rc, 0, stderr)
+
+    def test_rejects_unknown_module_in_allowlist(self) -> None:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as tmpdir:
+            root = Path(tmpdir)
+            allowlist_path = root / "scripts" / "legacy_example_import_allowlist.txt"
+            allowlist_path.parent.mkdir(parents=True, exist_ok=True)
+            allowlist_path.write_text("Verity/All.lean: NotMigrated\n", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                guard.parse_allowlist(allowlist_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -48,6 +48,7 @@
     "check_storage_layout.py",
     "check_manual_spec_quarantine.py",
     "check_spec_proof_migration_boundary.py",
+    "check_legacy_example_imports.py",
     "check_layer2_universality.py",
     "check_lean_hygiene.py",
     "check_gas_model_coverage.py",


### PR DESCRIPTION
## Summary
- add `scripts/check_legacy_example_imports.py` to fail closed on migrated legacy imports (`import Verity.Examples.<Contract>`) for the migrated contract set
- add documented allowlist file `scripts/legacy_example_import_allowlist.txt` with explicit temporary exemption modules for `Verity/All.lean`
- enforce stale-allowlist detection (missing file or listed module no longer imported)
- wire the guard into both `make check` and `.github/workflows/verify.yml` checks job
- update `scripts/verify_sync_spec.json` to keep workflow-sync invariants aligned
- add unit tests in `scripts/test_check_legacy_example_imports.py`

## Validation
- `python3 -m unittest scripts/test_check_legacy_example_imports.py -v`
- `python3 scripts/check_legacy_example_imports.py`
- `python3 scripts/check_verify_sync.py`
- `make check`

Closes #1143

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI/`make check` validation script and allowlist without changing compiler/proof logic, but may introduce new CI failures if legacy imports or allowlist drift exist.
> 
> **Overview**
> Adds a new Python guard (`scripts/check_legacy_example_imports.py`) that scans Lean sources for `import Verity.Examples.<Contract>` of a migrated-contract set and fails unless explicitly exempted via `scripts/legacy_example_import_allowlist.txt` (also failing on stale allowlist entries).
> 
> Wires the guard into the CI `checks` job, `make check`, and `scripts/verify_sync_spec.json`, and adds unit tests (`scripts/test_check_legacy_example_imports.py`) to validate allowlisting, stale detection, and comment/string scrubbing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca9a18268402543e30a92dee87b088a91ee2dd4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->