### PR TITLE
Canonicalize ERC721 namespace for interpreter/proofs

### DIFF
--- a/Compiler/Interpreter.lean
+++ b/Compiler/Interpreter.lean
@@ -14,7 +14,7 @@
 import Compiler.Constants
 import Verity.Examples.MacroContracts.Tokens
 import Verity.Examples.MacroContracts.Core
-import Verity.Examples.MacroContracts.Compat.ERC721
+import Verity.Examples.MacroContracts.ERC721Addressed
 import Verity.Examples.MacroContracts.Compat.CryptoHash
 import Compiler.DiffTestTypes
 import Compiler.Hex
@@ -408,17 +408,17 @@ end ERC20
 
 namespace ERC721
 
-abbrev mint := Verity.Examples.MacroContracts.Compat.ERC721.mint
-abbrev balanceOf := Verity.Examples.MacroContracts.Compat.ERC721.balanceOf
-abbrev ownerOf := Verity.Examples.MacroContracts.Compat.ERC721.ownerOf
-abbrev approve := Verity.Examples.MacroContracts.Compat.ERC721.approve
-abbrev getApproved := Verity.Examples.MacroContracts.Compat.ERC721.getApproved
-abbrev setApprovalForAll := Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll
-abbrev isApprovedForAll := Verity.Examples.MacroContracts.Compat.ERC721.isApprovedForAll
-abbrev transferFrom := Verity.Examples.MacroContracts.Compat.ERC721.transferFrom
-abbrev owner : StorageSlot Address := Verity.Examples.MacroContracts.Compat.ERC721.owner
-abbrev totalSupply : StorageSlot Uint256 := Verity.Examples.MacroContracts.Compat.ERC721.totalSupply
-abbrev nextTokenId : StorageSlot Uint256 := Verity.Examples.MacroContracts.Compat.ERC721.nextTokenId
+abbrev mint := Verity.Examples.MacroContracts.ERC721Addressed.mint
+abbrev balanceOf := Verity.Examples.MacroContracts.ERC721Addressed.balanceOf
+abbrev ownerOf := Verity.Examples.MacroContracts.ERC721Addressed.ownerOf
+abbrev approve := Verity.Examples.MacroContracts.ERC721Addressed.approve
+abbrev getApproved := Verity.Examples.MacroContracts.ERC721Addressed.getApproved
+abbrev setApprovalForAll := Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll
+abbrev isApprovedForAll := Verity.Examples.MacroContracts.ERC721Addressed.isApprovedForAll
+abbrev transferFrom := Verity.Examples.MacroContracts.ERC721Addressed.transferFrom
+abbrev owner : StorageSlot Address := Verity.Examples.MacroContracts.ERC721Addressed.owner
+abbrev totalSupply : StorageSlot Uint256 := Verity.Examples.MacroContracts.ERC721Addressed.totalSupply
+abbrev nextTokenId : StorageSlot Uint256 := Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId
 
 end ERC721
 

--- a/Verity/Examples/MacroContracts.lean
+++ b/Verity/Examples/MacroContracts.lean
@@ -1,4 +1,5 @@
 import Verity.Examples.MacroContracts.Common
 import Verity.Examples.MacroContracts.Core
 import Verity.Examples.MacroContracts.Tokens
+import Verity.Examples.MacroContracts.ERC721Addressed
 import Verity.Examples.MacroContracts.Smoke

--- a/Verity/Examples/MacroContracts/Compat/ERC721.lean
+++ b/Verity/Examples/MacroContracts/Compat/ERC721.lean
@@ -1,126 +1,30 @@
-import Verity.Core
-import Verity.EVM.Uint256
-import Verity.Stdlib.Math
+import Verity.Examples.MacroContracts.ERC721Addressed
 
 namespace Verity.Examples.MacroContracts.Compat.ERC721
 
-open Verity
-open Verity.EVM.Uint256
-open Verity.Stdlib.Math
+abbrev owner := Verity.Examples.MacroContracts.ERC721Addressed.owner
+abbrev totalSupply := Verity.Examples.MacroContracts.ERC721Addressed.totalSupply
+abbrev nextTokenId := Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId
+abbrev balances := Verity.Examples.MacroContracts.ERC721Addressed.balances
+abbrev owners := Verity.Examples.MacroContracts.ERC721Addressed.owners
+abbrev tokenApprovals := Verity.Examples.MacroContracts.ERC721Addressed.tokenApprovals
+abbrev operatorApprovals := Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals
 
