### PR TITLE
Add Contracts.Owned wrapper namespace slice

### DIFF
--- a/Contracts.lean
+++ b/Contracts.lean
@@ -1,3 +1,4 @@
 import Contracts.MacroContracts
 import Contracts.Counter
 import Contracts.SimpleStorage
+import Contracts.Owned

--- a/Contracts/Owned.lean
+++ b/Contracts/Owned.lean
@@ -1,0 +1,5 @@
+import Contracts.Owned.Contract
+import Contracts.Owned.Spec
+import Contracts.Owned.Invariants
+import Contracts.Owned.Proofs.Basic
+import Contracts.Owned.Proofs.Correctness

--- a/Contracts/Owned/Contract.lean
+++ b/Contracts/Owned/Contract.lean
@@ -1,0 +1,12 @@
+import Verity.Examples.Owned
+
+namespace Contracts.Owned.Contract
+
+abbrev owner := Verity.Examples.Owned.owner
+abbrev transferOwnership := Verity.Examples.Owned.transferOwnership
+abbrev getOwner := Verity.Examples.Owned.getOwner
+abbrev isOwner := Verity.Examples.Owned.isOwner
+abbrev onlyOwner := Verity.Examples.Owned.onlyOwner
+abbrev «constructor» := Verity.Examples.Owned.constructor
+
+end Contracts.Owned.Contract

--- a/Contracts/Owned/Invariants.lean
+++ b/Contracts/Owned/Invariants.lean
@@ -1,0 +1,7 @@
+import Verity.Specs.Owned.Invariants
+
+namespace Contracts.Owned.Invariants
+
+abbrev WellFormedState := Verity.Specs.Owned.WellFormedState
+
+end Contracts.Owned.Invariants

--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -1,0 +1,25 @@
+import Verity.Proofs.Owned.Basic
+
+namespace Contracts.Owned.Proofs.Basic
+
+abbrev setStorageAddr_updates_owner := Verity.Proofs.Owned.setStorageAddr_updates_owner
+abbrev getStorageAddr_reads_owner := Verity.Proofs.Owned.getStorageAddr_reads_owner
+abbrev setStorageAddr_preserves_other_slots := Verity.Proofs.Owned.setStorageAddr_preserves_other_slots
+abbrev setStorageAddr_preserves_uint_storage := Verity.Proofs.Owned.setStorageAddr_preserves_uint_storage
+abbrev setStorageAddr_preserves_map_storage := Verity.Proofs.Owned.setStorageAddr_preserves_map_storage
+abbrev setStorageAddr_preserves_context := Verity.Proofs.Owned.setStorageAddr_preserves_context
+abbrev constructor_meets_spec := Verity.Proofs.Owned.constructor_meets_spec
+abbrev constructor_sets_owner := Verity.Proofs.Owned.constructor_sets_owner
+abbrev getOwner_meets_spec := Verity.Proofs.Owned.getOwner_meets_spec
+abbrev getOwner_returns_owner := Verity.Proofs.Owned.getOwner_returns_owner
+abbrev getOwner_preserves_state := Verity.Proofs.Owned.getOwner_preserves_state
+abbrev isOwner_meets_spec := Verity.Proofs.Owned.isOwner_meets_spec
+abbrev isOwner_returns_correct_value := Verity.Proofs.Owned.isOwner_returns_correct_value
+abbrev transferOwnership_unfold := Verity.Proofs.Owned.transferOwnership_unfold
+abbrev transferOwnership_meets_spec_when_owner := Verity.Proofs.Owned.transferOwnership_meets_spec_when_owner
+abbrev transferOwnership_changes_owner_when_allowed := Verity.Proofs.Owned.transferOwnership_changes_owner_when_allowed
+abbrev constructor_getOwner_correct := Verity.Proofs.Owned.constructor_getOwner_correct
+abbrev constructor_preserves_wellformedness := Verity.Proofs.Owned.constructor_preserves_wellformedness
+abbrev getOwner_preserves_wellformedness := Verity.Proofs.Owned.getOwner_preserves_wellformedness
+
+end Contracts.Owned.Proofs.Basic

--- a/Contracts/Owned/Proofs/Correctness.lean
+++ b/Contracts/Owned/Proofs/Correctness.lean
@@ -1,0 +1,10 @@
+import Verity.Proofs.Owned.Correctness
+
+namespace Contracts.Owned.Proofs.Correctness
+
+abbrev transferOwnership_reverts_when_not_owner := Verity.Proofs.Owned.Correctness.transferOwnership_reverts_when_not_owner
+abbrev transferOwnership_preserves_wellformedness := Verity.Proofs.Owned.Correctness.transferOwnership_preserves_wellformedness
+abbrev constructor_transferOwnership_getOwner := Verity.Proofs.Owned.Correctness.constructor_transferOwnership_getOwner
+abbrev transferred_owner_cannot_act := Verity.Proofs.Owned.Correctness.transferred_owner_cannot_act
+
+end Contracts.Owned.Proofs.Correctness

--- a/Contracts/Owned/Spec.lean
+++ b/Contracts/Owned/Spec.lean
@@ -1,0 +1,10 @@
+import Verity.Specs.Owned.Spec
+
+namespace Contracts.Owned.Spec
+
+abbrev constructor_spec := Verity.Specs.Owned.constructor_spec
+abbrev getOwner_spec := Verity.Specs.Owned.getOwner_spec
+abbrev transferOwnership_spec := Verity.Specs.Owned.transferOwnership_spec
+abbrev isOwner_spec := Verity.Specs.Owned.isOwner_spec
+
+end Contracts.Owned.Spec

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -25,6 +25,7 @@ lean_lib «Examples» where
     .andSubmodules `Contracts.MacroContracts,
     .andSubmodules `Contracts.Counter,
     .andSubmodules `Contracts.SimpleStorage,
+    .andSubmodules `Contracts.Owned,
     .one `Verity.All,
     .submodules `Verity.Examples,
     .submodules `Verity.Specs.Counter,


### PR DESCRIPTION
## Summary
- add a new `Contracts.Owned` wrapper subtree mirroring the existing `Contracts.Counter` and `Contracts.SimpleStorage` migration pattern
- re-export Owned contract, spec, invariant, and proof symbols under the `Contracts.Owned.*` namespace
- wire `Contracts.Owned` into `Contracts.lean` and the `Examples` globs in `lakefile.lean`

## Why
This is the next incremental step in issue #1174 (top-level `Contracts/` migration), reducing namespace churn for downstream imports while keeping proofs/specs build-stable.

## Validation
- `lake build Contracts.Owned Contracts.Owned.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new wrapper modules and import/glob wiring without changing underlying `Verity.*` specs/proofs or contract behavior; main risk is minor build/import breakage from namespace or glob configuration.
> 
> **Overview**
> Adds a new `Contracts.Owned` module subtree mirroring the existing `Contracts.Counter` pattern, re-exporting the Owned contract API plus associated specs, invariants, and proofs via `abbrev` aliases under `Contracts.Owned.*`.
> 
> Wires the new namespace into `Contracts.lean` and includes `Contracts.Owned` in the `Examples` `lakefile.lean` globs so it builds and can be imported consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d455af70e9332a018e7cd64096eb637bca4c413. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->