### PR TITLE
SemanticBridge: add shared simp tactic and migrate bridge proofs

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -32,6 +32,7 @@ import Compiler.Proofs.EndToEnd
 import Compiler.Specs
 import Verity.Core
 import Contracts.MacroContracts.Core
+import Lean
 
 namespace Compiler.Proofs.SemanticBridge
 
@@ -40,6 +41,35 @@ open Compiler.Proofs.IRGeneration
 open Compiler.Proofs.YulGeneration
 open Verity
 open Verity.Core.Uint256
+open Lean Parser Tactic
+
+/-! ## Bridge Tactic Helpers -/
+
+/-- Canonical `simp` bundle for SemanticBridge IR execution unfolding. -/
+syntax (name := semantic_bridge_simp) "semantic_bridge_simp" : tactic
+
+/-- `semantic_bridge_simp` with extra local unfold/simp terms. -/
+syntax (name := semantic_bridge_simp_with)
+  "semantic_bridge_simp [" term,* "]" : tactic
+
+macro_rules
+  | `(tactic| semantic_bridge_simp) =>
+      `(tactic| simp [
+        mkIRTransaction, mkIRState, interpretIR,
+        execIRFunction, execIRStmts, execIRStmt,
+        evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
+        Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
+        Compiler.Proofs.YulGeneration.evalBuiltinCall, encodeEvents
+      ])
+  | `(tactic| semantic_bridge_simp [$[$extra:term],*]) =>
+      `(tactic| simp [
+        mkIRTransaction, mkIRState, interpretIR,
+        execIRFunction, execIRStmts, execIRStmt,
+        evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
+        Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
+        Compiler.Proofs.YulGeneration.evalBuiltinCall, encodeEvents,
+        $[$extra],*
+      ])
 
 /-! ## State Encoding
 
@@ -193,12 +223,8 @@ theorem simpleStorage_retrieve_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.SimpleStorage.retrieve,
-    Contracts.MacroContracts.SimpleStorage.storedData,
-    mkIRTransaction, mkIRState, interpretIR, simpleStorageIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeStorage, encodeEvents]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SimpleStorage.retrieve,
+    Contracts.MacroContracts.SimpleStorage.storedData, simpleStorageIRContract, encodeStorage]
 
 /-! ## Target Theorems: Counter -/
 
@@ -216,15 +242,9 @@ theorem counter_increment_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.Counter.increment,
-    Contracts.MacroContracts.Counter.count,
-    getStorage, setStorage, add,
-    mkIRTransaction, mkIRState, interpretIR, counterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.Counter.increment,
+    Contracts.MacroContracts.Counter.count, getStorage, setStorage, add,
+    counterIRContract, encodeStorage]
 
 theorem counter_decrement_semantic_bridge
     (state : ContractState) (sender : Address) :
@@ -241,15 +261,9 @@ theorem counter_decrement_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.Counter.decrement,
-    Contracts.MacroContracts.Counter.count,
-    getStorage, setStorage, sub,
-    mkIRTransaction, mkIRState, interpretIR, counterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.Counter.decrement,
+    Contracts.MacroContracts.Counter.count, getStorage, setStorage, sub,
+    counterIRContract, encodeStorage]
 
 theorem counter_getCount_semantic_bridge
     (state : ContractState) (sender : Address) :
@@ -267,15 +281,8 @@ theorem counter_getCount_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.Counter.getCount,
-    Contracts.MacroContracts.Counter.count,
-    getStorage,
-    mkIRTransaction, mkIRState, interpretIR, counterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.Counter.getCount,
+    Contracts.MacroContracts.Counter.count, getStorage, counterIRContract, encodeStorage]
 
 /-! ## Target Theorems: Owned -/
 
@@ -298,14 +305,8 @@ theorem owned_getOwner_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.Owned.getOwner,
-    getStorageAddr,
-    mkIRTransaction, mkIRState, interpretIR, ownedIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeStorageAddr, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.Owned.getOwner,
+    getStorageAddr, ownedIRContract, encodeStorageAddr]
 
 theorem owned_transferOwnership_semantic_bridge
     (state : ContractState) (sender : Address) (newOwner : Address)
@@ -324,15 +325,9 @@ theorem owned_transferOwnership_semantic_bridge
     | .revert _ _ => True
     := by
   subst hOwner
-  simp [Contract.run, Contracts.MacroContracts.Owned.transferOwnership,
-    Contracts.MacroContracts.Owned.owner,
-    getStorageAddr, setStorageAddr,
-    mkIRTransaction, mkIRState, interpretIR, ownedIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeStorageAddr, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.Owned.transferOwnership,
+    Contracts.MacroContracts.Owned.owner, getStorageAddr, setStorageAddr,
+    ownedIRContract, encodeStorageAddr]
 
 /-! ## Target Theorems: SafeCounter -/
 


### PR DESCRIPTION
## Summary
Progress on #1165 (semantic-bridge proof boilerplate reduction).

This PR introduces a small tactic macro that centralizes the repeated IR-unfold simp bundle used across SemanticBridge proofs, then migrates representative theorem proofs to it.

### What changed
- Added `semantic_bridge_simp` and `semantic_bridge_simp [..extras..]` in:
  - `Compiler/Proofs/SemanticBridge.lean`
- Migrated 6 bridge theorems to the new helper:
  - `simpleStorage_retrieve_semantic_bridge`
  - `counter_increment_semantic_bridge`
  - `counter_decrement_semantic_bridge`
  - `counter_getCount_semantic_bridge`
  - `owned_getOwner_semantic_bridge`
  - `owned_transferOwnership_semantic_bridge`

## Why this helps (#1165)
Issue #1165 calls out repeated per-theorem proof boilerplate and asks for macro/tactic support. This is an incremental step that:
- reduces repetitive unfold/simp lists,
- makes per-function bridge proofs shorter and easier to maintain,
- provides a reusable tactic entry point for further macro/template work.

## Validation
Attempted locally:
- `lake build Compiler.Proofs.SemanticBridge`

Current checkout fails in an existing unrelated dependency during the build:
- `Compiler/Proofs/YulGeneration/Preservation.lean:241:51` (unsolved goals)

So I could not complete full local `make check` verification from this workspace snapshot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: proof-only refactor that centralizes repeated `simp` unfold lists; main risk is build breakage if the new simp set misses lemmas or changes simp behavior.
> 
> **Overview**
> Introduces `semantic_bridge_simp` (and an extra-args variant) to centralize the long `simp` bundle used to unfold IR execution in semantic-bridge proofs.
> 
> Migrates the `SimpleStorage.retrieve`, `Counter` (`increment`/`decrement`/`getCount`), and `Owned` (`getOwner`/`transferOwnership`) bridge theorems to use the new tactic, reducing per-theorem proof boilerplate without changing the theorem statements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0062d757173be74fc5bbb95fe0f5d8c734751b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->