### PR TITLE
test: harden macro translate selector/IR invariants

### DIFF
--- a/Compiler/MacroTranslateInvariantTest.lean
+++ b/Compiler/MacroTranslateInvariantTest.lean
@@ -98,13 +98,23 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
   expectTrue s!"{spec.name}: write slots are unique (canonical + alias)" (allDistinct writes)
 
   let selectors ← Selector.computeSelectors spec
+  expectTrue s!"{spec.name}: selectors are unique" (allDistinct selectors)
   expectTrue s!"{spec.name}: selector count matches external function count"
     (selectors.length == extFns.length)
 
   let compileResult ← Selector.compileChecked spec selectors
   match compileResult with
-  | .ok _ =>
+  | .ok ir =>
       IO.println s!"✓ {spec.name}: compileChecked succeeds with canonical selectors"
+      let irFns := ir.functions
+      let irFnNames := irFns.map (·.name)
+      let irSelectors := irFns.map (·.selector)
+      expectTrue s!"{spec.name}: IR external function count matches spec external function count"
+        (irFns.length == extFns.length)
+      expectTrue s!"{spec.name}: IR external function names preserve spec order"
+        (irFnNames == fnNames)
+      expectTrue s!"{spec.name}: IR selectors preserve canonical selector order"
+        (irSelectors == selectors)
   | .error err =>
       throw (IO.userError s!"✗ {spec.name}: compileChecked failed: {err}")
 


### PR DESCRIPTION
## Summary
- strengthen `Compiler/MacroTranslateInvariantTest` with additional structural invariants per macro-generated contract
- assert computed selectors are unique
- after `compileChecked`, assert IR preserves external function count, declaration order, and selector ordering

## Why
Issue #1167 tracks trust-hardening for macro elaboration outputs. This adds another CI guardrail that detects divergence between canonical selector computation and compiled IR dispatch metadata.

Partial progress on #1167.

## Validation
- `lake build Compiler.MacroTranslateInvariantTest`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a Lean invariant test and only add additional assertions around selector uniqueness and IR metadata ordering.
> 
> **Overview**
> **Hardens macro translation invariants.** `Compiler/MacroTranslateInvariantTest.lean` now asserts computed function selectors are unique, then inspects the `.ok ir` result from `Selector.compileChecked` to ensure the emitted IR preserves the external function count, declaration order of names, and the canonical selector ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8a38dbdec6fe52c2e45d6abfce7b46a04cc3a25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->