### PR TITLE
TypedIR: add first-class TStmt.emit in typed pipeline

### DIFF
--- a/Verity/Core/Free/TypedIR.lean
+++ b/Verity/Core/Free/TypedIR.lean
@@ -62,6 +62,7 @@ inductive TStmt where
   | returnUint (value : TExpr .uint256)
   | returnAddr (value : TExpr .address)
   | expr (value : TExpr .unit)
+  | emit (eventName : String) (topics : List (TExpr .uint256))
   | rawLog (topics : List (TExpr .uint256)) (dataOffset dataSize : TExpr .uint256)
   | revert (reason : String)
   deriving Repr
@@ -185,6 +186,10 @@ def evalTExpr (s : TExecState) : TExpr ty → Ty.denote ty
   | .getMapping2 slot key1 key2 => s.world.storageMap2 slot (evalTExpr s key1) (evalTExpr s key2)
   | .getMappingUint slot key => s.world.storageMapUint slot (evalTExpr s key)
 
+/-- Deterministic placeholder topic0 for typed-path `emit`. -/
+def typedEventNameTopicWord (eventName : String) : Verity.Core.Uint256 :=
+  UInt64.toNat (hash eventName)
+
 /-- Check whether a statement is an EVM-halting terminal (`stop`, `return`). -/
 private def isTerminalStmt : TStmt → Bool
   | .stop | .returnUint _ | .returnAddr _ => true
@@ -234,6 +239,12 @@ def evalTStmtFuel : Nat → TExecState → TStmt → TExecResult
   | Nat.succ _, s, .expr value =>
       let _ := evalTExpr s value
       .ok s
+  | Nat.succ _, s, .emit eventName topics =>
+      let topicVals := topics.map (evalTExpr s ·)
+      .ok { s with world := { s.world with
+        events := s.world.events ++
+          [{ name := s!"log{topics.length + 1}", args := [0, 0],
+             indexedArgs := (typedEventNameTopicWord eventName) :: topicVals }] } }
   | Nat.succ _, s, .rawLog topics dataOffset dataSize =>
       let topicVals := topics.map (evalTExpr s ·)
       let offsetVal := evalTExpr s dataOffset

--- a/Verity/Core/Free/TypedIRCompiler.lean
+++ b/Verity/Core/Free/TypedIRCompiler.lean
@@ -45,11 +45,6 @@ private def pushLocal (v : TVar) : CompileM Unit :=
 private def emit (stmt : TStmt) : CompileM Unit :=
   modify fun st => { st with body := st.body.push stmt }
 
-private def eventNameTopicWord (eventName : String) : Verity.Core.Uint256 :=
-  -- Deterministic placeholder topic0 for typed-path `emit`.
-  -- Full Solidity event ABI hashing/encoding is handled in the Yul pipeline.
-  UInt64.toNat (hash eventName)
-
 private def paramTypeToTy : ParamType → Except String Ty
   | .uint256 => Except.ok Ty.uint256
   | .uint8 => Except.ok Ty.uint256
@@ -292,16 +287,13 @@ private def compileStmt (fields : List Field) : Stmt → CompileM Unit
       | _ =>
           throw "Typed IR compile error: multiple return values are not supported in phase 2.4"
   | .emit eventName args => do
-      -- Typed IR currently models event emission via raw EVM log opcodes.
-      -- We include a deterministic topic0 derived from the event name and
-      -- treat args as indexed topics (data payload omitted in this path).
+      -- Event payload words are modeled as indexed topics in typed mode.
       if args.length > 3 then
         throw s!"Typed IR compile error: emit supports at most 3 arguments in typed mode, got {args.length}"
       let argTopicExprs ← args.mapM (fun arg => do
         let argExpr ← compileExpr fields arg
         liftExcept <| asUInt256 argExpr)
-      let topic0 : TExpr .uint256 := TExpr.uintLit (eventNameTopicWord eventName)
-      emit (.rawLog (topic0 :: argTopicExprs) (TExpr.uintLit 0) (TExpr.uintLit 0))
+      emit (.emit eventName argTopicExprs)
   | .rawLog topics dataOffset dataSize => do
       if topics.length > 4 then
         throw s!"Typed IR compile error: rawLog supports at most 4 topics, got {topics.length}"

