### PR TITLE
proofs: add verity_frame helper and migrate OwnedCounter isolation

### DIFF
--- a/Contracts/OwnedCounter/Proofs/Isolation.lean
+++ b/Contracts/OwnedCounter/Proofs/Isolation.lean
@@ -20,6 +20,7 @@ open Contracts.MacroContracts.OwnedCounter
 open Contracts.OwnedCounter.Spec
 open Contracts.OwnedCounter.Proofs
 open Contracts.OwnedCounter.Invariants
+open Verity.Proofs.Stdlib.Automation
 
 /-! ## Counter operations preserve owner storage (count_preserves_owner)
 
@@ -70,21 +71,21 @@ theorem increment_context_preserved (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   context_preserved s (increment.run s).snd := by
   unfold context_preserved Specs.sameContext
-  rw [increment_unfold s h_owner]; simp [ContractResult.snd]
+  verity_frame (increment_unfold s h_owner)
 
 /-- Decrement preserves context (when authorized). -/
 theorem decrement_context_preserved (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   context_preserved s (decrement.run s).snd := by
   unfold context_preserved Specs.sameContext
-  rw [decrement_unfold s h_owner]; simp [ContractResult.snd]
+  verity_frame (decrement_unfold s h_owner)
 
 /-- TransferOwnership preserves context (when authorized). -/
 theorem transferOwnership_context_preserved (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :
   context_preserved s ((transferOwnership newOwner).run s).snd := by
   unfold context_preserved Specs.sameContext
-  rw [transferOwnership_unfold s newOwner h_owner]; simp [ContractResult.snd]
+  verity_frame (transferOwnership_unfold s newOwner h_owner)
 
 /-- getCount preserves context. -/
 theorem getCount_context_preserved (s : ContractState) :
@@ -113,19 +114,19 @@ theorem constructor_preserves_map_storage (s : ContractState) (initialOwner : Ad
 theorem increment_preserves_map_storage (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   (increment.run s).snd.storageMap = s.storageMap := by
-  rw [increment_unfold s h_owner]; simp [ContractResult.snd]
+  verity_frame (increment_unfold s h_owner)
 
 /-- Decrement preserves mapping storage. -/
 theorem decrement_preserves_map_storage (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   (decrement.run s).snd.storageMap = s.storageMap := by
-  rw [decrement_unfold s h_owner]; simp [ContractResult.snd]
+  verity_frame (decrement_unfold s h_owner)
 
 /-- TransferOwnership preserves mapping storage. -/
 theorem transferOwnership_preserves_map_storage (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :
   ((transferOwnership newOwner).run s).snd.storageMap = s.storageMap := by
-  rw [transferOwnership_unfold s newOwner h_owner]; simp [ContractResult.snd]
+  verity_frame (transferOwnership_unfold s newOwner h_owner)
 
 /-! ## Summary
 

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -69,6 +69,10 @@ syntax (name := verity_unfold)
 syntax (name := verity_unfold_with)
   "verity_unfold " simpLemma " with " simpLemma : tactic
 
+/-- Frame-proof helper: rewrite by an unfold lemma, then simplify result-state fields. -/
+syntax (name := verity_frame)
+  "verity_frame " rwRule : tactic
+
 macro_rules
   | `(tactic| verity_unfold $fn:simpLemma) =>
       `(tactic| simp only [
@@ -85,6 +89,8 @@ macro_rules
         Contract.run, ContractResult.snd, ContractResult.fst,
         $extra
       ])
+  | `(tactic| verity_frame $h:rwRule) =>
+      `(tactic| (rw [$h]; simp [ContractResult.snd]))
 
 /-!
 ## Index Normalization Helpers


### PR DESCRIPTION
## Summary
- add a small `verity_frame` tactic in `Verity.Proofs.Stdlib.Automation`:
  - `verity_frame <rwRule>` expands to `rw [<rwRule>]; simp [ContractResult.snd]`
- migrate repetitive frame-style proofs in `Contracts/OwnedCounter/Proofs/Isolation.lean` to use `verity_frame`
- keep proof shape unchanged (just remove repeated boilerplate)

## Why
Issue #1153 tracks repetitive isolation/frame proofs. This PR is an incremental step that introduces a reusable primitive and applies it to a dense proof file.

## Validation
- `lake build Verity.Proofs.Stdlib.Automation Contracts.OwnedCounter.Proofs.Isolation`
- `lake build Contracts.OwnedCounter.Proofs.Basic Contracts.OwnedCounter.Proofs.Correctness`

Refs #1153

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to proof automation and refactoring of existing theorems, with no impact on contract/runtime logic. Main risk is minor proof brittleness if the new tactic’s simp behavior differs from the inlined steps.
> 
> **Overview**
> Adds a new proof-automation tactic `verity_frame` in `Verity/Proofs/Stdlib/Automation.lean` to encapsulate the common pattern of rewriting by an unfold lemma and simplifying `ContractResult.snd`.
> 
> Updates `Contracts/OwnedCounter/Proofs/Isolation.lean` to import the automation module and replace several repetitive frame-style proofs (context and mapping-storage preservation for `increment`, `decrement`, and `transferOwnership`) with `verity_frame`, keeping the proof intent unchanged while reducing boilerplate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d8c194018fb4cd125965efca008cf7a1f96700f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->