### PR TITLE
Refactor: add Contracts.OwnedCounter wrapper namespace

### DIFF
--- a/Contracts.lean
+++ b/Contracts.lean
@@ -2,3 +2,4 @@ import Contracts.MacroContracts
 import Contracts.Counter
 import Contracts.SimpleStorage
 import Contracts.Owned
+import Contracts.OwnedCounter

--- a/Contracts/OwnedCounter.lean
+++ b/Contracts/OwnedCounter.lean
@@ -1,0 +1,6 @@
+import Contracts.OwnedCounter.Contract
+import Contracts.OwnedCounter.Spec
+import Contracts.OwnedCounter.Invariants
+import Contracts.OwnedCounter.Proofs.Basic
+import Contracts.OwnedCounter.Proofs.Correctness
+import Contracts.OwnedCounter.Proofs.Isolation

--- a/Contracts/OwnedCounter/Contract.lean
+++ b/Contracts/OwnedCounter/Contract.lean
@@ -1,0 +1,16 @@
+import Verity.Examples.OwnedCounter
+
+namespace Contracts.OwnedCounter.Contract
+
+abbrev owner := Verity.Examples.OwnedCounter.owner
+abbrev count := Verity.Examples.OwnedCounter.count
+abbrev increment := Verity.Examples.OwnedCounter.increment
+abbrev decrement := Verity.Examples.OwnedCounter.decrement
+abbrev getCount := Verity.Examples.OwnedCounter.getCount
+abbrev getOwner := Verity.Examples.OwnedCounter.getOwner
+abbrev transferOwnership := Verity.Examples.OwnedCounter.transferOwnership
+abbrev isOwner := Verity.Examples.OwnedCounter.isOwner
+abbrev onlyOwner := Verity.Examples.OwnedCounter.onlyOwner
+abbrev «constructor» := Verity.Examples.OwnedCounter.constructor
+
+end Contracts.OwnedCounter.Contract

