### PR TITLE
Cleanup legacy example duplicates after macro unification

### DIFF
--- a/Verity/All.lean
+++ b/Verity/All.lean
@@ -35,15 +35,6 @@ import Verity.Proofs.Stdlib.MappingAutomation
 import Verity.Proofs.Stdlib.ListSum
 
 -- Example contracts (EDSL implementations)
-import Verity.Examples.SimpleStorage
-import Verity.Examples.Counter
-import Verity.Examples.SafeCounter
-import Verity.Examples.Owned
-import Verity.Examples.OwnedCounter
-import Verity.Examples.Ledger
-import Verity.Examples.SimpleToken
-import Verity.Examples.ERC20
-import Verity.Examples.ERC721
 import Verity.Examples.ReentrancyExample
 import Verity.Examples.CryptoHash
 import Verity.Examples.MacroContracts

--- a/Verity/Examples/Counter.lean
+++ b/Verity/Examples/Counter.lean
@@ -1,51 +1,15 @@
-/-
-  Counter: Demonstrating arithmetic operations
-
-  This contract shows:
-  - Stateful counter variable
-  - Increment operation (addition with EVM modular semantics)
-  - Decrement operation (subtraction with EVM modular semantics)
-  - Getter for current count
-
-  Pattern: Basic arithmetic and state updates with EVM-compatible operations
--/
-
-import Verity.Core
-import Verity.EVM.Uint256
+import Verity.Examples.MacroContracts.Core
 
 namespace Verity.Examples.Counter
 
-open Verity
-open Verity.EVM.Uint256
-
--- Storage layout
 def count : StorageSlot Uint256 := ⟨0⟩
 
--- Increment the counter by 1 (with EVM modular arithmetic)
-def increment : Contract Unit := do
-  let current ← getStorage count
-  setStorage count (add current 1)
-
--- Decrement the counter by 1 (with EVM modular arithmetic)
-def decrement : Contract Unit := do
-  let current ← getStorage count
-  setStorage count (sub current 1)
-
--- Get the current count
-def getCount : Contract Uint256 := do
-  getStorage count
-
--- Example: Increment twice, decrement once
-def exampleUsage : Contract Uint256 := do
-  increment
-  increment
-  decrement
-  getCount
-
-#eval (exampleUsage.run { defaultState with
-  sender := 0xA11CE,
-  thisAddress := 0xC04273
-}).getValue?
--- Expected output: some 1
+abbrev increment := Verity.Examples.MacroContracts.Counter.increment
+abbrev decrement := Verity.Examples.MacroContracts.Counter.decrement
+abbrev getCount := Verity.Examples.MacroContracts.Counter.getCount
+abbrev previewAddTwice := Verity.Examples.MacroContracts.Counter.previewAddTwice
+abbrev previewOps := Verity.Examples.MacroContracts.Counter.previewOps
+abbrev previewEnvOps := Verity.Examples.MacroContracts.Counter.previewEnvOps
+abbrev previewLowLevel := Verity.Examples.MacroContracts.Counter.previewLowLevel
 
 end Verity.Examples.Counter

--- a/Verity/Examples/ERC20.lean
+++ b/Verity/Examples/ERC20.lean
@@ -1,127 +1,24 @@
-/-
-  ERC20 (foundation scaffold):
-  - balances mapping
-  - allowances double mapping
-  - owner-controlled minting
-  - transfer / approve / transferFrom
-
-  This module is intentionally proof-light and serves as the executable
-  contract baseline for issue #69.
--/
-
-import Verity.Core
-import Verity.EVM.Uint256
-import Verity.Stdlib.Math
+import Verity.Examples.MacroContracts.Tokens
 
 namespace Verity.Examples.ERC20
 
-open Verity
-open Verity.EVM.Uint256
-open Verity.Stdlib.Math
+abbrev owner := Verity.Examples.MacroContracts.ERC20.ownerSlot
+abbrev totalSupply := Verity.Examples.MacroContracts.ERC20.totalSupplySlot
+abbrev balances := Verity.Examples.MacroContracts.ERC20.balancesSlot
+abbrev allowances := Verity.Examples.MacroContracts.ERC20.allowancesSlot
+abbrev mint := Verity.Examples.MacroContracts.ERC20.mint
+abbrev transfer := Verity.Examples.MacroContracts.ERC20.transfer
+abbrev approve := Verity.Examples.MacroContracts.ERC20.approve
+abbrev transferFrom := Verity.Examples.MacroContracts.ERC20.transferFrom
+abbrev balanceOf := Verity.Examples.MacroContracts.ERC20.balanceOf
+abbrev allowanceOf := Verity.Examples.MacroContracts.ERC20.allowanceOf
+abbrev getTotalSupply := Verity.Examples.MacroContracts.ERC20.getTotalSupply
+abbrev getOwner := Verity.Examples.MacroContracts.ERC20.getOwner
+abbrev isOwner := Verity.Examples.MacroContracts.ERC20.isOwner
+abbrev onlyOwner := Verity.Examples.MacroContracts.ERC20.onlyOwner
 
