### PR TITLE
Enforce AXIOMS.md registry completeness in CI

### DIFF
--- a/scripts/check_axiom_locations.py
+++ b/scripts/check_axiom_locations.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
-"""Check that AXIOMS.md references correct line numbers for axiom declarations.
+"""Check that AXIOMS.md stays in sync with Lean axiom declarations.
 
 Parses AXIOMS.md for location patterns like `File.lean:NN` and verifies each
 axiom actually appears at the claimed line number in the source file.
+Also verifies:
+- every Lean kernel axiom is listed in AXIOMS.md
+- AXIOMS.md has no stale/extra axiom entries
+- AXIOMS.md trust summary active axiom count matches source
 
 Usage:
     python3 scripts/check_axiom_locations.py
@@ -11,8 +15,54 @@ Usage:
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
-from property_utils import ROOT, die, report_errors
+from property_utils import ROOT, die, report_errors, scrub_lean_code
+
+AXIOM_DECL_RE = re.compile(r"^(?:private |protected )?axiom\s+([A-Za-z_][A-Za-z0-9_']*)\b")
+
+
+def parse_axiom_entries(axioms_md_text: str) -> list[tuple[str, str, int]]:
+    """Extract (axiom_name, relative_path, claimed_line) entries from AXIOMS.md."""
+    blocks = re.findall(
+        r"### \d+\.\s+`([^`]+)`(?:[^\n]*)\n\n"
+        r"\*\*Location\*\*:\s*`([^:]+):(\d+)`",
+        axioms_md_text,
+    )
+    return [(name, rel_path, int(line)) for name, rel_path, line in blocks]
+
+
+def parse_active_axiom_count(axioms_md_text: str) -> int | None:
+    """Extract trust-summary active axiom count from AXIOMS.md, if present."""
+    match = re.search(r"^- Active axioms:\s*(\d+)\s*$", axioms_md_text, flags=re.MULTILINE)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def discover_repo_axioms() -> dict[str, tuple[str, int]]:
+    """Return all Lean axiom declarations as {name: (relative_path, line)}."""
+    discovered: dict[str, tuple[str, int]] = {}
+    for subdir in ("Compiler", "Verity"):
+        base_dir = ROOT / subdir
+        if not base_dir.exists():
+            continue
+        for lean_file in sorted(base_dir.rglob("*.lean")):
+            text = scrub_lean_code(lean_file.read_text(encoding="utf-8"))
+            rel_path = str(lean_file.relative_to(ROOT))
+            for i, line in enumerate(text.splitlines(), 1):
+                match = AXIOM_DECL_RE.match(line)
+                if match is None:
+                    continue
+                name = match.group(1)
+                if name in discovered:
+                    old_path, old_line = discovered[name]
+                    die(
+                        f"Duplicate axiom name {name!r}: "
+                        f"{old_path}:{old_line} and {rel_path}:{i}"
+                    )
+                discovered[name] = (rel_path, i)
+    return discovered
 
 
 def main() -> None:
@@ -22,22 +72,19 @@ def main() -> None:
 
     text = axioms_md.read_text(encoding="utf-8")
 
-    # Match patterns like: ### N. `axiom_name`
-    # followed by **Location**: `path/to/File.lean:NN`
-    axiom_blocks = re.findall(
-        r"### \d+\.\s+`([^`]+)`(?:[^\n]*)\n\n"
-        r"\*\*Location\*\*:\s*`([^:]+):(\d+)`",
-        text,
-    )
+    axiom_blocks = parse_axiom_entries(text)
 
     if not axiom_blocks:
         die("No axiom location entries found in AXIOMS.md")
 
+    discovered_axioms = discover_repo_axioms()
+    documented_names = {name for name, _, _ in axiom_blocks}
+    discovered_names = set(discovered_axioms)
+
     errors: list[str] = []
     checked = 0
 
-    for axiom_name, rel_path, claimed_line_str in axiom_blocks:
-        claimed_line = int(claimed_line_str)
+    for axiom_name, rel_path, claimed_line in axiom_blocks:
         source_file = ROOT / rel_path
 
         if not source_file.exists():
@@ -67,8 +114,31 @@ def main() -> None:
             print(f"  OK {axiom_name} at {rel_path}:{actual_line}")
             checked += 1
 
+    missing_from_docs = sorted(discovered_names - documented_names)
+    for axiom_name in missing_from_docs:
+        rel_path, line = discovered_axioms[axiom_name]
+        errors.append(
+            f"{axiom_name}: declared in {rel_path}:{line} but missing from AXIOMS.md"
+        )
+
+    stale_doc_entries = sorted(documented_names - discovered_names)
+    for axiom_name in stale_doc_entries:
+        errors.append(f"{axiom_name}: listed in AXIOMS.md but no Lean axiom declaration exists")
+
+    active_count = parse_active_axiom_count(text)
+    if active_count is None:
+        errors.append("AXIOMS.md: missing '- Active axioms: N' trust summary line")
+    elif active_count != len(discovered_axioms):
+        errors.append(
+            f"AXIOMS.md trust summary says Active axioms: {active_count}, "
+            f"but source has {len(discovered_axioms)}"
+        )
+
     report_errors(errors, "Axiom location check failed")
