### PR TITLE
test: pin macro contract signature/selector snapshots

### DIFF
--- a/Compiler/MacroTranslateInvariantTest.lean
+++ b/Compiler/MacroTranslateInvariantTest.lean
@@ -1,5 +1,6 @@
 import Compiler.ABI
 import Compiler.Selector
+import Compiler.Hex
 import Contracts.MacroContracts.Core
 import Contracts.MacroContracts.Tokens
 import Contracts.MacroContracts.Smoke
@@ -8,6 +9,7 @@ namespace Compiler.MacroTranslateInvariantTest
 
 open Compiler
 open Compiler.CompilationModel
+open Compiler.Hex
 
 private def contains (haystack needle : String) : Bool :=
   let h := haystack.toList
@@ -72,6 +74,58 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.MacroContracts.Uint8Smoke.spec
   ]
 
+private def functionSignature (fn : FunctionSpec) : String :=
+  let params := fn.params.map (fun p => paramTypeToSolidityString p.ty)
+  let paramStr := String.intercalate "," params
+  s!"{fn.name}({paramStr})"
+
+private def expectedExternalSignatures : List (String × List String) :=
+  [ ("SimpleStorage", ["store(uint256)", "retrieve()"])
+  , ("Counter", ["increment()", "decrement()", "getCount()", "previewAddTwice(uint256)",
+      "previewOps(uint256,uint256,uint256)", "previewEnvOps(uint256,uint256)",
+      "previewLowLevel(uint256,uint256)"])
+  , ("Owned", ["transferOwnership(address)", "getOwner()"])
+  , ("Ledger", ["deposit(uint256)", "withdraw(uint256)", "transfer(address,uint256)", "getBalance(address)"])
+  , ("SafeCounter", ["increment()", "decrement()", "getCount()"])
+  , ("OwnedCounter", ["increment()", "decrement()", "getCount()", "getOwner()", "transferOwnership(address)"])
+  , ("SimpleToken", ["mint(address,uint256)", "transfer(address,uint256)", "balanceOf(address)", "totalSupply()",
+      "owner()"])
+  , ("ERC20", ["mint(address,uint256)", "transfer(address,uint256)", "approve(address,uint256)",
+      "transferFrom(address,address,uint256)", "balanceOf(address)", "allowanceOf(address,address)",
+      "totalSupply()", "owner()"])
+  , ("ERC721", ["ownerOf(uint256)", "getApproved(uint256)", "approve(uint256,uint256)", "mint(uint256)",
+      "transferFrom(uint256,uint256,uint256)"])
+  , ("UintMapSmoke", ["setValue(uint256,uint256)", "getValue(uint256)"])
+  , ("Bytes32Smoke", ["setDigest(bytes32)", "getDigest()"])
+  , ("MappingWordSmoke", ["setWord1(uint256,uint256)", "getWord1(uint256)", "isWord1NonZero(uint256)"])
+  , ("StorageWordsSmoke", ["extSloadsLike(bytes32[])"])
+  , ("TupleSmoke", ["setFromPair((uint256,uint256))", "getPair(uint256)", "processConfig((address,address,uint256))"])
+  , ("Uint8Smoke", ["acceptSig((uint8,bytes32,bytes32))", "sigV()"])
+  ]
+
+private def expectedExternalSelectors : List (String × List String) :=
+  [ ("SimpleStorage", ["0x6057361d", "0x2e64cec1"])
+  , ("Counter", ["0xd09de08a", "0x2baeceb7", "0xa87d942c", "0x04a34e04", "0x8022f026", "0x0a7486d3", "0x9d4825af"])
+  , ("Owned", ["0xf2fde38b", "0x893d20e8"])
+  , ("Ledger", ["0xb6b55f25", "0x2e1a7d4d", "0xa9059cbb", "0xf8b2cb4f"])
+  , ("SafeCounter", ["0xd09de08a", "0x2baeceb7", "0xa87d942c"])
+  , ("OwnedCounter", ["0xd09de08a", "0x2baeceb7", "0xa87d942c", "0x893d20e8", "0xf2fde38b"])
+  , ("SimpleToken", ["0x40c10f19", "0xa9059cbb", "0x70a08231", "0x18160ddd", "0x8da5cb5b"])
+  , ("ERC20", ["0x40c10f19", "0xa9059cbb", "0x095ea7b3", "0x23b872dd", "0x70a08231", "0x1a46ec82", "0x18160ddd",
+      "0x8da5cb5b"])
+  , ("ERC721", ["0x6352211e", "0x081812fc", "0x5d35a3d9", "0xa0712d68", "0x310ed7f0"])
+  , ("UintMapSmoke", ["0x7b8d56e3", "0x0ff4c916"])
+  , ("Bytes32Smoke", ["0xed9fdc05", "0xae0d3e27"])
+  , ("MappingWordSmoke", ["0x60ab11c4", "0x8f8a322f", "0xea3aded7"])
+  , ("StorageWordsSmoke", ["0x764fa434"])
+  , ("TupleSmoke", ["0x712ea680", "0xbdf391cc", "0x01b427d2"])
+  , ("Uint8Smoke", ["0xc233eaa7", "0x62fc458b"])
+  ]
+
+private def expectedFor
+    (table : List (String × List String)) (contractName : String) : Option (List String) :=
+  (table.find? (fun entry => entry.1 == contractName)).map (·.2)
+
 -- Regression: `verity_contract` elaboration emits field-level findIdx simp lemmas.
 #check Contracts.MacroContracts.OwnedCounter.findIdx_owner_OwnedCounter
 #check Contracts.MacroContracts.OwnedCounter.findIdx_owner_OwnedCounter_decide