--- a/Verity/Core/Free/TypedIRCompilerCorrectness.lean
+++ b/Verity/Core/Free/TypedIRCompilerCorrectness.lean
@@ -64,8 +64,8 @@ def execCompiledRawLogLiterals
   execSourceRawLogLiterals init topics dataOffset dataSize
 
 /-- Deterministic placeholder topic0 for typed-path `emit`.
-Matches `TypedIRCompiler.eventNameTopicWord`. -/
-private def eventNameTopicWord (eventName : String) : Verity.Core.Uint256 :=
+Matches `TypedIR.typedEventNameTopicWord`. -/
+private def eventNameTopicWordLocal (eventName : String) : Verity.Core.Uint256 :=
   UInt64.toNat (hash eventName)
 
 /-- Direct source semantics for literal typed-path events:
@@ -75,7 +75,7 @@ def execSourceEmitLiterals
     TExecResult :=
   evalTStmts init
     [TStmt.rawLog
-      ((TExpr.uintLit (eventNameTopicWord eventName)) ::
+      ((TExpr.uintLit (eventNameTopicWordLocal eventName)) ::
         args.map (fun n : Nat => TExpr.uintLit (n : Verity.Core.Uint256)))
       (TExpr.uintLit 0)
       (TExpr.uintLit 0)]
@@ -5197,7 +5197,7 @@ def SupportedStmtFragment.toRequireFamilyClausesTailProgram
         tail := .rawLogLiterals topics dataOffset dataSize htopics }
   | .requireClausesThenEmitLiterals clauses eventName args hargs =>
       { clauses := clauses
-        tail := .rawLogLiterals ((eventNameTopicWord eventName) :: args) 0 0
+        tail := .rawLogLiterals ((eventNameTopicWordLocal eventName) :: args) 0 0
           (by simpa using Nat.succ_le_succ hargs) }
   | .requireClausesThenSetStorageLiteral clauses fieldName slot writeVal hfind =>
       { clauses := clauses

--- a/Verity/Core/Free/TypedIRLowering.lean
+++ b/Verity/Core/Free/TypedIRLowering.lean
@@ -90,6 +90,10 @@ where
         , .expr (.call "return" [.lit 0, .lit 32])
         ]
     | .expr value => [.expr (lowerTExpr value)]
+    | .emit eventName topics =>
+        [ .expr (.call s!"log{topics.length + 1}"
+            ([.lit 0, .lit 0, .lit (typedEventNameTopicWord eventName)] ++ topics.map lowerTExpr))
+        ]
     | .rawLog topics dataOffset dataSize =>
         [ .expr (.call s!"log{topics.length}" ([lowerTExpr dataOffset, lowerTExpr dataSize] ++ topics.map lowerTExpr))
         ]

--- a/Verity/Core/Free/TypedIRTests.lean
+++ b/Verity/Core/Free/TypedIRTests.lean
@@ -149,6 +149,22 @@ def compileEmitSucceeds : Bool :=
   | .ok _ => true
   | .error _ => false
 
