### PR TITLE
feat: add  tactic and standard unfold simp set

### DIFF
--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -18,7 +18,7 @@ namespace Contracts.OwnedCounter.Proofs
 open Verity
 open Contracts.MacroContracts.OwnedCounter
 open Contracts.OwnedCounter.Spec
-open Verity.Proofs.Stdlib.Automation (address_beq_false_of_ne)
+open Verity.Proofs.Stdlib.Automation
 open Contracts.OwnedCounter.Invariants
 
 /-! ## Owner Guard -/
@@ -100,9 +100,8 @@ theorem getOwner_preserves_state (s : ContractState) :
 
 theorem isOwner_correct (s : ContractState) :
   ((isOwner).run s).fst = (s.sender == s.storageAddr 0) := by
-  simp only [isOwner, msgSender, getStorageAddr, owner,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure,
-    Contract.run, ContractResult.fst]
+  verity_unfold isOwner
+  simp [owner]
 
 /-! ## Increment Correctness (Owner-Guarded) -/
 
@@ -121,10 +120,8 @@ theorem increment_unfold (s : ContractState)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  simp [increment, onlyOwner, isOwner, owner, count,
-    msgSender, getStorageAddr, getStorage, setStorage,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, h_owner]
+  verity_unfold increment
+  simp [owner, count, h_owner]
 
 theorem increment_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -165,10 +162,8 @@ theorem decrement_unfold (s : ContractState)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  simp [decrement, onlyOwner, isOwner, owner, count,
-    msgSender, getStorageAddr, getStorage, setStorage,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, h_owner]
+  verity_unfold decrement
+  simp [owner, count, h_owner]
 
 theorem decrement_meets_spec_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -208,10 +203,8 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  simp [transferOwnership, onlyOwner, isOwner, owner,
-    msgSender, getStorageAddr, setStorageAddr,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, h_owner]
+  verity_unfold transferOwnership
+  simp [owner, h_owner]
 
 theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -32,6 +32,47 @@ namespace Verity.Proofs.Stdlib.Automation
 
 open Verity
 open Compiler.CompilationModel
+open Lean Parser.Tactic
+
+/-!
+## Standard Unfold Simp Set
+-/
+
+/-- Canonical simp-lemma names used by `verity_unfold`. -/
+def verity_simp_set : List Lean.Name := [
+  ``msgSender,
+  ``getStorageAddr,
+  ``getStorage,
+  ``setStorage,
+  ``setStorageAddr,
+  ``getMapping,
+  ``setMapping,
+  ``setMapping2,
+  ``getMappingUint,
+  ``setMappingUint,
+  ``getMapping2,
+  ``Verity.require,
+  ``Verity.pure,
+  ``Verity.bind,
+  ``Bind.bind,
+  ``Pure.pure,
+  ``Contract.run,
+  ``ContractResult.snd,
+  ``ContractResult.fst
+]
+
+/-- Unfold a contract function with the standard Verity simp set. -/
+syntax (name := verity_unfold)
+  "verity_unfold " simpLemma : tactic
+
+macro_rules
+  | `(tactic| verity_unfold $fn:simpLemma) =>
+      `(tactic| simp only [
+        $fn, msgSender, getStorageAddr, getStorage, setStorage, setStorageAddr,
+        getMapping, setMapping, setMapping2, getMappingUint, setMappingUint, getMapping2,
+        Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
+        Contract.run, ContractResult.snd, ContractResult.fst
+      ])
 
 /-!
 ## Index Normalization Helpers


### PR DESCRIPTION
## Summary\n- adds  in  as the canonical standard unfold simp-name list\n- adds  tactic macro for standard contract-operation unfolding\n- migrates representative OwnedCounter proof blocks to use  (, , , )\n\n## Why\nProgress on #1152 by reducing repetitive unfolding boilerplate and standardizing the default simp set used in proof scripts.\n\n## Validation\n- ⚠ [39/39] Replayed Contracts.OwnedCounter.Proofs.Basic
warning: Contracts/OwnedCounter/Proofs/Basic.lean:291:40: This simp argument is unused:
  onlyOwner

Hint: Omit it from the simp argument list.
  simp only [setStorageAddr, increment, o̵n̵l̵y̵O̵w̵n̵e̵r̵,̵ ̵isOwner, owner, count,
  ̵  ̵ ̵ ̵getCount, getStorage, getStorageAddr,
  ̲  ̲ ̲ ̲setStorage, setStorageAddr,
  ̵  ̵ ̵ ̵msgSender, Verity.require, Verity.pure, Verity.bind,
  ̵  ̵ ̵ ̵Bind.bind,
  ̲  ̲ ̲ ̲Pure.pure, Contract.run, ContractResult.snd, ContractResult.fst]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/OwnedCounter/Proofs/Basic.lean:291:51: This simp argument is unused:
  isOwner

