### PR TITLE
Macro invariants: run randomized diff checks on mapping-safe external subset

### DIFF
--- a/Compiler/MacroTranslateInvariantTest.lean
+++ b/Compiler/MacroTranslateInvariantTest.lean
@@ -71,6 +71,9 @@ private def mappingBaseSlots (spec : CompilationModel) : List Nat :=
   indexed.filterMap (fun (idx, field) =>
     if isMappingLike field.ty then some (field.slot.getD idx) else none)
 
+private def functionUsesMappingSlot (fn : IRFunction) : Bool :=
+  contains (reprStr fn.body) "mappingSlot"
+
 private def seedFromName (name : String) : Nat :=
   name.toList.foldl (fun acc ch => acc * 131 + ch.toNat) 0
 
@@ -351,10 +354,24 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
         (irFnNames == fnNames)
       expectTrue s!"{spec.name}: IR selectors preserve canonical selector order"
         (irSelectors == selectors)
+      let indexedFns := List.zip (List.range extFns.length) extFns
+      let mappingSafeFns :=
+        indexedFns.filterMap (fun (idx, fnSpec) =>
+          match irFns.get? idx, selectors.get? idx with
+          | some irFn, some sel =>
+              if functionUsesMappingSlot irFn then none else some (fnSpec, sel)
+          | _, _ => none)
+      let mappingSafeExtFns := mappingSafeFns.map Prod.fst
+      let mappingSafeSelectors := mappingSafeFns.map Prod.snd
       if (mappingBaseSlots spec).isEmpty then
+        expectTrue s!"{spec.name}: all external functions are mapping-slot free"
+          (mappingSafeExtFns.length == extFns.length)
         runRandomDiffChecks spec ir extFns selectors 8
+      else if mappingSafeExtFns.isEmpty then
+        IO.println s!"ℹ {spec.name}: skipping randomized IR↔Yul checks (all external functions touch mappingSlot/keccak path in #eval)"
       else
-        IO.println s!"ℹ {spec.name}: skipping randomized IR↔Yul checks (mapping keccak path requires runtime FFI in #eval)"
+        IO.println s!"ℹ {spec.name}: randomized IR↔Yul checks use mapping-safe subset {mappingSafeExtFns.length}/{extFns.length}"
+        runRandomDiffChecks spec ir mappingSafeExtFns mappingSafeSelectors 8
   | .error err =>
       throw (IO.userError s!"✗ {spec.name}: compileChecked failed: {err}")
 


### PR DESCRIPTION
## Summary
- expands `Compiler/MacroTranslateInvariantTest` randomized IR↔Yul differential coverage for contracts that use mappings
- detects mapping-slot usage per compiled IR function (`mappingSlot` occurrence in function body repr)
- when a contract has mappings:
  - runs randomized checks on mapping-safe external functions instead of skipping the contract wholesale
  - keeps explicit skip only when **all** external functions touch `mappingSlot`
- adds an invariant for non-mapping contracts: all external functions must be mapping-slot free

## Why
Issue #1167 still had a broad gap for mapping contracts due `#eval` keccak-path limitations. This narrows the gap by exercising mapping contracts on selectors that do not require mapping-slot evaluation.

## Validation
- `lake build Compiler.MacroTranslateInvariantTest`
- `make check`

Closes part of #1167.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test/invariant logic and CI coverage. Main risk is test flakiness or misclassification from the string-based `mappingSlot` detection, potentially skipping or failing checks unexpectedly.
> 
> **Overview**
> **Improves randomized IR↔Yul differential coverage for contracts with mappings.** Instead of skipping randomized checks whenever a spec contains mappings, the test now detects per-function `mappingSlot` usage (via `reprStr fn.body`) and runs the randomized checks on the mapping-safe subset of external functions.
> 
> **Tightens invariants and skip behavior.** For non-mapping contracts it asserts all externals are mapping-slot free; for mapping contracts it only fully skips when *every* external function touches `mappingSlot`, otherwise it logs the subset size and runs the checks against that subset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5603ce1b4c057fb4ea1ccf3e52966a7efb6371c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->