### PR TITLE
refactor: extract CompilationModel ABI helper utilities

### DIFF
--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -21,6 +21,7 @@
   - Verified external library integration (#184)
 -/
 import Compiler.CompilationModel.Types
+import Compiler.CompilationModel.AbiHelpers
 import Compiler.CompilationModel.DynamicData
 import Compiler.CompilationModel.InternalNaming
 import Compiler.CompilationModel.LayoutValidation
@@ -338,114 +339,6 @@ def compileRequireFailCond (fields : List Field)
   | Expr.ge a b => return yulBinOp "lt" (← compileExpr fields dynamicSource a) (← compileExpr fields dynamicSource b)
   | Expr.le a b => return yulBinOp "gt" (← compileExpr fields dynamicSource a) (← compileExpr fields dynamicSource b)
   | cond => return YulExpr.call "iszero" [← compileExpr fields dynamicSource cond]
-
-def bytesFromString (s : String) : List UInt8 :=
-  s.toUTF8.data.toList
-
-def chunkBytes32 (bs : List UInt8) : List (List UInt8) :=
-  if bs.isEmpty then
-    []
-  else
-    let chunk := bs.take 32
-    chunk :: chunkBytes32 (bs.drop 32)
-termination_by bs.length
-decreasing_by
-  simp_wf
-  cases bs with
-  | nil => simp at *
-  | cons head tail => simp; omega
-
-def wordFromBytes (bs : List UInt8) : Nat :=
-  let padded := bs ++ List.replicate (32 - bs.length) (0 : UInt8)
-  padded.foldl (fun acc b => acc * 256 + b.toNat) 0
-
--- EVM constants (errorStringSelectorWord, addressMask, selectorShift,
--- freeMemoryPointer) are defined in Compiler.Constants and re-exported
--- via the `export` directive at the top of this namespace.
-
-def revertWithMessage (message : String) : List YulStmt :=
-  let bytes := bytesFromString message
-  let len := bytes.length
-  let paddedLen := ((len + 31) / 32) * 32
-  let header := [
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
-    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len])
-  ]
-  let dataStmts :=
-    (chunkBytes32 bytes).zipIdx.map fun (chunk, idx) =>
-      let offset := 68 + idx * 32
-      let word := wordFromBytes chunk
-      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex word])
-  let totalSize := 68 + paddedLen
-  header ++ dataStmts ++ [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit totalSize])]
-
-/-!
-### Event Topic Computation (#153)
-
-Compute the event signature hash (topic 0) from the event name and parameter types.
-This mirrors how Solidity computes event signatures: keccak256("EventName(type1,type2,...)").
-At compile time we use a placeholder; CI validates the selector matches solc output.
--/
-
-mutual
-  -- Map ParamType to its Solidity type string (used for event and function signatures)
-  def paramTypeToSolidityString : ParamType → String
-    | ParamType.uint256 => "uint256"
-    | ParamType.uint8 => "uint8"
-    | ParamType.address => "address"
-    | ParamType.bool => "bool"
-    | ParamType.bytes32 => "bytes32"
-    | ParamType.tuple ts =>
-        "(" ++ String.intercalate "," (paramTypeListToSolidityStrings ts) ++ ")"
-    | ParamType.array t => paramTypeToSolidityString t ++ "[]"
-    | ParamType.fixedArray t n => paramTypeToSolidityString t ++ "[" ++ toString n ++ "]"
-    | ParamType.bytes => "bytes"
-
-  private def paramTypeListToSolidityStrings : List ParamType → List String
-    | [] => []
-    | ty :: rest => paramTypeToSolidityString ty :: paramTypeListToSolidityStrings rest
-end
-
-def eventSignature (eventDef : EventDef) : String :=
-  let params := eventDef.params.map (fun p => paramTypeToSolidityString p.ty)
-  s!"{eventDef.name}(" ++ String.intercalate "," params ++ ")"
-
-def errorSignature (errorDef : ErrorDef) : String :=
-  s!"{errorDef.name}(" ++ String.intercalate "," (errorDef.params.map paramTypeToSolidityString) ++ ")"
-
-def fieldTypeToParamType : FieldType → ParamType
-  | FieldType.uint256 => ParamType.uint256
-  | FieldType.address => ParamType.address
-  | FieldType.mappingTyped _ => ParamType.uint256
-  | FieldType.mappingStruct _ _ => ParamType.uint256
-  | FieldType.mappingStruct2 _ _ _ => ParamType.uint256
-
-private def resolveReturns (context : String) (legacy : Option ParamType)
-    (returns : List ParamType) : Except String (List ParamType) := do
-  if returns.isEmpty then
-    pure (legacy.map (fun ty => [ty]) |>.getD [])
-  else
-    match legacy with
-    | none => pure returns
-    | some ty =>
-        if returns == [ty] then
-          pure returns
-        else
-          throw s!"Compilation error: {context} has conflicting return declarations (returnType vs returns)"
-
-def functionReturns (spec : FunctionSpec) : Except String (List ParamType) :=
-  resolveReturns s!"function '{spec.name}'"
-    (spec.returnType.map fieldTypeToParamType) spec.returns
-
-def externalFunctionReturns (spec : ExternalFunction) : Except String (List ParamType) :=
-  resolveReturns s!"external declaration '{spec.name}'" spec.returnType spec.returns
-
-def functionStateMutability (spec : FunctionSpec) : String :=
-  if spec.isPure then "pure"
-  else if spec.isView then "view"
-  else if spec.isPayable then "payable"
-  else "nonpayable"
 
 private def findParamType (params : List Param) (name : String) : Option ParamType :=
   (params.find? (fun p => p.name == name)).map (·.ty)

