### PR TITLE
proofs: migrate SafeCounter getCount helper to verity_unfold

### DIFF
--- a/Contracts/SafeCounter/Proofs/Basic.lean
+++ b/Contracts/SafeCounter/Proofs/Basic.lean
@@ -9,6 +9,7 @@
 -/
 
 import Verity.Proofs.Stdlib.Math
+import Verity.Proofs.Stdlib.Automation
 import Contracts.SafeCounter.Spec
 import Contracts.SafeCounter.Invariants
 
@@ -26,7 +27,8 @@ open Contracts.SafeCounter.Invariants
 
 private theorem getCount_run (s : ContractState) :
   (getCount).run s = ContractResult.success (s.storage 0) s := by
-  simp [getCount, count, getStorage, Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
+  verity_unfold getCount
+  simp [count]
 
 theorem getCount_meets_spec (s : ContractState) :
   let result := ((getCount).run s).fst


### PR DESCRIPTION
## Summary
- migrate `Contracts/SafeCounter/Proofs/Basic.lean` helper `getCount_run` from a manual `simp` unfold list to `verity_unfold getCount`
- add `Verity.Proofs.Stdlib.Automation` import for the tactic
- keep proof shape/behavior unchanged while reducing duplicated unfold boilerplate

## Why
- incremental progress on #1152 (standardize proof unfolding via `verity_unfold`)
- this helper is used by multiple downstream proofs in the same file, so centralizing the unfold path improves maintainability

Refs #1152

## Validation
- `lake build Contracts.SafeCounter.Proofs.Basic`
- `lake build Contracts.SafeCounter.Proofs.Correctness`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: proof-only refactor that changes unfolding tactics/imports without altering contract specs or runtime code. Main risk is limited to potential proof breakage if `verity_unfold`’s simp set changes.
> 
> **Overview**
> Migrates `Contracts/SafeCounter/Proofs/Basic.lean`’s `getCount_run` helper from a manual `simp` unfolding list to the standardized `verity_unfold getCount` tactic, followed by a smaller `simp [count]`.
> 
> Adds an import of `Verity.Proofs.Stdlib.Automation` to access `verity_unfold`, reducing duplicated proof boilerplate while keeping downstream `getCount_*` proofs unchanged in intent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06bf4256a52d4bf5646a82c1d6318e9b3bae96ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->