--- Storage layout
-def owner : StorageSlot Address := ⟨0⟩
-def totalSupply : StorageSlot Uint256 := ⟨1⟩
-def balances : StorageSlot (Address → Uint256) := ⟨2⟩
-def allowances : StorageSlot (Address → Address → Uint256) := ⟨3⟩
-
--- Access-control helpers
-def isOwner : Contract Bool := do
-  let sender ← msgSender
-  let currentOwner ← getStorageAddr owner
-  return sender == currentOwner
-
-def onlyOwner : Contract Unit := do
-  let ownerCheck ← isOwner
-  require ownerCheck "Caller is not the owner"
-
--- Constructor initializes owner and starts with zero supply.
-def constructor (initialOwner : Address) : Contract Unit := do
+def «constructor» (initialOwner : Address) : Contract Unit := do
   setStorageAddr owner initialOwner
   setStorage totalSupply 0
-
--- Owner-only mint with overflow checks on balance and supply.
-def mint (to : Address) (amount : Uint256) : Contract Unit := do
-  onlyOwner
-  let currentBalance ← getMapping balances to
-  let newBalance ← requireSomeUint (safeAdd currentBalance amount) "Balance overflow"
-  let currentSupply ← getStorage totalSupply
-  let newSupply ← requireSomeUint (safeAdd currentSupply amount) "Supply overflow"
-  setMapping balances to newBalance
-  setStorage totalSupply newSupply
-
--- EIP-20 transfer: sender -> recipient.
-def transfer (to : Address) (amount : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  let senderBalance ← getMapping balances sender
-  require (senderBalance >= amount) "Insufficient balance"
-
-  if sender == to then
-    pure ()
-  else
-    let recipientBalance ← getMapping balances to
-    let newRecipientBalance ← requireSomeUint (safeAdd recipientBalance amount) "Recipient balance overflow"
-    setMapping balances sender (sub senderBalance amount)
-    setMapping balances to newRecipientBalance
-
--- EIP-20 approve: owner(sender) -> spender allowance.
-def approve (spender : Address) (amount : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  setMapping2 allowances sender spender amount
-
--- EIP-20 transferFrom: move from `fromAddr` to `to` using sender's allowance.
-def transferFrom (fromAddr to : Address) (amount : Uint256) : Contract Unit := do
-  let spender ← msgSender
-  let currentAllowance ← getMapping2 allowances fromAddr spender
-  require (currentAllowance >= amount) "Insufficient allowance"
-
-  let fromBalance ← getMapping balances fromAddr
-  require (fromBalance >= amount) "Insufficient balance"
-
-  if fromAddr == to then
-    pure ()
-  else
-    let toBalance ← getMapping balances to
-    let newToBalance ← requireSomeUint (safeAdd toBalance amount) "Recipient balance overflow"
-    setMapping balances fromAddr (sub fromBalance amount)
-    setMapping balances to newToBalance
-
-  -- Keep MAX_UINT256 as "infinite allowance" (common ERC20 behavior).
-  if currentAllowance == MAX_UINT256 then
-    pure ()
-  else
-    setMapping2 allowances fromAddr spender (sub currentAllowance amount)
-
--- View helpers
-def balanceOf (addr : Address) : Contract Uint256 := do
-  getMapping balances addr
-
-def allowanceOf (ownerAddr spender : Address) : Contract Uint256 := do
-  getMapping2 allowances ownerAddr spender
-
-def getTotalSupply : Contract Uint256 := do
-  getStorage totalSupply
-
-def getOwner : Contract Address := do
-  getStorageAddr owner
-
--- Example flow: constructor + mint + approve + transferFrom.
-def exampleUsage : Contract (Uint256 × Uint256 × Uint256 × Uint256) := do
-  constructor 0xA11CE
-  mint 0xA11CE 1000
-  approve 0xA11CE 300
-  transferFrom 0xA11CE 0xB0B 250
-
-  let aliceBalance ← balanceOf 0xA11CE
-  let bobBalance ← balanceOf 0xB0B
-  let bobAllowance ← allowanceOf 0xA11CE 0xA11CE
-  let supply ← getTotalSupply
-  return (aliceBalance, bobBalance, bobAllowance, supply)
-
-#eval! (exampleUsage.run { defaultState with
-  sender := 0xA11CE,
-  thisAddress := 0xE20
-}).getValue?
--- Expected: some (750, 250, 50, 1000)
 
 end Verity.Examples.ERC20