@@ -101,6 +155,22 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
   expectTrue s!"{spec.name}: selector count matches external function count"
     (selectors.length == extFns.length)
 
+  let signatures := extFns.map functionSignature
+  match expectedFor expectedExternalSignatures spec.name with
+  | none =>
+      throw (IO.userError s!"✗ {spec.name}: missing expected external signature snapshot entry")
+  | some expectedSigs =>
+      expectTrue s!"{spec.name}: external signatures match pinned snapshot"
+        (signatures == expectedSigs)
+
+  let selectorHexes := selectors.map natToHex
+  match expectedFor expectedExternalSelectors spec.name with
+  | none =>
+      throw (IO.userError s!"✗ {spec.name}: missing expected selector snapshot entry")
+  | some expectedHexes =>
+      expectTrue s!"{spec.name}: selectors match pinned snapshot"
+        (selectorHexes == expectedHexes)
+
   let compileResult ← Selector.compileChecked spec selectors
   match compileResult with
   | .ok _ =>
@@ -119,6 +189,10 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
   expectTrue s!"{spec.name}: ABI contains every external function name" allNamesPresent
 
 #eval! do
+  expectTrue "macro spec count matches pinned signature snapshot"
+    (macroSpecs.length == expectedExternalSignatures.length)
+  expectTrue "macro spec count matches pinned selector snapshot"
+    (macroSpecs.length == expectedExternalSelectors.length)
   for spec in macroSpecs do
     checkSpec spec
 


### PR DESCRIPTION
## Summary
- strengthen `Compiler/MacroTranslateInvariantTest` with pinned snapshots for every current `verity_contract` macro spec
- assert exact external Solidity signatures per contract (order-sensitive)
- assert exact canonical selectors per contract (hex, order-sensitive)
- keep existing invariants (uniqueness, ABI count/name coverage, compileChecked) and add snapshot table-size guards

## Why
Issue #1167 calls out macro translator trust risk and asks for stronger regression checks. This PR adds deterministic snapshot checks that fail CI if macro translation drifts in function signature or selector generation for current contract corpus.

## Validation
- `lake build Compiler.MacroTranslateInvariantTest Compiler.Selector Compiler.ABI Contracts.MacroContracts.Core Contracts.MacroContracts.Tokens Contracts.MacroContracts.Smoke`
- `python3 scripts/check_builtin_list_sync.py`
- `python3 -m unittest scripts/test_check_builtin_list_sync.py -v`

Refs #1167

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that tighten regression coverage by asserting exact function signatures and selectors; risk is limited to potentially brittle CI failures when intentional ABI/selector changes occur.
> 
> **Overview**
> Adds pinned snapshots to `Compiler/MacroTranslateInvariantTest.lean` for each macro contract’s **external function signatures** (order-sensitive) and corresponding **canonical selector hexes**, failing fast if any contract is missing a snapshot entry.
> 
> Extends the existing invariant checks to compare computed signatures/selectors against these snapshots, and adds table-size guards to ensure the snapshot lists stay in sync with the set of macro specs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f85c0a7d9efdb36e255e2fd5b62d70972bd5d3b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->