### PR TITLE
proofs: use verity_unfold for OwnedCounter read helpers

### DIFF
--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -58,7 +58,8 @@ theorem constructor_preserves_count (s : ContractState) (initialOwner : Address)
 
 private theorem getCount_run (s : ContractState) :
   (getCount).run s = ContractResult.success (s.storage 1) s := by
-  simp [getCount, count, getStorage, Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
+  verity_unfold getCount
+  simp [count]
 
 theorem getCount_meets_spec (s : ContractState) :
   let result := ((getCount).run s).fst
@@ -78,7 +79,8 @@ theorem getCount_preserves_state (s : ContractState) :
 
 private theorem getOwner_run (s : ContractState) :
   (getOwner).run s = ContractResult.success (s.storageAddr 0) s := by
-  simp [getOwner, owner, getStorageAddr, Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
+  verity_unfold getOwner
+  simp [owner]
 
 theorem getOwner_meets_spec (s : ContractState) :
   let result := ((getOwner).run s).fst


### PR DESCRIPTION
## Summary
- migrate `Contracts/OwnedCounter/Proofs/Basic.lean` read helpers to `verity_unfold`
- replace manual standard unfold simp blocks in:
  - `getCount_run`
  - `getOwner_run`
- keep slot normalization explicit via small follow-up simp steps (`[count]`, `[owner]`)

## Why
Continues issue #1152 by removing remaining repetitive manual unfold boilerplate in another contract proof file while preserving proof readability.

## Validation
- `lake build Contracts.OwnedCounter.Proofs.Basic`
- `lake build Contracts.OwnedCounter.Proofs.Correctness`

Refs #1152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk proof-only refactor that changes automation/unfolding tactics but not contract logic. Potential risk is proof fragility if `verity_unfold`’s simp set changes, but behavior is equivalent.
> 
> **Overview**
> Updates `Contracts/OwnedCounter/Proofs/Basic.lean` to replace the manual `simp [...]` unfold boilerplate in `getCount_run` and `getOwner_run` with the standardized `verity_unfold` tactic.
> 
> Keeps storage-slot normalization explicit via follow-up `simp` steps (`[count]` and `[owner]`), improving consistency/readability without altering the proven statements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd634f1770abe8459eb8122e6f541bc265fe247d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->