### PR TITLE
Phase 1: introduce Contracts.MacroContracts namespace

### DIFF
--- a/Compiler/Interpreter.lean
+++ b/Compiler/Interpreter.lean
@@ -12,10 +12,10 @@
 -/
 
 import Compiler.Constants
-import Verity.Examples.MacroContracts.Tokens
-import Verity.Examples.MacroContracts.Core
-import Verity.Examples.MacroContracts.ERC721Addressed
-import Verity.Examples.MacroContracts.Compat.CryptoHash
+import Contracts.MacroContracts.Tokens
+import Contracts.MacroContracts.Core
+import Contracts.MacroContracts.ERC721Addressed
+import Contracts.MacroContracts.Compat.CryptoHash
 import Compiler.DiffTestTypes
 import Compiler.Hex
 

--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -31,7 +31,7 @@ import Compiler.Proofs.IRGeneration.IRInterpreter
 import Compiler.Proofs.EndToEnd
 import Compiler.Specs
 import Verity.Core
-import Verity.Examples.MacroContracts.Core
+import Contracts.MacroContracts.Core
 
 namespace Compiler.Proofs.SemanticBridge
 

--- a/Compiler/Specs.lean
+++ b/Compiler/Specs.lean
@@ -6,7 +6,7 @@
 -/
 
 import Compiler.CompilationModel
-import Verity.Examples.MacroContracts
+import Contracts.MacroContracts
 
 namespace Compiler.Specs
 

--- a/Contracts.lean
+++ b/Contracts.lean
@@ -1,0 +1,2 @@
+import Contracts.MacroContracts
+

--- a/Contracts/MacroContracts.lean
+++ b/Contracts/MacroContracts.lean
@@ -1,0 +1,6 @@
+import Contracts.MacroContracts.Common
+import Contracts.MacroContracts.Core
+import Contracts.MacroContracts.Tokens
+import Contracts.MacroContracts.ERC721Addressed
+import Contracts.MacroContracts.Smoke
+

--- a/Contracts/MacroContracts/Common.lean
+++ b/Contracts/MacroContracts/Common.lean
@@ -1,0 +1,2 @@
+import Verity.Examples.MacroContracts.Common
+

--- a/Contracts/MacroContracts/Compat/CryptoHash.lean
+++ b/Contracts/MacroContracts/Compat/CryptoHash.lean
@@ -1,0 +1,1 @@
+import Verity.Examples.MacroContracts.Compat.CryptoHash

--- a/Contracts/MacroContracts/Compat/ERC721.lean
+++ b/Contracts/MacroContracts/Compat/ERC721.lean
@@ -1,0 +1,1 @@
+import Verity.Examples.MacroContracts.Compat.ERC721

--- a/Contracts/MacroContracts/Core.lean
+++ b/Contracts/MacroContracts/Core.lean
@@ -1,0 +1,1 @@
+import Verity.Examples.MacroContracts.Core

--- a/Contracts/MacroContracts/ERC721Addressed.lean
+++ b/Contracts/MacroContracts/ERC721Addressed.lean
@@ -1,0 +1,1 @@
+import Verity.Examples.MacroContracts.ERC721Addressed

--- a/Contracts/MacroContracts/Smoke.lean
+++ b/Contracts/MacroContracts/Smoke.lean
@@ -1,0 +1,1 @@
+import Verity.Examples.MacroContracts.Smoke

--- a/Contracts/MacroContracts/Tokens.lean
+++ b/Contracts/MacroContracts/Tokens.lean
@@ -1,0 +1,1 @@
+import Verity.Examples.MacroContracts.Tokens

--- a/Verity/Proofs/ERC20/Basic.lean
+++ b/Verity/Proofs/ERC20/Basic.lean
@@ -3,7 +3,7 @@
 -/
 
 import Verity.Specs.ERC20.Spec
-import Verity.Examples.MacroContracts.Tokens
+import Contracts.MacroContracts.Tokens
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.Automation
 

--- a/Verity/Proofs/ERC721/Basic.lean
+++ b/Verity/Proofs/ERC721/Basic.lean
@@ -3,7 +3,7 @@
 -/
 
 import Verity.Specs.ERC721.Spec
-import Verity.Examples.MacroContracts.ERC721Addressed
+import Contracts.MacroContracts.ERC721Addressed
 
 namespace Verity.Proofs.ERC721
 

--- a/Verity/Proofs/SimpleStorage/Basic.lean
+++ b/Verity/Proofs/SimpleStorage/Basic.lean
@@ -6,7 +6,7 @@
   Status: Complete — all 13 proofs proven with zero axioms and zero sorry.
 -/
 
-import Verity.Examples.MacroContracts.Core
+import Contracts.MacroContracts.Core
 import Verity.Specs.SimpleStorage.Spec
 import Verity.Specs.SimpleStorage.Invariants
 

--- a/Verity/Proofs/SimpleToken/Basic.lean
+++ b/Verity/Proofs/SimpleToken/Basic.lean
@@ -9,7 +9,7 @@
   - Invariant preservation
 -/
 
-import Verity.Examples.MacroContracts.Tokens
+import Contracts.MacroContracts.Tokens
 import Verity.Proofs.Stdlib.Math
 import Verity.Proofs.Stdlib.Automation
 import Verity.Specs.SimpleToken.Spec

