### PR TITLE
ci: enforce MacroTranslateRoundTripFuzz coverage drift checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Check macro invariant suite coverage
         run: python3 scripts/check_macro_translate_invariant_coverage.py
 
+      - name: Check macro round-trip fuzz suite coverage
+        run: python3 scripts/check_macro_roundtrip_fuzz_coverage.py
+
       - name: Check storage layout consistency
         run: python3 scripts/check_storage_layout.py
 

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/check_issue_templates.py
 	python3 scripts/check_macro_property_test_generation.py --check
 	python3 scripts/check_macro_translate_invariant_coverage.py
+	python3 scripts/check_macro_roundtrip_fuzz_coverage.py
 	python3 scripts/check_storage_layout.py
 	python3 scripts/check_manual_spec_quarantine.py
 	python3 scripts/check_spec_proof_migration_boundary.py

--- a/scripts/check_macro_roundtrip_fuzz_coverage.py
+++ b/scripts/check_macro_roundtrip_fuzz_coverage.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Check that macro round-trip fuzz suite covers every `verity_contract` declaration."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from property_utils import ROOT
+
+DEFAULT_CONTRACTS_DIR = ROOT / "Contracts" / "MacroContracts"
+DEFAULT_FUZZ_FILE = ROOT / "Compiler" / "MacroTranslateRoundTripFuzz.lean"
+
+CONTRACT_RE = re.compile(r"\bverity_contract\s+([A-Za-z_][A-Za-z0-9_]*)\s+where\b")
+SUITE_ENTRY_RE = re.compile(
+    r"\bContracts\.MacroContracts(?:\.[A-Za-z_][A-Za-z0-9_]*)*\.([A-Za-z_][A-Za-z0-9_]*)\.spec\b"
+)
+MACRO_SPECS_DEF_RE = re.compile(
+    r"\bprivate\s+def\s+macroSpecs(?:\s*:\s*List\s+CompilationModel)?\s*:=\s*\[",
+    re.MULTILINE,
+)
+
+
+def _collect_contracts(sources: list[Path]) -> set[str]:
+    names: set[str] = set()
+    for path in sources:
+        text = path.read_text(encoding="utf-8")
+        names.update(CONTRACT_RE.findall(text))
+    return names
+
+
+def _extract_macro_specs_block(text: str) -> str | None:
+    match = MACRO_SPECS_DEF_RE.search(text)
+    if match is None:
+        return None
+
+    start = match.end() - 1
+    depth = 0
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                return text[start : idx + 1]
+    return None
+
+
+def _collect_suite_entries(path: Path) -> list[str] | None:
+    text = path.read_text(encoding="utf-8")
+    block = _extract_macro_specs_block(text)
+    if block is None:
+        return None
+    return SUITE_ENTRY_RE.findall(block)
+
+
+def _check_coverage(contract_sources: list[Path], fuzz_suite: Path) -> int:
+    declared = _collect_contracts(contract_sources)
+    covered_entries = _collect_suite_entries(fuzz_suite)
+
+    if covered_entries is None:
+        print("macro round-trip fuzz coverage check failed:", file=sys.stderr)
+        print(
+            "  could not locate `private def macroSpecs : List CompilationModel := [...]`",
+            file=sys.stderr,
+        )
+        return 1
+
+    covered = set(covered_entries)
+
+    if not declared:
+        print("no verity_contract declarations found", file=sys.stderr)
+        return 1
+
+    seen: set[str] = set()
+    duplicate_entries: list[str] = []
+    for name in covered_entries:
+        if name in seen and name not in duplicate_entries:
+            duplicate_entries.append(name)
+        seen.add(name)
+
+    missing = sorted(declared - covered)
+    extra = sorted(covered - declared)
+
+    if not missing and not extra and not duplicate_entries:
+        print("macro round-trip fuzz coverage OK")
+        return 0
+
+    print("macro round-trip fuzz coverage check failed:", file=sys.stderr)
+    for name in duplicate_entries:
+        print(
+            f"  duplicate macroSpecs entry in Compiler/MacroTranslateRoundTripFuzz.lean: {name}",
+            file=sys.stderr,
+        )
+    for name in missing:
+        print(
+            f"  missing in Compiler/MacroTranslateRoundTripFuzz.lean: {name}",
+            file=sys.stderr,
+        )
+    for name in extra:
+        print(
+            f"  unknown in Compiler/MacroTranslateRoundTripFuzz.lean: {name}",
+            file=sys.stderr,
+        )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--contracts-dir",
+        default=str(DEFAULT_CONTRACTS_DIR.relative_to(ROOT)),
+        help="Directory containing macro contract declarations (default: Contracts/MacroContracts).",
+    )
+    parser.add_argument(
+        "--fuzz-suite",
+        default=str(DEFAULT_FUZZ_FILE.relative_to(ROOT)),
+        help="Round-trip fuzz suite file to validate (default: Compiler/MacroTranslateRoundTripFuzz.lean).",
+    )
+    args = parser.parse_args()
+
+    contracts_dir = ROOT / args.contracts_dir
+    fuzz_suite = ROOT / args.fuzz_suite
+
+    if not contracts_dir.exists() or not contracts_dir.is_dir():
+        print(f"contracts directory not found: {contracts_dir}", file=sys.stderr)
+        return 1
+
+    if not fuzz_suite.exists():
+        print(f"round-trip fuzz suite file not found: {fuzz_suite}", file=sys.stderr)
+        return 1
+
+    contract_sources = sorted(contracts_dir.rglob("*.lean"))
+    if not contract_sources:
+        print(f"no .lean files found under: {contracts_dir}", file=sys.stderr)
+        return 1
+
+    return _check_coverage(contract_sources, fuzz_suite)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_macro_roundtrip_fuzz_coverage.py
+++ b/scripts/test_check_macro_roundtrip_fuzz_coverage.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import check_macro_roundtrip_fuzz_coverage as check
+
+
+class MacroRoundTripFuzzCoverageTests(unittest.TestCase):
+    def test_passes_when_contracts_match_suite_entries(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                verity_contract Owned where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateRoundTripFuzz.lean"
+            suite.write_text(
+                """
+                private def macroSpecs :=
+                  [ Contracts.MacroContracts.Counter.spec
+                  , Contracts.MacroContracts.Owned.spec
+                  ]
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 0)
+
+    def test_fails_when_contract_is_missing_from_suite(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                verity_contract Owned where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateRoundTripFuzz.lean"
+            suite.write_text(
+                """
+                private def macroSpecs :=
+                  [ Contracts.MacroContracts.Counter.spec ]
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 1)
+
+    def test_fails_when_suite_has_unknown_contract(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateRoundTripFuzz.lean"
+            suite.write_text(
+                """
+                private def macroSpecs :=
+                  [ Contracts.MacroContracts.Counter.spec
+                  , Contracts.MacroContracts.Ghost.spec
+                  ]
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 1)
+
+    def test_main_recursively_discovers_nested_contract_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts" / "MacroContracts"
+            (contracts_dir / "Compat").mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Compat" / "Nested.lean").write_text(
+                """
+                verity_contract NestedCounter where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateRoundTripFuzz.lean"
+            suite.write_text(
+                """
+                private def macroSpecs :=
+                  [ Contracts.MacroContracts.NestedCounter.spec ]
+                """,
+                encoding="utf-8",
+            )
+
+            with mock.patch(
+                "sys.argv",
+                [
+                    "check_macro_roundtrip_fuzz_coverage.py",
+                    "--contracts-dir",
+                    str(contracts_dir),
+                    "--fuzz-suite",
+                    str(suite),
+                ],
+            ):
+                self.assertEqual(check.main(), 0)
+
+    def test_accepts_nested_module_path_suite_entry(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract NestedCounter where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateRoundTripFuzz.lean"
+            suite.write_text(
+                """
+                private def macroSpecs :=
+                  [ Contracts.MacroContracts.Compat.Nested.NestedCounter.spec ]
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 0)
+
+    def test_fails_when_macro_specs_definition_missing(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateRoundTripFuzz.lean"
+            suite.write_text(
+                """
+                -- no macroSpecs definition on purpose
+                def unrelated : Nat := 0
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 1)
+
+    def test_fails_on_duplicate_macro_specs_entry(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateRoundTripFuzz.lean"
+            suite.write_text(
+                """
+                private def macroSpecs : List CompilationModel :=
+                  [ Contracts.MacroContracts.Counter.spec
+                  , Contracts.MacroContracts.Counter.spec
+                  ]
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 1)
+
+    def test_ignores_spec_references_outside_macro_specs(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "Core.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                verity_contract Owned where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateRoundTripFuzz.lean"
+            suite.write_text(
+                """
+                private def macroSpecs : List CompilationModel :=
+                  [ Contracts.MacroContracts.Counter.spec ]
+
+                -- This should not count towards macroSpecs coverage.
+                #check Contracts.MacroContracts.Owned.spec
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
+            self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -49,6 +49,7 @@
     "check_issue_templates.py",
     "check_macro_property_test_generation.py --check",
     "check_macro_translate_invariant_coverage.py",
+    "check_macro_roundtrip_fuzz_coverage.py",
     "check_storage_layout.py",
     "check_manual_spec_quarantine.py",
     "check_spec_proof_migration_boundary.py",


### PR DESCRIPTION
## Summary
- add `scripts/check_macro_roundtrip_fuzz_coverage.py` to enforce that `Compiler/MacroTranslateRoundTripFuzz.lean` covers every `verity_contract` declaration in `Contracts/MacroContracts/**`
- add regression tests in `scripts/test_check_macro_roundtrip_fuzz_coverage.py`
- wire the new check into CI/local parity paths:
  - `.github/workflows/verify.yml` checks job
  - `Makefile` `check` target
  - `scripts/verify_sync_spec.json`

## Why
Issue #1167 requires round-trip harness coverage across all macro contracts. This guard prevents silent drift where new `verity_contract` declarations are added but the round-trip fuzz suite is not updated.

## Validation
- `python3 scripts/check_macro_roundtrip_fuzz_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_check_macro_roundtrip_fuzz_coverage.py' -v`
- `python3 scripts/check_verify_sync.py`

Partial progress for #1167.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI gate that can fail builds based on regex parsing of Lean sources; risk is mainly false positives/negatives blocking merges rather than runtime impact.
> 
> **Overview**
> **Enforces round-trip fuzz harness coverage drift checks.** CI/local `make check` now runs a new validator that compares `Contracts/MacroContracts/**/*.lean` `verity_contract` declarations against `Compiler/MacroTranslateRoundTripFuzz.lean`’s `macroSpecs` entries, failing on missing/extra/duplicate suite entries.
> 
> Adds `scripts/check_macro_roundtrip_fuzz_coverage.py` plus unit tests, and wires the check into the verify workflow, `Makefile` `check` target, and `scripts/verify_sync_spec.json` for CI/local parity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d554ff897d331165a58fb345107d0ffb43008809. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->