### PR TITLE
SemanticBridge: add owner-precondition tactic helper

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -58,6 +58,12 @@ syntax (name := semantic_bridge_simp_with)
 syntax (name := semantic_bridge_split)
   "semantic_bridge_split " ident " : " term " with [" term,* "]" : tactic
 
+/-- `semantic_bridge_owner h with [...]` discharges the common owner
+    precondition by `subst`-ing the equality hypothesis, then runs
+    `semantic_bridge_simp` with the provided simp bundle. -/
+syntax (name := semantic_bridge_owner)
+  "semantic_bridge_owner " ident " with [" term,* "]" : tactic
+
 macro_rules
   | `(tactic| semantic_bridge_simp) =>
       `(tactic| simp [
@@ -81,6 +87,10 @@ macro_rules
         by_cases $h : $cond
         · semantic_bridge_simp [$[$extra],*, $h]
         · semantic_bridge_simp [$[$extra],*, $h])
+  | `(tactic| semantic_bridge_owner $h:ident with [$[$extra:term],*]) =>
+      `(tactic|
+        subst $h
+        semantic_bridge_simp [$[$extra],*])
 
 /-! ## State Encoding
 
@@ -311,8 +321,7 @@ theorem owned_transferOwnership_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  subst hOwner
-  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.Owned.transferOwnership,
+  semantic_bridge_owner hOwner with [Contract.run, Contracts.MacroContracts.Owned.transferOwnership,
     Contracts.MacroContracts.Owned.owner, getStorageAddr, setStorageAddr,
     ownedIRContract, encodeStorageAddr]
 
@@ -449,8 +458,7 @@ theorem ownedCounter_increment_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  subst hOwner
-  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.increment,
+  semantic_bridge_owner hOwner with [Contract.run, Contracts.MacroContracts.OwnedCounter.increment,
     Contracts.MacroContracts.OwnedCounter.owner, Contracts.MacroContracts.OwnedCounter.count,
     getStorageAddr, getStorage, setStorage,
     ownedCounterIRContract, encodeOwnedCounterStorage]
@@ -472,8 +480,7 @@ theorem ownedCounter_decrement_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  subst hOwner
-  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.decrement,
+  semantic_bridge_owner hOwner with [Contract.run, Contracts.MacroContracts.OwnedCounter.decrement,
     Contracts.MacroContracts.OwnedCounter.owner, Contracts.MacroContracts.OwnedCounter.count,
     getStorageAddr, getStorage, setStorage,
     ownedCounterIRContract, encodeOwnedCounterStorage]
@@ -495,8 +502,7 @@ theorem ownedCounter_transferOwnership_semantic_bridge
         encodeEvents s'.events = irResult.events
     | .revert _ _ => True
     := by
-  subst hOwner
-  semantic_bridge_simp [Contract.run, Contracts.MacroContracts.OwnedCounter.transferOwnership,
+  semantic_bridge_owner hOwner with [Contract.run, Contracts.MacroContracts.OwnedCounter.transferOwnership,
     Contracts.MacroContracts.OwnedCounter.owner, getStorageAddr, setStorageAddr,
     ownedCounterIRContract, encodeOwnedCounterStorage]
 


### PR DESCRIPTION
## Summary
- add `semantic_bridge_owner` tactic macro in `Compiler/Proofs/SemanticBridge.lean`
- encapsulate the repeated `subst hOwner` + `semantic_bridge_simp [...]` proof pattern
- migrate owner-gated bridge proofs to the new helper:
  - `owned_transferOwnership_semantic_bridge`
  - `ownedCounter_increment_semantic_bridge`
  - `ownedCounter_decrement_semantic_bridge`
  - `ownedCounter_transferOwnership_semantic_bridge`

## Why
This is an incremental `#1165` boilerplate reduction step: owner-gated semantic bridge proofs shared a mechanical precondition discharge + simp scaffold.

## Validation
- `make check`
- `lake build Compiler.Proofs.SemanticBridge` is still blocked by existing upstream failure in `Compiler/Proofs/YulGeneration/Preservation.lean` (`execBuildSwitch_none_none_aux` unsolved goal), unchanged by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Lean proof automation macros and refactor existing proofs without altering compiler/runtime logic. Main risk is proof fragility if `subst`/`simp` behavior differs in edge cases for owner-precondition theorems.
> 
> **Overview**
> Introduces a new `semantic_bridge_owner` tactic macro in `SemanticBridge.lean` that encapsulates the recurring owner-precondition proof pattern (`subst` the owner equality hypothesis, then run `semantic_bridge_simp` with a local simp bundle).
> 
> Updates the owner-gated semantic-bridge theorems (Owned `transferOwnership` and OwnedCounter `increment`/`decrement`/`transferOwnership`) to use the new helper, removing duplicated `subst hOwner` + `semantic_bridge_simp [...]` scaffolding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 718cde8f971bd897ad075fa21e2a0d31248a842f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->