### PR TITLE
Proofs: migrate SimpleToken Basic unfold sites to verity_unfold

### DIFF
--- a/Contracts/SimpleToken/Proofs/Basic.lean
+++ b/Contracts/SimpleToken/Proofs/Basic.lean
@@ -92,16 +92,18 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   · rfl
   · rfl
   · intro slotIdx h_neq
-    simp only [simpleTokenConstructor, setStorageAddr, setStorage, Contracts.MacroContracts.SimpleToken.ownerSlot,
-      Contracts.MacroContracts.SimpleToken.totalSupplySlot, Verity.bind, Bind.bind, Contract.run, ContractResult.snd]
+    verity_unfold simpleTokenConstructor
+    simp only [Contracts.MacroContracts.SimpleToken.ownerSlot,
+      Contracts.MacroContracts.SimpleToken.totalSupplySlot]
     split
     · next h =>
       have : slotIdx = 0 := beq_iff_eq.mp h
       exact absurd this h_neq
     · rfl
   · intro slotIdx h_neq
-    simp only [simpleTokenConstructor, setStorageAddr, setStorage, Contracts.MacroContracts.SimpleToken.ownerSlot,
-      Contracts.MacroContracts.SimpleToken.totalSupplySlot, Verity.bind, Bind.bind, Contract.run, ContractResult.snd]
+    verity_unfold simpleTokenConstructor
+    simp only [Contracts.MacroContracts.SimpleToken.ownerSlot,
+      Contracts.MacroContracts.SimpleToken.totalSupplySlot]
     split
     · next h =>
       have : slotIdx = 2 := beq_iff_eq.mp h
@@ -109,8 +111,9 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
     · rfl
   · rfl
   ·
-    simp [Specs.sameContext, simpleTokenConstructor, setStorageAddr, setStorage, Contracts.MacroContracts.SimpleToken.ownerSlot,
-      Contracts.MacroContracts.SimpleToken.totalSupplySlot, Verity.bind, Bind.bind, Contract.run, ContractResult.snd]
+    verity_unfold simpleTokenConstructor
+    simp [Specs.sameContext, Contracts.MacroContracts.SimpleToken.ownerSlot,
+      Contracts.MacroContracts.SimpleToken.totalSupplySlot]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((simpleTokenConstructor initialOwner).run s).snd
@@ -134,7 +137,8 @@ on overflow, matching Solidity ^0.8 checked arithmetic semantics.
 -- Helper: isOwner returns true when sender is owner
 theorem isOwner_true_when_owner (s : ContractState) (h : s.sender = s.storageAddr 0) :
   ((isOwner).run s).fst = true := by
-  simp [isOwner, msgSender, getStorageAddr, Contracts.MacroContracts.SimpleToken.ownerSlot, Verity.bind, Bind.bind, Contract.run, Verity.pure, Pure.pure, ContractResult.fst, h]
+  verity_unfold isOwner
+  simp [Contracts.MacroContracts.SimpleToken.ownerSlot, h]
 
 -- Helper: unfold mint when owner guard passes and no overflow
 private theorem mint_unfold (s : ContractState) (to : Address) (amount : Uint256)
@@ -392,9 +396,8 @@ theorem transfer_reverts_recipient_overflow (s : ContractState) (to : Address) (
 theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :
   let result := ((balanceOf addr).run s).fst
   balanceOf_spec addr result s := by
-  unfold balanceOf
-  simp [balanceOf_spec, getMapping, Contracts.MacroContracts.SimpleToken.balancesSlot,
-    Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
+  verity_unfold balanceOf
+  simp [balanceOf_spec, Contracts.MacroContracts.SimpleToken.balancesSlot]
 
 theorem balanceOf_returns_balance (s : ContractState) (addr : Address) :
   let result := ((balanceOf addr).run s).fst
@@ -404,8 +407,7 @@ theorem balanceOf_returns_balance (s : ContractState) (addr : Address) :
 theorem balanceOf_preserves_state (s : ContractState) (addr : Address) :
   let s' := ((balanceOf addr).run s).snd
   s' = s := by
-  unfold balanceOf
-  simp [getMapping, Verity.bind, Bind.bind, Verity.pure, Pure.pure, Contract.run]
+  verity_unfold balanceOf
 
 theorem getTotalSupply_meets_spec (s : ContractState) :
   let result := ((getTotalSupply).run s).fst
@@ -464,7 +466,9 @@ theorem constructor_getOwner_correct (s : ContractState) (initialOwner : Address
   let s' := ((simpleTokenConstructor initialOwner).run s).snd
   let result := ((getOwner).run s').fst
   result = initialOwner := by
-  simp only [simpleTokenConstructor, getOwner, setStorageAddr, setStorage, getStorageAddr, Contracts.MacroContracts.SimpleToken.ownerSlot, Contracts.MacroContracts.SimpleToken.totalSupplySlot, Verity.bind, Bind.bind, Contract.run, ContractResult.snd, ContractResult.fst]
+  verity_unfold simpleTokenConstructor with getOwner
+  simp only [Contracts.MacroContracts.SimpleToken.ownerSlot,
+    Contracts.MacroContracts.SimpleToken.totalSupplySlot]
   rfl
 
 /-! ## Invariant Preservation -/


### PR DESCRIPTION
## Summary
- migrate several manual unfold/simp blocks in `Contracts/SimpleToken/Proofs/Basic.lean` to `verity_unfold`
- keep brittle guard-heavy revert/read lemmas unchanged where broader simp context remains more stable
- reduce boilerplate in constructor/read-path proofs while preserving proof behavior

## Changes
- `constructor_meets_spec`: replace repeated manual unfold/simp sequences with `verity_unfold simpleTokenConstructor`
- `isOwner_true_when_owner`: use `verity_unfold isOwner`
- `balanceOf_meets_spec` and `balanceOf_preserves_state`: use `verity_unfold balanceOf`
- `constructor_getOwner_correct`: use `verity_unfold simpleTokenConstructor with getOwner`

## Validation
- `lake build Contracts.SimpleToken.Proofs.Basic Contracts.SimpleToken.Proofs.Isolation`

Refs #1152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that replaces manual `unfold`/`simp` sequences with `verity_unfold`, with no runtime contract logic changes. Risk is limited to potential proof brittleness if unfolding behavior differs, but scope is localized to a few lemmas.
> 
> **Overview**
> Refactors `Contracts/SimpleToken/Proofs/Basic.lean` to use `verity_unfold` in several constructor and read-path lemmas, replacing repeated manual `unfold`/`simp` blocks.
> 
> Updates `constructor_meets_spec`, `isOwner_true_when_owner`, `balanceOf_meets_spec`/`balanceOf_preserves_state`, and `constructor_getOwner_correct` (including `verity_unfold simpleTokenConstructor with getOwner`) to reduce proof boilerplate while preserving the existing proof goals and behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e1610da5f9bf68c3b809f8f8ccce867c2b5afa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->