--- a/Compiler/CompilationModel/AbiHelpers.lean
+++ b/Compiler/CompilationModel/AbiHelpers.lean
@@ -1,0 +1,103 @@
+import Compiler.CompilationModel.Types
+
+namespace Compiler.CompilationModel
+
+open Compiler
+open Compiler.Yul
+
+def bytesFromString (s : String) : List UInt8 :=
+  s.toUTF8.data.toList
+
+def chunkBytes32 (bs : List UInt8) : List (List UInt8) :=
+  if bs.isEmpty then
+    []
+  else
+    let chunk := bs.take 32
+    chunk :: chunkBytes32 (bs.drop 32)
+termination_by bs.length
+decreasing_by
+  simp_wf
+  cases bs with
+  | nil => simp at *
+  | cons head tail => simp; omega
+
+def wordFromBytes (bs : List UInt8) : Nat :=
+  let padded := bs ++ List.replicate (32 - bs.length) (0 : UInt8)
+  padded.foldl (fun acc b => acc * 256 + b.toNat) 0
+
+def revertWithMessage (message : String) : List YulStmt :=
+  let bytes := bytesFromString message
+  let len := bytes.length
+  let paddedLen := ((len + 31) / 32) * 32
+  let header := [
+    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.hex errorStringSelectorWord]),
+    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, YulExpr.lit 32]),
+    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 36, YulExpr.lit len])
+  ]
+  let dataStmts :=
+    (chunkBytes32 bytes).zipIdx.map fun (chunk, idx) =>
+      let offset := 68 + idx * 32
+      let word := wordFromBytes chunk
+      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit offset, YulExpr.hex word])
+  let totalSize := 68 + paddedLen
+  header ++ dataStmts ++ [YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit totalSize])]
+
+mutual
+  def paramTypeToSolidityString : ParamType → String
+    | ParamType.uint256 => "uint256"
+    | ParamType.uint8 => "uint8"
+    | ParamType.address => "address"
+    | ParamType.bool => "bool"
+    | ParamType.bytes32 => "bytes32"
+    | ParamType.tuple ts =>
+        "(" ++ String.intercalate "," (paramTypeListToSolidityStrings ts) ++ ")"
+    | ParamType.array t => paramTypeToSolidityString t ++ "[]"
+    | ParamType.fixedArray t n => paramTypeToSolidityString t ++ "[" ++ toString n ++ "]"
+    | ParamType.bytes => "bytes"
+
+  private def paramTypeListToSolidityStrings : List ParamType → List String
+    | [] => []
+    | ty :: rest => paramTypeToSolidityString ty :: paramTypeListToSolidityStrings rest
+end
+
+def eventSignature (eventDef : EventDef) : String :=
+  let params := eventDef.params.map (fun p => paramTypeToSolidityString p.ty)
+  s!"{eventDef.name}(" ++ String.intercalate "," params ++ ")"
+
+def errorSignature (errorDef : ErrorDef) : String :=
+  s!"{errorDef.name}(" ++ String.intercalate "," (errorDef.params.map paramTypeToSolidityString) ++ ")"
+
+def fieldTypeToParamType : FieldType → ParamType
+  | FieldType.uint256 => ParamType.uint256
+  | FieldType.address => ParamType.address
+  | FieldType.mappingTyped _ => ParamType.uint256
+  | FieldType.mappingStruct _ _ => ParamType.uint256
+  | FieldType.mappingStruct2 _ _ _ => ParamType.uint256
+
+private def resolveReturns (context : String) (legacy : Option ParamType)
+    (returns : List ParamType) : Except String (List ParamType) := do
+  if returns.isEmpty then
+    pure (legacy.map (fun ty => [ty]) |>.getD [])
+  else
+    match legacy with
+    | none => pure returns
+    | some ty =>
+        if returns == [ty] then
+          pure returns
+        else
+          throw s!"Compilation error: {context} has conflicting return declarations (returnType vs returns)"
+
+def functionReturns (spec : FunctionSpec) : Except String (List ParamType) :=
+  resolveReturns s!"function '{spec.name}'"
+    (spec.returnType.map fieldTypeToParamType) spec.returns
+
+def externalFunctionReturns (spec : ExternalFunction) : Except String (List ParamType) :=
+  resolveReturns s!"external declaration '{spec.name}'" spec.returnType spec.returns
+
+def functionStateMutability (spec : FunctionSpec) : String :=
+  if spec.isPure then "pure"
+  else if spec.isView then "view"
+  else if spec.isPayable then "payable"
+  else "nonpayable"
+
+end Compiler.CompilationModel


