### PR TITLE
Add deterministic Yul identity diff JSON report

### DIFF
--- a/docs/IDENTITY_CHECKER.md
+++ b/docs/IDENTITY_CHECKER.md
@@ -1,4 +1,4 @@
-# Yul Identity Checker (Groundwork)
+# Yul Identity Checker
 
 Issue: [#967](https://github.com/Th0rgal/verity/issues/967)
 
@@ -6,7 +6,7 @@ This document defines the target workflow for checking AST-level identity betwee
 
 ## Status
 
-Groundwork only. Interface and outputs below are proposed for implementation.
+`scripts/generate_yul_identity_diff_report.py` is now available for deterministic, machine-readable identity diff reports suitable for CI artifacts.
 
 ## Goals
 
@@ -15,24 +15,24 @@ Groundwork only. Interface and outputs below are proposed for implementation.
 3. Produce machine-readable reports for CI and rule authoring.
 4. Distinguish `non-identity` from `unsupported`.
 
-## Proposed CLI Shape
+## CLI Shape
 
 ```bash
-lake exe verity-compiler check-identity \
-  --parity-pack <pack-id> \
-  --solc-yul <path> \
-  --verity-yul <path> \
-  --report <path.json>
+python3 scripts/generate_yul_identity_diff_report.py \
+  --solc-dir <path> \
+  --verity-dir <path> \
+  --output <path.json>
 ```
 
-## Proposed Report Schema
+## Report Schema
 
-1. `packId`: parity pack used.
-2. `targetTuple`: pinned solc/optimizer/evm metadata.
-3. `status`: `identical | non_identical | unsupported`.
-4. `mismatches[]`: `{ nodePath, kind, lhs, rhs, sourceRef, irRef }`.
-5. `unsupported[]`: known unsupported construct IDs.
-6. `summary`: counts by mismatch kind.
+1. `status`: `identical | non_identical`.
+2. `summary`: file + mismatch counts (and by-kind totals).
+3. `mismatches[]`: stable entries with:
+   - `file`
+   - `path` (function/subtree-localized path)
+   - `kind`
+   - `verity` and `solc` values
 
 ## CI Integration
 

--- a/scripts/generate_yul_identity_diff_report.py
+++ b/scripts/generate_yul_identity_diff_report.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Generate a deterministic machine-readable Yul identity diff report.
+
+Compares Verity-generated Yul files against solc-generated Yul files and emits a
+stable JSON report with mismatch localization to function/subtree paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = ROOT / "artifacts" / "yul_identity_diff_report.json"
+
+FUNC_RE = re.compile(r"^\s*function\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*\(")
+
+
+@dataclass(frozen=True)
+class NormLine:
+    depth: int
+    text: str
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verity-dir", required=True, help="Directory containing Verity Yul files")
+    parser.add_argument("--solc-dir", required=True, help="Directory containing solc Yul files")
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help=f"Output JSON path (default: {DEFAULT_OUTPUT.relative_to(ROOT)})",
+    )
+    parser.add_argument(
+        "--fail-on-mismatch",
+        action="store_true",
+        help="Exit non-zero when non-identical output is detected",
+    )
+    return parser.parse_args(argv)
+
+
+def _strip_line_comment(line: str) -> str:
+    return line.split("//", 1)[0]
+
+
+def _normalize_line(line: str) -> str:
+    line = _strip_line_comment(line).strip()
+    if not line:
+        return ""
+    return " ".join(line.split())
+
+
+def _collect_yul_files(base: Path) -> Dict[str, Path]:
+    result: Dict[str, Path] = {}
+    if not base.exists():
+        return result
+    for path in sorted(base.rglob("*.yul")):
+        rel = path.relative_to(base).as_posix()
+        result[rel] = path
+    return result
+
+
+def _extract_scoped_lines(text: str) -> Dict[str, List[NormLine]]:
+    scoped: Dict[str, List[NormLine]] = {"<toplevel>": []}
+    current_scope = "<toplevel>"
+    function_depth: int | None = None
+    depth = 0
+
+    for raw in text.splitlines():
+        line = _normalize_line(raw)
+        if not line:
+            depth += raw.count("{")
+            depth -= raw.count("}")
+            continue
+
+        match = FUNC_RE.match(line)
+        if match:
+            current_scope = f"function:{match.group(1)}"
+            scoped.setdefault(current_scope, [])
+            function_depth = depth
+
+        scoped.setdefault(current_scope, []).append(NormLine(depth=max(depth, 0), text=line))
+
+        depth += raw.count("{")
+        depth -= raw.count("}")
+
+        if function_depth is not None and depth <= function_depth:
+            current_scope = "<toplevel>"
+            function_depth = None
+
+    return scoped
+
+
+def _compare_sequences(
+    rel_path: str,
+    scope: str,
+    lhs: List[NormLine],
+    rhs: List[NormLine],
+) -> List[dict]:
+    mismatches: List[dict] = []
+    max_len = max(len(lhs), len(rhs))
+    for idx in range(max_len):
+        left = lhs[idx] if idx < len(lhs) else None
+        right = rhs[idx] if idx < len(rhs) else None
+        if left is None:
+            mismatches.append(
+                {
+                    "file": rel_path,
+                    "path": f"{scope}/line:{idx + 1}",
+                    "kind": "missing_in_verity",
+                    "verity": None,
+                    "solc": right.text,
+                }
+            )
+            continue
+        if right is None:
+            mismatches.append(
+                {
+                    "file": rel_path,
+                    "path": f"{scope}/line:{idx + 1}",
+                    "kind": "missing_in_solc",
+                    "verity": left.text,
+                    "solc": None,
+                }
+            )
+            continue
+        if left.text != right.text:
+            mismatches.append(
+                {
+                    "file": rel_path,
+                    "path": f"{scope}/depth:{left.depth}/line:{idx + 1}",
+                    "kind": "line_mismatch",
+                    "verity": left.text,
+                    "solc": right.text,
+                }
+            )
+    return mismatches
+
+
+def _compare_file(rel_path: str, verity_text: str, solc_text: str) -> List[dict]:
+    mismatches: List[dict] = []
+    v_scopes = _extract_scoped_lines(verity_text)
+    s_scopes = _extract_scoped_lines(solc_text)
+
+    all_scopes = sorted(set(v_scopes.keys()) | set(s_scopes.keys()))
+    for scope in all_scopes:
+        v_seq = v_scopes.get(scope)
+        s_seq = s_scopes.get(scope)
+        if v_seq is None:
+            mismatches.append(
+                {
+                    "file": rel_path,
+                    "path": scope,
+                    "kind": "scope_missing_in_verity",
+                    "verity": None,
+                    "solc": "present",
+                }
+            )
+            continue
+        if s_seq is None:
+            mismatches.append(
+                {
+                    "file": rel_path,
+                    "path": scope,
+                    "kind": "scope_missing_in_solc",
+                    "verity": "present",
+                    "solc": None,
+                }
+            )
+            continue
+        mismatches.extend(_compare_sequences(rel_path, scope, v_seq, s_seq))
+
+    return mismatches
+
+
+def build_report(verity_dir: Path, solc_dir: Path) -> dict:
+    verity_files = _collect_yul_files(verity_dir)
+    solc_files = _collect_yul_files(solc_dir)
+
+    all_files = sorted(set(verity_files.keys()) | set(solc_files.keys()))
+    mismatches: List[dict] = []
+
+    for rel in all_files:
+        v_path = verity_files.get(rel)
+        s_path = solc_files.get(rel)
+        if v_path is None:
+            mismatches.append(
+                {
+                    "file": rel,
+                    "path": "<file>",
+                    "kind": "file_missing_in_verity",
+                    "verity": None,
+                    "solc": "present",
+                }
+            )
+            continue
+        if s_path is None:
+            mismatches.append(
+                {
+                    "file": rel,
+                    "path": "<file>",
+                    "kind": "file_missing_in_solc",
+                    "verity": "present",
+                    "solc": None,
+                }
+            )
+            continue
+        mismatches.extend(_compare_file(rel, v_path.read_text(encoding="utf-8"), s_path.read_text(encoding="utf-8")))
+
+    summary: Dict[str, int] = {}
+    for mismatch in mismatches:
+        kind = mismatch["kind"]
+        summary[kind] = summary.get(kind, 0) + 1
+
+    return {
+        "tool": {"name": "generate_yul_identity_diff_report", "schemaVersion": 1},
+        "inputs": {"verityDir": str(verity_dir), "solcDir": str(solc_dir)},
+        "status": "identical" if not mismatches else "non_identical",
+        "summary": {
+            "filesCompared": len(all_files),
+            "totalMismatches": len(mismatches),
+            "byKind": dict(sorted(summary.items())),
+        },
+        "mismatches": mismatches,
+    }
+
+
+def write_report(report: dict, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = build_report(Path(args.verity_dir), Path(args.solc_dir))
+    write_report(report, Path(args.output))
+    print(f"Wrote Yul identity report: {args.output}")
+    print(f"Status: {report['status']} ({report['summary']['totalMismatches']} mismatches)")
+    if args.fail_on_mismatch and report["status"] != "identical":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_generate_yul_identity_diff_report.py
+++ b/scripts/test_generate_yul_identity_diff_report.py
@@ -1,0 +1,115 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import generate_yul_identity_diff_report as checker
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class GenerateYulIdentityDiffReportTests(unittest.TestCase):
+    def test_identical_inputs_report_identical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            verity = root / "verity"
+            solc = root / "solc"
+            yul = """object "C" {
+  code {
+    function foo() {
+      let x := 1
+    }
+  }
+}
+"""
+            _write(verity / "C.yul", yul)
+            _write(solc / "C.yul", yul)
+
+            report = checker.build_report(verity, solc)
+            self.assertEqual(report["status"], "identical")
+            self.assertEqual(report["summary"]["totalMismatches"], 0)
+            self.assertEqual(report["mismatches"], [])
+
+    def test_mismatch_localizes_to_function_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            verity = root / "verity"
+            solc = root / "solc"
+            _write(
+                verity / "C.yul",
+                """object "C" {
+  code {
+    function foo() {
+      let x := 1
+    }
+  }
+}
+""",
+            )
+            _write(
+                solc / "C.yul",
+                """object "C" {
+  code {
+    function foo() {
+      let x := 2
+    }
+  }
+}
+""",
+            )
+
+            report = checker.build_report(verity, solc)
+            self.assertEqual(report["status"], "non_identical")
+            self.assertGreater(report["summary"]["totalMismatches"], 0)
+            first = report["mismatches"][0]
+            self.assertEqual(first["file"], "C.yul")
+            self.assertIn("function:foo", first["path"])
+
+    def test_repeated_runs_are_stable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            verity = root / "verity"
+            solc = root / "solc"
+            out1 = root / "r1.json"
+            out2 = root / "r2.json"
+
+            _write(
+                verity / "C.yul",
+                """object "C" {
+  code {
+    function foo() {
+      let x := 1
+    }
+  }
+}
+""",
+            )
+            _write(
+                solc / "C.yul",
+                """object "C" {
+  code {
+    function foo() {
+      let x := 2
+    }
+  }
+}
+""",
+            )
+
+            rc1 = checker.main(["--verity-dir", str(verity), "--solc-dir", str(solc), "--output", str(out1)])
+            rc2 = checker.main(["--verity-dir", str(verity), "--solc-dir", str(solc), "--output", str(out2)])
+            self.assertEqual(rc1, 0)
+            self.assertEqual(rc2, 0)
+
+            j1 = json.loads(out1.read_text(encoding="utf-8"))
+            j2 = json.loads(out2.read_text(encoding="utf-8"))
+            self.assertEqual(j1, j2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/generate_yul_identity_diff_report.py` to emit a stable machine-readable JSON diff between Verity and solc Yul outputs
- include mismatch localization by file + function/subtree path (`function:<name>/...`)
- add deterministic ordering and stable schema for CI/artifact consumption
- add unit tests for identical inputs, scope-localized mismatch detection, and repeated-run stability
- update identity-checker docs to document the new CLI/report

## Validation
- `python3 -m unittest scripts/test_generate_yul_identity_diff_report.py -v`
- `python3 scripts/check_verify_sync.py`
- `make check`

Closes #1149

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CI gating logic that parses `Compiler/Yul/PatchRules.lean` with regex to enforce non-empty `proofId` metadata on active object rewrite rules, which could cause false positives or new build failures if the Lean syntax/structure changes. The Yul identity diff report is additive and covered by unit tests, but its output schema will become a CI/artifact contract.
> 
> **Overview**
> **Adds a deterministic Yul identity diff report generator.** New `scripts/generate_yul_identity_diff_report.py` compares Verity vs `solc` `.yul` trees and emits a stable JSON report (deterministic file ordering, normalized lines, mismatch localization to `function:<name>/...` paths), with unit tests covering identical inputs, localized mismatches, and stability across runs.
> 
> **Tightens CI invariants around rewrite-rule proof metadata.** Introduces `scripts/check_rewrite_proof_metadata.py` (and tests) to fail CI when *active* `ObjectPatchRule`s in shipped bundles lack a resolvable, non-empty `proofId`; wires this check into `verify.yml`, `make check`, and `scripts/verify_sync_spec.json`.
> 
> Documentation updates `docs/IDENTITY_CHECKER.md` to reflect the new identity diff CLI and JSON schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9b11a50d4566fee1f8a9f5a537833e1187bd7ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->