### PR TITLE
proofs: migrate Ledger unfold helpers to verity_unfold

### DIFF
--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -112,8 +112,8 @@ private theorem withdraw_unfold (s : ContractState) (amount : Uint256)
         if slotIdx == 0 then (s.knownAddresses slotIdx).insert s.sender
         else s.knownAddresses slotIdx,
       events := s.events } := by
-  simp [withdraw, msgSender, getMapping, setMapping, balances,
-    Verity.require, Verity.bind, Bind.bind, Contract.run, h_balance]
+  verity_unfold withdraw
+  simp [balances, h_balance]
 
 theorem withdraw_meets_spec (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
@@ -152,9 +152,8 @@ private theorem transfer_unfold_self (s : ContractState) (to : Address) (amount 
   (h_balance : s.storageMap 0 s.sender >= amount)
   (h_eq : s.sender = to) :
   (transfer to amount).run s = ContractResult.success () s := by
-  simp [transfer, msgSender, getMapping, balances,
-    Verity.require, Verity.bind, Bind.bind, Verity.pure, Pure.pure,
-    Contract.run, uint256_ge_val_le (h_eq ▸ h_balance), h_eq]
+  verity_unfold transfer
+  simp [balances, Verity.pure, uint256_ge_val_le (h_eq ▸ h_balance), h_eq]
 
 /-- Helper: unfold transfer when balance sufficient and sender ≠ to. -/
 private theorem transfer_unfold_other (s : ContractState) (to : Address) (amount : Uint256)


### PR DESCRIPTION
## Summary
- migrate remaining Ledger helper unfold scripts to `verity_unfold` where stable
- update `withdraw_unfold` to use `verity_unfold withdraw`
- update `transfer_unfold_self` to use `verity_unfold transfer`
- keep the existing explicit script for `transfer_unfold_other` (it still needs the manual normalization path)

## Why
This is another incremental migration for #1152 to reduce repeated manual unfold lists and standardize proof scripts on `verity_unfold`.

## Validation
- `lake build Contracts.Ledger.Proofs.Basic Contracts.Ledger.Proofs.Correctness`
- `make check`

Refs #1152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: proof-script refactor only, replacing manual `simp`/unfold lists with `verity_unfold` in a couple of helper lemmas without changing contract specs or executable code.
> 
> **Overview**
> Migrates two Ledger proof helper lemmas (`withdraw_unfold` and `transfer_unfold_self`) from explicit `simp`/manual unfold lists to the standardized `verity_unfold` tactic, simplifying the proof scripts.
> 
> No behavioral/spec changes are introduced; `transfer_unfold_other` keeps its existing manual normalization proof path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8621cea03d904e9195e8de3ad4fa440c11f5365. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->