### PR TITLE
proofs: migrate remaining frame rewrites to verity_frame

### DIFF
--- a/Contracts/Owned/Proofs/Correctness.lean
+++ b/Contracts/Owned/Proofs/Correctness.lean
@@ -67,7 +67,7 @@ theorem transferred_owner_cannot_act (s : ContractState) (newOwner : Address)
   ∃ msg, (transferOwnership 42).run s' = ContractResult.revert msg s' := by
   have h_ne' : ((transferOwnership newOwner).run s).snd.sender ≠
       ((transferOwnership newOwner).run s).snd.storageAddr 0 := by
-    rw [transferOwnership_unfold s newOwner h_owner]; simp [ContractResult.snd, h_ne]
+    verity_frame (transferOwnership_unfold s newOwner h_owner) with h_ne
   exact transferOwnership_reverts_when_not_owner _ _ h_ne'
 
 /-! ## Summary

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -270,14 +270,14 @@ theorem increment_preserves_wellformedness (s : ContractState)
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) :
   let s' := (increment.run s).snd
   WellFormedState s' := by
-  rw [increment_unfold s h_owner]; simp [ContractResult.snd]
+  verity_frame (increment_unfold s h_owner)
   exact ⟨h.sender_nonzero, h.contract_nonzero, h.owner_nonzero⟩
 
 theorem decrement_preserves_wellformedness (s : ContractState)
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) :
   let s' := (decrement.run s).snd
   WellFormedState s' := by
-  rw [decrement_unfold s h_owner]; simp [ContractResult.snd]
+  verity_frame (decrement_unfold s h_owner)
   exact ⟨h.sender_nonzero, h.contract_nonzero, h.owner_nonzero⟩
 
 /-! ## Composition Sequence: constructor → increment → getCount -/


### PR DESCRIPTION
## Summary
- migrate remaining manual frame rewrite/simp patterns to `verity_frame` in:
  - `Contracts/OwnedCounter/Proofs/Basic.lean`
  - `Contracts/Owned/Proofs/Correctness.lean`
- use `verity_frame ... with ...` for the local side-condition case (`h_ne`)

## Details
- `increment_preserves_wellformedness`: `rw + simp` -> `verity_frame (increment_unfold s h_owner)`
- `decrement_preserves_wellformedness`: `rw + simp` -> `verity_frame (decrement_unfold s h_owner)`
- `transferred_owner_cannot_act`: local helper proof uses
  - `verity_frame (transferOwnership_unfold s newOwner h_owner) with h_ne`

## Validation
- `lake build Contracts.OwnedCounter.Proofs.Basic Contracts.Owned.Proofs.Correctness`
- `lake build Contracts.OwnedCounter.Proofs.Correctness Contracts.Owned.Proofs.Basic`

Closes #1153 (incremental).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk proof refactor: replaces manual `rw`/`simp` state-framing steps with `verity_frame`, without changing contract code or theorem statements. Main risk is proof brittleness if `verity_frame` behavior/regressions differ from the prior rewrite/simp patterns.
> 
> **Overview**
> **Proof refactor:** migrates a few remaining manual frame `rw`/`simp` patterns to `verity_frame` in `Contracts/OwnedCounter/Proofs/Basic.lean` (well-formedness preservation for `increment`/`decrement`) and `Contracts/Owned/Proofs/Correctness.lean` (helper step in `transferred_owner_cannot_act`).
> 
> Uses `verity_frame ... with ...` to discharge a local side-condition (`h_ne`) while framing the post-state, standardizing proof style across these theorems.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aea1eff612c40e29d579a5b9514e55a3996306a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->