### PR TITLE
Issue #1152: migrate SafeCounter helper proofs to verity_unfold

### DIFF
--- a/Contracts/SafeCounter/Proofs/Basic.lean
+++ b/Contracts/SafeCounter/Proofs/Basic.lean
@@ -67,9 +67,8 @@ private theorem increment_unfold (s : ContractState)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  simp only [increment, getStorage, setStorage, count, requireSomeUint,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure,
-    Contract.run,
+  verity_unfold increment
+  simp [count, requireSomeUint, Verity.pure, Pure.pure,
     safeAdd_some (s.storage 0) 1 h_no_overflow]
 
 theorem increment_meets_spec (s : ContractState)
@@ -103,9 +102,8 @@ theorem increment_preserves_other_slots (s : ContractState)
 theorem increment_reverts_overflow (s : ContractState)
   (h_overflow : (s.storage 0 : Nat) + 1 > MAX_UINT256) :
   ∃ msg, (increment).run s = ContractResult.revert msg s := by
-  simp [increment, getStorage, count, requireSomeUint,
-    Verity.bind, Bind.bind,
-    Verity.require, Contract.run,
+  verity_unfold increment
+  simp [count, requireSomeUint, Verity.bind, Bind.bind, Verity.require,
     safeAdd_none (s.storage 0) 1 h_overflow]
 
 /-! ## Decrement Correctness -/
@@ -125,9 +123,8 @@ private theorem decrement_unfold (s : ContractState)
       blockTimestamp := s.blockTimestamp,
       knownAddresses := s.knownAddresses,
       events := s.events } := by
-  simp only [decrement, getStorage, setStorage, count, requireSomeUint,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure,
-    Contract.run,
+  verity_unfold decrement
+  simp [count, requireSomeUint, Verity.pure, Pure.pure,
     safeSub_some (s.storage 0) 1 h_no_underflow]
 
 theorem decrement_meets_spec (s : ContractState)
@@ -161,9 +158,8 @@ theorem decrement_preserves_other_slots (s : ContractState)
 theorem decrement_reverts_underflow (s : ContractState)
   (h_underflow : s.storage 0 = 0) :
   ∃ msg, (decrement).run s = ContractResult.revert msg s := by
-  simp [decrement, getStorage, count, requireSomeUint,
-    Verity.bind, Bind.bind,
-    Verity.require, Contract.run,
+  verity_unfold decrement
+  simp [count, requireSomeUint, Verity.bind, Bind.bind, Verity.require,
     safeSub_none (s.storage 0) 1 (show (1 : Nat) > (s.storage 0 : Nat) by rw [h_underflow]; decide)]
 
 /-! ## State Preservation -/


### PR DESCRIPTION
## Summary
- migrate remaining SafeCounter helper unfold proofs to `verity_unfold`
- replace four manual unfold blocks with `verity_unfold` + focused simplification
- keep `requireSomeUint` and `safeAdd/safeSub` branch lemmas explicit where needed

## Linked issue
- Closes #1152 (incremental migration progress)

## Validation
- `lake build Contracts.SafeCounter.Proofs.Basic`
- `lake build Contracts.SafeCounter.Proofs.Correctness`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only Lean proof scripts (no contract/spec logic changes), mainly altering unfolding/simplification tactics.
> 
> **Overview**
> **Migrates SafeCounter helper proofs to `verity_unfold`.** In `Contracts/SafeCounter/Proofs/Basic.lean`, the helper lemmas and revert proofs for `increment`/`decrement` switch from manual `simp`-based unfolding (`simp only [...]` including `Contract.run`) to `verity_unfold` followed by focused `simp`.
> 
> The arithmetic branch lemmas (`safeAdd_some`/`safeAdd_none`, `safeSub_some`/`safeSub_none`) and `requireSomeUint` remain explicit in the simplifications, but the proof structure is streamlined and less brittle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fc0c6557a0d2ced426124ac849c71d96f69a70f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->