### PR TITLE
specs: extract transfer mapping spec helper

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -36,19 +36,13 @@ def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
 /-- transfer: sender balance decreases and recipient balance increases by amount -/
 def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
   s.storageMap 2 sender ≥ amount ∧
-  (if sender == to
-    then s'.storageMap 2 sender = s.storageMap 2 sender
-    else s'.storageMap 2 sender = sub (s.storageMap 2 sender) amount) ∧
-  (if sender == to
-    then s'.storageMap 2 to = s.storageMap 2 to
-    else s'.storageMap 2 to = add (s.storageMap 2 to) amount) ∧
-  (if sender == to
-    then storageMapUnchangedExceptKeyAtSlot 2 sender s s'
-    else storageMapUnchangedExceptKeysAtSlot 2 sender to s s') ∧
-  s'.storage 1 = s.storage 1 ∧
-  s'.storageAddr 0 = s.storageAddr 0 ∧
-  sameStorageMap2 s s' ∧
-  sameContext s s'
+  storageMapTransferSpec 2 sender to amount
+    (fun st st' =>
+      st'.storage 1 = st.storage 1 ∧
+      st'.storageAddr 0 = st.storageAddr 0 ∧
+      sameStorageMap2 st st' ∧
+      sameContext st st')
+    s s'
 
 /-- approve: updates the owner-spender allowance mapping entry -/
 def approve_spec (ownerAddr spender : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Contracts/Ledger/Spec.lean
+++ b/Contracts/Ledger/Spec.lean
@@ -31,16 +31,7 @@ def withdraw_spec (amount : Uint256) (s s' : ContractState) : Prop :=
 
 /-- transfer: moves amount from sender to recipient -/
 def transfer_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  (if s.sender == to
-    then s'.storageMap 0 s.sender = s.storageMap 0 s.sender
-    else s'.storageMap 0 s.sender = sub (s.storageMap 0 s.sender) amount) ∧
-  (if s.sender == to
-    then s'.storageMap 0 to = s.storageMap 0 to
-    else s'.storageMap 0 to = add (s.storageMap 0 to) amount) ∧
-  (if s.sender == to
-    then storageMapUnchangedExceptKeyAtSlot 0 s.sender s s'
-    else storageMapUnchangedExceptKeysAtSlot 0 s.sender to s s') ∧
-  sameStorageAddrContext s s'
+  storageMapTransferSpec 0 s.sender to amount sameStorageAddrContext s s'
 
 /-- getBalance: returns balance at given address, no state change -/
 def getBalance_spec (addr : Address) (result : Uint256) (s : ContractState) : Prop :=

--- a/Contracts/SimpleToken/Spec.lean
+++ b/Contracts/SimpleToken/Spec.lean
@@ -35,17 +35,11 @@ def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
 /-- Transfer: moves amount from sender to recipient, preserves total supply -/
 def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
   s.storageMap 1 sender ≥ amount ∧
-  (if sender == to
-    then s'.storageMap 1 sender = s.storageMap 1 sender
-    else s'.storageMap 1 sender = sub (s.storageMap 1 sender) amount) ∧
-  (if sender == to
-    then s'.storageMap 1 to = s.storageMap 1 to
-    else s'.storageMap 1 to = add (s.storageMap 1 to) amount) ∧
-  (if sender == to
-    then storageMapUnchangedExceptKeyAtSlot 1 sender s s'
-    else storageMapUnchangedExceptKeysAtSlot 1 sender to s s') ∧
-  s'.storageAddr 0 = s.storageAddr 0 ∧
-  sameStorageAddrContext s s'
+  storageMapTransferSpec 1 sender to amount
+    (fun st st' =>
+      st'.storageAddr 0 = st.storageAddr 0 ∧
+      sameStorageAddrContext st st')
+    s s'
 
 /-- balanceOf: returns the balance of the given address -/
 def balanceOf_spec (addr : Address) (result : Uint256) (s : ContractState) : Prop :=

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -6,10 +6,12 @@
 -/
 
 import Verity.Core
+import Verity.EVM.Uint256
 
 namespace Verity.Specs
 
 open Verity
+open Verity.EVM.Uint256
 
 /-- Contract context (sender, address, msg value, timestamp) is unchanged. -/
 def sameContext (s s' : ContractState) : Prop :=
@@ -188,6 +190,26 @@ def storageMapAndStorageUpdateSpec
   s'.storage storageSlot = storageValue s ∧
   storageMapUnchangedExceptKeyAtSlot mapSlot key s s' ∧
   storageUnchangedExcept storageSlot s s' ∧
+  frame s s'
+
+/-- Canonical two-state spec shape for transfer-style updates on one mapping slot.
+When `from == to`, balances are unchanged; otherwise `from` is debited and `to` is credited. -/
+@[simp]
+def storageMapTransferSpec
+    (slot : Nat)
+    (fromAddr to : Address)
+    (amount : Uint256)
+    (frame : ContractState → ContractState → Prop)
+    (s s' : ContractState) : Prop :=
+  (if fromAddr == to
+    then s'.storageMap slot fromAddr = s.storageMap slot fromAddr
+    else s'.storageMap slot fromAddr = sub (s.storageMap slot fromAddr) amount) ∧
+  (if fromAddr == to
+    then s'.storageMap slot to = s.storageMap slot to
+    else s'.storageMap slot to = add (s.storageMap slot to) amount) ∧
+  (if fromAddr == to
+    then storageMapUnchangedExceptKeyAtSlot slot fromAddr s s'
+    else storageMapUnchangedExceptKeysAtSlot slot fromAddr to s s') ∧
   frame s s'
 
 /-- All storage (uint256, addr, map, mapUint, map2) is unchanged. -/


### PR DESCRIPTION
## Summary
- add shared `storageMapTransferSpec` combinator in `Verity.Specs.Common`
- migrate transfer spec boilerplate in:
  - `Contracts/Ledger/Spec.lean`
  - `Contracts/SimpleToken/Spec.lean`
  - `Contracts/ERC20/Spec.lean`
- keep compatibility with existing proof scripts by marking the helper `@[simp]`

## Why
Issue #1166 tracks declarative spec generation and reducing repeated, error-prone hand-written spec scaffolding. This extracts another repeated shape (transfer-style mapping updates) into a reusable helper and migrates three contracts as proof of concept.

## Validation
- `lake build Verity.Specs.Common Contracts.Ledger.Spec Contracts.SimpleToken.Spec Contracts.ERC20.Spec Contracts.Ledger.Proofs.Basic Contracts.SimpleToken.Proofs.Basic Contracts.ERC20.Proofs.Basic`
- `make check`

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of Lean spec definitions: behavior should be equivalent, but any subtle mismatch in the new helper could break existing proofs or downstream spec generation.
> 
> **Overview**
> Introduces a shared `storageMapTransferSpec` helper in `Verity/Specs/Common.lean` to capture the canonical “transfer between two addresses” mapping-update pattern (including the `from == to` no-op case) and marks it `@[simp]` for proof compatibility.
> 
> Refactors `transfer_spec` in `Contracts/Ledger/Spec.lean`, `Contracts/SimpleToken/Spec.lean`, and `Contracts/ERC20/Spec.lean` to use this helper instead of repeating the inline `if`/unchanged-keys boilerplate, preserving each contract’s existing frame conditions and any balance preconditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b10021818215c86c727bbba3fd4eec98c2925440. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->