### PR TITLE
CI: fix verify cache-key mismatch and timeout cancellations

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -197,7 +197,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: changes
     if: needs.changes.outputs.code == 'true'
     steps:
@@ -366,7 +366,7 @@ jobs:
   # (Verity/**) never invalidate this cache.
   build-compiler:
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 240
     needs: changes
     if: needs.changes.outputs.compiler == 'true'
     steps:
@@ -398,7 +398,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .lake
-          key: lake-compiler-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('Compiler/**/*.lean', 'Verity/**/*.lean') }}
+          key: lake-compiler-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('Compiler/**/*.lean') }}
           restore-keys: |
             lake-compiler-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-
 
@@ -543,7 +543,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .lake
-          key: lake-compiler-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-${{ hashFiles('lake-manifest.json') }}
+          key: lake-compiler-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('Compiler/**/*.lean') }}
 
       - name: Upload generated Yul
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- fix `build-compiler` cache-key mismatch between restore/save steps
- align compiler cache invalidation with intended scope (`Compiler/**/*.lean` only)
- raise `build` timeout from 30 to 45 minutes
- raise `build-compiler` timeout from 150 to 240 minutes

## Why
Recent `Verify proofs` runs on `main` were ending in `cancelled` state because:
1. `build` hit the 30-minute timeout during the axiom-audit stage.
2. `build-compiler` hit the 150-minute timeout while rebuilding from scratch.
3. The compiler cache restore/save keys did not match, forcing partial-hit behavior and clearing `.lake` each run.

This restores effective compiler cache reuse and avoids timeout-driven false-negative CI status.

## Validation
- `python3 scripts/check_verify_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only workflow tweaks (timeouts and cache keys) that don’t affect production code, but could change build reproducibility/perf if the cache key scoping is wrong.
> 
> **Overview**
> Adjusts the Verify GitHub Actions workflow to reduce false-negative CI results by **increasing job timeouts** (`build` 30→45 min, `build-compiler` 150→240 min).
> 
> Fixes the `build-compiler` Lake cache behavior by **making restore/save keys match** and scoping compiler cache invalidation to `Compiler/**/*.lean` only (excluding `Verity/**` from the cache key), improving cache reuse and avoiding unnecessary cache clears.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eca065645c8d88219c0dfc2f9a78b88360ca790c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->