--- a/Verity/Examples/ERC721.lean
+++ b/Verity/Examples/ERC721.lean
@@ -1,135 +1,30 @@
-/-
-  ERC721 (foundation scaffold):
-  - balances mapping
-  - token ownership by tokenId
-  - token approvals and operator approvals
-
-  This module provides a compile-safe executable baseline for issue #73.
--/
-
-import Verity.Core
-import Verity.EVM.Uint256
-import Verity.Stdlib.Math
+import Verity.Examples.MacroContracts.ERC721Addressed
 
 namespace Verity.Examples.ERC721
 
-open Verity
-open Verity.EVM.Uint256
-open Verity.Stdlib.Math
+abbrev owner := Verity.Examples.MacroContracts.ERC721Addressed.owner
+abbrev totalSupply := Verity.Examples.MacroContracts.ERC721Addressed.totalSupply
+abbrev nextTokenId := Verity.Examples.MacroContracts.ERC721Addressed.nextTokenId
+abbrev balances := Verity.Examples.MacroContracts.ERC721Addressed.balances
+abbrev owners := Verity.Examples.MacroContracts.ERC721Addressed.owners
+abbrev tokenApprovals := Verity.Examples.MacroContracts.ERC721Addressed.tokenApprovals
+abbrev operatorApprovals := Verity.Examples.MacroContracts.ERC721Addressed.operatorApprovals
 
--- Storage layout
-def owner : StorageSlot Address := ⟨0⟩
-def totalSupply : StorageSlot Uint256 := ⟨1⟩
-def nextTokenId : StorageSlot Uint256 := ⟨2⟩
-def balances : StorageSlot (Address → Uint256) := ⟨3⟩
-def owners : StorageSlot (Uint256 → Uint256) := ⟨4⟩
-def tokenApprovals : StorageSlot (Uint256 → Uint256) := ⟨5⟩
-def operatorApprovals : StorageSlot (Address → Address → Uint256) := ⟨6⟩
+abbrev addressToWord := Verity.Examples.MacroContracts.ERC721Addressed.addressToWord
+abbrev wordToAddress := Verity.Examples.MacroContracts.ERC721Addressed.wordToAddress
+abbrev boolToWord := Verity.Examples.MacroContracts.ERC721Addressed.boolToWord
 
-def addressToWord (a : Address) : Uint256 :=
-  (a.toNat : Uint256)
+abbrev isOwner := Verity.Examples.MacroContracts.ERC721Addressed.isOwner
+abbrev onlyOwner := Verity.Examples.MacroContracts.ERC721Addressed.onlyOwner
 
