### PR TITLE
Proofs: migrate remaining frame rewrites to verity_frame

### DIFF
--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -252,8 +252,7 @@ theorem transferOwnership_preserves_count (s : ContractState) (newOwner : Addres
   (h_owner : s.sender = s.storageAddr 0) :
   let s' := ((transferOwnership newOwner).run s).snd
   s'.storage = s.storage := by
-  rw [transferOwnership_unfold s newOwner h_owner]
-  simp [ContractResult.snd]
+  verity_frame (transferOwnership_unfold s newOwner h_owner)
 
 /-! ## Well-Formedness Preservation -/
 
@@ -270,14 +269,14 @@ theorem increment_preserves_wellformedness (s : ContractState)
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) :
   let s' := (increment.run s).snd
   WellFormedState s' := by
-  rw [increment_unfold s h_owner]; simp [ContractResult.snd]
+  verity_frame (increment_unfold s h_owner)
   exact ⟨h.sender_nonzero, h.contract_nonzero, h.owner_nonzero⟩
 
 theorem decrement_preserves_wellformedness (s : ContractState)
   (h : WellFormedState s) (h_owner : s.sender = s.storageAddr 0) :
   let s' := (decrement.run s).snd
   WellFormedState s' := by
-  rw [decrement_unfold s h_owner]; simp [ContractResult.snd]
+  verity_frame (decrement_unfold s h_owner)
   exact ⟨h.sender_nonzero, h.contract_nonzero, h.owner_nonzero⟩
 
 /-! ## Composition Sequence: constructor → increment → getCount -/


### PR DESCRIPTION
## Summary
This is an incremental follow-up for #1153 that migrates remaining frame-style proof steps from manual:
- `rw [.._unfold ..]; simp [ContractResult.snd]`

to:
- `verity_frame (.._unfold ..)`

## Changes
- `Contracts/Ledger/Proofs/Basic.lean`
  - `deposit_increases_balance`
  - `withdraw_decreases_balance`
- `Contracts/Owned/Proofs/Correctness.lean`
  - `transferOwnership_preserves_wellformedness`
- `Contracts/OwnedCounter/Proofs/Basic.lean`
  - `increment_preserves_owner`
  - `decrement_preserves_owner`
  - `transferOwnership_preserves_count`
  - `increment_preserves_wellformedness`
  - `decrement_preserves_wellformedness`
- `Contracts/OwnedCounter/Proofs/Correctness.lean`
  - `transferOwnership_preserves_wellformedness`

No semantic changes; this reduces repetitive boilerplate and standardizes frame discharge.

## Validation
- `lake build Contracts.Ledger.Proofs.Basic Contracts.Owned.Proofs.Correctness Contracts.OwnedCounter.Proofs.Basic Contracts.OwnedCounter.Proofs.Correctness`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk proof-only refactor that replaces `rw`/`simp` boilerplate with `verity_frame`; no contract semantics or specs change.
> 
> **Overview**
> Migrates a few remaining `OwnedCounter` correctness lemmas from manual `rw [..._unfold]; simp` framing to the standardized `verity_frame` tactic (notably `transferOwnership_preserves_count`, `increment_preserves_wellformedness`, and `decrement_preserves_wellformedness`).
> 
> This is a proof-maintenance cleanup that reduces repetitive boilerplate while keeping the proved statements and contract behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d37b1e54d1b1186c0b95201bcff72096e5a8fde7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->