Hint: Omit it from the simp argument list.
  simp only [setStorageAddr, increment, onlyOwner, i̵s̵O̵w̵n̵e̵r̵,̵ ̵owner, count, getCount, getStorage,
  ̲  ̲ ̲ ̲getStorageAddr, setStorage, setStorageAddr, msgSender, Verity.require, Verity.pure, Verity.bind,
      Bind.bind, Pure.pure, Contract.run, ContractResult.snd, ContractResult.fst]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
Build completed successfully.\n- [PASS] paths
[PASS] jobs
[PASS] python-commands
[PASS] multiseed
[PASS] foundry
[PASS] artifacts
[PASS] makefile
verify sync passed: 7 invariant groups\n- Running CI-equivalent checks job...
python3 scripts/check_property_manifest.py
Property manifest check passed.
python3 scripts/check_property_coverage.py
Property coverage check passed.
python3 scripts/check_contract_structure.py
Checking 9 contracts for complete file structure...
  (Excluding: CryptoHash, MacroContracts, ReentrancyExample)

  OK Counter
  OK ERC20
  OK ERC721
  OK Ledger
  OK Owned
  OK OwnedCounter
  OK SafeCounter
  OK SimpleStorage
  OK SimpleToken

OK: All 9 contracts have complete file structure
python3 scripts/check_case_insensitive_path_conflicts.py
python3 scripts/check_axiom_locations.py
  OK keccak256_first_4_bytes at Compiler/Selectors.lean:41
  OK resultsMatch_switchCaseBody_of_resultsMatch_body at Compiler/Proofs/YulGeneration/Preservation.lean:300

OK: 2 documented axiom locations are accurate; registry is complete and synchronized with 2 source axioms
python3 scripts/generate_verification_status.py --check
Verification artifact is up to date: /workspaces/mission-3356d738/repo-run-20260305/artifacts/verification_status.json
python3 scripts/check_doc_counts.py
Documentation count check passed (272 theorems, 10 categories, 2 axioms, 475 tests, 38 suites, 0 sorry, 250/272 covered, 22 exclusions).
python3 scripts/check_interop_matrix_sync.py
Interop matrix is synchronized across docs (6 feature rows checked).
python3 scripts/check_verify_sync.py
[PASS] paths
[PASS] jobs
[PASS] python-commands
[PASS] multiseed
[PASS] foundry
[PASS] artifacts
[PASS] makefile
verify sync passed: 7 invariant groups
python3 scripts/check_issue_template_forms.py
issue template forms OK (4 file(s))
python3 scripts/check_solc_pin.py
✓ solc pin is consistent (0.8.33+commit.64118f21)
python3 scripts/check_property_manifest_sync.py
Property manifest sync check passed.
python3 scripts/check_issue_templates.py
issue template contamination check passed
python3 scripts/check_macro_property_test_generation.py --check
macro property-test artifacts are up to date: artifacts/macro_property_tests
python3 scripts/check_macro_translate_invariant_coverage.py
macro invariant suite coverage OK
python3 scripts/check_macro_roundtrip_fuzz_coverage.py
macro round-trip fuzz coverage OK
python3 scripts/check_storage_layout.py
Storage layout validation passed.

============================================================
STORAGE LAYOUT REPORT
============================================================

  Counter
    Slot 0: count (Uint256)

  CryptoHash
    Slot 0: lastHash (Uint256)

  Ledger
    Slot 0: balances ((Address → Uint256))

  Owned
    Slot 0: owner (Address)

  OwnedCounter
    Slot 0: owner (Address)
    Slot 1: count (Uint256)

  ReentrancyExample
    Slot 0: reentrancyLock (Uint256)
    Slot 1: totalSupply (Uint256)
    Slot 2: balances ((Address → Uint256))

  SafeCounter
    Slot 0: count (Uint256)

  SimpleToken
    Slot 0: owner (Address)
    Slot 1: balances ((Address → Uint256))
    Slot 2: totalSupply (Uint256)