-    print(f"\nOK: All {checked} axiom locations in AXIOMS.md are accurate")
+    print(
+        f"\nOK: {checked} documented axiom locations are accurate; "
+        f"registry is complete and synchronized with {len(discovered_axioms)} source axioms"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_axiom_locations.py
+++ b/scripts/test_check_axiom_locations.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_axiom_locations
+
+
+class CheckAxiomLocationsTests(unittest.TestCase):
+    def test_parse_axiom_entries(self) -> None:
+        text = (
+            "### 1. `a1`\n\n"
+            "**Location**: `Compiler/Foo.lean:12`\n\n"
+            "### 2. `a2` (private)\n\n"
+            "**Location**: `Verity/Bar.lean:34`\n"
+        )
+        self.assertEqual(
+            check_axiom_locations.parse_axiom_entries(text),
+            [("a1", "Compiler/Foo.lean", 12), ("a2", "Verity/Bar.lean", 34)],
+        )
+
+    def test_parse_active_axiom_count(self) -> None:
+        self.assertEqual(
+            check_axiom_locations.parse_active_axiom_count("- Active axioms: 3\n"),
+            3,
+        )
+        self.assertIsNone(check_axiom_locations.parse_active_axiom_count("no summary line"))
+
+    def test_discover_repo_axioms_ignores_comments_and_strings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Compiler").mkdir(parents=True, exist_ok=True)
+            (root / "Verity").mkdir(parents=True, exist_ok=True)
+            (root / "Compiler" / "A.lean").write_text(
+                "\n".join(
+                    [
+                        "-- axiom commented_out : True",
+                        "/- axiom in_block_comment : True -/",
+                        "def s := \"axiom in_string\"",
+                        "axiom real_axiom : True",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            old_root = check_axiom_locations.ROOT
+            try:
+                check_axiom_locations.ROOT = root
+                discovered = check_axiom_locations.discover_repo_axioms()
+            finally:
+                check_axiom_locations.ROOT = old_root
+
+        self.assertEqual(discovered, {"real_axiom": ("Compiler/A.lean", 4)})
+
+    def test_main_reports_missing_registry_entries_and_count_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Compiler").mkdir(parents=True, exist_ok=True)
+            (root / "Verity").mkdir(parents=True, exist_ok=True)
+            (root / "Compiler" / "A.lean").write_text(
+                "axiom documented_axiom : True\naxiom missing_axiom : True\n",
+                encoding="utf-8",
+            )
+            (root / "AXIOMS.md").write_text(
+                "\n".join(
+                    [
+                        "### 1. `documented_axiom`",
+                        "",
+                        "**Location**: `Compiler/A.lean:1`",
+                        "",
+                        "## Trust Summary",
+                        "",
+                        "- Active axioms: 1",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            stderr = io.StringIO()
+            old_root = check_axiom_locations.ROOT
+            try:
+                check_axiom_locations.ROOT = root
+                with redirect_stderr(stderr), self.assertRaises(SystemExit):
+                    check_axiom_locations.main()
+            finally:
+                check_axiom_locations.ROOT = old_root
+
+            err = stderr.getvalue()
+            self.assertIn("missing_axiom: declared in Compiler/A.lean:2 but missing from AXIOMS.md", err)
+            self.assertIn("AXIOMS.md trust summary says Active axioms: 1, but source has 2", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- harden `scripts/check_axiom_locations.py` to verify full registry sync, not only line numbers
- enforce that every Lean kernel `axiom` declaration is documented in `AXIOMS.md`
- enforce no stale/extra axiom entries remain in `AXIOMS.md`
- enforce `- Active axioms: N` in `AXIOMS.md` matches discovered source axiom count
- add focused unit tests for parsing/discovery and drift detection failure modes

## Why
`AXIOMS.md` can drift even when location lines are accurate (missing declarations, stale entries, or stale trust-summary count). This guard closes that gap and keeps trust-surface docs machine-enforced.

Closes #1158

## Validation
- `python3 -m unittest scripts/test_check_axiom_locations.py -v`
- `python3 scripts/check_axiom_locations.py`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because CI enforcement becomes stricter and relies on repo-wide axiom discovery/parsing, which could introduce false positives or new failure modes if Lean syntax patterns vary.
> 
> **Overview**
> `scripts/check_axiom_locations.py` now *discovers all Lean `axiom` declarations* under `Compiler/` and `Verity/` (scrubbing comments/strings) and enforces that `AXIOMS.md` is fully synchronized: every discovered axiom is documented, no documented entries are stale, and the trust summary `- Active axioms: N` matches the discovered count (in addition to verifying per-entry line numbers).
> 
> Adds unit tests covering AXIOMS.md parsing, trust-summary parsing, discovery correctness (ignoring comments/strings), and failure reporting for missing registry entries and count drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4000a57f973a5f57c40fcc89e2e3b634b4818f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->