### PR TITLE
proofs: apply semantic bridge automation to SimpleStorage store

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -181,33 +181,9 @@ theorem simpleStorage_store_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  simp [Contract.run, Contracts.MacroContracts.SimpleStorage.store, setStorage]
-  simp [mkIRTransaction, mkIRState, encodeStorage,
-    simpleStorageIRContract, interpretIR, execIRFunction,
-    IRState.setVar, IRState.getVar, execIRStmts, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
-    Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackend,
-    Compiler.Proofs.YulGeneration.evalBuiltinCall, encodeEvents]
-  let stopState : IRState :=
-    { vars := [("value", calldataloadWord 0x6057361d [value.val] 4)]
-      «storage» := fun s => if s = 0 then calldataloadWord 0x6057361d [value.val] 4 else (state.storage s).val
-      memory := fun _ => 0
-      calldata := [value.val]
-      returnValue := none
-      sender := sender.val
-      selector := 0x6057361d
-      events := List.map encodeEvent state.events }
-  have hstop : execIRStmt
-      (1 + (1 + sizeOf "value" + (1 + sizeOf "calldataload" + 7)) +
-        (1 + (1 + (1 + sizeOf "sstore" + (2 + (1 + (1 + sizeOf "value") + 1)))) +
-          (1 + (1 + (1 + sizeOf "stop")))))
-      stopState (Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])) =
-      IRExecResult.stop stopState := by
-    simpa [Nat.add_comm] using
-      (execIRStmt_stop_succ
-        ((1 + sizeOf "value" + (1 + sizeOf "calldataload" + 7)) +
-          (1 + (1 + (1 + sizeOf "sstore" + (2 + (1 + (1 + sizeOf "value") + 1)))) +
-            (1 + (1 + (1 + sizeOf "stop")))))
-        stopState)
+  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.SimpleStorage.store,
+    Contracts.MacroContracts.SimpleStorage.storedData, setStorage,
+    simpleStorageIRContract, encodeStorage]
   intro x
   by_cases hx : x = 0
   · subst hx


### PR DESCRIPTION
## Summary
- replace the remaining manual `simpleStorage_store_semantic_bridge` unfold/simp scaffold with `semantic_bridge_simp`
- remove the local `stopState`/`hstop` proof boilerplate that is now covered by existing bridge automation
- keep the slot-0/non-slot storage split reasoning intact for the post-state storage equality obligation

## Validation
- `make check`
- `lake build Compiler.Proofs.SemanticBridge` is still blocked by the existing upstream `Compiler/Proofs/YulGeneration/Preservation.lean` unsolved-goal regression (unchanged by this PR)

Refs #1165

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Lean proof automation and should not affect compiler/runtime behavior, but could impact proof robustness if simp lemmas drift.
> 
> **Overview**
> **Simplifies the `SimpleStorage.store` semantic-bridge proof** by swapping the long manual `simp`/unfold chain (and the local `stopState`/`hstop` boilerplate) for a single `semantic_bridge_simp` invocation.
> 
> Keeps the existing post-state storage reasoning, still splitting slot `0` vs non-`0` to discharge the remaining storage-equality obligation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f843f19111dc8b0f202f3da47b092ef04adb065d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->