### PR DESCRIPTION
## Summary
- extract ABI/signature + revert-message helper defs from `Compiler/CompilationModel.lean` into new module `Compiler/CompilationModel/AbiHelpers.lean`
- import the new helper module from `Compiler/CompilationModel.lean`
- keep API surface unchanged (`Compiler.CompilationModel` namespace defs are preserved)

## Why
`CompilationModel.lean` is still a large monolith under issue #1157. This is a low-risk decomposition step that moves a self-contained helper cluster without changing behavior.

Partial progress on #1157.

## Validation
- `lake build Compiler.CompilationModel.AbiHelpers Compiler.CompilationModel Compiler.ABI Compiler.Selector`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily moves helper definitions into a new module; main risk is import/namespace wiring or accidental behavior drift in shared ABI encoding utilities.
> 
> **Overview**
> **Extracts ABI/signature helper utilities out of the `CompilationModel` monolith.** A new `Compiler/CompilationModel/AbiHelpers.lean` module now owns helpers for revert-message construction (`revertWithMessage` + byte/word helpers), Solidity signature string generation (`paramTypeToSolidityString`, `eventSignature`, `errorSignature`), and return/mutability helpers (`functionReturns`, `externalFunctionReturns`, `functionStateMutability`).
> 
> `Compiler/CompilationModel.lean` now imports `AbiHelpers` and removes the inlined implementations, keeping the same `Compiler.CompilationModel`-namespaced API surface while reducing file size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ccaf1a8162e1f6935cf118d946e5e042b341232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->