### PR TITLE
Proof automation: extend verity_frame with local simp support

### DIFF
--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -73,6 +73,10 @@ syntax (name := verity_unfold_with)
 syntax (name := verity_frame)
   "verity_frame " rwRule : tactic
 
+/-- `verity_frame` with an extra local simp lemma for frame side conditions. -/
+syntax (name := verity_frame_with)
+  "verity_frame " rwRule " with " simpLemma : tactic
+
 macro_rules
   | `(tactic| verity_unfold $fn:simpLemma) =>
       `(tactic| simp only [
@@ -91,6 +95,8 @@ macro_rules
       ])
   | `(tactic| verity_frame $h:rwRule) =>
       `(tactic| (rw [$h]; simp [ContractResult.snd]))
+  | `(tactic| verity_frame $h:rwRule with $extra:simpLemma) =>
+      `(tactic| (rw [$h]; simp [ContractResult.snd, $extra]))
 
 /-!
 ## Index Normalization Helpers


### PR DESCRIPTION
## Summary
- extend `verity_frame` in `Verity.Proofs.Stdlib.Automation` with:
  - `verity_frame <rw-rule> with <simp-lemma>`
- keep the existing `verity_frame <rw-rule>` form unchanged

## Why
`main` already migrated OwnedCounter isolation to `verity_frame` in PR #1248. This change is an incremental follow-up for issue #1153 so frame proofs can handle local side conditions without dropping back to manual `rw` + `simp` scripting.

## Validation
- `lake build Verity.Proofs.Stdlib.Automation`
- `make check`

Progress on #1153

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small proof-automation tactic variant (`verity_frame ... with ...`) without changing core semantics or runtime code.
> 
> **Overview**
> Extends proof automation in `Verity/Proofs/Stdlib/Automation.lean` by adding a new `verity_frame ... with ...` form that rewrites via a given rule and then `simp`s the resulting state using `ContractResult.snd` plus an extra caller-supplied simp lemma.
> 
> This keeps the existing `verity_frame` behavior intact while allowing local simp support for frame side conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8a2dda48ef1159fc28e780827f942359288b9ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->