-def wordToAddress (w : Uint256) : Address :=
-  Verity.Core.Address.ofNat (w : Nat)
-
-def boolToWord (b : Bool) : Uint256 :=
-  if b then 1 else 0
-
-def isOwner : Contract Bool := do
-  let sender ← msgSender
-  let currentOwner ← getStorageAddr owner
-  return sender == currentOwner
-
-def onlyOwner : Contract Unit := do
-  let ownerCheck ← isOwner
-  require ownerCheck "Caller is not the owner"
-
--- Constructor initializes owner and zeroes core counters.
-def constructor (initialOwner : Address) : Contract Unit := do
-  setStorageAddr owner initialOwner
-  setStorage totalSupply 0
-  setStorage nextTokenId 0
-
--- Core ERC721 view helpers.
-def balanceOf (addr : Address) : Contract Uint256 := do
-  getMapping balances addr
-
-def ownerOf (tokenId : Uint256) : Contract Address := do
-  let ownerWord ← getMappingUint owners tokenId
-  require (ownerWord != 0) "Token does not exist"
-  return wordToAddress ownerWord
-
-def getApproved (tokenId : Uint256) : Contract Address := do
-  let ownerWord ← getMappingUint owners tokenId
-  require (ownerWord != 0) "Token does not exist"
-  let approvedWord ← getMappingUint tokenApprovals tokenId
-  return wordToAddress approvedWord
-
-def isApprovedForAll (ownerAddr operator : Address) : Contract Bool := do
-  let flag ← getMapping2 operatorApprovals ownerAddr operator
-  return flag != 0
-
--- Approve a specific address for a single tokenId.
-def approve (approved : Address) (tokenId : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  let tokenOwner ← ownerOf tokenId
-  require (sender == tokenOwner) "Not token owner"
-  setMappingUint tokenApprovals tokenId (addressToWord approved)
-
--- Set or clear global operator approval for sender.
-def setApprovalForAll (operator : Address) (approved : Bool) : Contract Unit := do
-  let sender ← msgSender
-  setMapping2 operatorApprovals sender operator (boolToWord approved)
-
--- Owner-only mint with sequential token IDs.
-def mint (to : Address) : Contract Uint256 := do
-  onlyOwner
-  require (to != 0) "Invalid recipient"
-
-  let tokenId ← getStorage nextTokenId
-  let currentOwnerWord ← getMappingUint owners tokenId
-  require (currentOwnerWord == 0) "Token already minted"
-
-  let recipientBalance ← getMapping balances to
-  let newRecipientBalance ← requireSomeUint (safeAdd recipientBalance 1) "Balance overflow"
-
-  let currentSupply ← getStorage totalSupply
-  let newSupply ← requireSomeUint (safeAdd currentSupply 1) "Supply overflow"
-
-  setMappingUint owners tokenId (addressToWord to)
-  setMapping balances to newRecipientBalance
-  setStorage totalSupply newSupply
-  setStorage nextTokenId (add tokenId 1)
-  return tokenId
-
--- Transfer token from owner to recipient with approval checks.
-def transferFrom (fromAddr to : Address) (tokenId : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  require (to != 0) "Invalid recipient"
-
-  let ownerWord ← getMappingUint owners tokenId
-  require (ownerWord != 0) "Token does not exist"
-
-  let tokenOwner := wordToAddress ownerWord
-  require (tokenOwner == fromAddr) "From is not owner"
-
-  let approvedWord ← getMappingUint tokenApprovals tokenId
-  let operatorWord ← getMapping2 operatorApprovals fromAddr sender
-  let senderWord := addressToWord sender
-  let authorized := sender == fromAddr || approvedWord == senderWord || operatorWord != 0
-  require authorized "Not authorized"
-
-  if fromAddr == to then
-    pure ()
-  else
-    let fromBalance ← getMapping balances fromAddr
-    require (fromBalance >= 1) "Insufficient balance"
-    let toBalance ← getMapping balances to
-    let newToBalance ← requireSomeUint (safeAdd toBalance 1) "Balance overflow"
-    setMapping balances fromAddr (sub fromBalance 1)
-    setMapping balances to newToBalance
-
-  setMappingUint owners tokenId (addressToWord to)
-  setMappingUint tokenApprovals tokenId 0
+abbrev «constructor» := Verity.Examples.MacroContracts.ERC721Addressed.constructor
+abbrev balanceOf := Verity.Examples.MacroContracts.ERC721Addressed.balanceOf
+abbrev ownerOf := Verity.Examples.MacroContracts.ERC721Addressed.ownerOf
+abbrev getApproved := Verity.Examples.MacroContracts.ERC721Addressed.getApproved
+abbrev isApprovedForAll := Verity.Examples.MacroContracts.ERC721Addressed.isApprovedForAll
+abbrev approve := Verity.Examples.MacroContracts.ERC721Addressed.approve
+abbrev setApprovalForAll := Verity.Examples.MacroContracts.ERC721Addressed.setApprovalForAll
+abbrev mint := Verity.Examples.MacroContracts.ERC721Addressed.mint
+abbrev transferFrom := Verity.Examples.MacroContracts.ERC721Addressed.transferFrom
 
 end Verity.Examples.ERC721

--- a/Verity/Examples/Ledger.lean
+++ b/Verity/Examples/Ledger.lean
@@ -1,76 +1,12 @@
-/-
-  Ledger: Demonstrates mapping storage pattern
-
-  This contract shows how to use mappings (Address → Uint256) for
-  tracking balances per address. It implements basic deposit,
-  withdraw, and transfer operations with EVM modular arithmetic.
--/
-
-import Verity.Core
-import Verity.EVM.Uint256
-import Verity.Stdlib.Math
+import Verity.Examples.MacroContracts.Core
 
 namespace Verity.Examples.Ledger
 
-open Verity
-open Verity.EVM.Uint256
-open Verity.Stdlib.Math (safeAdd requireSomeUint)
-
--- Storage: balances mapping (Address → Uint256)
 def balances : StorageSlot (Address → Uint256) := ⟨0⟩
 
--- Deposit: add to caller's balance (with EVM modular arithmetic)
-def deposit (amount : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  let currentBalance ← getMapping balances sender
-  setMapping balances sender (add currentBalance amount)
-
--- Withdraw: subtract from caller's balance (with safety check and EVM modular arithmetic)
-def withdraw (amount : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  let currentBalance ← getMapping balances sender
-  require (currentBalance >= amount) "Insufficient balance"
-  setMapping balances sender (sub currentBalance amount)
-
--- Transfer: move balance from caller to another address (with overflow protection)
-def transfer (to : Address) (amount : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  let senderBalance ← getMapping balances sender
-  require (senderBalance >= amount) "Insufficient balance"
-
-  if sender == to then
-    pure ()
-  else
-    let recipientBalance ← getMapping balances to
-    let newRecipientBalance ← requireSomeUint (safeAdd recipientBalance amount) "Recipient balance overflow"
-    setMapping balances sender (sub senderBalance amount)
-    setMapping balances to newRecipientBalance
-
--- Get balance of any address
-def getBalance (addr : Address) : Contract Uint256 := do
-  getMapping balances addr
-
--- Example usage: Alice deposits 100, withdraws 30, transfers 50 to Bob
-def exampleUsage : Contract (Uint256 × Uint256) := do
-  -- Alice deposits 100
-  deposit 100
-
-  -- Alice withdraws 30 (balance: 70)
-  withdraw 30
-
-  -- Alice transfers 50 to Bob (Alice: 20, Bob: 50)
-  transfer 0xB0B 50
-
-  -- Return both balances
-  let aliceBalance ← getBalance 0xA11CE
-  let bobBalance ← getBalance 0xB0B
-  return (aliceBalance, bobBalance)
-
--- Evaluate the example
-#eval! (exampleUsage.run { defaultState with
-  sender := 0xA11CE,
-  thisAddress := 0x1ED6E2
-}).getValue?
--- Expected output: some (20, 50) - Alice has 20, Bob has 50
+abbrev deposit := Verity.Examples.MacroContracts.Ledger.deposit
+abbrev withdraw := Verity.Examples.MacroContracts.Ledger.withdraw
+abbrev transfer := Verity.Examples.MacroContracts.Ledger.transfer
+abbrev getBalance := Verity.Examples.MacroContracts.Ledger.getBalance
 
 end Verity.Examples.Ledger

--- a/Verity/Examples/Owned.lean
+++ b/Verity/Examples/Owned.lean
@@ -1,60 +1,15 @@
-/-
-  Owned: Demonstrating the ownership pattern
-
-  This contract shows:
-  - Owner address storage
-  - Access control with onlyOwner pattern
-  - Using msgSender for authentication
-  - Using require for authorization checks
-  - Transfer ownership functionality
-
-  Pattern: Access control and ownership
--/
-
-import Verity.Core
+import Verity.Examples.MacroContracts.Core
 
 namespace Verity.Examples.Owned
 
-open Verity
-
--- Storage layout
 def owner : StorageSlot Address := ⟨0⟩
 
--- Helper: Check if caller is owner
-def isOwner : Contract Bool := do
-  let sender ← msgSender
-  let currentOwner ← getStorageAddr owner
-  return sender == currentOwner
+abbrev transferOwnership := Verity.Examples.MacroContracts.Owned.transferOwnership
+abbrev getOwner := Verity.Examples.MacroContracts.Owned.getOwner
+abbrev isOwner := Verity.Examples.MacroContracts.Owned.isOwner
+abbrev onlyOwner := Verity.Examples.MacroContracts.Owned.onlyOwner
 
--- Modifier pattern: Only owner can proceed
-def onlyOwner : Contract Unit := do
-  let ownerCheck ← isOwner
-  require ownerCheck "Caller is not the owner"
-
--- Initialize contract with owner
-def constructor (initialOwner : Address) : Contract Unit := do
+def «constructor» (initialOwner : Address) : Contract Unit := do
   setStorageAddr owner initialOwner
-
--- Transfer ownership to new address
-def transferOwnership (newOwner : Address) : Contract Unit := do
-  onlyOwner
-  setStorageAddr owner newOwner
-
--- Get current owner
-def getOwner : Contract Address := do
-  getStorageAddr owner
-
--- Example: Initialize, check owner, transfer ownership
-def exampleUsage : Contract Address := do
-  constructor 0xA11CE
-  transferOwnership 0xB0B
-  getOwner
-
--- Note: This will evaluate in a context where msgSender is set
-#eval (exampleUsage.run { defaultState with
-  sender := 0xA11CE,  -- Alice is the caller
-  thisAddress := 0xC0437AC7
-}).getValue?
--- Expected output: some 0xB0B (after transfer)
 
 end Verity.Examples.Owned

--- a/Verity/Examples/OwnedCounter.lean
+++ b/Verity/Examples/OwnedCounter.lean
@@ -1,84 +1,19 @@
-/-
-  OwnedCounter: Demonstrating pattern composition
-
-  This contract shows:
-  - Combining Owned and Counter patterns
-  - Owner-controlled counter operations
-  - Multiple storage slots (owner Address + count Uint256)
-  - Access control on state updates
-  - Pattern composition without interference
-
-  Pattern: Composition of ownership and arithmetic
--/
-
-import Verity.Core
-import Verity.EVM.Uint256
+import Verity.Examples.MacroContracts.Core
 
 namespace Verity.Examples.OwnedCounter
 
-open Verity
-open Verity.EVM.Uint256
-
--- Storage layout
 def owner : StorageSlot Address := ⟨0⟩
 def count : StorageSlot Uint256 := ⟨1⟩
 
--- Helper: Check if caller is owner
-def isOwner : Contract Bool := do
-  let sender ← msgSender
-  let currentOwner ← getStorageAddr owner
-  return sender == currentOwner
+abbrev increment := Verity.Examples.MacroContracts.OwnedCounter.increment
+abbrev decrement := Verity.Examples.MacroContracts.OwnedCounter.decrement
+abbrev getCount := Verity.Examples.MacroContracts.OwnedCounter.getCount
+abbrev getOwner := Verity.Examples.MacroContracts.OwnedCounter.getOwner
+abbrev transferOwnership := Verity.Examples.MacroContracts.OwnedCounter.transferOwnership
+abbrev isOwner := Verity.Examples.MacroContracts.OwnedCounter.isOwner
+abbrev onlyOwner := Verity.Examples.MacroContracts.OwnedCounter.onlyOwner
 
--- Modifier pattern: Only owner can proceed
-def onlyOwner : Contract Unit := do
-  let ownerCheck ← isOwner
-  require ownerCheck "Caller is not the owner"
-
--- Initialize contract with owner
-def constructor (initialOwner : Address) : Contract Unit := do
+def «constructor» (initialOwner : Address) : Contract Unit := do
   setStorageAddr owner initialOwner
-
--- Increment the counter (owner-only, with EVM modular arithmetic)
-def increment : Contract Unit := do
-  onlyOwner
-  let current ← getStorage count
-  setStorage count (add current 1)
-
--- Decrement the counter (owner-only, with EVM modular arithmetic)
-def decrement : Contract Unit := do
-  onlyOwner
-  let current ← getStorage count
-  setStorage count (sub current 1)
-
--- Get the current count (public read)
-def getCount : Contract Uint256 := do
-  getStorage count
-
--- Get current owner (public read)
-def getOwner : Contract Address := do
-  getStorageAddr owner
-
--- Transfer ownership (owner-only)
-def transferOwnership (newOwner : Address) : Contract Unit := do
-  onlyOwner
-  setStorageAddr owner newOwner
-
--- Example: Initialize with Alice, increment twice, transfer to Bob, try to increment
-def exampleUsage : Contract (Uint256 × Address) := do
-  constructor 0xA11CE
-  increment
-  increment
-  transferOwnership 0xB0B
-  -- Note: Next increment would fail if caller is still Alice
-  -- But in this example context, we just read the final state
-  let finalCount ← getCount
-  let finalOwner ← getOwner
-  return (finalCount, finalOwner)
-
-#eval (exampleUsage.run { defaultState with
-  sender := 0xA11CE,  -- Alice is the caller
-  thisAddress := 0xC0437AC7
-}).getValue?
--- Expected output: some (2, 0xB0B)
 
 end Verity.Examples.OwnedCounter

