### PR TITLE
proofs: adopt semantic_bridge_simp across remaining bridge theorems

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -349,24 +349,14 @@ theorem safeCounter_increment_semantic_bridge
         irResult.success = false
     := by
   by_cases hOverflow : state.storage 0 = (Uint256.max)
-  · simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
+  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
       Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
       requireSomeUint, safeAdd, Uint256.max, hOverflow,
-      mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-      execIRFunction, execIRStmts, execIRStmt,
-      evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-      encodeStorage, encodeEvents,
-      Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-      Compiler.Proofs.YulGeneration.evalBuiltinCall]
-  · simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
+      safeCounterIRContract, encodeStorage]
+  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
       Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
       requireSomeUint, safeAdd, Uint256.max, hOverflow,
-      mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-      execIRFunction, execIRStmts, execIRStmt,
-      evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-      encodeStorage, encodeEvents,
-      Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-      Compiler.Proofs.YulGeneration.evalBuiltinCall]
+      safeCounterIRContract, encodeStorage]
 
 theorem safeCounter_decrement_semantic_bridge
     (state : ContractState) (sender : Address) :
@@ -386,24 +376,14 @@ theorem safeCounter_decrement_semantic_bridge
         irResult.success = false
     := by
   by_cases hUnderflow : state.storage 0 = 0
-  · simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
+  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
       Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
       requireSomeUint, safeSub, hUnderflow,
-      mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-      execIRFunction, execIRStmts, execIRStmt,
-      evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-      encodeStorage, encodeEvents,
-      Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-      Compiler.Proofs.YulGeneration.evalBuiltinCall]
-  · simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
+      safeCounterIRContract, encodeStorage]
+  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
       Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
       requireSomeUint, safeSub, hUnderflow,
-      mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-      execIRFunction, execIRStmts, execIRStmt,
-      evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-      encodeStorage, encodeEvents,
-      Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-      Compiler.Proofs.YulGeneration.evalBuiltinCall]
+      safeCounterIRContract, encodeStorage]
 
 theorem safeCounter_getCount_semantic_bridge
     (state : ContractState) (sender : Address) :
@@ -421,15 +401,9 @@ theorem safeCounter_getCount_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.SafeCounter.getCount,
-    Contracts.MacroContracts.SafeCounter.count,
-    getStorage,
-    mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.getCount,
+    Contracts.MacroContracts.SafeCounter.count, getStorage,
+    safeCounterIRContract, encodeStorage]
 
 /-! ## Target Theorems: OwnedCounter -/
 
@@ -456,15 +430,9 @@ theorem ownedCounter_getCount_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.getCount,
-    Contracts.MacroContracts.OwnedCounter.count,
-    getStorage,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.getCount,
+    Contracts.MacroContracts.OwnedCounter.count, getStorage,
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 theorem ownedCounter_getOwner_semantic_bridge
     (state : ContractState) (sender : Address) :
@@ -483,15 +451,9 @@ theorem ownedCounter_getOwner_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.getOwner,
-    Contracts.MacroContracts.OwnedCounter.owner,
-    getStorageAddr,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.getOwner,
+    Contracts.MacroContracts.OwnedCounter.owner, getStorageAddr,
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 theorem ownedCounter_increment_semantic_bridge
     (state : ContractState) (sender : Address)
@@ -511,16 +473,10 @@ theorem ownedCounter_increment_semantic_bridge
     | .revert _ _ => True
     := by
   subst hOwner
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.increment,
-    Contracts.MacroContracts.OwnedCounter.owner,
-    Contracts.MacroContracts.OwnedCounter.count,
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.increment,
+    Contracts.MacroContracts.OwnedCounter.owner, Contracts.MacroContracts.OwnedCounter.count,
     getStorageAddr, getStorage, setStorage,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 theorem ownedCounter_decrement_semantic_bridge
     (state : ContractState) (sender : Address)
@@ -540,16 +496,10 @@ theorem ownedCounter_decrement_semantic_bridge
     | .revert _ _ => True
     := by
   subst hOwner
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.decrement,
-    Contracts.MacroContracts.OwnedCounter.owner,
-    Contracts.MacroContracts.OwnedCounter.count,
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.decrement,
+    Contracts.MacroContracts.OwnedCounter.owner, Contracts.MacroContracts.OwnedCounter.count,
     getStorageAddr, getStorage, setStorage,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 theorem ownedCounter_transferOwnership_semantic_bridge
     (state : ContractState) (sender : Address) (newOwner : Address)
@@ -569,15 +519,9 @@ theorem ownedCounter_transferOwnership_semantic_bridge
     | .revert _ _ => True
     := by
   subst hOwner
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.transferOwnership,
-    Contracts.MacroContracts.OwnedCounter.owner,
-    getStorageAddr, setStorageAddr,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.transferOwnership,
+    Contracts.MacroContracts.OwnedCounter.owner, getStorageAddr, setStorageAddr,
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 /-! ## Composed End-to-End: EDSL → IR → Yul -/
 


### PR DESCRIPTION
## Summary
- continues #1165 by expanding `semantic_bridge_simp` usage across remaining repetitive semantic-bridge proofs
- replaces repeated large `simp` blocks in `Compiler/Proofs/SemanticBridge.lean` with the shared bridge tactic
- keeps theorem statements/behavior unchanged while reducing boilerplate and maintenance cost

## What changed
- migrated these proofs to `semantic_bridge_simp [...]`:
  - `safeCounter_increment_semantic_bridge` (both overflow branches)
  - `safeCounter_decrement_semantic_bridge` (both underflow branches)
  - `safeCounter_getCount_semantic_bridge`
  - `ownedCounter_getCount_semantic_bridge`
  - `ownedCounter_getOwner_semantic_bridge`
  - `ownedCounter_increment_semantic_bridge`
  - `ownedCounter_decrement_semantic_bridge`
  - `ownedCounter_transferOwnership_semantic_bridge`

## Validation
- `python3 scripts/check_verify_sync.py`
- `make check`
- attempted: `lake build Compiler.Proofs.SemanticBridge`
  - blocked by existing upstream failure in `Compiler/Proofs/YulGeneration/Preservation.lean` (`execBuildSwitch_none_none_aux` unsolved goals), unrelated to this refactor

Refs #1165

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors proof scripts only by replacing large `simp` unfold lists with a shared tactic, so runtime semantics are unchanged; risk is limited to proof fragility/compilation in `SemanticBridge.lean`.
> 
> **Overview**
> **Refactors semantic-bridge proofs to reduce boilerplate.** The SafeCounter and OwnedCounter bridge theorems now use `semantic_bridge_simp [...]` instead of repeating long `simp` unfold lists (including both overflow/underflow branches).
> 
> The theorem statements/behavior stay the same; this primarily centralizes the IR/Yul unfolding set and trims per-proof arguments (e.g., passing `safeCounterIRContract`/`ownedCounterIRContract` and the relevant storage encoding functions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 569922feb936defafe5a2545d9d51eef50089236. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->