+def compileEmitTypedShapeOk : Bool :=
+  match (compileStmts []
+      [Compiler.CompilationModel.Stmt.emit "Transfer"
+        [Compiler.CompilationModel.Expr.literal 1, Compiler.CompilationModel.Expr.literal 2]]).run {} with
+  | .ok st =>
+      match st.2.body.toList with
+      | [TStmt.emit "Transfer" topics] =>
+          match topics with
+          | [t1, t2] =>
+              match lowerTExpr t1, lowerTExpr t2 with
+              | .lit 1, .lit 2 => true
+              | _, _ => false
+          | _ => false
+      | _ => false
+  | .error _ => false
+
 def compileEmitLoweringShapeOk : Bool :=
   match (compileStmts []
       [Compiler.CompilationModel.Stmt.emit "Transfer"
@@ -206,7 +222,10 @@ example : compileRawLogTooManyTopicsFails = true := by native_decide
 /-- Typed-IR compiler accepts source-level `Stmt.emit`. -/
 example : compileEmitSucceeds = true := by native_decide
 
-/-- Typed-IR compiler lowers `Stmt.emit` to `rawLog`/`logN` with empty data payload. -/
+/-- Typed-IR compiler lowers `Stmt.emit` into first-class typed `TStmt.emit`. -/
+example : compileEmitTypedShapeOk = true := by native_decide
+
+/-- Typed-IR compiler lowers `TStmt.emit` to `logN` with empty data payload. -/
 example : compileEmitLoweringShapeOk = true := by native_decide
 
 /-- Typed-IR compiler preserves event identity via a distinct topic0. -/
@@ -259,6 +278,14 @@ example :
   simp [evalTStmt, evalTStmtFuel, defaultEvalFuel]
   rfl
 
+/-- Typed emits are recorded as append-only event entries. -/
+example :
+    match evalTStmt baseState (TStmt.emit "Transfer" [TExpr.uintLit 1, TExpr.uintLit 2]) with
+    | .ok s' => s'.world.events.length = baseState.world.events.length + 1
+    | .revert _ => False := by
+  simp [evalTStmt, evalTStmtFuel, defaultEvalFuel]
+  rfl
+
 /-- Branching and block execution compose through `evalTBlock`. -/
 example :
     match evalTStmt baseState
@@ -302,6 +329,12 @@ example :
 example :
     lowerTStmts [TStmt.rawLog [] (TExpr.uintLit 0) (TExpr.uintLit 32)] =
       [.expr (.call "log0" [.lit 0, .lit 32])] := by
+  rfl
+
+/-- Lowering emits `log3` for typed `emit` with two indexed args. -/
+example :
+    lowerTStmts [TStmt.emit "Transfer" [TExpr.uintLit 1, TExpr.uintLit 2]] =
+      [.expr (.call "log3" [.lit 0, .lit 0, .lit (typedEventNameTopicWord "Transfer"), .lit 1, .lit 2])] := by
   rfl
 
 def counterTmp : TVar := { id := 10, ty := .uint256 }


### PR DESCRIPTION
## Summary
- add first-class `TStmt.emit` to typed IR
- compile source `Stmt.emit` directly to `TStmt.emit` (instead of lowering to `rawLog` in the compiler)
- add typed evaluator semantics for `TStmt.emit` as a `logN` side-effect with deterministic `topic0`
- add Yul lowering for `TStmt.emit` to `log{n+1}(0,0,topic0,...)`
- extend tests for:
  - typed compiler shape (`Stmt.emit -> TStmt.emit`)
  - evaluator event append behavior for typed emit
  - exact Yul lowering shape for typed emit
- resolve naming collision in correctness helpers (`eventNameTopicWordLocal`)

## Why
Issue #1191 asks for event emission support in the typed IR statement type and pipeline. This PR introduces a first-class typed emit node and keeps event behavior non-functional (side-channel only), while preserving existing raw-log support.

## Validation
- `lake build Verity.Core.Free.TypedIRTests`
- `lake build Verity.Core.Free.TypedIRCompilerCorrectness`
- `python3 scripts/check_proof_length.py`

Closes #1191

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches typed IR semantics, compiler output shape, and Yul lowering for event emission, so downstream assumptions about `emit` lowering/log topic counts could break if any consumers still expect `rawLog`.
> 
> **Overview**
> Adds **first-class event emission** to the typed pipeline via `TStmt.emit`, rather than compiling source `Stmt.emit` directly into `rawLog`.
> 
> Updates the typed evaluator to record `emit` as an append-only `log{n+1}` event with empty data payload and a deterministic placeholder `topic0` (`typedEventNameTopicWord`), and updates Yul lowering to generate `log{n+1}(0,0,topic0,...)`.
> 
> Adjusts correctness helpers to avoid naming collisions and extends tests to assert the new typed statement shape, evaluator side effects, and exact lowering form.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e607eab0acec18b07d79bcfcdc6017c17028eb4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->