### PR TITLE
proofs: expand verity_frame migrations

### DIFF
--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -83,13 +83,13 @@ theorem deposit_meets_spec (s : ContractState) (amount : Uint256) :
 theorem deposit_increases_balance (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd
   s'.storageMap 0 s.sender = EVM.Uint256.add (s.storageMap 0 s.sender) amount := by
-  rw [deposit_unfold]; simp [ContractResult.snd]
+  verity_frame deposit_unfold
 
 theorem deposit_preserves_other_balances (s : ContractState) (amount : Uint256)
   (addr : Address) (h_ne : addr ≠ s.sender) :
   let s' := ((deposit amount).run s).snd
   s'.storageMap 0 addr = s.storageMap 0 addr := by
-  rw [deposit_unfold]; simp [ContractResult.snd, beq_iff_eq, h_ne]
+  verity_frame deposit_unfold with h_ne
 
 /-! ## Withdraw Correctness -/
 
@@ -135,7 +135,7 @@ theorem withdraw_decreases_balance (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
   let s' := ((withdraw amount).run s).snd
   s'.storageMap 0 s.sender = EVM.Uint256.sub (s.storageMap 0 s.sender) amount := by
-  rw [withdraw_unfold s amount h_balance]; simp [ContractResult.snd]
+  verity_frame (withdraw_unfold s amount h_balance)
 
 theorem withdraw_reverts_insufficient (s : ContractState) (amount : Uint256)
   (h_insufficient : ¬(s.storageMap 0 s.sender >= amount)) :

--- a/Contracts/Owned/Proofs/Correctness.lean
+++ b/Contracts/Owned/Proofs/Correctness.lean
@@ -42,7 +42,7 @@ theorem transferOwnership_preserves_wellformedness (s : ContractState) (newOwner
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) (h_new : newOwner ≠ 0) :
   let s' := ((transferOwnership newOwner).run s).snd
   WellFormedState s' := by
-  rw [transferOwnership_unfold s newOwner h_owner]; simp [ContractResult.snd]
+  verity_frame (transferOwnership_unfold s newOwner h_owner)
   exact ⟨h_owner ▸ h.sender_nonzero, h.contract_nonzero, h_new⟩
 
 /-! ## End-to-End Composition -/

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -240,15 +240,13 @@ theorem increment_preserves_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   let s' := (increment.run s).snd
   s'.storageAddr = s.storageAddr := by
-  rw [increment_unfold s h_owner]
-  simp [ContractResult.snd]
+  verity_frame (increment_unfold s h_owner)
 
 theorem decrement_preserves_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
   let s' := (decrement.run s).snd
   s'.storageAddr = s.storageAddr := by
-  rw [decrement_unfold s h_owner]
-  simp [ContractResult.snd]
+  verity_frame (decrement_unfold s h_owner)
 
 theorem transferOwnership_preserves_count (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :

--- a/Contracts/OwnedCounter/Proofs/Correctness.lean
+++ b/Contracts/OwnedCounter/Proofs/Correctness.lean
@@ -66,7 +66,7 @@ theorem transferOwnership_preserves_wellformedness (s : ContractState) (newOwner
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) (h_new : newOwner ≠ 0) :
   let s' := ((transferOwnership newOwner).run s).snd
   WellFormedState s' := by
-  rw [transferOwnership_unfold s newOwner h_owner]; simp [ContractResult.snd]
+  verity_frame (transferOwnership_unfold s newOwner h_owner)
   exact ⟨h_owner ▸ h.sender_nonzero, h.contract_nonzero, h_new⟩
 
 /-! ## Ownership Transfer Preserves Counter Value


### PR DESCRIPTION
## Summary
- migrate additional frame-style proof scripts from `rw [...]; simp [ContractResult.snd, ...]` to `verity_frame`
- use the `with` variant where local side-condition simp hypotheses are needed
- keep theorem statements and proof obligations unchanged

## Files
- `Contracts/Ledger/Proofs/Basic.lean`
- `Contracts/OwnedCounter/Proofs/Basic.lean`
- `Contracts/OwnedCounter/Proofs/Correctness.lean`
- `Contracts/Owned/Proofs/Correctness.lean`

## Validation
- `lake build Contracts.Ledger.Proofs.Basic Contracts.OwnedCounter.Proofs.Basic Contracts.OwnedCounter.Proofs.Correctness Contracts.Owned.Proofs.Correctness`

Refs #1153

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to refactoring Lean proof scripts (rewrites/simp) to use `verity_frame`, without modifying contract specs, theorem statements, or executable code.
> 
> **Overview**
> Refactors several contract correctness proofs to use the `verity_frame` tactic instead of manual `rw [...]` + `simp [ContractResult.snd, ...]`, including the `with` variant when local side-condition simp hypotheses are required.
> 
> Updates are confined to proof scripts in `Ledger`, `Owned`, and `OwnedCounter` theorems (e.g., deposit/withdraw balance frames and ownership/wellformedness preservation), keeping all proof goals and statements unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd28acb6f505624f9852a6bc0d46ed0e6c62ea3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->