--- a/Verity/Specs/Counter/Spec.lean
+++ b/Verity/Specs/Counter/Spec.lean
@@ -4,7 +4,7 @@
 
 import Verity.Specs.Common
 import Verity.EVM.Uint256
-import Verity.Examples.MacroContracts.Core
+import Contracts.MacroContracts.Core
 
 namespace Verity.Specs.Counter
 

--- a/Verity/Specs/Ledger/Spec.lean
+++ b/Verity/Specs/Ledger/Spec.lean
@@ -5,7 +5,7 @@
 import Verity.Specs.Common
 import Verity.Specs.Common.Sum
 import Verity.EVM.Uint256
-import Verity.Examples.MacroContracts.Core
+import Contracts.MacroContracts.Core
 
 namespace Verity.Specs.Ledger
 

--- a/Verity/Specs/Owned/Spec.lean
+++ b/Verity/Specs/Owned/Spec.lean
@@ -3,7 +3,7 @@
 -/
 
 import Verity.Specs.Common
-import Verity.Examples.MacroContracts.Core
+import Contracts.MacroContracts.Core
 
 namespace Verity.Specs.Owned
 

--- a/Verity/Specs/OwnedCounter/Spec.lean
+++ b/Verity/Specs/OwnedCounter/Spec.lean
@@ -4,7 +4,7 @@
 
 import Verity.Specs.Common
 import Verity.EVM.Uint256
-import Verity.Examples.MacroContracts.Core
+import Contracts.MacroContracts.Core
 
 namespace Verity.Specs.OwnedCounter
 

--- a/Verity/Specs/SafeCounter/Spec.lean
+++ b/Verity/Specs/SafeCounter/Spec.lean
@@ -5,7 +5,7 @@
 import Verity.Specs.Common
 import Verity.Stdlib.Math
 import Verity.EVM.Uint256
-import Verity.Examples.MacroContracts.Core
+import Contracts.MacroContracts.Core
 
 namespace Verity.Specs.SafeCounter
 

--- a/Verity/Specs/SimpleStorage/Spec.lean
+++ b/Verity/Specs/SimpleStorage/Spec.lean
@@ -3,7 +3,7 @@
 -/
 
 import Verity.Specs.Common
-import Verity.Examples.MacroContracts.Core
+import Contracts.MacroContracts.Core
 
 namespace Verity.Specs.SimpleStorage
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -21,6 +21,8 @@ lean_lib «Verity» where
 
 lean_lib «Examples» where
   globs := #[
+    .one `Contracts,
+    .andSubmodules `Contracts.MacroContracts,
     .one `Verity.All,
     .submodules `Verity.Examples,
     .submodules `Verity.Specs.Counter,


### PR DESCRIPTION
## Summary
This is a focused first step for #1174.

- Added a new top-level `Contracts` namespace entrypoint and `Contracts.MacroContracts.*` modules.
- Implemented these as forwarding shims to existing `Verity.Examples.MacroContracts.*` modules for compatibility.
- Migrated high-coupling imports (compiler, selected specs, selected proofs) to `Contracts.MacroContracts.*`.
- Wired the new namespace into the `Examples` Lean library globs in `lakefile.lean`.

## Why this helps
Issue #1174 proposes moving contract code into top-level `Contracts/`. This PR creates a stable import namespace (`Contracts.MacroContracts.*`) and migrates key consumers now, so later physical moves of contract/spec/proof files become mechanical and lower-risk.

## Files changed
- New namespace shims:
  - `Contracts.lean`
  - `Contracts/MacroContracts*.lean`
  - `Contracts/MacroContracts/Compat/*.lean`
- Migrated imports:
  - `Compiler/Specs.lean`
  - `Compiler/Proofs/SemanticBridge.lean`
  - `Compiler/Interpreter.lean`
  - `Verity/Specs/{Counter,Ledger,Owned,OwnedCounter,SafeCounter,SimpleStorage}/Spec.lean`
  - `Verity/Proofs/{ERC20,ERC721,SimpleStorage,SimpleToken}/Basic.lean`
- Build wiring:
  - `lakefile.lean`

## Validation
- `lake build Contracts.MacroContracts Compiler.Interpreter Verity.Specs.Counter.Spec Verity.Specs.Ledger.Spec Verity.Specs.Owned.Spec Verity.Specs.OwnedCounter.Spec Verity.Specs.SafeCounter.Spec Verity.Specs.SimpleStorage.Spec`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily Lean module import rewrites plus new forwarding modules; main risk is build breakage from miswired globs or unresolved imports rather than semantic changes.
> 
> **Overview**
> Adds a new top-level `Contracts` entrypoint and `Contracts.MacroContracts.*` modules implemented as forwarding shims to the existing `Verity.Examples.MacroContracts.*` contracts (including `Compat/*`).
> 
> Updates the compiler (`Compiler/Interpreter.lean`, `Compiler/Specs.lean`, `Compiler/Proofs/SemanticBridge.lean`) and selected `Verity.Specs`/`Verity.Proofs` modules to import contracts via `Contracts.MacroContracts.*` instead of `Verity.Examples.MacroContracts.*`, and wires the new namespace into the `Examples` library globs in `lakefile.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 919edd378ad839896c66c42be50db228fb8b3a75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->