### PR TITLE
ci: detect duplicate macro contract declarations in fuzz coverage guard

### DIFF
--- a/scripts/check_macro_roundtrip_fuzz_coverage.py
+++ b/scripts/check_macro_roundtrip_fuzz_coverage.py
@@ -23,12 +23,16 @@ MACRO_SPECS_DEF_RE = re.compile(
 )
 
 
-def _collect_contracts(sources: list[Path]) -> set[str]:
+def _collect_contracts(sources: list[Path]) -> tuple[set[str], dict[str, list[Path]]]:
     names: set[str] = set()
+    locations: dict[str, list[Path]] = {}
     for path in sources:
         text = path.read_text(encoding="utf-8")
-        names.update(CONTRACT_RE.findall(text))
-    return names
+        for name in CONTRACT_RE.findall(text):
+            names.add(name)
+            locations.setdefault(name, []).append(path)
+    duplicates = {name: paths for name, paths in locations.items() if len(paths) > 1}
+    return names, duplicates
 
 
 def _extract_macro_specs_block(text: str) -> str | None:
@@ -58,7 +62,7 @@ def _collect_suite_entries(path: Path) -> list[str] | None:
 
 
 def _check_coverage(contract_sources: list[Path], fuzz_suite: Path) -> int:
-    declared = _collect_contracts(contract_sources)
+    declared, duplicate_declarations = _collect_contracts(contract_sources)
     covered_entries = _collect_suite_entries(fuzz_suite)
 
     if covered_entries is None:
@@ -85,11 +89,17 @@ def _check_coverage(contract_sources: list[Path], fuzz_suite: Path) -> int:
     missing = sorted(declared - covered)
     extra = sorted(covered - declared)
 
-    if not missing and not extra and not duplicate_entries:
+    if not missing and not extra and not duplicate_entries and not duplicate_declarations:
         print("macro round-trip fuzz coverage OK")
         return 0
 
     print("macro round-trip fuzz coverage check failed:", file=sys.stderr)
+    for name in sorted(duplicate_declarations):
+        paths = ", ".join(sorted(str(path) for path in duplicate_declarations[name]))
+        print(
+            f"  duplicate verity_contract declaration name: {name} ({paths})",
+            file=sys.stderr,
+        )
     for name in duplicate_entries:
         print(
             f"  duplicate macroSpecs entry in Compiler/MacroTranslateRoundTripFuzz.lean: {name}",

--- a/scripts/test_check_macro_roundtrip_fuzz_coverage.py
+++ b/scripts/test_check_macro_roundtrip_fuzz_coverage.py
@@ -198,6 +198,40 @@ class MacroRoundTripFuzzCoverageTests(unittest.TestCase):
             rc = check._check_coverage([contracts_dir / "Core.lean"], suite)
             self.assertEqual(rc, 1)
 
+    def test_fails_on_duplicate_contract_declaration_name(self) -> None:
+        with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
+            root = Path(tmpdir)
+            contracts_dir = root / "Contracts"
+            contracts_dir.mkdir(parents=True, exist_ok=True)
+            (contracts_dir / "A.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            (contracts_dir / "B.lean").write_text(
+                """
+                verity_contract Counter where
+                  storage
+                """,
+                encoding="utf-8",
+            )
+            suite = root / "MacroTranslateRoundTripFuzz.lean"
+            suite.write_text(
+                """
+                private def macroSpecs :=
+                  [ Contracts.MacroContracts.Counter.spec ]
+                """,
+                encoding="utf-8",
+            )
+
+            rc = check._check_coverage(
+                [contracts_dir / "A.lean", contracts_dir / "B.lean"],
+                suite,
+            )
+            self.assertEqual(rc, 1)
+
     def test_ignores_spec_references_outside_macro_specs(self) -> None:
         with tempfile.TemporaryDirectory(dir=check.ROOT) as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary
- harden `check_macro_roundtrip_fuzz_coverage.py` to fail when duplicate `verity_contract` declaration names exist
- include source file paths in the duplicate-declaration failure message for fast remediation
- add regression test coverage for duplicate declaration detection

## Why
Issue #1167 tracks making macro round-trip testing reliable in CI. The existing coverage checker reduced declarations to a set of names, so duplicate declarations with the same name could silently pass coverage checks. This weakens the guard's signal when contracts are reorganized or copied.

## Validation
- `python3 scripts/check_macro_roundtrip_fuzz_coverage.py`
- `python3 -m unittest discover -s scripts -p 'test_check_macro_roundtrip_fuzz_coverage.py' -v`
- `python3 scripts/check_verify_sync.py`
- `make check`

Closes #1167

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a CI/utility script and its unit tests, tightening validation without affecting production runtime behavior.
> 
> **Overview**
> The macro round-trip fuzz coverage guard now **fails when the same `verity_contract` name is declared in multiple source files**, instead of silently de-duplicating via a set.
> 
> The checker reports the duplicate contract name along with the *file paths* where it was found, and the test suite adds a regression case ensuring duplicate declarations cause a non-zero exit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7c08a5da674ed695e3732da2ddec4ebb7248a3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->