### PR TITLE
refactor: extract mapping write helpers from CompilationModel

### DIFF
--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -24,6 +24,7 @@ import Compiler.CompilationModel.Types
 import Compiler.CompilationModel.DynamicData
 import Compiler.CompilationModel.InternalNaming
 import Compiler.CompilationModel.LayoutValidation
+import Compiler.CompilationModel.MappingWrites
 import Compiler.CompilationModel.UsageAnalysis
 import Compiler.CompilationModel.ValidationHelpers
 
@@ -2449,107 +2450,6 @@ private def validateExternalCallTargetsInConstructor
   | none => pure ()
   | some spec =>
       spec.body.forM (validateExternalCallTargetsInStmt externals "constructor")
-
-private def compileMappingSlotWrite (fields : List Field) (field : String)
-    (keyExpr valueExpr : YulExpr) (label : String) (wordOffset : Nat := 0) : Except String (List YulStmt) :=
-  if !isMapping fields field then
-    throw s!"Compilation error: field '{field}' is not a mapping"
-  else
-    match findFieldWriteSlots fields field with
-    | some slots =>
-        match slots with
-        | [] =>
-            throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in {label}"
-        | [slot] =>
-            let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyExpr]
-            let writeSlot := if wordOffset == 0 then mappingBase else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset]
-            pure [
-              YulStmt.expr (YulExpr.call "sstore" [
-                writeSlot,
-                valueExpr
-              ])
-            ]
-        | _ =>
-            let compatSlotExpr := fun (slot : Nat) =>
-              let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key"]
-              if wordOffset == 0 then mappingBase else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset]
-            pure [
-              YulStmt.block (
-                [YulStmt.let_ "__compat_key" keyExpr, YulStmt.let_ "__compat_value" valueExpr] ++
-                slots.map (fun slot =>
-                  YulStmt.expr (YulExpr.call "sstore" [
-                    compatSlotExpr slot,
-                    YulExpr.ident "__compat_value"
-                  ]))
-              )
-            ]
-    | none => throw s!"Compilation error: unknown mapping field '{field}' in {label}"
-
-private def compileMappingPackedSlotWrite (fields : List Field) (field : String)
-    (keyExpr valueExpr : YulExpr) (wordOffset : Nat) (packed : PackedBits)
-    (label : String) : Except String (List YulStmt) :=
-  if !isMapping fields field then
-    throw s!"Compilation error: field '{field}' is not a mapping"
-  else if !packedBitsValid packed then
-    throw s!"Compilation error: {label} for field '{field}' has invalid packed range offset={packed.offset} width={packed.width}. Require 0 < width <= 256, offset < 256, and offset + width <= 256."
-  else
-    match findFieldWriteSlots fields field with
-    | some slots =>
-        match slots with
-        | [] =>
-            throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in {label}"
-        | [slot] =>
-            let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyExpr]
-            let writeSlot := if wordOffset == 0 then mappingBase else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset]
-            let maskNat := packedMaskNat packed
-            let shiftedMaskNat := packedShiftedMaskNat packed
-            pure [
-              YulStmt.block [
-                YulStmt.let_ "__compat_value" valueExpr,
-                YulStmt.let_ "__compat_packed" (YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat]),
-                YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [writeSlot]),
-                YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
-                  YulExpr.ident "__compat_slot_word",
-                  YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
-                ]),
-                YulStmt.expr (YulExpr.call "sstore" [
-                  writeSlot,
-                  YulExpr.call "or" [
-                    YulExpr.ident "__compat_slot_cleared",
-                    YulExpr.call "shl" [YulExpr.lit packed.offset, YulExpr.ident "__compat_packed"]
-                  ]
-                ])
-              ]
-            ]
-        | _ =>
-            let slotExpr := fun (slot : Nat) =>
-              let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key"]
-              if wordOffset == 0 then mappingBase else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset]
-            let maskNat := packedMaskNat packed
-            let shiftedMaskNat := packedShiftedMaskNat packed
-            pure [
-              YulStmt.block (
-                [YulStmt.let_ "__compat_key" keyExpr,
-                 YulStmt.let_ "__compat_value" valueExpr,
-                 YulStmt.let_ "__compat_packed" (YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat])] ++
-                slots.map (fun slot =>
-                  YulStmt.block [
-                    YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [slotExpr slot]),
-                    YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
-                      YulExpr.ident "__compat_slot_word",
-                      YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
-                    ]),
-                    YulStmt.expr (YulExpr.call "sstore" [
-                      slotExpr slot,
-                      YulExpr.call "or" [
-                        YulExpr.ident "__compat_slot_cleared",
-                        YulExpr.call "shl" [YulExpr.lit packed.offset, YulExpr.ident "__compat_packed"]
-                      ]
-                    ])
-                  ])
-              )
-            ]
-    | none => throw s!"Compilation error: unknown mapping field '{field}' in {label}"
 
 mutual
 private def supportedCustomErrorParamType : ParamType → Bool

