### PR TITLE
Add verity_spec tactic and migrate spec proof PoC

### DIFF
--- a/Contracts/Counter/Proofs/Basic.lean
+++ b/Contracts/Counter/Proofs/Basic.lean
@@ -102,8 +102,7 @@ theorem decrement_subtracts_one (s : ContractState) :
 theorem getCount_meets_spec (s : ContractState) :
   let result := ((getCount).run s).fst
   getCount_spec result s := by
-  verity_unfold getCount
-  simp [count, getCount_spec]
+  verity_spec getCount_spec unfold getCount with count
 
 theorem getCount_reads_count_value (s : ContractState) :
   let result := ((getCount).run s).fst

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -64,8 +64,7 @@ private theorem getCount_run (s : ContractState) :
 theorem getCount_meets_spec (s : ContractState) :
   let result := ((getCount).run s).fst
   getCount_spec result s := by
-  rw [getCount_run s]
-  simp [getCount_spec]
+  verity_spec getCount_spec using (getCount_run s)
 
 theorem getCount_returns_count (s : ContractState) :
   ((getCount).run s).fst = s.storage 1 := by
@@ -85,8 +84,7 @@ private theorem getOwner_run (s : ContractState) :
 theorem getOwner_meets_spec (s : ContractState) :
   let result := ((getOwner).run s).fst
   getOwner_spec result s := by
-  rw [getOwner_run s]
-  simp [getOwner_spec]
+  verity_spec getOwner_spec using (getOwner_run s)
 
 theorem getOwner_returns_owner (s : ContractState) :
   ((getOwner).run s).fst = s.storageAddr 0 := by

--- a/Contracts/SimpleStorage/Proofs/Basic.lean
+++ b/Contracts/SimpleStorage/Proofs/Basic.lean
@@ -83,8 +83,7 @@ theorem store_meets_spec (s : ContractState) (value : Uint256) :
 theorem retrieve_meets_spec (s : ContractState) :
   let result := ((retrieve).run s).fst
   retrieve_spec result s := by
-  verity_unfold retrieve
-  simp [storedData, retrieve_spec]
+  verity_spec retrieve_spec unfold retrieve with storedData
 
 -- Main theorem: store then retrieve returns the stored value
 -- This is the key correctness property!

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -77,6 +77,22 @@ syntax (name := verity_frame)
 syntax (name := verity_frame_with)
   "verity_frame " rwRule " with " simpLemma : tactic
 
