### PR TITLE
refactor(compilation-model): extract dynamic data helpers

### DIFF
--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -26,6 +26,7 @@ import Compiler.ECM
 import Compiler.IR
 import Compiler.Yul.Ast
 import Compiler.Identifier
+import Compiler.CompilationModel.DynamicData
 import Compiler.CompilationModel.InternalNaming
 
 namespace Compiler.CompilationModel
@@ -508,58 +509,6 @@ private def yulNegatedBinOp (op : String) (a b : YulExpr) : YulExpr :=
 
 private def yulToBool (e : YulExpr) : YulExpr :=
   YulExpr.call "iszero" [YulExpr.call "iszero" [e]]
-
-private inductive DynamicDataSource where
-  | calldata
-  | memory
-  deriving DecidableEq
-
-private def dynamicWordLoad (source : DynamicDataSource) (offset : YulExpr) : YulExpr :=
-  match source with
-  | .calldata => YulExpr.call "calldataload" [offset]
-  | .memory => YulExpr.call "mload" [offset]
-
-private def checkedArrayElementCalldataHelperName : String :=
-  "__verity_array_element_calldata_checked"
-
-private def checkedArrayElementMemoryHelperName : String :=
-  "__verity_array_element_memory_checked"
-
-private def checkedArrayElementHelper (helperName loadOp : String) : YulStmt :=
-  YulStmt.funcDef helperName ["data_offset", "length", "index"] ["word"] [
-    YulStmt.if_ (YulExpr.call "iszero" [
-      YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
-    ]) [
-      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
-    ],
-    YulStmt.assign "word" (YulExpr.call loadOp [
-      YulExpr.call "add" [
-        YulExpr.ident "data_offset",
-        YulExpr.call "mul" [YulExpr.ident "index", YulExpr.lit 32]
-      ]
-    ])
-  ]
-
-private def checkedArrayElementCalldataHelper : YulStmt :=
-  checkedArrayElementHelper checkedArrayElementCalldataHelperName "calldataload"
-
-private def checkedArrayElementMemoryHelper : YulStmt :=
-  checkedArrayElementHelper checkedArrayElementMemoryHelperName "mload"
-
-private def dynamicCopyData (source : DynamicDataSource)
-    (destOffset sourceOffset len : YulExpr) : List YulStmt :=
-  match source with
-  | .calldata =>
-      [YulStmt.expr (YulExpr.call "calldatacopy" [destOffset, sourceOffset, len])]
-  | .memory =>
-      [YulStmt.for_
-        [YulStmt.let_ "__copy_i" (YulExpr.lit 0)]
-        (YulExpr.call "lt" [YulExpr.ident "__copy_i", len])
-        [YulStmt.assign "__copy_i" (YulExpr.call "add" [YulExpr.ident "__copy_i", YulExpr.lit 32])]
-        [YulStmt.expr (YulExpr.call "mstore" [
-          YulExpr.call "add" [destOffset, YulExpr.ident "__copy_i"],
-          YulExpr.call "mload" [YulExpr.call "add" [sourceOffset, YulExpr.ident "__copy_i"]]
-        ])]]
 
 private def compileMappingSlotRead (fields : List Field) (field : String) (keyExpr : YulExpr)
     (label : String) (wordOffset : Nat := 0) : Except String YulExpr :=

--- a/Compiler/CompilationModel/DynamicData.lean
+++ b/Compiler/CompilationModel/DynamicData.lean
@@ -1,0 +1,59 @@
+import Compiler.Yul.Ast
+
+namespace Compiler.CompilationModel
+
+open Compiler.Yul
+
+inductive DynamicDataSource where
+  | calldata
+  | memory
+  deriving DecidableEq
+
+def dynamicWordLoad (source : DynamicDataSource) (offset : YulExpr) : YulExpr :=
+  match source with
+  | .calldata => YulExpr.call "calldataload" [offset]
+  | .memory => YulExpr.call "mload" [offset]
+
+def checkedArrayElementCalldataHelperName : String :=
+  "__verity_array_element_calldata_checked"
+
+def checkedArrayElementMemoryHelperName : String :=
+  "__verity_array_element_memory_checked"
+
+private def checkedArrayElementHelper (helperName loadOp : String) : YulStmt :=
+  YulStmt.funcDef helperName ["data_offset", "length", "index"] ["word"] [
+    YulStmt.if_ (YulExpr.call "iszero" [
+      YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
+    ]) [
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+    ],
+    YulStmt.assign "word" (YulExpr.call loadOp [
+      YulExpr.call "add" [
+        YulExpr.ident "data_offset",
+        YulExpr.call "mul" [YulExpr.ident "index", YulExpr.lit 32]
+      ]
+    ])
+  ]
+
+def checkedArrayElementCalldataHelper : YulStmt :=
+  checkedArrayElementHelper checkedArrayElementCalldataHelperName "calldataload"
+
+def checkedArrayElementMemoryHelper : YulStmt :=
+  checkedArrayElementHelper checkedArrayElementMemoryHelperName "mload"
+
+def dynamicCopyData (source : DynamicDataSource)
+    (destOffset sourceOffset len : YulExpr) : List YulStmt :=
+  match source with
+  | .calldata =>
+      [YulStmt.expr (YulExpr.call "calldatacopy" [destOffset, sourceOffset, len])]
+  | .memory =>
+      [YulStmt.for_
+        [YulStmt.let_ "__copy_i" (YulExpr.lit 0)]
+        (YulExpr.call "lt" [YulExpr.ident "__copy_i", len])
+        [YulStmt.assign "__copy_i" (YulExpr.call "add" [YulExpr.ident "__copy_i", YulExpr.lit 32])]
+        [YulStmt.expr (YulExpr.call "mstore" [
+          YulExpr.call "add" [destOffset, YulExpr.ident "__copy_i"],
+          YulExpr.call "mload" [YulExpr.call "add" [sourceOffset, YulExpr.ident "__copy_i"]]
+        ])]]
+
+end Compiler.CompilationModel


### PR DESCRIPTION
## Summary
- extract dynamic-data helper definitions from `Compiler/CompilationModel.lean`
- add new `Compiler/CompilationModel/DynamicData.lean` module for source/load/copy and checked-array helper logic
- import the new module from `CompilationModel.lean` and remove the duplicated local definitions

## Why
Issue #1157 tracks decomposing `CompilationModel.lean` into smaller modules. This is another low-risk, behavior-preserving split that reduces file size and keeps dynamic-data logic localized.

## Validation
- `lake env lean Compiler/CompilationModel/DynamicData.lean`
- `lake env lean Compiler/CompilationModel.lean`

Refs #1157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves existing dynamic-data Yul helper definitions into a separate module; behavior should be unchanged aside from potential namespace/import issues.
> 
> **Overview**
> Extracts dynamic-data Yul helpers (dynamic source enum, word loads, checked array element helpers, and calldata/memory copy logic) out of `Compiler/CompilationModel.lean` into a new `Compiler/CompilationModel/DynamicData.lean` module.
> 
> `CompilationModel.lean` now imports this module and removes the inlined helper definitions, keeping the compilation logic the same while reducing file size and improving organization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d22732894b46c313ee66ccede3532120875e3db2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->