### PR TITLE
feat(proofs): add verity_spec helper and migrate basic spec proofs

### DIFF
--- a/Contracts/Counter/Proofs/Basic.lean
+++ b/Contracts/Counter/Proofs/Basic.lean
@@ -62,15 +62,10 @@ theorem setStorage_preserves_map_storage (s : ContractState) (value : Uint256) :
 theorem increment_meets_spec (s : ContractState) :
   let s' := ((increment).run s).snd
   increment_spec s s' := by
-  refine ⟨?_, ?_, ?_⟩
-  · rfl
-  · intro slotIdx h_neq
-    verity_unfold increment
-    simp [count]
-    intro h_eq
-    exact (h_neq h_eq).elim
-  · verity_unfold increment
-    simp [Specs.sameAddrMapContext, Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap]
+  verity_unfold increment
+  verity_spec increment_spec with count
+  intro slotIdx h_neq
+  simp [h_neq]
 
 theorem increment_adds_one (s : ContractState) :
   let s' := ((increment).run s).snd
@@ -82,15 +77,10 @@ theorem increment_adds_one (s : ContractState) :
 theorem decrement_meets_spec (s : ContractState) :
   let s' := ((decrement).run s).snd
   decrement_spec s s' := by
-  refine ⟨?_, ?_, ?_⟩
-  · rfl
-  · intro slotIdx h_neq
-    verity_unfold decrement
-    simp [count]
-    intro h_eq
-    exact (h_neq h_eq).elim
-  · verity_unfold decrement
-    simp [Specs.sameAddrMapContext, Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap]
+  verity_unfold decrement
+  verity_spec decrement_spec with count
+  intro slotIdx h_neq
+  simp [h_neq]
 
 theorem decrement_subtracts_one (s : ContractState) :
   let s' := ((decrement).run s).snd

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -128,8 +128,7 @@ theorem increment_meets_spec_when_owner (s : ContractState)
   let s' := (increment.run s).snd
   increment_spec s s' := by
   rw [increment_unfold s h_owner]
-  simp [increment_spec, ContractResult.snd, Specs.sameAddrMapContext,
-    Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap]
+  verity_spec increment_spec
   intro slotIdx h_neq
   simp [h_neq]
 
@@ -170,8 +169,7 @@ theorem decrement_meets_spec_when_owner (s : ContractState)
   let s' := (decrement.run s).snd
   decrement_spec s s' := by
   rw [decrement_unfold s h_owner]
-  simp [decrement_spec, ContractResult.snd, Specs.sameAddrMapContext,
-    Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap]
+  verity_spec decrement_spec
   intro slotIdx h_neq
   simp [h_neq]
 
@@ -211,8 +209,7 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   let s' := ((transferOwnership newOwner).run s).snd
   transferOwnership_spec newOwner s s' := by
   rw [transferOwnership_unfold s newOwner h_owner]
-  simp [transferOwnership_spec, ContractResult.snd, Specs.sameStorageMapContext,
-    Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
+  verity_spec transferOwnership_spec
   intro slotIdx h_neq
   simp [h_neq]
 

--- a/Contracts/SimpleStorage/Proofs/Basic.lean
+++ b/Contracts/SimpleStorage/Proofs/Basic.lean
@@ -74,8 +74,7 @@ theorem store_meets_spec (s : ContractState) (value : Uint256) :
   let s' := ((store value).run s).snd
   store_spec value s s' := by
   verity_unfold store
-  simp [storedData, store_spec, Specs.sameAddrMapContext,
-    Specs.sameContext, Specs.sameStorageAddr, Specs.sameStorageMap]
+  verity_spec store_spec with storedData
   intro slotIdx h_neq
   simp [h_neq]
 

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -24,6 +24,7 @@
 -/
 
 import Verity.Core
+import Verity.Specs.Common
 import Verity.Stdlib.Math
 import Verity.EVM.Uint256
 import Compiler.CompilationModel
@@ -93,6 +94,14 @@ syntax (name := verity_spec_unfold)
 syntax (name := verity_spec_unfold_with)
   "verity_spec " simpLemma " unfold " simpLemma " with " simpLemma : tactic
 
+/-- Discharge a common `*_meets_spec` goal after unfolding/rewrite setup. -/
+syntax (name := verity_spec)
+  "verity_spec " simpLemma : tactic
+
+/-- `verity_spec` with one extra simp lemma. -/
+syntax (name := verity_spec_with)
+  "verity_spec " simpLemma " with " simpLemma : tactic
+
 macro_rules
   | `(tactic| verity_unfold $fn:simpLemma) =>
       `(tactic| simp only [
@@ -147,6 +156,18 @@ macro_rules
          simp [$spec, ContractResult.snd, $extra]
          try (intro slotIdx h_neq; simp [h_neq])
          try (intro n h_neq; simp [h_neq])))
+
+macro "verity_spec " spec:simpLemma : tactic =>
+  `(tactic|
+    (simp [$spec, ContractResult.snd, Verity.Specs.sameAddrMapContext,
+      Verity.Specs.sameStorageMapContext, Verity.Specs.sameContext, Verity.Specs.sameStorage,
+      Verity.Specs.sameStorageAddr, Verity.Specs.sameStorageMap]))
+
+macro "verity_spec " spec:simpLemma " with " extra:simpLemma : tactic =>
+  `(tactic|
+    (simp [$spec, ContractResult.snd, Verity.Specs.sameAddrMapContext,
+      Verity.Specs.sameStorageMapContext, Verity.Specs.sameContext, Verity.Specs.sameStorage,
+      Verity.Specs.sameStorageAddr, Verity.Specs.sameStorageMap, $extra]))
 
 /-!
 ## Index Normalization Helpers


### PR DESCRIPTION
## Summary
- add `verity_spec` helper tactics in `Verity.Proofs.Stdlib.Automation`
  - `verity_spec <spec>`
  - `verity_spec <spec> with <extra-simp-lemma>`
- migrate representative `*_meets_spec` proofs across three contracts:
  - `Contracts/Counter/Proofs/Basic.lean`
  - `Contracts/SimpleStorage/Proofs/Basic.lean`
  - `Contracts/OwnedCounter/Proofs/Basic.lean`
- remove repeated inline spec-discharge simp blocks and replace with shared automation

## Validation
- `lake build Verity.Proofs.Stdlib.Automation Contracts.Counter.Proofs.Basic Contracts.SimpleStorage.Proofs.Basic Contracts.OwnedCounter.Proofs.Basic`
- `python3 scripts/check_verify_sync.py`
- `make check`

Closes #1154

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Lean proof automation and refactors existing `*_meets_spec` proofs; main risk is minor proof fragility if the new simp set is too broad or missing lemmas.
> 
> **Overview**
> Introduces a new `verity_spec` tactic (and `with` variant) in `Verity/Proofs/Stdlib/Automation.lean` to discharge the common “meets spec” goals by centralizing the standard `simp` set for `Specs.same*` obligations.
> 
> Updates representative proofs in `Contracts/Counter/Proofs/Basic.lean`, `Contracts/SimpleStorage/Proofs/Basic.lean`, and `Contracts/OwnedCounter/Proofs/Basic.lean` to replace repeated inline spec-discharge `simp` blocks with the shared `verity_spec` helper after `verity_unfold`/rewrite setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95ddb011b537b08e5c91a4829f95f7e6671d084d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->