--- Storage layout
-abbrev owner : StorageSlot Address := ⟨0⟩
-abbrev totalSupply : StorageSlot Uint256 := ⟨1⟩
-abbrev nextTokenId : StorageSlot Uint256 := ⟨2⟩
-abbrev balances : StorageSlot (Address → Uint256) := ⟨3⟩
-abbrev owners : StorageSlot (Uint256 → Uint256) := ⟨4⟩
-abbrev tokenApprovals : StorageSlot (Uint256 → Uint256) := ⟨5⟩
-abbrev operatorApprovals : StorageSlot (Address → Address → Uint256) := ⟨6⟩
+abbrev addressToWord := Verity.Examples.MacroContracts.ERC721Addressed.addressToWord
+abbrev wordToAddress := Verity.Examples.MacroContracts.ERC721Addressed.wordToAddress
+abbrev boolToWord := Verity.Examples.MacroContracts.ERC721Addressed.boolToWord
 
-def addressToWord (a : Address) : Uint256 :=
-  (a.toNat : Uint256)
+abbrev isOwner := Verity.Examples.MacroContracts.ERC721Addressed.isOwner
+abbrev onlyOwner := Verity.Examples.MacroContracts.ERC721Addressed.onlyOwner
 
-def wordToAddress (w : Uint256) : Address :=
-  Verity.Core.Address.ofNat (w : Nat)
-
-def boolToWord (b : Bool) : Uint256 :=
-  if b then 1 else 0
-
-def isOwner : Contract Bool := do
-  let sender ← msgSender
-  let currentOwner ← getStorageAddr owner
-  return sender == currentOwner
-
-def onlyOwner : Contract Unit := do
-  let ownerCheck ← isOwner
-  require ownerCheck "Caller is not the owner"
-
--- Constructor initializes owner and zeroes core counters.
-def constructor (initialOwner : Address) : Contract Unit := do
-  setStorageAddr owner initialOwner
-  setStorage totalSupply 0
-  setStorage nextTokenId 0
-
--- Core ERC721 view helpers.
-def balanceOf (addr : Address) : Contract Uint256 := do
-  getMapping balances addr
-
-def ownerOf (tokenId : Uint256) : Contract Address := do
-  let ownerWord ← getMappingUint owners tokenId
-  require (ownerWord != 0) "Token does not exist"
-  return wordToAddress ownerWord
-
-def getApproved (tokenId : Uint256) : Contract Address := do
-  let ownerWord ← getMappingUint owners tokenId
-  require (ownerWord != 0) "Token does not exist"
-  let approvedWord ← getMappingUint tokenApprovals tokenId
-  return wordToAddress approvedWord
-
-def isApprovedForAll (ownerAddr operator : Address) : Contract Bool := do
-  let flag ← getMapping2 operatorApprovals ownerAddr operator
-  return flag != 0
-
--- Approve a specific address for a single tokenId.
-def approve (approved : Address) (tokenId : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  let tokenOwner ← ownerOf tokenId
-  require (sender == tokenOwner) "Not token owner"
-  setMappingUint tokenApprovals tokenId (addressToWord approved)
-
--- Set or clear global operator approval for sender.
-def setApprovalForAll (operator : Address) (approved : Bool) : Contract Unit := do
-  let sender ← msgSender
-  setMapping2 operatorApprovals sender operator (boolToWord approved)
-
--- Owner-only mint with sequential token IDs.
-def mint (to : Address) : Contract Uint256 := do
-  onlyOwner
-  require (to != 0) "Invalid recipient"
-
-  let tokenId ← getStorage nextTokenId
-  let currentOwnerWord ← getMappingUint owners tokenId
-  require (currentOwnerWord == 0) "Token already minted"
-
-  let recipientBalance ← getMapping balances to
-  let newRecipientBalance ← requireSomeUint (safeAdd recipientBalance 1) "Balance overflow"
-
-  let currentSupply ← getStorage totalSupply
-  let newSupply ← requireSomeUint (safeAdd currentSupply 1) "Supply overflow"
-
-  setMappingUint owners tokenId (addressToWord to)
-  setMapping balances to newRecipientBalance
-  setStorage totalSupply newSupply
-  setStorage nextTokenId (add tokenId 1)
-  return tokenId
-
--- Transfer token from owner to recipient with approval checks.
-def transferFrom (fromAddr to : Address) (tokenId : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  require (to != 0) "Invalid recipient"
-
-  let ownerWord ← getMappingUint owners tokenId
-  require (ownerWord != 0) "Token does not exist"
-
-  let tokenOwner := wordToAddress ownerWord
-  require (tokenOwner == fromAddr) "From is not owner"
-
-  let approvedWord ← getMappingUint tokenApprovals tokenId
-  let operatorWord ← getMapping2 operatorApprovals fromAddr sender
-  let senderWord := addressToWord sender
-  let authorized := sender == fromAddr || approvedWord == senderWord || operatorWord != 0
-  require authorized "Not authorized"
-
-  if fromAddr == to then
-    pure ()
-  else
-    let fromBalance ← getMapping balances fromAddr
-    require (fromBalance >= 1) "Insufficient balance"
-    let toBalance ← getMapping balances to
-    let newToBalance ← requireSomeUint (safeAdd toBalance 1) "Balance overflow"
-    setMapping balances fromAddr (sub fromBalance 1)
-    setMapping balances to newToBalance
-
-  setMappingUint owners tokenId (addressToWord to)
-  setMappingUint tokenApprovals tokenId 0
+abbrev constructor := Verity.Examples.MacroContracts.ERC721Addressed.constructor
+abbrev balanceOf := Verity.Examples.MacroContracts.ERC721Addressed.balanceOf
+abbrev ownerOf := Verity.Examples.MacroContracts.ERC721Addressed.ownerOf
+abbrev getApproved := Verity.Examples.MacroContracts.ERC721Addressed.getApproved
+abbrev isApprovedForAll := Verity.Examples.MacroContracts.ERC721Addressed.isApprovedForAll
+abbrev approve := Verity.Examples.MacroContracts.ERC721Addressed.approve
+abbrev setApprovalForAll := Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll
+abbrev mint := Verity.Examples.MacroContracts.ERC721Addressed.mint
+abbrev transferFrom := Verity.Examples.MacroContracts.ERC721Addressed.transferFrom
 
 end Verity.Examples.MacroContracts.Compat.ERC721

--- a/Verity/Examples/MacroContracts/ERC721Addressed.lean
+++ b/Verity/Examples/MacroContracts/ERC721Addressed.lean
@@ -1,0 +1,126 @@
+import Verity.Core
+import Verity.EVM.Uint256
+import Verity.Stdlib.Math
+
+namespace Verity.Examples.MacroContracts.ERC721Addressed
+
+open Verity
+open Verity.EVM.Uint256
+open Verity.Stdlib.Math
+
+-- Storage layout
+abbrev owner : StorageSlot Address := ⟨0⟩
+abbrev totalSupply : StorageSlot Uint256 := ⟨1⟩
+abbrev nextTokenId : StorageSlot Uint256 := ⟨2⟩
+abbrev balances : StorageSlot (Address → Uint256) := ⟨3⟩
+abbrev owners : StorageSlot (Uint256 → Uint256) := ⟨4⟩
+abbrev tokenApprovals : StorageSlot (Uint256 → Uint256) := ⟨5⟩
+abbrev operatorApprovals : StorageSlot (Address → Address → Uint256) := ⟨6⟩
+
+def addressToWord (a : Address) : Uint256 :=
+  (a.toNat : Uint256)
+
+def wordToAddress (w : Uint256) : Address :=
+  Verity.Core.Address.ofNat (w : Nat)
+
+def boolToWord (b : Bool) : Uint256 :=
+  if b then 1 else 0
+
+def isOwner : Contract Bool := do
+  let sender ← msgSender
+  let currentOwner ← getStorageAddr owner
+  return sender == currentOwner
+
+def onlyOwner : Contract Unit := do
+  let ownerCheck ← isOwner
+  require ownerCheck "Caller is not the owner"
+
+-- Constructor initializes owner and zeroes core counters.
+def constructor (initialOwner : Address) : Contract Unit := do
+  setStorageAddr owner initialOwner
+  setStorage totalSupply 0
+  setStorage nextTokenId 0
+
+-- Core ERC721 view helpers.
+def balanceOf (addr : Address) : Contract Uint256 := do
+  getMapping balances addr
+
+def ownerOf (tokenId : Uint256) : Contract Address := do
+  let ownerWord ← getMappingUint owners tokenId
+  require (ownerWord != 0) "Token does not exist"
+  return wordToAddress ownerWord
+
+def getApproved (tokenId : Uint256) : Contract Address := do
+  let ownerWord ← getMappingUint owners tokenId
+  require (ownerWord != 0) "Token does not exist"
+  let approvedWord ← getMappingUint tokenApprovals tokenId
+  return wordToAddress approvedWord
+
+def isApprovedForAll (ownerAddr operator : Address) : Contract Bool := do
+  let flag ← getMapping2 operatorApprovals ownerAddr operator
+  return flag != 0
+
+-- Approve a specific address for a single tokenId.
+def approve (approved : Address) (tokenId : Uint256) : Contract Unit := do
+  let sender ← msgSender
+  let tokenOwner ← ownerOf tokenId
+  require (sender == tokenOwner) "Not token owner"
+  setMappingUint tokenApprovals tokenId (addressToWord approved)
+
+-- Set or clear global operator approval for sender.
+def setApprovalForAll (operator : Address) (approved : Bool) : Contract Unit := do
+  let sender ← msgSender
+  setMapping2 operatorApprovals sender operator (boolToWord approved)
+
+-- Owner-only mint with sequential token IDs.
+def mint (to : Address) : Contract Uint256 := do
+  onlyOwner
+  require (to != 0) "Invalid recipient"
+
+  let tokenId ← getStorage nextTokenId
+  let currentOwnerWord ← getMappingUint owners tokenId
+  require (currentOwnerWord == 0) "Token already minted"
+
+  let recipientBalance ← getMapping balances to
+  let newRecipientBalance ← requireSomeUint (safeAdd recipientBalance 1) "Balance overflow"
+
+  let currentSupply ← getStorage totalSupply
+  let newSupply ← requireSomeUint (safeAdd currentSupply 1) "Supply overflow"
+
+  setMappingUint owners tokenId (addressToWord to)
+  setMapping balances to newRecipientBalance
+  setStorage totalSupply newSupply
+  setStorage nextTokenId (add tokenId 1)
+  return tokenId
+
+-- Transfer token from owner to recipient with approval checks.
+def transferFrom (fromAddr to : Address) (tokenId : Uint256) : Contract Unit := do
+  let sender ← msgSender
+  require (to != 0) "Invalid recipient"
+
+  let ownerWord ← getMappingUint owners tokenId
+  require (ownerWord != 0) "Token does not exist"
+
+  let tokenOwner := wordToAddress ownerWord
+  require (tokenOwner == fromAddr) "From is not owner"
+
+  let approvedWord ← getMappingUint tokenApprovals tokenId
+  let operatorWord ← getMapping2 operatorApprovals fromAddr sender
+  let senderWord := addressToWord sender
+  let authorized := sender == fromAddr || approvedWord == senderWord || operatorWord != 0
+  require authorized "Not authorized"
+
+  if fromAddr == to then
+    pure ()
+  else
+    let fromBalance ← getMapping balances fromAddr
+    require (fromBalance >= 1) "Insufficient balance"
+    let toBalance ← getMapping balances to
+    let newToBalance ← requireSomeUint (safeAdd toBalance 1) "Balance overflow"
+    setMapping balances fromAddr (sub fromBalance 1)
+    setMapping balances to newToBalance
+
+  setMappingUint owners tokenId (addressToWord to)
+  setMappingUint tokenApprovals tokenId 0
+
+end Verity.Examples.MacroContracts.ERC721Addressed

--- a/Verity/Proofs/ERC721/Basic.lean
+++ b/Verity/Proofs/ERC721/Basic.lean
@@ -3,7 +3,7 @@
 -/
 
 import Verity.Specs.ERC721.Spec
-import Verity.Examples.MacroContracts.Compat.ERC721
+import Verity.Examples.MacroContracts.ERC721Addressed
 
 namespace Verity.Proofs.ERC721
 
@@ -12,100 +12,100 @@ open Verity.Specs.ERC721
 
 /-- `constructor` sets owner slot 0 and zero-initializes supply/counter slots. -/
 theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
-    constructor_spec initialOwner s ((Verity.Examples.MacroContracts.Compat.ERC721.constructor initialOwner).runState s) := by
+    constructor_spec initialOwner s ((Verity.Examples.MacroContracts.ERC721Addressed.constructor initialOwner).runState s) := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · simp [Verity.Examples.MacroContracts.Compat.ERC721.constructor, Verity.Examples.MacroContracts.Compat.ERC721.owner, setStorageAddr,
+  · simp [Verity.Examples.MacroContracts.ERC721Addressed.constructor, Verity.Examples.MacroContracts.ERC721Addressed.owner, setStorageAddr,
       setStorage, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Verity.Examples.MacroContracts.Compat.ERC721.constructor, Verity.Examples.MacroContracts.Compat.ERC721.totalSupply, setStorageAddr,
+  · simp [Verity.Examples.MacroContracts.ERC721Addressed.constructor, Verity.Examples.MacroContracts.ERC721Addressed.totalSupply, setStorageAddr,
       setStorage, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Verity.Examples.MacroContracts.Compat.ERC721.constructor, Verity.Examples.MacroContracts.Compat.ERC721.nextTokenId, setStorageAddr,
+  · simp [Verity.Examples.MacroContracts.ERC721Addressed.constructor, Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr,
       setStorage, Contract.runState, Verity.bind, Bind.bind]
   · intro slot h_neq
-    simp [Verity.Examples.MacroContracts.Compat.ERC721.constructor, Verity.Examples.MacroContracts.Compat.ERC721.owner,
-      Verity.Examples.MacroContracts.Compat.ERC721.totalSupply, Verity.Examples.MacroContracts.Compat.ERC721.nextTokenId, setStorageAddr,
+    simp [Verity.Examples.MacroContracts.ERC721Addressed.constructor, Verity.Examples.MacroContracts.ERC721Addressed.owner,
+      Verity.Examples.MacroContracts.ERC721Addressed.totalSupply, Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr,
       setStorage,
       Contract.runState, Verity.bind, Bind.bind, h_neq]
   · intro slot h_slot1 h_slot2
-    simp [Verity.Examples.MacroContracts.Compat.ERC721.constructor, Verity.Examples.MacroContracts.Compat.ERC721.owner,
-      Verity.Examples.MacroContracts.Compat.ERC721.totalSupply, Verity.Examples.MacroContracts.Compat.ERC721.nextTokenId, setStorageAddr,
+    simp [Verity.Examples.MacroContracts.ERC721Addressed.constructor, Verity.Examples.MacroContracts.ERC721Addressed.owner,
+      Verity.Examples.MacroContracts.ERC721Addressed.totalSupply, Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr,
       setStorage,
       Contract.runState, Verity.bind, Bind.bind, h_slot1, h_slot2]
-  · simp [Specs.sameStorageMap, Verity.Examples.MacroContracts.Compat.ERC721.constructor, Verity.Examples.MacroContracts.Compat.ERC721.owner,
-      Verity.Examples.MacroContracts.Compat.ERC721.totalSupply, Verity.Examples.MacroContracts.Compat.ERC721.nextTokenId,
+  · simp [Specs.sameStorageMap, Verity.Examples.MacroContracts.ERC721Addressed.constructor, Verity.Examples.MacroContracts.ERC721Addressed.owner,
+      Verity.Examples.MacroContracts.ERC721Addressed.totalSupply, Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId,
       setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMap2, Verity.Examples.MacroContracts.Compat.ERC721.constructor, Verity.Examples.MacroContracts.Compat.ERC721.owner,
-      Verity.Examples.MacroContracts.Compat.ERC721.totalSupply, Verity.Examples.MacroContracts.Compat.ERC721.nextTokenId,
+  · simp [Specs.sameStorageMap2, Verity.Examples.MacroContracts.ERC721Addressed.constructor, Verity.Examples.MacroContracts.ERC721Addressed.owner,
+      Verity.Examples.MacroContracts.ERC721Addressed.totalSupply, Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId,
       setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMapUint, Verity.Examples.MacroContracts.Compat.ERC721.constructor, Verity.Examples.MacroContracts.Compat.ERC721.owner,
-      Verity.Examples.MacroContracts.Compat.ERC721.totalSupply, Verity.Examples.MacroContracts.Compat.ERC721.nextTokenId,
+  · simp [Specs.sameStorageMapUint, Verity.Examples.MacroContracts.ERC721Addressed.constructor, Verity.Examples.MacroContracts.ERC721Addressed.owner,
+      Verity.Examples.MacroContracts.ERC721Addressed.totalSupply, Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId,
       setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameContext, Verity.Examples.MacroContracts.Compat.ERC721.constructor, Verity.Examples.MacroContracts.Compat.ERC721.owner,
-      Verity.Examples.MacroContracts.Compat.ERC721.totalSupply, Verity.Examples.MacroContracts.Compat.ERC721.nextTokenId,
+  · simp [Specs.sameContext, Verity.Examples.MacroContracts.ERC721Addressed.constructor, Verity.Examples.MacroContracts.ERC721Addressed.owner,
+      Verity.Examples.MacroContracts.ERC721Addressed.totalSupply, Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId,
       setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
 
 /-- `balanceOf` returns balances slot 3 at address `addr`. -/
 theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :
-    balanceOf_spec addr ((Verity.Examples.MacroContracts.Compat.ERC721.balanceOf addr).runValue s) s := by
-  simp [Verity.Examples.MacroContracts.Compat.ERC721.balanceOf, balanceOf_spec, getMapping, Contract.runValue,
-    Verity.Examples.MacroContracts.Compat.ERC721.balances]
+    balanceOf_spec addr ((Verity.Examples.MacroContracts.ERC721Addressed.balanceOf addr).runValue s) s := by
+  simp [Verity.Examples.MacroContracts.ERC721Addressed.balanceOf, balanceOf_spec, getMapping, Contract.runValue,
+    Verity.Examples.MacroContracts.ERC721Addressed.balances]
 
 /-- `ownerOf` reverts for unminted tokens and returns owner for minted tokens. -/
 theorem ownerOf_meets_spec (s : ContractState) (tokenId : Uint256) :
-    ownerOf_spec tokenId ((Verity.Examples.MacroContracts.Compat.ERC721.ownerOf tokenId).run s) s := by
+    ownerOf_spec tokenId ((Verity.Examples.MacroContracts.ERC721Addressed.ownerOf tokenId).run s) s := by
   cases h_owner : (s.storageMapUint 4 tokenId != 0) <;>
-    simp [ownerOf_spec, Verity.Examples.MacroContracts.Compat.ERC721.ownerOf, Contract.run, Verity.bind, Bind.bind,
-      getMappingUint, Verity.Examples.MacroContracts.Compat.ERC721.owners, Verity.Examples.MacroContracts.Compat.ERC721.wordToAddress,
+    simp [ownerOf_spec, Verity.Examples.MacroContracts.ERC721Addressed.ownerOf, Contract.run, Verity.bind, Bind.bind,
+      getMappingUint, Verity.Examples.MacroContracts.ERC721Addressed.owners, Verity.Examples.MacroContracts.ERC721Addressed.wordToAddress,
       Verity.Specs.ERC721.wordToAddress, Pure.pure, Verity.pure,
       require, h_owner]
 
 /-- `getApproved` reverts for unminted tokens and returns approval for minted tokens. -/
 theorem getApproved_meets_spec (s : ContractState) (tokenId : Uint256) :
-    getApproved_spec tokenId ((Verity.Examples.MacroContracts.Compat.ERC721.getApproved tokenId).run s) s := by
+    getApproved_spec tokenId ((Verity.Examples.MacroContracts.ERC721Addressed.getApproved tokenId).run s) s := by
   cases h_owner : (s.storageMapUint 4 tokenId != 0) <;>
-    simp [getApproved_spec, Verity.Examples.MacroContracts.Compat.ERC721.getApproved, Contract.run, Verity.bind, Bind.bind,
-      getMappingUint, Verity.Examples.MacroContracts.Compat.ERC721.owners, Verity.Examples.MacroContracts.Compat.ERC721.tokenApprovals,
-      Verity.Examples.MacroContracts.Compat.ERC721.wordToAddress, Verity.Specs.ERC721.wordToAddress, Pure.pure, Verity.pure,
+    simp [getApproved_spec, Verity.Examples.MacroContracts.ERC721Addressed.getApproved, Contract.run, Verity.bind, Bind.bind,
+      getMappingUint, Verity.Examples.MacroContracts.ERC721Addressed.owners, Verity.Examples.MacroContracts.ERC721Addressed.tokenApprovals,
+      Verity.Examples.MacroContracts.ERC721Addressed.wordToAddress, Verity.Specs.ERC721.wordToAddress, Pure.pure, Verity.pure,
       require, h_owner]
 
 /-- `isApprovedForAll` checks nonzero operator-approval flag in slot 6. -/
 theorem isApprovedForAll_meets_spec (s : ContractState) (ownerAddr operator : Address) :
-    isApprovedForAll_spec ownerAddr operator ((Verity.Examples.MacroContracts.Compat.ERC721.isApprovedForAll ownerAddr operator).runValue s) s := by
-  simp [isApprovedForAll_spec, Verity.Examples.MacroContracts.Compat.ERC721.isApprovedForAll, Contract.runValue, Verity.bind, Bind.bind,
-    getMapping2, Verity.Examples.MacroContracts.Compat.ERC721.operatorApprovals]
+    isApprovedForAll_spec ownerAddr operator ((Verity.Examples.MacroContracts.ERC721Addressed.isApprovedForAll ownerAddr operator).runValue s) s := by
+  simp [isApprovedForAll_spec, Verity.Examples.MacroContracts.ERC721Addressed.isApprovedForAll, Contract.runValue, Verity.bind, Bind.bind,
+    getMapping2, Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals]
   simp [Pure.pure, Verity.pure]
 
 /-- `setApprovalForAll` writes sender/operator flag and leaves other state unchanged. -/
 theorem setApprovalForAll_meets_spec (s : ContractState) (operator : Address) (approved : Bool) :
-    setApprovalForAll_spec s.sender operator approved s ((Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll operator approved).runState s) := by
+    setApprovalForAll_spec s.sender operator approved s ((Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll operator approved).runState s) := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · cases approved <;>
-      simp [Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll, Verity.Examples.MacroContracts.Compat.ERC721.operatorApprovals,
-        setMapping2, Verity.Examples.MacroContracts.Compat.ERC721.boolToWord, Verity.Specs.ERC721.boolToWord,
+      simp [Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll, Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals,
+        setMapping2, Verity.Examples.MacroContracts.ERC721Addressed.boolToWord, Verity.Specs.ERC721.boolToWord,
         msgSender, Contract.runState, Verity.bind, Bind.bind]
   · intro o' op' h_neq
-    simp [Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll, Verity.Examples.MacroContracts.Compat.ERC721.operatorApprovals,
-      setMapping2, Verity.Examples.MacroContracts.Compat.ERC721.boolToWord,
+    simp [Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll, Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals,
+      setMapping2, Verity.Examples.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq]
   · intro op' h_neq
-    simp [Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll, Verity.Examples.MacroContracts.Compat.ERC721.operatorApprovals,
-      setMapping2, Verity.Examples.MacroContracts.Compat.ERC721.boolToWord,
+    simp [Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll, Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals,
+      setMapping2, Verity.Examples.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq]
-  · simp [Specs.sameStorage, Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll, Verity.Examples.MacroContracts.Compat.ERC721.operatorApprovals,
-      setMapping2, Verity.Examples.MacroContracts.Compat.ERC721.boolToWord,
+  · simp [Specs.sameStorage, Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll, Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals,
+      setMapping2, Verity.Examples.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageAddr, Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll, Verity.Examples.MacroContracts.Compat.ERC721.operatorApprovals,
-      setMapping2, Verity.Examples.MacroContracts.Compat.ERC721.boolToWord,
+  · simp [Specs.sameStorageAddr, Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll, Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals,
+      setMapping2, Verity.Examples.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMap, Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll, Verity.Examples.MacroContracts.Compat.ERC721.operatorApprovals,
-      setMapping2, Verity.Examples.MacroContracts.Compat.ERC721.boolToWord,
+  · simp [Specs.sameStorageMap, Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll, Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals,
+      setMapping2, Verity.Examples.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMapUint, Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll,
-      Verity.Examples.MacroContracts.Compat.ERC721.operatorApprovals, setMapping2,
-      Verity.Examples.MacroContracts.Compat.ERC721.boolToWord,
+  · simp [Specs.sameStorageMapUint, Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll,
+      Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals, setMapping2,
+      Verity.Examples.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameContext, Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll,
-      Verity.Examples.MacroContracts.Compat.ERC721.operatorApprovals, setMapping2,
-      Verity.Examples.MacroContracts.Compat.ERC721.boolToWord,
+  · simp [Specs.sameContext, Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll,
+      Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals, setMapping2,
+      Verity.Examples.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
 
 end Verity.Proofs.ERC721

--- a/Verity/Proofs/ERC721/Correctness.lean
+++ b/Verity/Proofs/ERC721/Correctness.lean
@@ -12,33 +12,33 @@ open Verity.Specs.ERC721
 
 /-- Read-only `balanceOf` preserves state. -/
 theorem balanceOf_preserves_state (s : ContractState) (addr : Address) :
-    ((Verity.Examples.MacroContracts.Compat.ERC721.balanceOf addr).runState s) = s := by
-  simp [Verity.Examples.MacroContracts.Compat.ERC721.balanceOf, getMapping, Contract.runState]
+    ((Verity.Examples.MacroContracts.ERC721Addressed.balanceOf addr).runState s) = s := by
+  simp [Verity.Examples.MacroContracts.ERC721Addressed.balanceOf, getMapping, Contract.runState]
 
 /-- Read-only `ownerOf` preserves state. -/
 theorem ownerOf_preserves_state (s : ContractState) (tokenId : Uint256) :
-    ((Verity.Examples.MacroContracts.Compat.ERC721.ownerOf tokenId).runState s) = s := by
-  cases h_owner : (s.storageMapUint Verity.Examples.MacroContracts.Compat.ERC721.owners.slot tokenId != 0) <;>
-    simp [Verity.Examples.MacroContracts.Compat.ERC721.ownerOf, getMappingUint, Contract.runState, Verity.bind, Bind.bind,
+    ((Verity.Examples.MacroContracts.ERC721Addressed.ownerOf tokenId).runState s) = s := by
+  cases h_owner : (s.storageMapUint Verity.Examples.MacroContracts.ERC721Addressed.owners.slot tokenId != 0) <;>
+    simp [Verity.Examples.MacroContracts.ERC721Addressed.ownerOf, getMappingUint, Contract.runState, Verity.bind, Bind.bind,
       require, Pure.pure, Verity.pure, h_owner]
 
 /-- Read-only `getApproved` preserves state. -/
 theorem getApproved_preserves_state (s : ContractState) (tokenId : Uint256) :
-    ((Verity.Examples.MacroContracts.Compat.ERC721.getApproved tokenId).runState s) = s := by
-  cases h_owner : (s.storageMapUint Verity.Examples.MacroContracts.Compat.ERC721.owners.slot tokenId != 0) <;>
-    simp [Verity.Examples.MacroContracts.Compat.ERC721.getApproved, getMappingUint, Contract.runState, Verity.bind, Bind.bind,
+    ((Verity.Examples.MacroContracts.ERC721Addressed.getApproved tokenId).runState s) = s := by
+  cases h_owner : (s.storageMapUint Verity.Examples.MacroContracts.ERC721Addressed.owners.slot tokenId != 0) <;>
+    simp [Verity.Examples.MacroContracts.ERC721Addressed.getApproved, getMappingUint, Contract.runState, Verity.bind, Bind.bind,
       require, Pure.pure, Verity.pure, h_owner]
 
 /-- Read-only `isApprovedForAll` preserves state. -/
 theorem isApprovedForAll_preserves_state (s : ContractState) (ownerAddr operator : Address) :
-    ((Verity.Examples.MacroContracts.Compat.ERC721.isApprovedForAll ownerAddr operator).runState s) = s := by
-  simp [Verity.Examples.MacroContracts.Compat.ERC721.isApprovedForAll, getMapping2, Contract.runState, Verity.bind, Bind.bind]
+    ((Verity.Examples.MacroContracts.ERC721Addressed.isApprovedForAll ownerAddr operator).runState s) = s := by
+  simp [Verity.Examples.MacroContracts.ERC721Addressed.isApprovedForAll, getMapping2, Contract.runState, Verity.bind, Bind.bind]
   simp [Pure.pure, Verity.pure]
 
 /-- `setApprovalForAll` satisfies the balance-neutral invariant helper. -/
 theorem setApprovalForAll_is_balance_neutral_holds
     (s : ContractState) (operator : Address) (approved : Bool) :
-    setApprovalForAll_is_balance_neutral s ((Verity.Examples.MacroContracts.Compat.ERC721.setApprovalForAll operator approved).runState s) := by
+    setApprovalForAll_is_balance_neutral s ((Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll operator approved).runState s) := by
   have h := setApprovalForAll_meets_spec s operator approved
   rcases h with ⟨_, _, _, h_storage, h_storageAddr, h_storageMap, h_storageMapUint, _⟩
   exact ⟨h_storage, h_storageAddr, h_storageMap, h_storageMapUint⟩


### PR DESCRIPTION
## Summary
- add canonical ERC721 module at `Verity.Examples.MacroContracts.ERC721Addressed`
- switch `Compiler/Interpreter.lean` ERC721 wiring to canonical module (no `Compat/ERC721` import)
- switch ERC721 proofs to canonical module import/references
- convert `Verity.Examples.MacroContracts.Compat.ERC721` into a thin compatibility shim forwarding to canonical definitions
- include canonical module from `Verity/Examples/MacroContracts.lean`

## Why
Issue #1142 requires interpreter/proofs to stop depending on `Compat/ERC721` and move toward a single canonical ERC721 namespace while preserving behavior.

## Validation
- `lake build Compiler.Interpreter Verity.Proofs.ERC721.Basic Verity.Proofs.ERC721.Correctness Verity.Examples.MacroContracts.Compat.ERC721`
- `make check`

Closes #1142

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a module/namespace reshuffle that should preserve ERC721 behavior; main risk is missing/incorrect rewiring causing build or proof failures in downstream imports.
> 
> **Overview**
> Introduces a new canonical ERC721 implementation module, `Verity.Examples.MacroContracts.ERC721Addressed`, and exports it from `Verity/Examples/MacroContracts.lean`.
> 
> Rewires the differential-testing interpreter (`Compiler/Interpreter.lean`) and ERC721 proofs (`Verity/Proofs/ERC721/*`) to reference `ERC721Addressed` directly, and reduces `MacroContracts/Compat/ERC721.lean` to a thin forwarding shim to keep the old import path working.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6adff6c4b97bab752d141dbd6ec391e2eb338d15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->