### PR TITLE
harden macro invariant suite coverage parsing

### DIFF
--- a/scripts/check_macro_translate_invariant_coverage.py
+++ b/scripts/check_macro_translate_invariant_coverage.py
@@ -17,6 +17,10 @@ CONTRACT_RE = re.compile(r"\bverity_contract\s+([A-Za-z_][A-Za-z0-9_]*)\s+where\
 SUITE_ENTRY_RE = re.compile(
     r"\bContracts\.MacroContracts(?:\.[A-Za-z_][A-Za-z0-9_]*)*\.([A-Za-z_][A-Za-z0-9_]*)\.spec\b"
 )
+MACRO_SPECS_DEF_RE = re.compile(
+    r"\bprivate\s+def\s+macroSpecs(?:\s*:\s*List\s+CompilationModel)?\s*:=\s*\[",
+    re.MULTILINE,
+)
 
 
 def _collect_contracts(sources: list[Path]) -> set[str]:
@@ -27,27 +31,74 @@ def _collect_contracts(sources: list[Path]) -> set[str]:
     return names
 
 
-def _collect_suite_entries(path: Path) -> set[str]:
+def _extract_macro_specs_block(text: str) -> str | None:
+    match = MACRO_SPECS_DEF_RE.search(text)
+    if match is None:
+        return None
+
+    # Start at the opening `[` and extract until the matching `]`.
+    start = match.end() - 1
+    depth = 0
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                return text[start : idx + 1]
+    return None
+
+
+def _collect_suite_entries(path: Path) -> list[str] | None:
     text = path.read_text(encoding="utf-8")
-    return set(SUITE_ENTRY_RE.findall(text))
+    block = _extract_macro_specs_block(text)
+    if block is None:
+        return None
+    return SUITE_ENTRY_RE.findall(block)
 
 
 def _check_coverage(contract_sources: list[Path], invariant_suite: Path) -> int:
     declared = _collect_contracts(contract_sources)
-    covered = _collect_suite_entries(invariant_suite)
+    covered_entries = _collect_suite_entries(invariant_suite)
+
+    if covered_entries is None:
+        print(
+            "macro invariant suite coverage check failed:",
+            file=sys.stderr,
+        )
+        print(
+            "  could not locate `private def macroSpecs : List CompilationModel := [...]`",
+            file=sys.stderr,
+        )
+        return 1
+
+    covered = set(covered_entries)
 
     if not declared:
         print("no verity_contract declarations found", file=sys.stderr)
         return 1
 
+    seen: set[str] = set()
+    duplicate_entries: list[str] = []
+    for name in covered_entries:
+        if name in seen and name not in duplicate_entries:
+            duplicate_entries.append(name)
+        seen.add(name)
+
     missing = sorted(declared - covered)
     extra = sorted(covered - declared)
 
-    if not missing and not extra:
+    if not missing and not extra and not duplicate_entries:
         print("macro invariant suite coverage OK")
         return 0
 
     print("macro invariant suite coverage check failed:", file=sys.stderr)
+    for name in duplicate_entries:
+        print(
+            f"  duplicate macroSpecs entry in Compiler/MacroTranslateInvariantTest.lean: {name}",
+            file=sys.stderr,
+        )
     for name in missing:
         print(f"  missing in Compiler/MacroTranslateInvariantTest.lean: {name}", file=sys.stderr)
     for name in extra:

--- a/scripts/test_check_macro_translate_invariant_coverage.py
+++ b/scripts/test_check_macro_translate_invariant_coverage.py
@@ -148,6 +148,85 @@ class MacroTranslateInvariantCoverageTests(unittest.TestCase):
             rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
             self.assertEqual(rc, 0)
 
+    def test_fails_when_macro_specs_definition_missing(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateInvariantTest.lean"
+            suite.write_text(
+                """
+                -- no macroSpecs definition on purpose
+                def unrelated : Nat := 0
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 1)
+
+    def test_fails_on_duplicate_macro_specs_entry(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateInvariantTest.lean"
+            suite.write_text(
+                """
+                private def macroSpecs : List CompilationModel :=
+                  [ Contracts.MacroContracts.Counter.spec
+                  , Contracts.MacroContracts.Counter.spec
+                  ]
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 1)
+
+    def test_ignores_spec_references_outside_macro_specs(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                verity_contract Owned where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateInvariantTest.lean"
+            suite.write_text(
+                """
+                private def macroSpecs : List CompilationModel :=
+                  [ Contracts.MacroContracts.Counter.spec ]
+
+                -- This should not count towards macroSpecs coverage.
+                #check Contracts.MacroContracts.Owned.spec
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- tighten `check_macro_translate_invariant_coverage.py` to parse entries from the `macroSpecs` list block directly instead of scanning all `*.spec` mentions in the file
- fail closed when `macroSpecs` cannot be found
- detect duplicate `macroSpecs` entries as a CI failure condition
- add regression tests for missing `macroSpecs`, duplicate entries, and stray `#check ...spec` references outside the suite block

## Why
This strengthens issue #1167 guardrails by ensuring coverage checks reflect the actual invariant suite input (`macroSpecs`) rather than incidental references elsewhere in the file.

Partial progress on #1167.

## Validation
- `python3 -m unittest discover -s scripts -p 'test_check_macro_translate_invariant_coverage.py' -v`
- `python3 scripts/check_macro_translate_invariant_coverage.py`
- `python3 scripts/check_verify_sync.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens the CI coverage check to only consider entries inside the `macroSpecs` list, fail when the definition can’t be found, and treat duplicates as errors; this may introduce new CI failures if the Lean suite format differs from the expected pattern.
> 
> **Overview**
> The macro invariant suite coverage checker now extracts coverage *only* from the `private def macroSpecs := [...]` list block (instead of scanning the whole file for `*.spec` references), and **fails closed** if the `macroSpecs` definition can’t be located.
> 
> It also treats **duplicate `macroSpecs` entries** as a coverage failure and adds unit tests covering missing `macroSpecs`, duplicates, and ignoring stray `*.spec` references outside the list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d18ff6396a53d843bac41c96a9bab8ab34c90609. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->