### PR TITLE
proof: migrate more SemanticBridge theorems to semantic_bridge_simp

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -349,24 +349,14 @@ theorem safeCounter_increment_semantic_bridge
         irResult.success = false
     := by
   by_cases hOverflow : state.storage 0 = (Uint256.max)
-  · simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
+  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
       Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
       requireSomeUint, safeAdd, Uint256.max, hOverflow,
-      mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-      execIRFunction, execIRStmts, execIRStmt,
-      evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-      encodeStorage, encodeEvents,
-      Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-      Compiler.Proofs.YulGeneration.evalBuiltinCall]
-  · simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
+      safeCounterIRContract, encodeStorage]
+  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
       Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
       requireSomeUint, safeAdd, Uint256.max, hOverflow,
-      mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-      execIRFunction, execIRStmts, execIRStmt,
-      evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-      encodeStorage, encodeEvents,
-      Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-      Compiler.Proofs.YulGeneration.evalBuiltinCall]
+      safeCounterIRContract, encodeStorage]
 
 theorem safeCounter_decrement_semantic_bridge
     (state : ContractState) (sender : Address) :
@@ -386,24 +376,14 @@ theorem safeCounter_decrement_semantic_bridge
         irResult.success = false
     := by
   by_cases hUnderflow : state.storage 0 = 0
-  · simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
+  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
       Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
       requireSomeUint, safeSub, hUnderflow,
-      mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-      execIRFunction, execIRStmts, execIRStmt,
-      evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-      encodeStorage, encodeEvents,
-      Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-      Compiler.Proofs.YulGeneration.evalBuiltinCall]
-  · simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
+      safeCounterIRContract, encodeStorage]
+  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
       Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
       requireSomeUint, safeSub, hUnderflow,
-      mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-      execIRFunction, execIRStmts, execIRStmt,
-      evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-      encodeStorage, encodeEvents,
-      Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-      Compiler.Proofs.YulGeneration.evalBuiltinCall]
+      safeCounterIRContract, encodeStorage]
 
 theorem safeCounter_getCount_semantic_bridge
     (state : ContractState) (sender : Address) :
@@ -421,15 +401,10 @@ theorem safeCounter_getCount_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.SafeCounter.getCount,
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.getCount,
     Contracts.MacroContracts.SafeCounter.count,
     getStorage,
-    mkIRTransaction, mkIRState, interpretIR, safeCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+    safeCounterIRContract, encodeStorage]
 
 /-! ## Target Theorems: OwnedCounter -/
 
@@ -456,15 +431,10 @@ theorem ownedCounter_getCount_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.getCount,
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.getCount,
     Contracts.MacroContracts.OwnedCounter.count,
     getStorage,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 theorem ownedCounter_getOwner_semantic_bridge
     (state : ContractState) (sender : Address) :
@@ -483,15 +453,10 @@ theorem ownedCounter_getOwner_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.getOwner,
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.getOwner,
     Contracts.MacroContracts.OwnedCounter.owner,
     getStorageAddr,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 theorem ownedCounter_increment_semantic_bridge
     (state : ContractState) (sender : Address)
@@ -511,16 +476,11 @@ theorem ownedCounter_increment_semantic_bridge
     | .revert _ _ => True
     := by
   subst hOwner
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.increment,
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.increment,
     Contracts.MacroContracts.OwnedCounter.owner,
     Contracts.MacroContracts.OwnedCounter.count,
     getStorageAddr, getStorage, setStorage,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 theorem ownedCounter_decrement_semantic_bridge
     (state : ContractState) (sender : Address)
@@ -540,16 +500,11 @@ theorem ownedCounter_decrement_semantic_bridge
     | .revert _ _ => True
     := by
   subst hOwner
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.decrement,
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.decrement,
     Contracts.MacroContracts.OwnedCounter.owner,
     Contracts.MacroContracts.OwnedCounter.count,
     getStorageAddr, getStorage, setStorage,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 theorem ownedCounter_transferOwnership_semantic_bridge
     (state : ContractState) (sender : Address) (newOwner : Address)
@@ -569,15 +524,10 @@ theorem ownedCounter_transferOwnership_semantic_bridge
     | .revert _ _ => True
     := by
   subst hOwner
-  simp [Contract.run, Contracts.MacroContracts.OwnedCounter.transferOwnership,
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.transferOwnership,
     Contracts.MacroContracts.OwnedCounter.owner,
     getStorageAddr, setStorageAddr,
-    mkIRTransaction, mkIRState, interpretIR, ownedCounterIRContract,
-    execIRFunction, execIRStmts, execIRStmt,
-    evalIRExpr, evalIRCall, evalIRExprs, IRState.getVar, IRState.setVar,
-    encodeOwnedCounterStorage, encodeEvents,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall]
+    ownedCounterIRContract, encodeOwnedCounterStorage]
 
 /-! ## Composed End-to-End: EDSL → IR → Yul -/
 


### PR DESCRIPTION
## Summary
- migrate additional `SemanticBridge` proofs from repeated manual `simp` blocks to `semantic_bridge_simp`
- cover the remaining SafeCounter and OwnedCounter bridge theorems in this file
- keep theorem statements and proof logic unchanged; this is boilerplate reduction only

## Linked issue
- closes part of #1165

## Validation
- attempted: `lake build Compiler.Proofs.SemanticBridge`
- currently blocked by existing upstream failure in `Compiler/Proofs/YulGeneration/Preservation.lean` (`execBuildSwitch_none_none_aux` unsolved goal), unrelated to this refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Lean proof scripts and primarily restructure `simp` invocations without altering theorem statements or executable code.
> 
> **Overview**
> **SemanticBridge proof cleanup:** migrates the remaining `SafeCounter` and `OwnedCounter` (including `OwnedCounter` methods like `getCount`, `getOwner`, `increment`, `decrement`, `transferOwnership`) semantic-bridge theorems to use `semantic_bridge_simp`.
> 
> This replaces long, repeated `simp` unfold lists (e.g., `interpretIR`/`execIR*`/`evalIR*`/`evalBuiltinCall*`) with the shared tactic plus a small set of contract-specific extras such as `safeCounterIRContract`, `ownedCounterIRContract`, and the relevant storage encoders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6df06a7eee9bf04f66f3c416068cad0abc7b579e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->