--- a/Verity/Examples/SafeCounter.lean
+++ b/Verity/Examples/SafeCounter.lean
@@ -1,53 +1,11 @@
-/-
-  SafeCounter: Demonstrating safe arithmetic operations
-
-  This contract shows:
-  - Using stdlib Math.safeAdd and Math.safeSub
-  - Checked arithmetic that prevents overflow/underflow
-  - Handling Option results from safe operations
-  - requireSome helper for clean error handling
-
-  Pattern: Safe arithmetic with overflow/underflow protection
--/
-
-import Verity.Core
-import Verity.Stdlib.Math
+import Verity.Examples.MacroContracts.Core
 
 namespace Verity.Examples.SafeCounter
 
-open Verity
-open Verity.Stdlib.Math
-
--- Storage layout
 def count : StorageSlot Uint256 := ⟨0⟩
 
--- Increment the counter by 1 (with overflow check)
-def increment : Contract Unit := do
-  let current ← getStorage count
-  let newCount ← requireSomeUint (safeAdd current 1) "Overflow in increment"
-  setStorage count newCount
-
--- Decrement the counter by 1 (with underflow check)
-def decrement : Contract Unit := do
-  let current ← getStorage count
-  let newCount ← requireSomeUint (safeSub current 1) "Underflow in decrement"
-  setStorage count newCount
-
--- Get the current count
-def getCount : Contract Uint256 := do
-  getStorage count
-
--- Example: Increment twice, decrement once
-def exampleUsage : Contract Uint256 := do
-  increment
-  increment
-  decrement
-  getCount
-
-#eval (exampleUsage.run { defaultState with
-  sender := 0xA11CE,
-  thisAddress := 0x5AFE
-}).getValue?
--- Expected output: some 1
+abbrev increment := Verity.Examples.MacroContracts.SafeCounter.increment
+abbrev decrement := Verity.Examples.MacroContracts.SafeCounter.decrement
+abbrev getCount := Verity.Examples.MacroContracts.SafeCounter.getCount
 
 end Verity.Examples.SafeCounter

