### PR TITLE
Specs: extend helper coverage for constructor/update patterns

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -15,13 +15,12 @@ open Verity.Specs
 
 /-- constructor: sets owner and initializes total supply to zero -/
 def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
-  s'.storageAddr 0 = initialOwner ∧
-  s'.storage 1 = 0 ∧
-  storageAddrUnchangedExcept 0 s s' ∧
-  storageUnchangedExcept 1 s s' ∧
-  sameStorageMap s s' ∧
-  sameStorageMap2 s s' ∧
-  sameContext s s'
+  storageAddrStorageUpdateSpec
+    0 1
+    (fun _ => initialOwner)
+    (fun _ => 0)
+    (fun st st' => sameStorageMap st st' ∧ sameStorageMap2 st st' ∧ sameContext st st')
+    s s'
 
 /-- mint: increases recipient balance and total supply by amount -/
 def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Contracts/ERC721/Spec.lean
+++ b/Contracts/ERC721/Spec.lean
@@ -22,14 +22,13 @@ def boolToWord (b : Bool) : Uint256 :=
 /-- constructor: sets owner and initializes counters to zero -/
 def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
   s'.storageAddr 0 = initialOwner ∧
-  s'.storage 1 = 0 ∧
-  s'.storage 2 = 0 ∧
   storageAddrUnchangedExcept 0 s s' ∧
-  (∀ slot : Nat, slot ≠ 1 → slot ≠ 2 → s'.storage slot = s.storage slot) ∧
-  sameStorageMap s s' ∧
-  sameStorageMap2 s s' ∧
-  sameStorageMapUint s s' ∧
-  sameContext s s'
+  storage2UpdateSpec
+    1 2
+    (fun _ => 0)
+    (fun _ => 0)
+    (fun st st' => sameStorageMap st st' ∧ sameStorageMap2 st st' ∧ sameStorageMapUint st st' ∧ sameContext st st')
+    s s'
 
 /-- balanceOf: returns current balance of `addr` -/
 def balanceOf_spec (addr : Address) (result : Uint256) (s : ContractState) : Prop :=

--- a/Contracts/SimpleStorage/Spec.lean
+++ b/Contracts/SimpleStorage/Spec.lean
@@ -12,9 +12,7 @@ open Verity.Specs
 
 /-- Store: updates the storage at slot 0 -/
 def store_spec (value : Uint256) (s s' : ContractState) : Prop :=
-  s'.storage 0 = value ∧
-  storageUnchangedExcept 0 s s' ∧
-  sameAddrMapContext s s'
+  storageUpdateSpec 0 (fun _ => value) sameAddrMapContext s s'
 
 /-- Retrieve: returns the value at slot 0 -/
 def retrieve_spec (result : Uint256) (s : ContractState) : Prop :=

--- a/Contracts/SimpleToken/Spec.lean
+++ b/Contracts/SimpleToken/Spec.lean
@@ -15,12 +15,12 @@ open Verity.Specs
 
 /-- Constructor: sets owner and initializes total supply to 0 -/
 def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
-  s'.storageAddr 0 = initialOwner ∧
-  s'.storage 2 = 0 ∧
-  storageAddrUnchangedExcept 0 s s' ∧
-  storageUnchangedExcept 2 s s' ∧
-  sameStorageMap s s' ∧
-  sameContext s s'
+  storageAddrStorageUpdateSpec
+    0 2
+    (fun _ => initialOwner)
+    (fun _ => 0)
+    (fun st st' => sameStorageMap st st' ∧ sameContext st st')
+    s s'
 
 /-- Mint: increases balance and total supply by amount (owner only) -/
 def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -118,6 +118,30 @@ def storageAddrUpdateSpec
   storageAddrUnchangedExcept slot s s' ∧
   frame s s'
 
+/-- Canonical two-state spec shape for updating one `storageAddr` slot and one `storage` slot. -/
+def storageAddrStorageUpdateSpec
+    (addrSlot storageSlot : Nat)
+    (addrValue : ContractState → Address)
+    (storageValue : ContractState → Uint256)
+    (frame : ContractState → ContractState → Prop)
+    (s s' : ContractState) : Prop :=
+  s'.storageAddr addrSlot = addrValue s ∧
+  s'.storage storageSlot = storageValue s ∧
+  storageAddrUnchangedExcept addrSlot s s' ∧
+  storageUnchangedExcept storageSlot s s' ∧
+  frame s s'
+
+/-- Canonical two-state spec shape for updating two `storage` slots. -/
+def storage2UpdateSpec
+    (slot1 slot2 : Nat)
+    (value1 value2 : ContractState → Uint256)
+    (frame : ContractState → ContractState → Prop)
+    (s s' : ContractState) : Prop :=
+  s'.storage slot1 = value1 s ∧
+  s'.storage slot2 = value2 s ∧
+  (∀ other : Nat, other ≠ slot1 → other ≠ slot2 → s'.storage other = s.storage other) ∧
+  frame s s'
+
 /-- All mapping storage slots except `slot` are unchanged. -/
 def storageMapUnchangedExceptSlot (slot : Nat) (s s' : ContractState) : Prop :=
   ∀ other : Nat, other ≠ slot → ∀ addr : Address, s'.storageMap other addr = s.storageMap other addr


### PR DESCRIPTION
## Summary
This continues issue #1166 by expanding the shared spec-shape combinators and migrating more hand-written boilerplate to declarative helpers.

### What changed
- Added two reusable spec helpers in `Verity/Specs/Common.lean`:
  - `storageAddrStorageUpdateSpec` (one `storageAddr` + one `storage` update)
  - `storage2UpdateSpec` (two `storage` updates)
- Migrated manual constructor/spec boilerplate to helper-based definitions in:
  - `Contracts/SimpleStorage/Spec.lean` (`store_spec`)
  - `Contracts/SimpleToken/Spec.lean` (`constructor_spec`)
  - `Contracts/ERC20/Spec.lean` (`constructor_spec`)
  - `Contracts/ERC721/Spec.lean` (`constructor_spec`)

## Validation
- `lake build Verity.Specs.Common Contracts.SimpleStorage.Spec Contracts.SimpleToken.Spec Contracts.ERC20.Spec Contracts.ERC721.Spec`
- `make check`

## Issue
- Closes part of #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes shared spec-shape helpers in `Verity/Specs/Common.lean` and rewrites several core contract specs to depend on them; mistakes could subtly weaken or misframe “unchanged” conditions across specs.
> 
> **Overview**
> Adds new reusable spec combinators in `Verity/Specs/Common.lean` for common state-transition patterns: `storageAddrStorageUpdateSpec` (update one `storageAddr` + one `storage`) and `storage2UpdateSpec` (update two `storage` slots).
> 
> Refactors multiple contract specs to use these helpers instead of hand-written conjunctions: `Contracts/ERC20.Spec.constructor_spec`, `Contracts/SimpleToken.Spec.constructor_spec`, `Contracts/ERC721.Spec.constructor_spec`, and `Contracts/SimpleStorage.Spec.store_spec`, reducing boilerplate while preserving the same framing/unchanged constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33e15e567d6cd1fcc43094aa57051060711fa1fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->