### PR TITLE
Refactor #1174: add Contracts.Counter namespace and build wiring

### DIFF
--- a/Contracts.lean
+++ b/Contracts.lean
@@ -1,2 +1,2 @@
 import Contracts.MacroContracts
-
+import Contracts.Counter

--- a/Contracts/Counter.lean
+++ b/Contracts/Counter.lean
@@ -1,0 +1,5 @@
+import Contracts.Counter.Contract
+import Contracts.Counter.Spec
+import Contracts.Counter.Invariants
+import Contracts.Counter.Proofs.Basic
+import Contracts.Counter.Proofs.Correctness

--- a/Contracts/Counter/Contract.lean
+++ b/Contracts/Counter/Contract.lean
@@ -1,0 +1,14 @@
+import Verity.Examples.Counter
+
+namespace Contracts.Counter.Contract
+
+abbrev count := Verity.Examples.Counter.count
+abbrev increment := Verity.Examples.Counter.increment
+abbrev decrement := Verity.Examples.Counter.decrement
+abbrev getCount := Verity.Examples.Counter.getCount
+abbrev previewAddTwice := Verity.Examples.Counter.previewAddTwice
+abbrev previewOps := Verity.Examples.Counter.previewOps
+abbrev previewEnvOps := Verity.Examples.Counter.previewEnvOps
+abbrev previewLowLevel := Verity.Examples.Counter.previewLowLevel
+
+end Contracts.Counter.Contract

--- a/Contracts/Counter/Invariants.lean
+++ b/Contracts/Counter/Invariants.lean
@@ -1,0 +1,12 @@
+import Verity.Specs.Counter.Invariants
+
+namespace Contracts.Counter.Invariants
+
+abbrev WellFormedState := Verity.Specs.Counter.WellFormedState
+abbrev storage_isolated := Verity.Specs.Counter.storage_isolated
+abbrev addr_storage_unchanged := Verity.Specs.Counter.addr_storage_unchanged
+abbrev map_storage_unchanged := Verity.Specs.Counter.map_storage_unchanged
+abbrev context_preserved := Verity.Specs.Counter.context_preserved
+abbrev state_preserved_except_count := Verity.Specs.Counter.state_preserved_except_count
+
+end Contracts.Counter.Invariants

--- a/Contracts/Counter/Proofs/Basic.lean
+++ b/Contracts/Counter/Proofs/Basic.lean
@@ -1,0 +1,25 @@
+import Verity.Proofs.Counter.Basic
+
+namespace Contracts.Counter.Proofs.Basic
+
+abbrev setStorage_updates_count := Verity.Proofs.Counter.setStorage_updates_count
+abbrev getStorage_reads_count := Verity.Proofs.Counter.getStorage_reads_count
+abbrev setStorage_preserves_other_slots := Verity.Proofs.Counter.setStorage_preserves_other_slots
+abbrev setStorage_preserves_context := Verity.Proofs.Counter.setStorage_preserves_context
+abbrev setStorage_preserves_addr_storage := Verity.Proofs.Counter.setStorage_preserves_addr_storage
+abbrev setStorage_preserves_map_storage := Verity.Proofs.Counter.setStorage_preserves_map_storage
+abbrev increment_meets_spec := Verity.Proofs.Counter.increment_meets_spec
+abbrev increment_adds_one := Verity.Proofs.Counter.increment_adds_one
+abbrev decrement_meets_spec := Verity.Proofs.Counter.decrement_meets_spec
+abbrev decrement_subtracts_one := Verity.Proofs.Counter.decrement_subtracts_one
+abbrev getCount_meets_spec := Verity.Proofs.Counter.getCount_meets_spec
+abbrev getCount_reads_count_value := Verity.Proofs.Counter.getCount_reads_count_value
+abbrev increment_getCount_correct := Verity.Proofs.Counter.increment_getCount_correct
+abbrev decrement_getCount_correct := Verity.Proofs.Counter.decrement_getCount_correct
+abbrev increment_twice_adds_two := Verity.Proofs.Counter.increment_twice_adds_two
+abbrev increment_decrement_cancel := Verity.Proofs.Counter.increment_decrement_cancel
+abbrev increment_preserves_wellformedness := Verity.Proofs.Counter.increment_preserves_wellformedness
+abbrev decrement_preserves_wellformedness := Verity.Proofs.Counter.decrement_preserves_wellformedness
+abbrev getCount_preserves_state := Verity.Proofs.Counter.getCount_preserves_state
+
+end Contracts.Counter.Proofs.Basic