--- a/Verity/Examples/SimpleStorage.lean
+++ b/Verity/Examples/SimpleStorage.lean
@@ -1,40 +1,9 @@
-/-
-  SimpleStorage: The "Hello World" of smart contracts
+import Verity.Examples.MacroContracts.Core
 
-  This contract demonstrates:
-  - Basic storage (one uint256 value)
-  - A setter function
-  - A getter function
+namespace Verity.Examples.SimpleStorage
 
-  Pattern: Simplest possible stateful contract
--/
+abbrev storedData := Verity.Examples.MacroContracts.SimpleStorage.storedData
+abbrev store := Verity.Examples.MacroContracts.SimpleStorage.store
+abbrev retrieve := Verity.Examples.MacroContracts.SimpleStorage.retrieve
 
-import Verity.Core
-
-namespace Verity.Examples
-
-open Verity
-
--- Storage layout
-def storedData : StorageSlot Uint256 := ⟨0⟩
-
--- Set the stored value
-def store (value : Uint256) : Contract Unit := do
-  setStorage storedData value
-
--- Get the stored value
-def retrieve : Contract Uint256 := do
-  getStorage storedData
-
--- Example: Store and retrieve
-def exampleUsage : Contract Uint256 := do
-  store 42
-  retrieve
-
-#eval (exampleUsage.run { defaultState with
-  sender := 0xA11CE,
-  thisAddress := 0xC0437AC7
-}).getValue?
--- Expected output: some 42
-
-end Verity.Examples
+end Verity.Examples.SimpleStorage

