### PR TITLE
Refactor: extract internal naming helpers from CompilationModel

### DIFF
--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -26,6 +26,7 @@ import Compiler.ECM
 import Compiler.IR
 import Compiler.Yul.Ast
 import Compiler.Identifier
+import Compiler.CompilationModel.InternalNaming
 
 namespace Compiler.CompilationModel
 
@@ -571,29 +572,6 @@ private def compileMappingSlotRead (fields : List Field) (field : String) (keyEx
       let finalSlot := if wordOffset == 0 then mappingBase else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset]
       pure (YulExpr.call "sload" [finalSlot])
     | none => throw s!"Compilation error: unknown mapping field '{field}' in {label}"
-
-/-- Prefix prepended to internal function names in generated Yul to avoid
-    collision with external function names and EVM/Yul builtins.
-    Used by compileExpr, compileStmt, and compileInternalFunction. -/
-def internalFunctionPrefix : String := "internal_"
-
-/-- Build the Yul-level name for an internal function. -/
-def internalFunctionYulName (name : String) : String :=
-  s!"{internalFunctionPrefix}{name}"
-
-private def pickFreshName (base : String) (usedNames : List String) : String :=
-  if !usedNames.contains base then
-    base
-  else
-    let rec go (suffix : Nat) (remaining : Nat) : String :=
-      let candidate := s!"{base}_{suffix}"
-      if !usedNames.contains candidate then
-        candidate
-      else
-        match remaining with
-        | 0 => s!"{base}_fresh"
-        | n + 1 => go (suffix + 1) n
-    go 1 usedNames.length
 
 mutual
 private def collectExprNames : Expr → List String

--- a/Compiler/CompilationModel/InternalNaming.lean
+++ b/Compiler/CompilationModel/InternalNaming.lean
@@ -1,0 +1,26 @@
+namespace Compiler.CompilationModel
+
+/-- Prefix prepended to internal function names in generated Yul to avoid
+    collision with external function names and EVM/Yul builtins.
+    Used by compileExpr, compileStmt, and compileInternalFunction. -/
+def internalFunctionPrefix : String := "internal_"
+
+/-- Build the Yul-level name for an internal function. -/
+def internalFunctionYulName (name : String) : String :=
+  s!"{internalFunctionPrefix}{name}"
+
+def pickFreshName (base : String) (usedNames : List String) : String :=
+  if !usedNames.contains base then
+    base
+  else
+    let rec go (suffix : Nat) (remaining : Nat) : String :=
+      let candidate := s!"{base}_{suffix}"
+      if !usedNames.contains candidate then
+        candidate
+      else
+        match remaining with
+        | 0 => s!"{base}_fresh"
+        | n + 1 => go (suffix + 1) n
+    go 1 usedNames.length
+
+end Compiler.CompilationModel


### PR DESCRIPTION
## Summary
This is an incremental split of `Compiler/CompilationModel.lean` to reduce file size and isolate reusable naming logic.

Changes:
- Added `Compiler/CompilationModel/InternalNaming.lean`
- Moved:
  - `internalFunctionPrefix`
  - `internalFunctionYulName`
  - `pickFreshName`
- Updated `Compiler/CompilationModel.lean` to import the new module and remove in-file duplicates.

## Why
`CompilationModel.lean` is currently ~5.4k lines. Extracting independent helpers into focused modules is a low-risk way to improve maintainability and unblock deeper splits.

This PR is scoped as a safe first step toward issue #1157.

## Validation
- `lake build Compiler.CompilationModel Compiler.Selector Compiler.ABI`

## Issue
- Partially addresses #1157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only moves internal naming utilities into a new module and updates imports; behavior should remain unchanged aside from potential namespace/import issues.
> 
> **Overview**
> Refactors `CompilationModel` by extracting internal Yul naming helpers into a new `Compiler/CompilationModel/InternalNaming.lean` module.
> 
> `CompilationModel.lean` now imports this module and removes the in-file definitions of `internalFunctionPrefix`, `internalFunctionYulName`, and `pickFreshName`, keeping call sites unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c77cdf19e62d2a5a70ec886ed82481211a2f0d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->