### PR TITLE
fix: align Ledger transfer overflow proofs with wrapping semantics

### DIFF
--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -19,8 +19,7 @@ namespace Contracts.Ledger.Proofs
 open Verity
 open Contracts.MacroContracts.Ledger
 open Contracts.Ledger.Spec
-open Verity.Stdlib.Math (safeAdd requireSomeUint MAX_UINT256)
-open Verity.Proofs.Stdlib.Math (safeAdd_some safeAdd_none)
+open Verity.Stdlib.Math (MAX_UINT256)
 open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne uint256_ge_val_le)
 open Contracts.Ledger.Invariants
 
@@ -157,11 +156,10 @@ private theorem transfer_unfold_self (s : ContractState) (to : Address) (amount 
     Verity.require, Verity.bind, Bind.bind, Verity.pure, Pure.pure,
     Contract.run, uint256_ge_val_le (h_eq ▸ h_balance), h_eq]
 
-/-- Helper: unfold transfer when balance sufficient, sender ≠ to, and no overflow. -/
+/-- Helper: unfold transfer when balance sufficient and sender ≠ to. -/
 private theorem transfer_unfold_other (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount)
-  (h_ne : s.sender ≠ to)
-  (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
+  (h_ne : s.sender ≠ to) :
   (transfer to amount).run s = ContractResult.success ()
     { «storage» := s.storage,
       storageAddr := s.storageAddr,
@@ -181,18 +179,16 @@ private theorem transfer_unfold_other (s : ContractState) (to : Address) (amount
       events := s.events } := by
   simp only [transfer, Contracts.MacroContracts.Ledger.balances,
     msgSender, getMapping, setMapping,
-    requireSomeUint,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, h_balance, h_ne, beq_iff_eq, safeAdd_some (s.storageMap 0 to) amount h_no_overflow,
-    decide_eq_true_eq, ite_true, ite_false, HAdd.hAdd]
+    Verity.require, Verity.bind, Bind.bind, Pure.pure,
+    Contract.run, h_balance, h_ne, beq_iff_eq,
+    decide_eq_true_eq, ite_true, ite_false]
   congr 1
   congr 1
   funext slotIdx
   split <;> simp [*]
 
 theorem transfer_meets_spec (s : ContractState) (to : Address) (amount : Uint256)
-  (h_balance : s.storageMap 0 s.sender >= amount)
-  (h_no_overflow : s.sender ≠ to → (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
+  (h_balance : s.storageMap 0 s.sender >= amount) :
   let s' := ((transfer to amount).run s).snd
   transfer_spec to amount s s' := by
   by_cases h_eq : s.sender = to
@@ -204,7 +200,7 @@ theorem transfer_meets_spec (s : ContractState) (to : Address) (amount : Uint256
     · simp [h_eq, Specs.storageMapUnchangedExceptKeyAtSlot,
         Specs.storageMapUnchangedExceptKey, Specs.storageMapUnchangedExceptSlot]
     · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameContext]
-  · rw [transfer_unfold_other s to amount h_balance h_eq (h_no_overflow h_eq)]
+  · rw [transfer_unfold_other s to amount h_balance h_eq]
     simp only [ContractResult.snd, transfer_spec]
     have h_ne' := address_beq_false_of_ne s.sender to h_eq
     refine ⟨?_, ?_, ?_, ?_⟩
@@ -222,27 +218,25 @@ theorem transfer_self_preserves_balance (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
   let s' := ((transfer s.sender amount).run s).snd
   s'.storageMap 0 s.sender = s.storageMap 0 s.sender := by
-  have h := transfer_meets_spec s s.sender amount h_balance (fun h => absurd rfl h)
+  have h := transfer_meets_spec s s.sender amount h_balance
   simp [transfer_spec] at h
   exact h.1
 
 theorem transfer_decreases_sender (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount)
-  (h_ne : s.sender ≠ to)
-  (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
+  (h_ne : s.sender ≠ to) :
   let s' := ((transfer to amount).run s).snd
   s'.storageMap 0 s.sender = EVM.Uint256.sub (s.storageMap 0 s.sender) amount := by
-  have h := transfer_meets_spec s to amount h_balance (fun _ => h_no_overflow)
+  have h := transfer_meets_spec s to amount h_balance
   simp [transfer_spec, h_ne, beq_iff_eq] at h
   exact h.1
 
 theorem transfer_increases_recipient (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount)
-  (h_ne : s.sender ≠ to)
-  (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
+  (h_ne : s.sender ≠ to) :
   let s' := ((transfer to amount).run s).snd
   s'.storageMap 0 to = EVM.Uint256.add (s.storageMap 0 to) amount := by
-  have h := transfer_meets_spec s to amount h_balance (fun _ => h_no_overflow)
+  have h := transfer_meets_spec s to amount h_balance
   simp [transfer_spec, h_ne, beq_iff_eq] at h
   exact h.2.1
 
@@ -254,15 +248,31 @@ theorem transfer_reverts_insufficient (s : ContractState) (to : Address) (amount
     show (s.storageMap 0 s.sender >= amount) = false from by
       simp [ge_iff_le] at h_insufficient ⊢; omega]
 
--- Transfer reverts on recipient balance overflow
--- NOTE: Pre-existing issue — Ledger.transfer does not use safeAdd, so this
--- theorem is currently unprovable. Marked sorry to match upstream HEAD state.
-theorem transfer_reverts_recipient_overflow (s : ContractState) (to : Address) (amount : Uint256)
+-- Transfer does not revert on recipient overflow; Uint256 addition wraps.
+theorem transfer_succeeds_recipient_overflow (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount)
   (h_ne : s.sender ≠ to)
-  (h_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) > MAX_UINT256) :
-  ∃ msg, (transfer to amount).run s = ContractResult.revert msg s := by
-  sorry
+  (_h_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) > MAX_UINT256) :
+  ∃ s', (transfer to amount).run s = ContractResult.success () s' := by
+  let s' : ContractState :=
+    { «storage» := s.storage,
+      storageAddr := s.storageAddr,
+      storageMap := fun slotIdx addr =>
+        if (slotIdx == 0 && addr == to) = true then EVM.Uint256.add (s.storageMap 0 to) amount
+        else if (slotIdx == 0 && addr == s.sender) = true then EVM.Uint256.sub (s.storageMap 0 s.sender) amount
+        else s.storageMap slotIdx addr,
+      storageMapUint := s.storageMapUint,
+      storageMap2 := s.storageMap2,
+      sender := s.sender,
+      thisAddress := s.thisAddress,
+      msgValue := s.msgValue,
+      blockTimestamp := s.blockTimestamp,
+      knownAddresses := fun slotIdx =>
+        if slotIdx == 0 then ((s.knownAddresses slotIdx).insert s.sender).insert to
+        else s.knownAddresses slotIdx,
+      events := s.events }
+  refine ⟨s', ?_⟩
+  simpa [s'] using transfer_unfold_other s to amount h_balance h_ne
 
 /-! ## State Preservation -/
 
@@ -324,12 +334,12 @@ Withdraw (guarded):
 8. withdraw_decreases_balance
 9. withdraw_reverts_insufficient
 
-Transfer (guarded, sender ≠ to, overflow-safe):
+Transfer (guarded, sender ≠ to):
 10. transfer_meets_spec
 11. transfer_decreases_sender
 12. transfer_increases_recipient
 13. transfer_reverts_insufficient
-14. transfer_reverts_recipient_overflow
+14. transfer_succeeds_recipient_overflow
 
 State preservation:
 15. deposit_preserves_non_mapping

--- a/Contracts/Ledger/Proofs/Conservation.lean
+++ b/Contracts/Ledger/Proofs/Conservation.lean
@@ -22,7 +22,6 @@ open Contracts.Ledger.Spec
 open Contracts.Ledger.Proofs
 open Verity.Proofs.Stdlib.ListSum (countOcc countOccU countOcc_cons_eq countOcc_cons_ne
   countOccU_cons_eq countOccU_cons_ne map_sum_point_update map_sum_point_decrease map_sum_transfer_eq)
-open Verity.Stdlib.Math (MAX_UINT256)
 open Verity.Proofs.Stdlib.Automation (evm_add_eq_hadd)
 
 /-! ## Deposit: Exact Sum Equation -/
@@ -96,14 +95,13 @@ theorem withdraw_sum_singleton_sender (s : ContractState) (amount : Uint256)
     gains `amount`. The equation holds exactly (not just as an inequality). -/
 theorem transfer_sum_equation (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount)
-  (h_ne : s.sender ≠ to)
-  (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
+  (h_ne : s.sender ≠ to) :
   ∀ addrs : List Address,
     (addrs.map (fun addr => ((transfer to amount).run s).snd.storageMap 0 addr)).sum
       + countOccU s.sender addrs * amount
     = (addrs.map (fun addr => s.storageMap 0 addr)).sum
       + countOccU to addrs * amount := by
-  have h_spec := transfer_meets_spec s to amount h_balance (fun _ => h_no_overflow)
+  have h_spec := transfer_meets_spec s to amount h_balance
   simp [transfer_spec, h_ne, beq_iff_eq] at h_spec
   obtain ⟨h_sender_bal, h_recip_bal, h_other_bal, _, _, _⟩ := h_spec
   have h_recip_bal' :
@@ -121,13 +119,12 @@ theorem transfer_sum_equation (s : ContractState) (to : Address) (amount : Uint2
 theorem transfer_sum_preserved_unique (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount)
   (h_ne : s.sender ≠ to)
-  (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256)
   (addrs : List Address)
   (h_sender_once : countOcc s.sender addrs = 1)
   (h_to_once : countOcc to addrs = 1) :
   (addrs.map (fun addr => ((transfer to amount).run s).snd.storageMap 0 addr)).sum
   = (addrs.map (fun addr => s.storageMap 0 addr)).sum := by
-  have h := transfer_sum_equation s to amount h_balance h_ne h_no_overflow addrs
+  have h := transfer_sum_equation s to amount h_balance h_ne addrs
   simp [countOccU, h_sender_once, h_to_once] at h
   have h' : (addrs.map (fun addr => ((transfer to amount).run s).snd.storageMap 0 addr)).sum + amount =
       (addrs.map (fun addr => s.storageMap 0 addr)).sum + amount := by

--- a/Contracts/Ledger/Proofs/Correctness.lean
+++ b/Contracts/Ledger/Proofs/Correctness.lean
@@ -15,7 +15,6 @@ open Verity
 open Contracts.MacroContracts.Ledger
 open Contracts.Ledger.Spec
 open Contracts.Ledger.Proofs
-open Verity.Stdlib.Math (MAX_UINT256)
 open Contracts.Ledger.Invariants
 
 /-! ## Invariant Preservation -/
@@ -24,11 +23,10 @@ open Contracts.Ledger.Invariants
 theorem transfer_preserves_wellformedness (s : ContractState) (to : Address) (amount : Uint256)
   (h : WellFormedState s)
   (h_balance : s.storageMap 0 s.sender >= amount)
-  (h_ne : s.sender ≠ to)
-  (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
+  (h_ne : s.sender ≠ to) :
   let s' := ((transfer to amount).run s).snd
   WellFormedState s' := by
-  have h_spec := transfer_meets_spec s to amount h_balance (fun _ => h_no_overflow)
+  have h_spec := transfer_meets_spec s to amount h_balance
   simp [transfer_spec, h_ne, beq_iff_eq] at h_spec
   obtain ⟨_, _, _, _, _, h_sender, h_this, _, _⟩ := h_spec
   constructor
@@ -37,11 +35,10 @@ theorem transfer_preserves_wellformedness (s : ContractState) (to : Address) (am
 
 /-- Transfer preserves non-mapping storage. -/
 theorem transfer_preserves_non_mapping (s : ContractState) (to : Address) (amount : Uint256)
-  (h_balance : s.storageMap 0 s.sender >= amount) (h_ne : s.sender ≠ to)
-  (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
+  (h_balance : s.storageMap 0 s.sender >= amount) (h_ne : s.sender ≠ to) :
   let s' := ((transfer to amount).run s).snd
   non_mapping_storage_unchanged s s' := by
-  have h_spec := transfer_meets_spec s to amount h_balance (fun _ => h_no_overflow)
+  have h_spec := transfer_meets_spec s to amount h_balance
   simp [transfer_spec, h_ne, beq_iff_eq] at h_spec
   obtain ⟨_, _, _, h_storage, h_addr, _h_ctx⟩ := h_spec
   simp [non_mapping_storage_unchanged]
@@ -59,21 +56,19 @@ theorem withdraw_getBalance_correct (s : ContractState) (amount : Uint256)
 
 /-- After transfer, sender's balance is decreased. -/
 theorem transfer_getBalance_sender_correct (s : ContractState) (to : Address) (amount : Uint256)
-  (h_balance : s.storageMap 0 s.sender >= amount) (h_ne : s.sender ≠ to)
-  (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
+  (h_balance : s.storageMap 0 s.sender >= amount) (h_ne : s.sender ≠ to) :
   let s' := ((transfer to amount).run s).snd
   ((getBalance s.sender).run s').fst = EVM.Uint256.sub (s.storageMap 0 s.sender) amount := by
   simp only [getBalance_returns_balance]
-  exact transfer_decreases_sender s to amount h_balance h_ne h_no_overflow
+  exact transfer_decreases_sender s to amount h_balance h_ne
 
 /-- After transfer, recipient's balance is increased. -/
 theorem transfer_getBalance_recipient_correct (s : ContractState) (to : Address) (amount : Uint256)
-  (h_balance : s.storageMap 0 s.sender >= amount) (h_ne : s.sender ≠ to)
-  (h_no_overflow : (s.storageMap 0 to : Nat) + (amount : Nat) ≤ MAX_UINT256) :
+  (h_balance : s.storageMap 0 s.sender >= amount) (h_ne : s.sender ≠ to) :
   let s' := ((transfer to amount).run s).snd
   ((getBalance to).run s').fst = EVM.Uint256.add (s.storageMap 0 to) amount := by
   simp only [getBalance_returns_balance]
-  exact transfer_increases_recipient s to amount h_balance h_ne h_no_overflow
+  exact transfer_increases_recipient s to amount h_balance h_ne
 
 /-! ## Deposit-Withdraw Cancellation
 


### PR DESCRIPTION
## Summary
This fixes an unsound proof regression reported by Cursor Bugbot in `Contracts/Ledger/Proofs/Basic.lean`.

### What was wrong
- `transfer_reverts_recipient_overflow` had been replaced with `sorry`.
- The theorem statement itself was false for the current Ledger implementation because `Ledger.transfer` uses wrapping `add` for recipient balance updates (not `safeAdd` + revert).

### What this PR changes
- Removes the unsound theorem and replaces it with a sound one:
  - `transfer_succeeds_recipient_overflow`
  - proves transfer still succeeds in overflow cases (Uint256 wrapping semantics).
- Refactors transfer proof helpers to match actual contract behavior:
  - `transfer_unfold_other` no longer assumes no-overflow
  - `transfer_meets_spec` no longer carries a no-overflow precondition
- Updates downstream Ledger proofs to remove obsolete no-overflow assumptions:
  - `Contracts/Ledger/Proofs/Correctness.lean`
  - `Contracts/Ledger/Proofs/Conservation.lean`

## Validation
- `lake build Contracts.Ledger.Proofs.Basic Contracts.Ledger.Proofs.Correctness Contracts.Ledger.Proofs.Conservation`
- `python3 scripts/check_proof_length.py`

Both pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the formal statements and assumptions around `transfer` to match wrapping recipient addition, which affects downstream correctness and conservation proofs but does not modify runtime contract code.
> 
> **Overview**
> **Aligns `Ledger.transfer` proofs with wrapping Uint256 semantics.** The transfer proof helper `transfer_unfold_other` and `transfer_meets_spec` drop the previous *no-overflow* precondition (and related `safeAdd` machinery), reflecting that recipient balance updates use wrapping `add` rather than reverting.
> 
> **Fixes the overflow theorem and updates downstream proofs.** Replaces the unprovable/incorrect `transfer_reverts_recipient_overflow` (previously `sorry`) with `transfer_succeeds_recipient_overflow`, and removes obsolete overflow hypotheses from dependent theorems in `Correctness.lean` and `Conservation.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6f34da0617b826ce3f37cc6cb6d62f66799f15c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->