--- a/Contracts/Counter/Proofs/Correctness.lean
+++ b/Contracts/Counter/Proofs/Correctness.lean
@@ -1,0 +1,15 @@
+import Verity.Proofs.Counter.Correctness
+
+namespace Contracts.Counter.Proofs.Correctness
+
+abbrev increment_state_preserved_except_count := Verity.Proofs.Counter.Correctness.increment_state_preserved_except_count
+abbrev decrement_state_preserved_except_count := Verity.Proofs.Counter.Correctness.decrement_state_preserved_except_count
+abbrev getCount_state_preserved := Verity.Proofs.Counter.Correctness.getCount_state_preserved
+abbrev increment_getCount_meets_spec := Verity.Proofs.Counter.Correctness.increment_getCount_meets_spec
+abbrev decrement_getCount_meets_spec := Verity.Proofs.Counter.Correctness.decrement_getCount_meets_spec
+abbrev two_increments_meets_spec := Verity.Proofs.Counter.Correctness.two_increments_meets_spec
+abbrev increment_decrement_meets_cancel := Verity.Proofs.Counter.Correctness.increment_decrement_meets_cancel
+abbrev getCount_preserves_wellformedness := Verity.Proofs.Counter.Correctness.getCount_preserves_wellformedness
+abbrev decrement_at_zero_wraps_max := Verity.Proofs.Counter.Correctness.decrement_at_zero_wraps_max
+
+end Contracts.Counter.Proofs.Correctness

--- a/Contracts/Counter/Spec.lean
+++ b/Contracts/Counter/Spec.lean
@@ -1,0 +1,13 @@
+import Verity.Specs.Counter.Spec
+
+namespace Contracts.Counter.Spec
+
+abbrev increment_spec := Verity.Specs.Counter.increment_spec
+abbrev decrement_spec := Verity.Specs.Counter.decrement_spec
+abbrev getCount_spec := Verity.Specs.Counter.getCount_spec
+abbrev increment_getCount_spec := Verity.Specs.Counter.increment_getCount_spec
+abbrev decrement_getCount_spec := Verity.Specs.Counter.decrement_getCount_spec
+abbrev increment_decrement_cancel := Verity.Specs.Counter.increment_decrement_cancel
+abbrev two_increments_spec := Verity.Specs.Counter.two_increments_spec
+
+end Contracts.Counter.Spec

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -23,6 +23,7 @@ lean_lib «Examples» where
   globs := #[
     .one `Contracts,
     .andSubmodules `Contracts.MacroContracts,
+    .andSubmodules `Contracts.Counter,
     .one `Verity.All,
     .submodules `Verity.Examples,
     .submodules `Verity.Specs.Counter,


### PR DESCRIPTION
## Summary

This lands a concrete migration slice for #1174 by introducing a new top-level `Contracts.Counter` namespace while preserving full backward compatibility.

- Added `Contracts/Counter/*` modules:
  - `Contracts.Counter.Contract`
  - `Contracts.Counter.Spec`
  - `Contracts.Counter.Invariants`
  - `Contracts.Counter.Proofs.Basic`
  - `Contracts.Counter.Proofs.Correctness`
- Added `Contracts/Counter.lean` aggregator.
- Wired `Contracts.Counter` into top-level imports and Examples build globs:
  - `Contracts.lean`
  - `lakefile.lean`

## Design

To keep risk low and preserve theorem stability, this phase uses **namespace wrappers** (`abbrev` re-exports) over the existing `Verity.*` Counter implementation/spec/proofs. This makes `Contracts.Counter.*` import paths available immediately without breaking current users.

## Validation

- `lake build Contracts.Counter Contracts.Counter.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive wrapper modules (`abbrev` re-exports) plus import/build wiring, with no changes to underlying counter specs/proofs or runtime behavior.
> 
> **Overview**
> Adds a new top-level `Contracts.Counter` namespace (plus `Contracts/Counter.lean` aggregator) that **re-exports** the existing counter contract, specs, invariants, and proofs from `Verity.*` via `abbrev` wrappers.
> 
> Wires the new namespace into the default `Contracts.lean` imports and includes `Contracts.Counter` in the `Examples` `lakefile.lean` globs so it is built and importable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1037c045fa2afe2164b237316983ded30222a45b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->