### PR TITLE
proofs: continue verity_unfold migration in Owned/Ledger

### DIFF
--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -62,8 +62,8 @@ private theorem deposit_unfold (s : ContractState) (amount : Uint256) :
         if slotIdx == 0 then (s.knownAddresses slotIdx).insert s.sender
         else s.knownAddresses slotIdx,
       events := s.events } := by
-  simp only [deposit, msgSender, getMapping, setMapping, balances,
-    Verity.bind, Bind.bind, Contract.run]
+  verity_unfold deposit
+  simp only [balances]
 
 theorem deposit_meets_spec (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd

--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -100,7 +100,8 @@ theorem getOwner_preserves_state (s : ContractState) :
 theorem isOwner_meets_spec (s : ContractState) :
   let result := ((isOwner).run s).fst
   isOwner_spec result s := by
-  simp only [isOwner, isOwner_spec, msgSender, getStorageAddr, owner, Verity.bind, Bind.bind, Contract.run, ContractResult.fst]
+  verity_unfold isOwner
+  simp only [isOwner_spec]
   rfl
 
 theorem isOwner_returns_correct_value (s : ContractState) :


### PR DESCRIPTION
## Summary
This continues issue #1152 by migrating additional proof unfold call-sites from manual simp lists to `verity_unfold`.

### Changes
- `Contracts/Owned/Proofs/Basic.lean`
  - `isOwner_meets_spec` now uses `verity_unfold isOwner`.
- `Contracts/Ledger/Proofs/Basic.lean`
  - `deposit_unfold` now uses `verity_unfold deposit` plus a local `balances` simplification.

This reduces duplicated unfold boilerplate and further standardizes proof entrypoints around `verity_unfold`.

## Validation
- `lake build Contracts.Owned.Proofs.Basic Contracts.Ledger.Proofs.Basic`

## Issue
- Closes part of #1152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only refactors Lean proof scripts to use `verity_unfold` instead of manual `simp` unfold lists, without changing contract logic or specs.
> 
> **Overview**
> Continues the proof automation migration by replacing manual `simp`-based unfolding with `verity_unfold` in `Contracts/Owned/Proofs/Basic.lean` (`isOwner_meets_spec`) and `Contracts/Ledger/Proofs/Basic.lean` (`deposit_unfold`).
> 
> The `deposit_unfold` helper now does a targeted `simp only [balances]` after `verity_unfold` to keep the proof shape stable while reducing duplicated boilerplate across proofs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28895e4ee1490aef837ece3d30a35407e098e56f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->