--- a/Verity/Examples/SimpleToken.lean
+++ b/Verity/Examples/SimpleToken.lean
@@ -1,106 +1,21 @@
-/-
-  SimpleToken: Demonstrates pattern composition with mappings
-
-  This contract shows:
-  - Combining Owned (access control) + Ledger (balances mapping) patterns
-  - Owner-controlled minting with overflow protection (safeAdd)
-  - Public transfer operations with EVM modular arithmetic
-  - Total supply tracking
-  - Pattern composition with mappings works seamlessly
-
-  Pattern: Token contract (ERC20-like, minimal) with EVM-compatible operations
--/
-
-import Verity.Core
-import Verity.EVM.Uint256
-import Verity.Stdlib.Math
+import Verity.Examples.MacroContracts.Tokens
 
 namespace Verity.Examples.SimpleToken
 
-open Verity
-open Verity.EVM.Uint256
-open Verity.Stdlib.Math
-
--- Storage layout
 def owner : StorageSlot Address := ⟨0⟩
 def balances : StorageSlot (Address → Uint256) := ⟨1⟩
 def totalSupply : StorageSlot Uint256 := ⟨2⟩
 
--- Helper: Check if caller is owner
-def isOwner : Contract Bool := do
-  let sender ← msgSender
-  let currentOwner ← getStorageAddr owner
-  return sender == currentOwner
+abbrev mint := Verity.Examples.MacroContracts.SimpleToken.mint
+abbrev transfer := Verity.Examples.MacroContracts.SimpleToken.transfer
+abbrev balanceOf := Verity.Examples.MacroContracts.SimpleToken.balanceOf
+abbrev getTotalSupply := Verity.Examples.MacroContracts.SimpleToken.getTotalSupply
+abbrev getOwner := Verity.Examples.MacroContracts.SimpleToken.getOwner
+abbrev isOwner := Verity.Examples.MacroContracts.SimpleToken.isOwner
+abbrev onlyOwner := Verity.Examples.MacroContracts.SimpleToken.onlyOwner
 
--- Modifier pattern: Only owner can proceed
-def onlyOwner : Contract Unit := do
-  let ownerCheck ← isOwner
-  require ownerCheck "Caller is not the owner"
-
--- Initialize contract with owner
-def constructor (initialOwner : Address) : Contract Unit := do
+def «constructor» (initialOwner : Address) : Contract Unit := do
   setStorageAddr owner initialOwner
   setStorage totalSupply 0
-
--- Mint tokens to an address (owner-only, with overflow protection)
--- Follows checks-before-effects: all require guards execute before state mutations,
--- so revert always carries the original (unmodified) state.
-def mint (to : Address) (amount : Uint256) : Contract Unit := do
-  onlyOwner
-  let currentBalance ← getMapping balances to
-  let newBalance ← requireSomeUint (safeAdd currentBalance amount) "Balance overflow"
-  let currentSupply ← getStorage totalSupply
-  let newSupply ← requireSomeUint (safeAdd currentSupply amount) "Supply overflow"
-  setMapping balances to newBalance
-  setStorage totalSupply newSupply
-
--- Transfer tokens from caller to another address (with overflow protection)
-def transfer (to : Address) (amount : Uint256) : Contract Unit := do
-  let sender ← msgSender
-  let senderBalance ← getMapping balances sender
-  require (senderBalance >= amount) "Insufficient balance"
-
-  if sender == to then
-    pure ()
-  else
-    let recipientBalance ← getMapping balances to
-    let newRecipientBalance ← requireSomeUint (safeAdd recipientBalance amount) "Recipient balance overflow"
-    setMapping balances sender (sub senderBalance amount)
-    setMapping balances to newRecipientBalance
-
--- Get balance of an address
-def balanceOf (addr : Address) : Contract Uint256 := do
-  getMapping balances addr
-
--- Get total supply
-def getTotalSupply : Contract Uint256 := do
-  getStorage totalSupply
-
--- Get current owner
-def getOwner : Contract Address := do
-  getStorageAddr owner
-
--- Example usage: Alice creates token, mints 1000 to herself, transfers 300 to Bob
-def exampleUsage : Contract (Uint256 × Uint256 × Uint256) := do
-  constructor 0xA11CE
-
-  -- Alice mints 1000 tokens to herself
-  mint 0xA11CE 1000
-
-  -- Alice transfers 300 to Bob
-  transfer 0xB0B 300
-
-  -- Return: (Alice balance, Bob balance, total supply)
-  let aliceBalance ← balanceOf 0xA11CE
-  let bobBalance ← balanceOf 0xB0B
-  let supply ← getTotalSupply
-  return (aliceBalance, bobBalance, supply)
-
--- Evaluate the example
-#eval! (exampleUsage.run { defaultState with
-  sender := 0xA11CE,
-  thisAddress := 0x5143
-}).getValue?
--- Expected output: some (700, 300, 1000) - Alice: 700, Bob: 300, supply: 1000
 
 end Verity.Examples.SimpleToken