+/-- Spec-proof helper: rewrite via an unfold lemma, then discharge standard spec goals. -/
+syntax (name := verity_spec_using)
+  "verity_spec " simpLemma " using " rwRule : tactic
+
+/-- `verity_spec` with an extra local simp lemma for contract-specific slots/fields. -/
+syntax (name := verity_spec_using_with)
+  "verity_spec " simpLemma " using " rwRule " with " simpLemma : tactic
+
+/-- Spec-proof helper: unfold a function with `verity_unfold`, then discharge spec goals. -/
+syntax (name := verity_spec_unfold)
+  "verity_spec " simpLemma " unfold " simpLemma : tactic
+
+/-- `verity_spec` unfold-mode with an extra local simp lemma. -/
+syntax (name := verity_spec_unfold_with)
+  "verity_spec " simpLemma " unfold " simpLemma " with " simpLemma : tactic
+
 macro_rules
   | `(tactic| verity_unfold $fn:simpLemma) =>
       `(tactic| simp only [
@@ -97,6 +113,40 @@ macro_rules
       `(tactic| (rw [$h]; simp [ContractResult.snd]))
   | `(tactic| verity_frame $h:rwRule with $extra:simpLemma) =>
       `(tactic| (rw [$h]; simp [ContractResult.snd, $extra]))
+  | `(tactic| verity_spec $spec:simpLemma using $h:rwRule) =>
+      `(tactic|
+        (rw [$h]
+         simp [$spec, ContractResult.snd]
+         try (intro slotIdx h_neq; simp [h_neq])
+         try (intro n h_neq; simp [h_neq])))
+  | `(tactic| verity_spec $spec:simpLemma using $h:rwRule with $extra:simpLemma) =>
+      `(tactic|
+        (rw [$h]
+         simp [$spec, ContractResult.snd, $extra]
+         try (intro slotIdx h_neq; simp [h_neq])
+         try (intro n h_neq; simp [h_neq])))
+  | `(tactic| verity_spec $spec:simpLemma unfold $fn:simpLemma) =>
+      `(tactic|
+        (simp only [
+           $fn, msgSender, getStorageAddr, getStorage, setStorage, setStorageAddr,
+           getMapping, setMapping, setMapping2, getMappingUint, setMappingUint, getMapping2,
+           Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
+           Contract.run, ContractResult.snd, ContractResult.fst
+         ]
+         simp [$spec, ContractResult.snd]
+         try (intro slotIdx h_neq; simp [h_neq])
+         try (intro n h_neq; simp [h_neq])))
+  | `(tactic| verity_spec $spec:simpLemma unfold $fn:simpLemma with $extra:simpLemma) =>
+      `(tactic|
+        (simp only [
+           $fn, msgSender, getStorageAddr, getStorage, setStorage, setStorageAddr,
+           getMapping, setMapping, setMapping2, getMappingUint, setMappingUint, getMapping2,
+           Verity.require, Verity.pure, Verity.bind, Bind.bind, Pure.pure,
+           Contract.run, ContractResult.snd, ContractResult.fst, $extra
+         ]
+         simp [$spec, ContractResult.snd, $extra]
+         try (intro slotIdx h_neq; simp [h_neq])
+         try (intro n h_neq; simp [h_neq])))
 
 /-!
 ## Index Normalization Helpers


### PR DESCRIPTION
## Summary
- add new `verity_spec` tactic in `Verity.Proofs.Stdlib.Automation` with two usage modes:
  - `verity_spec <spec> using <rw-lemma>`
  - `verity_spec <spec> unfold <fn>`
- migrate proof-of-concept `*_meets_spec` theorems across three contracts:
  - `Contracts/Counter/Proofs/Basic.lean`: `getCount_meets_spec`
  - `Contracts/SimpleStorage/Proofs/Basic.lean`: `retrieve_meets_spec`
  - `Contracts/OwnedCounter/Proofs/Basic.lean`: `getCount_meets_spec`, `getOwner_meets_spec`

## Why
Issue #1154 asks for a reusable spec-discharge tactic and migration proof-of-concept across Counter, SimpleStorage, and OwnedCounter. This PR adds the tactic and migrates representative spec theorems in each target contract while keeping existing complex conjunct-style proofs unchanged.

## Validation
- `lake build Verity.Proofs.Stdlib.Automation Contracts.Counter.Proofs.Basic Contracts.SimpleStorage.Proofs.Basic Contracts.OwnedCounter.Proofs.Basic Contracts.Counter.Proofs.Correctness Contracts.SimpleStorage.Proofs.Correctness Contracts.OwnedCounter.Proofs.Correctness`

Closes #1154

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Lean proof automation and a small refactor of a few `*_meets_spec` theorems, with no impact on compiled contract behavior.
> 
> **Overview**
> Adds a new proof-automation tactic, `verity_spec`, to `Verity/Proofs/Stdlib/Automation.lean` to standardize spec-discharge patterns, supporting both *rewrite-from-unfold-lemma* and *unfold-and-simp* modes (optionally with extra simp lemmas).
> 
> Migrates a proof-of-concept set of spec-correctness theorems to use `verity_spec` (`Counter.getCount_meets_spec`, `SimpleStorage.retrieve_meets_spec`, and `OwnedCounter.getCount_meets_spec`/`getOwner_meets_spec`), replacing the prior manual `verity_unfold`/`rw`/`simp` steps with the new tactic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2582ef360ece890e89291dba1a7a82d82b497f55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->