### PR TITLE
Specs: factor canonical storage-update spec combinators

### DIFF
--- a/Contracts/Counter/Spec.lean
+++ b/Contracts/Counter/Spec.lean
@@ -17,15 +17,11 @@ open Verity.EVM.Uint256
 
 /-- Increment: increases count by 1 -/
 def increment_spec (s s' : ContractState) : Prop :=
-  s'.storage 0 = add (s.storage 0) 1 ∧
-  storageUnchangedExcept 0 s s' ∧
-  sameAddrMapContext s s'
+  storageUpdateSpec 0 (fun st => add (st.storage 0) 1) sameAddrMapContext s s'
 
 /-- Decrement: decreases count by 1 -/
 def decrement_spec (s s' : ContractState) : Prop :=
-  s'.storage 0 = sub (s.storage 0) 1 ∧
-  storageUnchangedExcept 0 s s' ∧
-  sameAddrMapContext s s'
+  storageUpdateSpec 0 (fun st => sub (st.storage 0) 1) sameAddrMapContext s s'
 
 /-- getCount: returns the current count -/
 def getCount_spec (result : Uint256) (s : ContractState) : Prop :=

--- a/Contracts/Owned/Spec.lean
+++ b/Contracts/Owned/Spec.lean
@@ -15,9 +15,7 @@ open Contracts.MacroContracts.Owned
 
 /-- Constructor: sets the owner to the provided address -/
 def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
-  s'.storageAddr 0 = initialOwner ∧
-  storageAddrUnchangedExcept 0 s s' ∧
-  sameStorageMapContext s s'
+  storageAddrUpdateSpec 0 (fun _ => initialOwner) sameStorageMapContext s s'
 
 /-- getOwner: returns the current owner address -/
 def getOwner_spec (result : Address) (s : ContractState) : Prop :=
@@ -25,9 +23,7 @@ def getOwner_spec (result : Address) (s : ContractState) : Prop :=
 
 /-- transferOwnership: updates owner to new address (owner only) -/
 def transferOwnership_spec (newOwner : Address) (s s' : ContractState) : Prop :=
-  s'.storageAddr 0 = newOwner ∧
-  storageAddrUnchangedExcept 0 s s' ∧
-  sameStorageMapContext s s'
+  storageAddrUpdateSpec 0 (fun _ => newOwner) sameStorageMapContext s s'
 
 /-- isOwner: returns true if sender equals current owner -/
 def isOwner_spec (result : Bool) (s : ContractState) : Prop :=

--- a/Contracts/OwnedCounter/Spec.lean
+++ b/Contracts/OwnedCounter/Spec.lean
@@ -17,9 +17,7 @@ open Verity.EVM.Uint256
 
 /-- Constructor: sets owner -/
 def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
-  s'.storageAddr 0 = initialOwner ∧
-  storageAddrUnchangedExcept 0 s s' ∧
-  sameStorageMapContext s s'
+  storageAddrUpdateSpec 0 (fun _ => initialOwner) sameStorageMapContext s s'
 
 /-- getCount: returns current count -/
 def getCount_spec (result : Uint256) (s : ContractState) : Prop :=
@@ -31,20 +29,14 @@ def getOwner_spec (result : Address) (s : ContractState) : Prop :=
 
 /-- increment: increases count by 1 (owner only) -/
 def increment_spec (s s' : ContractState) : Prop :=
-  s'.storage 1 = add (s.storage 1) 1 ∧
-  storageUnchangedExcept 1 s s' ∧
-  sameAddrMapContext s s'
+  storageUpdateSpec 1 (fun st => add (st.storage 1) 1) sameAddrMapContext s s'
 
 /-- decrement: decreases count by 1 (owner only) -/
 def decrement_spec (s s' : ContractState) : Prop :=
-  s'.storage 1 = sub (s.storage 1) 1 ∧
-  storageUnchangedExcept 1 s s' ∧
-  sameAddrMapContext s s'
+  storageUpdateSpec 1 (fun st => sub (st.storage 1) 1) sameAddrMapContext s s'
 
 /-- transferOwnership: changes owner (owner only) -/
 def transferOwnership_spec (newOwner : Address) (s s' : ContractState) : Prop :=
-  s'.storageAddr 0 = newOwner ∧
-  storageAddrUnchangedExcept 0 s s' ∧
-  sameStorageMapContext s s'
+  storageAddrUpdateSpec 0 (fun _ => newOwner) sameStorageMapContext s s'
 
 end Contracts.OwnedCounter.Spec

--- a/Contracts/SafeCounter/Spec.lean
+++ b/Contracts/SafeCounter/Spec.lean
@@ -19,15 +19,11 @@ open Contracts.MacroContracts.SafeCounter
 
 /-- increment: increases count by 1 (with overflow check) -/
 def increment_spec (s s' : ContractState) : Prop :=
-  s'.storage 0 = add (s.storage 0) 1 ∧
-  storageUnchangedExcept 0 s s' ∧
-  sameAddrMapContext s s'
+  storageUpdateSpec 0 (fun st => add (st.storage 0) 1) sameAddrMapContext s s'
 
 /-- decrement: decreases count by 1 (with underflow check) -/
 def decrement_spec (s s' : ContractState) : Prop :=
-  s'.storage 0 = sub (s.storage 0) 1 ∧
-  storageUnchangedExcept 0 s s' ∧
-  sameAddrMapContext s s'
+  storageUpdateSpec 0 (fun st => sub (st.storage 0) 1) sameAddrMapContext s s'
 
 /-- getCount: returns current count -/
 def getCount_spec (result : Uint256) (s : ContractState) : Prop :=

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -98,6 +98,26 @@ def storageUnchangedExcept (slot : Nat) (s s' : ContractState) : Prop :=
 def storageAddrUnchangedExcept (slot : Nat) (s s' : ContractState) : Prop :=
   ∀ other : Nat, other ≠ slot → s'.storageAddr other = s.storageAddr other
 
+/-- Canonical two-state spec shape for updating one `storage` slot. -/
+def storageUpdateSpec
+    (slot : Nat)
+    (value : ContractState → Uint256)
+    (frame : ContractState → ContractState → Prop)
+    (s s' : ContractState) : Prop :=
+  s'.storage slot = value s ∧
+  storageUnchangedExcept slot s s' ∧
+  frame s s'
+
+/-- Canonical two-state spec shape for updating one `storageAddr` slot. -/
+def storageAddrUpdateSpec
+    (slot : Nat)
+    (value : ContractState → Address)
+    (frame : ContractState → ContractState → Prop)
+    (s s' : ContractState) : Prop :=
+  s'.storageAddr slot = value s ∧
+  storageAddrUnchangedExcept slot s s' ∧
+  frame s s'
+
 /-- All mapping storage slots except `slot` are unchanged. -/
 def storageMapUnchangedExceptSlot (slot : Nat) (s s' : ContractState) : Prop :=
   ∀ other : Nat, other ≠ slot → ∀ addr : Address, s'.storageMap other addr = s.storageMap other addr


### PR DESCRIPTION
## Summary
- add reusable helper combinators in `Verity/Specs/Common.lean`:
  - `storageUpdateSpec`
  - `storageAddrUpdateSpec`
- migrate repetitive hand-written spec boilerplate to helpers across multiple contracts:
  - `Contracts/Counter/Spec.lean`
  - `Contracts/SafeCounter/Spec.lean`
  - `Contracts/Owned/Spec.lean`
  - `Contracts/OwnedCounter/Spec.lean`

This is an incremental step toward issue #1166 (declarative spec generation) while keeping changes fully mechanical and low-risk.

## Validation
- `lake build Verity.Specs.Common Contracts.Counter.Spec Contracts.SafeCounter.Spec Contracts.Owned.Spec Contracts.OwnedCounter.Spec`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical refactor of spec definitions; main risk is an unintended semantic mismatch in the new helper predicates affecting downstream proofs.
> 
> **Overview**
> Introduces reusable predicates `storageUpdateSpec` and `storageAddrUpdateSpec` in `Verity/Specs/Common.lean` to capture the common “update one storage slot + frame + everything else unchanged” spec pattern.
> 
> Updates the `Counter`, `SafeCounter`, `Owned`, and `OwnedCounter` specs to use these helpers instead of repeating the three-conjunct boilerplate for single-slot storage/address updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e36cc1dfdb83098f8c03749388b5a28393fe8c7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->