--- a/scripts/check_contract_structure.py
+++ b/scripts/check_contract_structure.py
@@ -70,9 +70,8 @@ def check_contract(name: str) -> list[str]:
 def check_all_lean_imports(contracts: list[str]) -> list[str]:
     """Check that All.lean imports all required modules for each contract.
 
-    For each contract, verifies the Examples import and all imports
-    corresponding to EXPECTED_STRUCTURE (Spec, Invariants, Proofs, Basic,
-    Correctness).
+    For each contract, verifies imports corresponding to EXPECTED_STRUCTURE
+    (Spec, Invariants, Proofs, Basic, Correctness).
     """
     all_lean = ROOT / "Verity" / "All.lean"
     if not all_lean.exists():
@@ -81,10 +80,6 @@ def check_all_lean_imports(contracts: list[str]) -> list[str]:
     line_set = {line.strip() for line in all_lean.read_text().splitlines()}
     missing = []
     for name in contracts:
-        # Check Examples import
-        examples_import = f"import Verity.Examples.{name}"
-        if examples_import not in line_set:
-            missing.append(f"Verity/All.lean missing: {examples_import}")
         # Check imports for each file in EXPECTED_STRUCTURE
         for template in EXPECTED_STRUCTURE:
             path = template.format(name=name)

--- a/scripts/legacy_example_import_allowlist.txt
+++ b/scripts/legacy_example_import_allowlist.txt
@@ -3,5 +3,3 @@
 #   <repo-relative-lean-file>: <MigratedContract>[, <MigratedContract>...]
 #
 # Keep entries minimal and remove them as migration cleanup lands.
-
-Verity/All.lean: SimpleStorage, Counter, SafeCounter, Owned, OwnedCounter, Ledger, SimpleToken, ERC20, ERC721


### PR DESCRIPTION
Closes #1141

## Summary
- deprecate migrated legacy example modules by converting them into forwarding shims to macro-contract canonical implementations for:
  - `SimpleStorage`, `Counter`, `SafeCounter`, `Owned`, `OwnedCounter`, `Ledger`, `SimpleToken`, `ERC20`, `ERC721`
- remove migrated legacy example imports from `Verity/All.lean`
- remove the temporary allowlist exemption for these imports from `scripts/legacy_example_import_allowlist.txt`
- align `scripts/check_contract_structure.py` with migration policy by no longer requiring `import Verity.Examples.<Contract>` lines in `Verity/All.lean`

## Validation
- `lake build Verity.Examples.SimpleStorage Verity.Examples.Counter Verity.Examples.SafeCounter Verity.Examples.Owned Verity.Examples.OwnedCounter Verity.Examples.Ledger Verity.Examples.SimpleToken Verity.Examples.ERC20 Verity.Examples.ERC721`
- `python3 scripts/check_legacy_example_imports.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes public module imports (removing legacy `Verity.Examples.*` from `Verity/All.lean`) and rewires example contract modules to forward to macro-generated implementations, which could affect downstream `import Verity` consumers and name resolution.
> 
> **Overview**
> Removes the migrated legacy example contract implementations (`SimpleStorage`, `Counter`, `SafeCounter`, `Owned`, `OwnedCounter`, `Ledger`, `SimpleToken`, `ERC20`, `ERC721`) and replaces them with thin forwarding shims (`abbrev` aliases) to the canonical `Verity.Examples.MacroContracts.*` versions, keeping only minimal local storage-slot/constructor definitions where needed.
> 
> Stops treating `Verity/All.lean` as an aggregator for these legacy `Verity.Examples.<Contract>` modules, updates `scripts/check_contract_structure.py` to no longer require those example imports, and deletes the corresponding exemption from `scripts/legacy_example_import_allowlist.txt` so the legacy-import guard no longer needs to whitelist `Verity/All.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eec40e4754bb149db957494dd1e10941864a2075. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->