--- a/Contracts/OwnedCounter/Invariants.lean
+++ b/Contracts/OwnedCounter/Invariants.lean
@@ -1,0 +1,10 @@
+import Verity.Specs.OwnedCounter.Invariants
+
+namespace Contracts.OwnedCounter.Invariants
+
+abbrev WellFormedState := Verity.Specs.OwnedCounter.WellFormedState
+abbrev count_preserves_owner := Verity.Specs.OwnedCounter.count_preserves_owner
+abbrev owner_preserves_count := Verity.Specs.OwnedCounter.owner_preserves_count
+abbrev context_preserved := Verity.Specs.OwnedCounter.context_preserved
+
+end Contracts.OwnedCounter.Invariants

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -1,0 +1,35 @@
+import Verity.Proofs.OwnedCounter.Basic
+
+namespace Contracts.OwnedCounter.Proofs.Basic
+
+abbrev constructor_meets_spec := Verity.Proofs.OwnedCounter.constructor_meets_spec
+abbrev constructor_sets_owner := Verity.Proofs.OwnedCounter.constructor_sets_owner
+abbrev constructor_preserves_count := Verity.Proofs.OwnedCounter.constructor_preserves_count
+abbrev getCount_meets_spec := Verity.Proofs.OwnedCounter.getCount_meets_spec
+abbrev getCount_returns_count := Verity.Proofs.OwnedCounter.getCount_returns_count
+abbrev getCount_preserves_state := Verity.Proofs.OwnedCounter.getCount_preserves_state
+abbrev getOwner_meets_spec := Verity.Proofs.OwnedCounter.getOwner_meets_spec
+abbrev getOwner_returns_owner := Verity.Proofs.OwnedCounter.getOwner_returns_owner
+abbrev getOwner_preserves_state := Verity.Proofs.OwnedCounter.getOwner_preserves_state
+abbrev isOwner_correct := Verity.Proofs.OwnedCounter.isOwner_correct
+abbrev increment_unfold := Verity.Proofs.OwnedCounter.increment_unfold
+abbrev increment_meets_spec_when_owner := Verity.Proofs.OwnedCounter.increment_meets_spec_when_owner
+abbrev increment_adds_one_when_owner := Verity.Proofs.OwnedCounter.increment_adds_one_when_owner
+abbrev increment_reverts_when_not_owner := Verity.Proofs.OwnedCounter.increment_reverts_when_not_owner
+abbrev decrement_unfold := Verity.Proofs.OwnedCounter.decrement_unfold
+abbrev decrement_meets_spec_when_owner := Verity.Proofs.OwnedCounter.decrement_meets_spec_when_owner
+abbrev decrement_subtracts_one_when_owner := Verity.Proofs.OwnedCounter.decrement_subtracts_one_when_owner
+abbrev decrement_reverts_when_not_owner := Verity.Proofs.OwnedCounter.decrement_reverts_when_not_owner
+abbrev transferOwnership_unfold := Verity.Proofs.OwnedCounter.transferOwnership_unfold
+abbrev transferOwnership_meets_spec_when_owner := Verity.Proofs.OwnedCounter.transferOwnership_meets_spec_when_owner
+abbrev transferOwnership_changes_owner := Verity.Proofs.OwnedCounter.transferOwnership_changes_owner
+abbrev transferOwnership_reverts_when_not_owner := Verity.Proofs.OwnedCounter.transferOwnership_reverts_when_not_owner
+abbrev increment_preserves_owner := Verity.Proofs.OwnedCounter.increment_preserves_owner
+abbrev decrement_preserves_owner := Verity.Proofs.OwnedCounter.decrement_preserves_owner
+abbrev transferOwnership_preserves_count := Verity.Proofs.OwnedCounter.transferOwnership_preserves_count
+abbrev constructor_preserves_wellformedness := Verity.Proofs.OwnedCounter.constructor_preserves_wellformedness
+abbrev increment_preserves_wellformedness := Verity.Proofs.OwnedCounter.increment_preserves_wellformedness
+abbrev decrement_preserves_wellformedness := Verity.Proofs.OwnedCounter.decrement_preserves_wellformedness
+abbrev constructor_increment_getCount := Verity.Proofs.OwnedCounter.constructor_increment_getCount
+
+end Contracts.OwnedCounter.Proofs.Basic

--- a/Contracts/OwnedCounter/Proofs/Correctness.lean
+++ b/Contracts/OwnedCounter/Proofs/Correctness.lean
@@ -1,0 +1,11 @@
+import Verity.Proofs.OwnedCounter.Correctness
+
+namespace Contracts.OwnedCounter.Proofs.Correctness
+
+abbrev transfer_then_increment_reverts := Verity.Proofs.OwnedCounter.Correctness.transfer_then_increment_reverts
+abbrev transfer_then_decrement_reverts := Verity.Proofs.OwnedCounter.Correctness.transfer_then_decrement_reverts
+abbrev transfer_then_transfer_reverts := Verity.Proofs.OwnedCounter.Correctness.transfer_then_transfer_reverts
+abbrev transferOwnership_preserves_wellformedness := Verity.Proofs.OwnedCounter.Correctness.transferOwnership_preserves_wellformedness
+abbrev increment_survives_transfer := Verity.Proofs.OwnedCounter.Correctness.increment_survives_transfer
+
+end Contracts.OwnedCounter.Proofs.Correctness

