### PR TITLE
proof: add semantic_bridge_split scaffold macro

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -52,6 +52,12 @@ syntax (name := semantic_bridge_simp) "semantic_bridge_simp" : tactic
 syntax (name := semantic_bridge_simp_with)
   "semantic_bridge_simp [" term,* "]" : tactic
 
+/-- `semantic_bridge_split h : cond with [...]` generates the common
+    two-branch `by_cases` skeleton and runs `semantic_bridge_simp` in both
+    branches with the same simp bundle plus the branch hypothesis. -/
+syntax (name := semantic_bridge_split)
+  "semantic_bridge_split " ident " : " term " with [" term,* "]" : tactic
+
 macro_rules
   | `(tactic| semantic_bridge_simp) =>
       `(tactic| simp [
@@ -70,6 +76,11 @@ macro_rules
         Compiler.Proofs.YulGeneration.evalBuiltinCall, encodeEvents,
         $[$extra],*
       ])
+  | `(tactic| semantic_bridge_split $h:ident : $cond:term with [$[$extra:term],*]) =>
+      `(tactic|
+        by_cases $h : $cond
+        · semantic_bridge_simp [$[$extra],*, $h]
+        · semantic_bridge_simp [$[$extra],*, $h])
 
 /-! ## State Encoding
 
@@ -348,15 +359,10 @@ theorem safeCounter_increment_semantic_bridge
         let irResult := interpretIR safeCounterIRContract tx irState
         irResult.success = false
     := by
-  by_cases hOverflow : state.storage 0 = (Uint256.max)
-  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
-      Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
-      requireSomeUint, safeAdd, Uint256.max, hOverflow,
-      safeCounterIRContract, encodeStorage]
-  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
-      Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
-      requireSomeUint, safeAdd, Uint256.max, hOverflow,
-      safeCounterIRContract, encodeStorage]
+  semantic_bridge_split hOverflow : state.storage 0 = (Uint256.max) with
+    [Contract.run, Contracts.MacroContracts.SafeCounter.increment,
+    Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
+    requireSomeUint, safeAdd, Uint256.max, safeCounterIRContract, encodeStorage]
 
 theorem safeCounter_decrement_semantic_bridge
     (state : ContractState) (sender : Address) :
@@ -375,15 +381,10 @@ theorem safeCounter_decrement_semantic_bridge
         let irResult := interpretIR safeCounterIRContract tx irState
         irResult.success = false
     := by
-  by_cases hUnderflow : state.storage 0 = 0
-  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
-      Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
-      requireSomeUint, safeSub, hUnderflow,
-      safeCounterIRContract, encodeStorage]
-  · semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
-      Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
-      requireSomeUint, safeSub, hUnderflow,
-      safeCounterIRContract, encodeStorage]
+  semantic_bridge_split hUnderflow : state.storage 0 = 0 with
+    [Contract.run, Contracts.MacroContracts.SafeCounter.decrement,
+    Contracts.MacroContracts.SafeCounter.count, getStorage, setStorage,
+    requireSomeUint, safeSub, safeCounterIRContract, encodeStorage]
 
 theorem safeCounter_getCount_semantic_bridge
     (state : ContractState) (sender : Address) :


### PR DESCRIPTION
## Summary
- add `semantic_bridge_split` tactic macro in `Compiler/Proofs/SemanticBridge.lean`
- this macro generates the common `by_cases` + two-branch `semantic_bridge_simp` skeleton
- migrate `safeCounter_increment_semantic_bridge` and `safeCounter_decrement_semantic_bridge` to the new macro

## Linked issue
- closes part of #1165

## Validation
- attempted: `lake build Compiler.Proofs.SemanticBridge`
- result: blocked by existing upstream failure in `Compiler/Proofs/YulGeneration/Preservation.lean` (`execBuildSwitch_none_none_aux` unsolved goal), unrelated to this refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to Lean proof automation: it introduces a small tactic macro and replaces duplicated `by_cases` scaffolding in two theorems. Main risk is unexpected simp behavior if the new macro’s hypothesis injection changes proof reduction.
> 
> **Overview**
> Adds a new proof-helper tactic, `semantic_bridge_split`, which generates a `by_cases` split and runs `semantic_bridge_simp` in both branches with the branch hypothesis included in the simp set.
> 
> Refactors `safeCounter_increment_semantic_bridge` and `safeCounter_decrement_semantic_bridge` to use this macro, removing duplicated two-branch `by_cases`/`semantic_bridge_simp` blocks while keeping the same unfolding/simp bundle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad1f915465a66bc6fadd629d3088d4c0b2e6d332. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->