python3 scripts/check_manual_spec_quarantine.py
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
python3 scripts/check_spec_proof_migration_boundary.py
Spec-proof migration boundary check passed (16 allowlisted files; no out-of-bound legacy references).
python3 scripts/check_legacy_example_imports.py
Legacy migrated-contract import guard passed (170 Lean files scanned; 9 explicit exemption module(s)).
python3 scripts/check_layer2_universality.py
Layer-2 universality check passed (15 semantic bridge theorem headers validated).
python3 scripts/check_lean_hygiene.py
Lean hygiene check passed (0 debug commands in proofs, 1 allowUnsafeReducibility, 0 sorry (expected 0), 0 native_decide in proofs).
python3 scripts/check_gas_model_coverage.py
OK: static gas model covers all emitted Yul calls (26 names) across: artifacts/yul
python3 scripts/check_mapping_slot_boundary.py
✓ Mapping slot boundary is enforced
python3 scripts/check_yul_builtin_boundary.py
✓ Yul builtin boundary is enforced
python3 scripts/check_rewrite_proof_metadata.py
Rewrite proof metadata check passed (active object rewrite rules have non-empty proof refs).
python3 scripts/check_builtin_list_sync.py
✓ Builtin lists in sync (85 Linker, 78+4 CompilationModel)
python3 scripts/check_evmyullean_capability_boundary.py
✓ EVMYulLean capability boundary is enforced
python3 scripts/generate_evmyullean_capability_report.py --check
EVMYulLean capability report is up to date: /workspaces/mission-3356d738/repo-run-20260305/artifacts/evmyullean_capability_report.json
EVMYulLean unsupported-node report is up to date: /workspaces/mission-3356d738/repo-run-20260305/artifacts/evmyullean_unsupported_nodes.json
python3 scripts/generate_evmyullean_adapter_report.py --check
EVMYulLean adapter report is up to date: /workspaces/mission-3356d738/repo-run-20260305/artifacts/evmyullean_adapter_report.json
python3 scripts/generate_print_axioms.py --check
OK: /workspaces/mission-3356d738/repo-run-20260305/PrintAxioms.lean is up to date.
python3 scripts/check_proof_length.py
Proof length check: 951 proofs scanned.
  891 under 30 lines (good)
  44 between 30-50 lines (acceptable)
  16 over 50 lines (allowlisted)

Proof length check passed. No new proofs exceed the 50-line hard limit.
python3 scripts/check_issue_1060_integrity.py
issue #1060 integrity check passed
python3 -m unittest discover -s scripts -p 'test_*.py' -v
  OK documented_axiom at Compiler/A.lean:1
✓ Builtin lists in sync (3 Linker, 1+1 CompilationModel)
Documentation count check passed (272 theorems, 10 categories, 2 axioms, 475 tests, 38 suites, 0 sorry, 250/272 covered, 22 exclusions).
Interop matrix is synchronized across docs (1 feature rows checked).
issue #1060 integrity check passed
issue template forms OK (1 file(s))
Legacy migrated-contract import guard passed (1 Lean files scanned; 1 explicit exemption module(s)).
Legacy migrated-contract import guard passed (1 Lean files scanned; 0 explicit exemption module(s)).
wrote macro property-test artifacts (1 file(s)): tmpjj70emb0/artifacts
wrote macro property-test artifacts (1 file(s)): tmpap17n3po/artifacts
wrote macro property-test artifacts (1 file(s)): tmp45d3vk5y/artifacts
macro property-test artifacts are up to date: tmp45d3vk5y/artifacts
macro round-trip fuzz coverage OK
macro round-trip fuzz coverage OK
macro round-trip fuzz coverage OK
macro invariant suite coverage OK
macro invariant suite coverage OK
macro invariant suite coverage OK
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Spec-proof migration boundary check passed (1 allowlisted files; no out-of-bound legacy references).
Spec-proof migration boundary check passed (0 allowlisted files; no out-of-bound legacy references).
✓ Yul builtin boundary is enforced
Wrote Lean warning baseline to /tmp/tmppw3n4ug9/baseline.json
Wrote Yul identity report: /tmp/tmpgft4ubr4/r1.json
Status: non_identical (1 mismatches)
Wrote Yul identity report: /tmp/tmpgft4ubr4/r2.json
Status: non_identical (1 mismatches)
All checks passed.\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Lean proof automation and refactor existing proofs without altering contract/spec semantics. Main risk is accidental over/under-unfolding impacting proof stability as the tactic is adopted elsewhere.
> 
> **Overview**
> **Proof automation:** Introduces `verity_simp_set` and a new `verity_unfold` tactic in `Verity.Proofs.Stdlib.Automation` that expands a target contract definition using a standardized `simp only` lemma set (msg sender/storage/mapping ops, `require`, monad ops, and `ContractResult` projections).
> 
> **Proof refactor:** Migrates key `Contracts/OwnedCounter/Proofs/Basic.lean` blocks (e.g., `isOwner_correct`, `increment_unfold`, `decrement_unfold`, `transferOwnership_unfold`) to use `verity_unfold` and simplifies imports accordingly, reducing repetitive unfolding boilerplate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91f15ff96a9c6a389f412650745153bfaa60fdc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->