--- a/Contracts/OwnedCounter/Proofs/Isolation.lean
+++ b/Contracts/OwnedCounter/Proofs/Isolation.lean
@@ -1,0 +1,20 @@
+import Verity.Proofs.OwnedCounter.Isolation
+
+namespace Contracts.OwnedCounter.Proofs.Isolation
+
+abbrev increment_count_preserves_owner := Verity.Proofs.OwnedCounter.Isolation.increment_count_preserves_owner
+abbrev decrement_count_preserves_owner := Verity.Proofs.OwnedCounter.Isolation.decrement_count_preserves_owner
+abbrev constructor_owner_preserves_count := Verity.Proofs.OwnedCounter.Isolation.constructor_owner_preserves_count
+abbrev transferOwnership_owner_preserves_count := Verity.Proofs.OwnedCounter.Isolation.transferOwnership_owner_preserves_count
+abbrev constructor_context_preserved := Verity.Proofs.OwnedCounter.Isolation.constructor_context_preserved
+abbrev increment_context_preserved := Verity.Proofs.OwnedCounter.Isolation.increment_context_preserved
+abbrev decrement_context_preserved := Verity.Proofs.OwnedCounter.Isolation.decrement_context_preserved
+abbrev transferOwnership_context_preserved := Verity.Proofs.OwnedCounter.Isolation.transferOwnership_context_preserved
+abbrev getCount_context_preserved := Verity.Proofs.OwnedCounter.Isolation.getCount_context_preserved
+abbrev getOwner_context_preserved := Verity.Proofs.OwnedCounter.Isolation.getOwner_context_preserved
+abbrev constructor_preserves_map_storage := Verity.Proofs.OwnedCounter.Isolation.constructor_preserves_map_storage
+abbrev increment_preserves_map_storage := Verity.Proofs.OwnedCounter.Isolation.increment_preserves_map_storage
+abbrev decrement_preserves_map_storage := Verity.Proofs.OwnedCounter.Isolation.decrement_preserves_map_storage
+abbrev transferOwnership_preserves_map_storage := Verity.Proofs.OwnedCounter.Isolation.transferOwnership_preserves_map_storage
+
+end Contracts.OwnedCounter.Proofs.Isolation

--- a/Contracts/OwnedCounter/Spec.lean
+++ b/Contracts/OwnedCounter/Spec.lean
@@ -1,0 +1,12 @@
+import Verity.Specs.OwnedCounter.Spec
+
+namespace Contracts.OwnedCounter.Spec
+
+abbrev constructor_spec := Verity.Specs.OwnedCounter.constructor_spec
+abbrev getCount_spec := Verity.Specs.OwnedCounter.getCount_spec
+abbrev getOwner_spec := Verity.Specs.OwnedCounter.getOwner_spec
+abbrev increment_spec := Verity.Specs.OwnedCounter.increment_spec
+abbrev decrement_spec := Verity.Specs.OwnedCounter.decrement_spec
+abbrev transferOwnership_spec := Verity.Specs.OwnedCounter.transferOwnership_spec
+
+end Contracts.OwnedCounter.Spec

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -26,6 +26,7 @@ lean_lib «Examples» where
     .andSubmodules `Contracts.Counter,
     .andSubmodules `Contracts.SimpleStorage,
     .andSubmodules `Contracts.Owned,
+    .andSubmodules `Contracts.OwnedCounter,
     .one `Verity.All,
     .submodules `Verity.Examples,
     .submodules `Verity.Specs.Counter,


### PR DESCRIPTION
## Summary
- add top-level `Contracts.OwnedCounter` wrapper modules for contract/spec/invariants/proofs
- expose `Basic`, `Correctness`, and `Isolation` proof wrappers under `Contracts.OwnedCounter.Proofs.*`
- wire the new namespace into `Contracts.lean` and `Examples` globs in `lakefile.lean`

## Validation
- `lake build Contracts.OwnedCounter Contracts.OwnedCounter.Proofs.Correctness Contracts.OwnedCounter.Proofs.Isolation`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive and mostly `abbrev` re-exports, with the main impact being new module imports and build globs.
> 
> **Overview**
> Adds a new top-level `Contracts.OwnedCounter` module family that re-exports the underlying `Verity.*.OwnedCounter` **contract interface**, **specs**, **invariants**, and grouped proofs (`Proofs.Basic`, `Proofs.Correctness`, `Proofs.Isolation`) via `abbrev` wrappers.
> 
> Updates `Contracts.lean` to import `Contracts.OwnedCounter` and extends the `Examples` `lakefile.lean` globs to include the new `Contracts.OwnedCounter` submodules so they build and are discoverable like the existing contract wrappers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78d298cc48e05ef62aeb1b0492c58f182ea07a95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->