### PR TITLE
Refactor #1174: add Contracts.SimpleStorage namespace wrappers

### DIFF
--- a/Contracts.lean
+++ b/Contracts.lean
@@ -1,2 +1,3 @@
 import Contracts.MacroContracts
 import Contracts.Counter
+import Contracts.SimpleStorage

--- a/Contracts/SimpleStorage.lean
+++ b/Contracts/SimpleStorage.lean
@@ -1,0 +1,5 @@
+import Contracts.SimpleStorage.Contract
+import Contracts.SimpleStorage.Spec
+import Contracts.SimpleStorage.Invariants
+import Contracts.SimpleStorage.Proofs.Basic
+import Contracts.SimpleStorage.Proofs.Correctness

--- a/Contracts/SimpleStorage/Contract.lean
+++ b/Contracts/SimpleStorage/Contract.lean
@@ -1,0 +1,9 @@
+import Verity.Examples.SimpleStorage
+
+namespace Contracts.SimpleStorage.Contract
+
+abbrev storedData := Verity.Examples.SimpleStorage.storedData
+abbrev store := Verity.Examples.SimpleStorage.store
+abbrev retrieve := Verity.Examples.SimpleStorage.retrieve
+
+end Contracts.SimpleStorage.Contract

--- a/Contracts/SimpleStorage/Invariants.lean
+++ b/Contracts/SimpleStorage/Invariants.lean
@@ -1,0 +1,11 @@
+import Verity.Specs.SimpleStorage.Invariants
+
+namespace Contracts.SimpleStorage.Invariants
+
+abbrev WellFormedState := Verity.Specs.SimpleStorage.WellFormedState
+abbrev storage_isolated := Verity.Specs.SimpleStorage.storage_isolated
+abbrev addr_storage_unchanged := Verity.Specs.SimpleStorage.addr_storage_unchanged
+abbrev map_storage_unchanged := Verity.Specs.SimpleStorage.map_storage_unchanged
+abbrev context_preserved := Verity.Specs.SimpleStorage.context_preserved
+
+end Contracts.SimpleStorage.Invariants

--- a/Contracts/SimpleStorage/Proofs/Basic.lean
+++ b/Contracts/SimpleStorage/Proofs/Basic.lean
@@ -1,0 +1,19 @@
+import Verity.Proofs.SimpleStorage.Basic
+
+namespace Contracts.SimpleStorage.Proofs.Basic
+
+abbrev setStorage_updates_slot := Verity.Proofs.SimpleStorage.setStorage_updates_slot
+abbrev getStorage_reads_slot := Verity.Proofs.SimpleStorage.getStorage_reads_slot
+abbrev setStorage_preserves_other_slots := Verity.Proofs.SimpleStorage.setStorage_preserves_other_slots
+abbrev setStorage_preserves_sender := Verity.Proofs.SimpleStorage.setStorage_preserves_sender
+abbrev setStorage_preserves_address := Verity.Proofs.SimpleStorage.setStorage_preserves_address
+abbrev setStorage_preserves_addr_storage := Verity.Proofs.SimpleStorage.setStorage_preserves_addr_storage
+abbrev setStorage_preserves_map_storage := Verity.Proofs.SimpleStorage.setStorage_preserves_map_storage
+abbrev store_meets_spec := Verity.Proofs.SimpleStorage.store_meets_spec
+abbrev retrieve_meets_spec := Verity.Proofs.SimpleStorage.retrieve_meets_spec
+abbrev store_retrieve_correct := Verity.Proofs.SimpleStorage.store_retrieve_correct
+abbrev store_preserves_wellformedness := Verity.Proofs.SimpleStorage.store_preserves_wellformedness
+abbrev retrieve_preserves_state := Verity.Proofs.SimpleStorage.retrieve_preserves_state
+abbrev retrieve_twice_idempotent := Verity.Proofs.SimpleStorage.retrieve_twice_idempotent
+
+end Contracts.SimpleStorage.Proofs.Basic

--- a/Contracts/SimpleStorage/Proofs/Correctness.lean
+++ b/Contracts/SimpleStorage/Proofs/Correctness.lean
@@ -1,0 +1,13 @@
+import Verity.Proofs.SimpleStorage.Correctness
+
+namespace Contracts.SimpleStorage.Proofs.Correctness
+
+abbrev store_retrieve_roundtrip_holds := Verity.Proofs.SimpleStorage.Correctness.store_retrieve_roundtrip_holds
+abbrev store_preserves_storage_isolated := Verity.Proofs.SimpleStorage.Correctness.store_preserves_storage_isolated
+abbrev store_preserves_addr_storage := Verity.Proofs.SimpleStorage.Correctness.store_preserves_addr_storage
+abbrev store_preserves_map_storage := Verity.Proofs.SimpleStorage.Correctness.store_preserves_map_storage
+abbrev store_preserves_context := Verity.Proofs.SimpleStorage.Correctness.store_preserves_context
+abbrev retrieve_preserves_context := Verity.Proofs.SimpleStorage.Correctness.retrieve_preserves_context
+abbrev retrieve_preserves_wellformedness := Verity.Proofs.SimpleStorage.Correctness.retrieve_preserves_wellformedness
+
+end Contracts.SimpleStorage.Proofs.Correctness

--- a/Contracts/SimpleStorage/Spec.lean
+++ b/Contracts/SimpleStorage/Spec.lean
@@ -1,0 +1,9 @@
+import Verity.Specs.SimpleStorage.Spec
+
+namespace Contracts.SimpleStorage.Spec
+
+abbrev store_spec := Verity.Specs.SimpleStorage.store_spec
+abbrev retrieve_spec := Verity.Specs.SimpleStorage.retrieve_spec
+abbrev store_retrieve_roundtrip := Verity.Specs.SimpleStorage.store_retrieve_roundtrip
+
+end Contracts.SimpleStorage.Spec

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -24,6 +24,7 @@ lean_lib «Examples» where
     .one `Contracts,
     .andSubmodules `Contracts.MacroContracts,
     .andSubmodules `Contracts.Counter,
+    .andSubmodules `Contracts.SimpleStorage,
     .one `Verity.All,
     .submodules `Verity.Examples,
     .submodules `Verity.Specs.Counter,


### PR DESCRIPTION
## Summary
- add new `Contracts.SimpleStorage` namespace wrapper modules for contract/spec/invariants/proofs
- re-export existing `Verity.*` SimpleStorage definitions/theorems via `abbrev` to provide stable `Contracts.*` imports
- wire `Contracts.SimpleStorage` into `Contracts.lean` and the `Examples` library globs in `lakefile.lean`

## Validation
- `lake build Contracts.SimpleStorage Contracts.SimpleStorage.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds wrapper modules and build globs that re-export existing `Verity.*` SimpleStorage definitions without changing contract logic or proofs.
> 
> **Overview**
> Adds a new `Contracts.SimpleStorage` module tree (`Contract`, `Spec`, `Invariants`, `Proofs.Basic`, `Proofs.Correctness`) that *re-exports* the existing `Verity.*.SimpleStorage` definitions and theorems via `abbrev`, providing stable `Contracts.*` imports.
> 
> Updates `Contracts.lean` to import `Contracts.SimpleStorage` and updates `lakefile.lean` to include `Contracts.SimpleStorage` in the `Examples` library globs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3721414bc74404356060537bf532298a5d6c7703. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->