### PR TITLE
proofs: migrate ERC20/SimpleToken unfold helpers to verity_unfold

### DIFF
--- a/Contracts/ERC20/Proofs/Basic.lean
+++ b/Contracts/ERC20/Proofs/Basic.lean
@@ -106,10 +106,8 @@ private theorem mint_unfold (s : ContractState) (to : Address) (amount : Uint256
         events := s.events } := by
   have h_safe_bal := safeAdd_some (s.storageMap 2 to) amount h_no_bal_overflow
   have h_safe_sup := safeAdd_some (s.storage 1) amount h_no_sup_overflow
-  simp only [mint, onlyOwner, isOwner, ownerSlot, balancesSlot, totalSupplySlot,
-    msgSender, getStorageAddr, getStorage, getMapping, setMapping, setStorage,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run,
+  verity_unfold mint
+  simp only [ownerSlot, balancesSlot, totalSupplySlot,
     h_owner, beq_self_eq_true, ite_true]
   unfold requireSomeUint
   rw [h_safe_bal]
@@ -166,9 +164,8 @@ private theorem transfer_unfold_self (s : ContractState) (to : Address) (amount 
     (h_eq : s.sender = to) :
     (transfer to amount).run s = ContractResult.success () s := by
   have h_balance' := uint256_ge_val_le (h_eq ▸ h_balance)
-  simp [transfer, balancesSlot, msgSender, getMapping,
-    Verity.require, Verity.pure, Pure.pure, Verity.bind, Bind.bind,
-    Contract.run, h_balance', h_eq]
+  verity_unfold transfer
+  simp [balancesSlot, Verity.pure, h_balance', h_eq]
 
 /-- Helper: unfold `transfer` on the successful non-self path with no overflow. -/
 private theorem transfer_unfold_other (s : ContractState) (to : Address) (amount : Uint256)

--- a/Contracts/SimpleToken/Proofs/Basic.lean
+++ b/Contracts/SimpleToken/Proofs/Basic.lean
@@ -161,12 +161,10 @@ private theorem mint_unfold (s : ContractState) (to : Address) (amount : Uint256
   have h_safe_bal := safeAdd_some (s.storageMap 1 to) amount h_no_bal_overflow
   have h_safe_sup := safeAdd_some (s.storage 2) amount h_no_sup_overflow
   -- Unfold mint (checks-before-effects ordering: both requireSomeUint before mutations)
-  simp only [mint, Contracts.MacroContracts.SimpleToken.onlyOwner, isOwner,
-    Contracts.MacroContracts.SimpleToken.ownerSlot, Contracts.MacroContracts.SimpleToken.balancesSlot, Contracts.MacroContracts.SimpleToken.totalSupplySlot,
-    msgSender, getStorageAddr, setStorageAddr, getStorage, setStorage, getMapping, setMapping,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst,
-    h_owner, beq_self_eq_true, ite_true]
+  verity_unfold mint
+  simp only [Contracts.MacroContracts.SimpleToken.onlyOwner, isOwner,
+    Contracts.MacroContracts.SimpleToken.ownerSlot, Contracts.MacroContracts.SimpleToken.balancesSlot,
+    Contracts.MacroContracts.SimpleToken.totalSupplySlot, h_owner, beq_self_eq_true, ite_true]
   -- Unfold and rewrite safeAdd results for both checks
   unfold requireSomeUint
   rw [h_safe_bal]
@@ -264,10 +262,9 @@ private theorem transfer_unfold_self (s : ContractState) (to : Address) (amount 
   (h_eq : s.sender = to) :
   (transfer to amount).run s = ContractResult.success () s := by
   have h_balance' := uint256_ge_val_le (h_eq ▸ h_balance)
-  simp [transfer, Contracts.MacroContracts.SimpleToken.balancesSlot,
-    msgSender, getMapping, setMapping,
-    Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
-    Contract.run, ContractResult.snd, ContractResult.fst,
+  verity_unfold transfer
+  simp [Contracts.MacroContracts.SimpleToken.balancesSlot,
+    Verity.require, Verity.pure, Pure.pure, Verity.bind, Bind.bind, Contract.run,
     h_balance', h_eq, beq_iff_eq]
 
 -- Helper lemma: after unfolding transfer with sufficient balance, distinct recipient, and no overflow
@@ -300,7 +297,7 @@ private theorem transfer_unfold_other (s : ContractState) (to : Address) (amount
     Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
     Contract.run, ContractResult.snd, ContractResult.fst,
     h_balance, h_ne, beq_iff_eq, h_safe, ge_iff_le, decide_eq_true_eq,
-    h_balance', ite_true, ite_false, HAdd.hAdd, Add.add]
+    ite_true, ite_false, HAdd.hAdd, Add.add]
   congr 1
   -- The two ContractState records differ in storageMap and knownAddresses
   congr 1


### PR DESCRIPTION
## Summary
- migrate additional manual unfold/simp helper proofs to `verity_unfold`
- update unfold-heavy helper lemmas in:
  - `Contracts/ERC20/Proofs/Basic.lean`
  - `Contracts/SimpleToken/Proofs/Basic.lean`
- keep proof behavior unchanged while reducing repetitive boilerplate around standard contract monad unfolding

## Details
- `ERC20`:
  - `mint_unfold`: replace long `simp only [...]` unfold list with `verity_unfold mint`
  - `transfer_unfold_self`: replace manual unfold list with `verity_unfold transfer`
- `SimpleToken`:
  - `mint_unfold`: replace long `simp only [...]` unfold list with `verity_unfold mint`
  - `transfer_unfold_self`: replace manual unfold list with `verity_unfold transfer`

## Validation
- `lake build Contracts.ERC20.Proofs.Basic`
- `lake build Contracts.SimpleToken.Proofs.Basic`

Refs #1152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that replaces manual unfold/simp boilerplate with `verity_unfold`; low risk aside from potential proof fragility if the tactic’s simp set changes.
> 
> **Overview**
> Migrates several unfold-heavy helper lemmas in `Contracts/ERC20/Proofs/Basic.lean` and `Contracts/SimpleToken/Proofs/Basic.lean` from long `simp only [...]` unfold lists to the standardized `verity_unfold` tactic.
> 
> This keeps the proven behavior/specs the same while reducing repetitive proof boilerplate for `mint` and `transfer` success-path unfold helpers (notably `mint_unfold` and `transfer_unfold_self`), with minor simp-set cleanups in related transfer proofs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94d969c78b95a206d90ef74149114be00381996c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->