--- a/Compiler/CompilationModel/MappingWrites.lean
+++ b/Compiler/CompilationModel/MappingWrites.lean
@@ -1,0 +1,110 @@
+import Compiler.CompilationModel.Types
+import Compiler.CompilationModel.ValidationHelpers
+
+namespace Compiler.CompilationModel
+
+open Compiler
+open Compiler.Yul
+
+def compileMappingSlotWrite (fields : List Field) (field : String)
+    (keyExpr valueExpr : YulExpr) (label : String) (wordOffset : Nat := 0) : Except String (List YulStmt) :=
+  if !isMapping fields field then
+    throw s!"Compilation error: field '{field}' is not a mapping"
+  else
+    match findFieldWriteSlots fields field with
+    | some slots =>
+        match slots with
+        | [] =>
+            throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in {label}"
+        | [slot] =>
+            let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyExpr]
+            let writeSlot := if wordOffset == 0 then mappingBase else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset]
+            pure [
+              YulStmt.expr (YulExpr.call "sstore" [
+                writeSlot,
+                valueExpr
+              ])
+            ]
+        | _ =>
+            let compatSlotExpr := fun (slot : Nat) =>
+              let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key"]
+              if wordOffset == 0 then mappingBase else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset]
+            pure [
+              YulStmt.block (
+                [YulStmt.let_ "__compat_key" keyExpr, YulStmt.let_ "__compat_value" valueExpr] ++
+                slots.map (fun slot =>
+                  YulStmt.expr (YulExpr.call "sstore" [
+                    compatSlotExpr slot,
+                    YulExpr.ident "__compat_value"
+                  ]))
+              )
+            ]
+    | none => throw s!"Compilation error: unknown mapping field '{field}' in {label}"
+
+def compileMappingPackedSlotWrite (fields : List Field) (field : String)
+    (keyExpr valueExpr : YulExpr) (wordOffset : Nat) (packed : PackedBits)
+    (label : String) : Except String (List YulStmt) :=
+  if !isMapping fields field then
+    throw s!"Compilation error: field '{field}' is not a mapping"
+  else if !packedBitsValid packed then
+    throw s!"Compilation error: {label} for field '{field}' has invalid packed range offset={packed.offset} width={packed.width}. Require 0 < width <= 256, offset < 256, and offset + width <= 256."
+  else
+    match findFieldWriteSlots fields field with
+    | some slots =>
+        match slots with
+        | [] =>
+            throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in {label}"
+        | [slot] =>
+            let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, keyExpr]
+            let writeSlot := if wordOffset == 0 then mappingBase else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset]
+            let maskNat := packedMaskNat packed
+            let shiftedMaskNat := packedShiftedMaskNat packed
+            pure [
+              YulStmt.block [
+                YulStmt.let_ "__compat_value" valueExpr,
+                YulStmt.let_ "__compat_packed" (YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat]),
+                YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [writeSlot]),
+                YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
+                  YulExpr.ident "__compat_slot_word",
+                  YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
+                ]),
+                YulStmt.expr (YulExpr.call "sstore" [
+                  writeSlot,
+                  YulExpr.call "or" [
+                    YulExpr.ident "__compat_slot_cleared",
+                    YulExpr.call "shl" [YulExpr.lit packed.offset, YulExpr.ident "__compat_packed"]
+                  ]
+                ])
+              ]
+            ]
+        | _ =>
+            let slotExpr := fun (slot : Nat) =>
+              let mappingBase := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key"]
+              if wordOffset == 0 then mappingBase else YulExpr.call "add" [mappingBase, YulExpr.lit wordOffset]
+            let maskNat := packedMaskNat packed
+            let shiftedMaskNat := packedShiftedMaskNat packed
+            pure [
+              YulStmt.block (
+                [YulStmt.let_ "__compat_key" keyExpr,
+                 YulStmt.let_ "__compat_value" valueExpr,
+                 YulStmt.let_ "__compat_packed" (YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat])] ++
+                slots.map (fun slot =>
+                  YulStmt.block [
+                    YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [slotExpr slot]),
+                    YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
+                      YulExpr.ident "__compat_slot_word",
+                      YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
+                    ]),
+                    YulStmt.expr (YulExpr.call "sstore" [
+                      slotExpr slot,
+                      YulExpr.call "or" [
+                        YulExpr.ident "__compat_slot_cleared",
+                        YulExpr.call "shl" [YulExpr.lit packed.offset, YulExpr.ident "__compat_packed"]
+                      ]
+                    ])
+                  ])
+              )
+            ]
+    | none => throw s!"Compilation error: unknown mapping field '{field}' in {label}"
+
+end Compiler.CompilationModel


### PR DESCRIPTION
## Summary
This is another low-risk incremental split for #1157.

- Extract `compileMappingSlotWrite` and `compileMappingPackedSlotWrite` from `Compiler/CompilationModel.lean`
- Add new module: `Compiler/CompilationModel/MappingWrites.lean`
- Import the new module from `Compiler/CompilationModel.lean`
- Keep behavior and diagnostics unchanged

## Why
`CompilationModel.lean` is still large and central. Pulling cohesive helper blocks into focused modules reduces review surface and keeps future changes safer.

## Validation
- `lake build Compiler.CompilationModel.MappingWrites Compiler.CompilationModel Compiler.Selector Compiler.ABI Compiler.MacroTranslateInvariantTest`

Refs #1157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves existing mapping storage write compilation helpers into a separate module; behavior should remain unchanged aside from a slightly wider (non-`private`) API surface.
> 
> **Overview**
> Refactors the compilation model by extracting the mapping storage write helpers (`compileMappingSlotWrite` and `compileMappingPackedSlotWrite`) out of `CompilationModel.lean` into a new `CompilationModel/MappingWrites.lean` module.
> 
> `CompilationModel.lean` now imports `Compiler.CompilationModel.MappingWrites`, keeping the same code paths for `Stmt.setMapping*` compilation while reducing the size of the central file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bba5a3975d51c4bdbac7c8629a8879c4089b2f1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->