### PR TITLE
tests: lock in admin letVar supported-stmt coverage

### DIFF
--- a/Verity/Core/Free/TypedIRTests.lean
+++ b/Verity/Core/Free/TypedIRTests.lean
@@ -1932,6 +1932,68 @@ example (init : TExecState) :
   erc20_totalSupply_correctness init
 
 open Compiler.CompilationModel in
+/-- Admin `setOwner` pattern belongs to the supported fragment grammar. -/
+example : SupportedStmtList adminPatternFields
+    [ Stmt.letVar "sender" Expr.caller
+    , Stmt.letVar "ownerVar" (Expr.storage "owner")
+    , Stmt.require (Expr.eq (Expr.localVar "sender") (Expr.localVar "ownerVar")) "not owner"
+    , Stmt.require (Expr.logicalNot (Expr.eq (Expr.param "newOwner") (Expr.localVar "ownerVar")))
+        "already owner"
+    , Stmt.setStorage "owner" (Expr.param "newOwner")
+    , Stmt.stop ] :=
+  witness_letCallerLetStorageAddrReqEqReqNeqSetStorageAddrParamStop_owner_supported
+
+open Compiler.CompilationModel in
+/-- Admin `setFeeRecipient` pattern belongs to the supported fragment grammar. -/
+example : SupportedStmtList adminPatternFields
+    [ Stmt.letVar "sender" Expr.caller
+    , Stmt.letVar "currentFeeRecipient" (Expr.storage "feeRecipient")
+    , Stmt.require (Expr.eq (Expr.localVar "sender") (Expr.localVar "currentFeeRecipient"))
+        "not fee recipient"
+    , Stmt.require
+        (Expr.logicalNot (Expr.eq (Expr.param "newFeeRecipient") (Expr.localVar "currentFeeRecipient")))
+        "already fee recipient"
+    , Stmt.setStorage "feeRecipient" (Expr.param "newFeeRecipient")
+    , Stmt.stop ] :=
+  witness_letCallerLetStorageAddrReqEqReqNeqSetStorageAddrParamStop_feeRecipient_supported
+
+open Compiler.CompilationModel in
+/-- `setOwner` supported-list compilation correctness instantiation. -/
+example (init : TExecState) :
+    ∃ fragments : List (SupportedStmtFragment adminPatternFields),
+      supportedStmtFragmentsToStmts fragments =
+        [ Stmt.letVar "sender" Expr.caller
+        , Stmt.letVar "ownerVar" (Expr.storage "owner")
+        , Stmt.require (Expr.eq (Expr.localVar "sender") (Expr.localVar "ownerVar")) "not owner"
+        , Stmt.require (Expr.logicalNot (Expr.eq (Expr.param "newOwner") (Expr.localVar "ownerVar")))
+            "already owner"
+        , Stmt.setStorage "owner" (Expr.param "newOwner")
+        , Stmt.stop ] ∧
+      execCompiledSupportedStmtFragments adminPatternFields init fragments =
+        execSourceSupportedStmtFragments adminPatternFields init fragments :=
+  compile_supported_stmt_list_semantics adminPatternFields init _
+    witness_letCallerLetStorageAddrReqEqReqNeqSetStorageAddrParamStop_owner_supported
+
+open Compiler.CompilationModel in
+/-- `setFeeRecipient` supported-list compilation correctness instantiation. -/
+example (init : TExecState) :
+    ∃ fragments : List (SupportedStmtFragment adminPatternFields),
+      supportedStmtFragmentsToStmts fragments =
+        [ Stmt.letVar "sender" Expr.caller
+        , Stmt.letVar "currentFeeRecipient" (Expr.storage "feeRecipient")
+        , Stmt.require (Expr.eq (Expr.localVar "sender") (Expr.localVar "currentFeeRecipient"))
+            "not fee recipient"
+        , Stmt.require
+            (Expr.logicalNot (Expr.eq (Expr.param "newFeeRecipient") (Expr.localVar "currentFeeRecipient")))
+            "already fee recipient"
+        , Stmt.setStorage "feeRecipient" (Expr.param "newFeeRecipient")
+        , Stmt.stop ] ∧
+      execCompiledSupportedStmtFragments adminPatternFields init fragments =
+        execSourceSupportedStmtFragments adminPatternFields init fragments :=
+  compile_supported_stmt_list_semantics adminPatternFields init _
+    witness_letCallerLetStorageAddrReqEqReqNeqSetStorageAddrParamStop_feeRecipient_supported
+
+open Compiler.CompilationModel in
 /-- ERC20.owner correctness instantiation. -/
 example (init : TExecState) :
     ∃ fragments : List (SupportedStmtFragment erc20Fields),


### PR DESCRIPTION
## Summary
- add explicit `TypedIRTests` coverage for admin `letVar` guard patterns introduced for Morpho-style admin functions
- assert `SupportedStmtList` derivations for both `setOwner` and `setFeeRecipient` statement shapes
- add correctness instantiations proving compiled/source semantics agreement for both patterns via `compile_supported_stmt_list_semantics`

## Validation
- `lake build Verity.Core.Free.TypedIRTests`
- `make check`

Closes #1146

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Lean test/proof instantiations and do not modify compiler or runtime semantics.
> 
> **Overview**
> Locks in support for Morpho-style admin update functions by adding `TypedIRTests` examples that the `setOwner` and `setFeeRecipient` statement shapes are derivable as a `SupportedStmtList`.
> 
> Adds corresponding correctness instantiations via `compile_supported_stmt_list_semantics`, proving compiled execution agrees with source semantics for both admin patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2ebe5d023bfb1acb5c5e8347f60fde2867c6f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->