### PR TITLE
refactor: extract ECM axiom collection from CompilationModel

### DIFF
--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -23,6 +23,7 @@
 import Compiler.CompilationModel.Types
 import Compiler.CompilationModel.AbiHelpers
 import Compiler.CompilationModel.DynamicData
+import Compiler.CompilationModel.EcmAxiomCollection
 import Compiler.CompilationModel.InternalNaming
 import Compiler.CompilationModel.LayoutValidation
 import Compiler.CompilationModel.MappingWrites
@@ -4080,28 +4081,5 @@ def compile (spec : CompilationModel) (selectors : List Nat) : Except String IRC
     usesMapping := mappingHelpersRequired
     internalFunctions := arrayElementHelpers ++ internalFuncDefs
   }
-
-/-- Collect all unique (moduleName, axiom) pairs from ECM statements in a spec.
-    Used for axiom aggregation reports. -/
-def collectEcmAxioms (spec : CompilationModel) : List (String × String) :=
-  let stmtsFromFn (fn : FunctionSpec) := fn.body
-  let stmtsFromCtor : List Stmt := match spec.constructor with
-    | some ctor => ctor.body
-    | none => []
-  let allStmts := stmtsFromCtor ++ spec.functions.flatMap stmtsFromFn
-  let pairs := allStmts.flatMap collectStmtEcmAxioms
-  pairs.foldl (fun acc p => if acc.contains p then acc else acc ++ [p]) []
-where
-  collectStmtEcmAxioms : Stmt → List (String × String)
-    | .ecm mod args =>
-        let fromArgs := args.flatMap collectExprEcmAxioms
-        mod.axioms.map (fun a => (mod.name, a)) ++ fromArgs
-    | .ite _ thenBr elseBr =>
-        thenBr.flatMap collectStmtEcmAxioms ++ elseBr.flatMap collectStmtEcmAxioms
-    | .forEach _ _ body => body.flatMap collectStmtEcmAxioms
-    | _ => []
-  collectExprEcmAxioms : Expr → List (String × String)
-    | .ite cond a b => collectExprEcmAxioms cond ++ collectExprEcmAxioms a ++ collectExprEcmAxioms b
-    | _ => []
 
 end Compiler.CompilationModel

--- a/Compiler/CompilationModel/EcmAxiomCollection.lean
+++ b/Compiler/CompilationModel/EcmAxiomCollection.lean
@@ -1,0 +1,28 @@
+import Compiler.CompilationModel.Types
+
+namespace Compiler.CompilationModel
+
+/-- Collect all unique (moduleName, axiom) pairs from ECM statements in a spec.
+    Used for axiom aggregation reports. -/
+def collectEcmAxioms (spec : CompilationModel) : List (String × String) :=
+  let stmtsFromFn (fn : FunctionSpec) := fn.body
+  let stmtsFromCtor : List Stmt := match spec.constructor with
+    | some ctor => ctor.body
+    | none => []
+  let allStmts := stmtsFromCtor ++ spec.functions.flatMap stmtsFromFn
+  let pairs := allStmts.flatMap collectStmtEcmAxioms
+  pairs.foldl (fun acc p => if acc.contains p then acc else acc ++ [p]) []
+where
+  collectStmtEcmAxioms : Stmt → List (String × String)
+    | .ecm mod args =>
+        let fromArgs := args.flatMap collectExprEcmAxioms
+        mod.axioms.map (fun a => (mod.name, a)) ++ fromArgs
+    | .ite _ thenBr elseBr =>
+        thenBr.flatMap collectStmtEcmAxioms ++ elseBr.flatMap collectStmtEcmAxioms
+    | .forEach _ _ body => body.flatMap collectStmtEcmAxioms
+    | _ => []
+  collectExprEcmAxioms : Expr → List (String × String)
+    | .ite cond a b => collectExprEcmAxioms cond ++ collectExprEcmAxioms a ++ collectExprEcmAxioms b
+    | _ => []
+
+end Compiler.CompilationModel


### PR DESCRIPTION
## Summary
- extract `collectEcmAxioms` from `Compiler/CompilationModel.lean` into `Compiler/CompilationModel/EcmAxiomCollection.lean`
- import the new module from `Compiler/CompilationModel.lean`
- keep behavior unchanged while continuing the incremental `CompilationModel.lean` split

## Validation
- `lake build Compiler.CompilationModel.EcmAxiomCollection Compiler.CompilationModel Compiler.CompileDriver Compiler.Selector Compiler.ABI Compiler.MacroTranslateInvariantTest`
- `python3 scripts/check_builtin_list_sync.py`
- `python3 -m unittest scripts/test_check_builtin_list_sync.py -v`

Closes #1157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor that moves `collectEcmAxioms` into a new module and updates imports; runtime/compiler behavior should be unchanged aside from potential build/import wiring issues.
> 
> **Overview**
> Extracts ECM axiom aggregation logic into a new `Compiler.CompilationModel.EcmAxiomCollection` module and imports it from `CompilationModel.lean`.
> 
> This keeps `collectEcmAxioms` available for verbose axiom reporting (e.g., in `CompileDriver`) while continuing to split up the large `CompilationModel.lean` file without changing functionality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa77e9a38b6f6a4550ee8d47d4d83a2451459a7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->