### PR TITLE
specs: factor mapping2 update pattern for ERC20 approve

### DIFF
--- a/Contracts/ERC20/Proofs/Basic.lean
+++ b/Contracts/ERC20/Proofs/Basic.lean
@@ -42,22 +42,27 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
 /-- `approve` writes allowance(sender, spender) and leaves other state unchanged. -/
 theorem approve_meets_spec (s : ContractState) (spender : Address) (amount : Uint256) :
     approve_spec s.sender spender amount s ((approve spender amount).runState s) := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_⟩
   · simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · intro o' sp' h_neq
-    simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
-      h_neq]
-  · intro sp' h_neq
-    simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
-      h_neq]
-  · simp [Specs.sameStorage, approve, allowancesSlot, setMapping2, msgSender,
-      Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageAddr, approve, allowancesSlot, setMapping2, msgSender,
-      Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMap, approve, allowancesSlot, setMapping2, msgSender,
-      Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameContext, approve, allowancesSlot, setMapping2, msgSender,
-      Contract.runState, Verity.bind, Bind.bind]
+  · refine ⟨?_, ?_, ?_⟩
+    · intro o' h_neq sp'
+      simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
+        h_neq]
+    · intro sp' h_neq
+      simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
+        h_neq]
+    · intro slotIdx h_neq o' sp'
+      simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
+        h_neq]
+  · refine ⟨?_, ?_, ?_, ?_⟩
+    · simp [Specs.sameStorage, approve, allowancesSlot, setMapping2, msgSender,
+        Contract.runState, Verity.bind, Bind.bind]
+    · simp [Specs.sameStorageAddr, approve, allowancesSlot, setMapping2, msgSender,
+        Contract.runState, Verity.bind, Bind.bind]
+    · simp [Specs.sameStorageMap, approve, allowancesSlot, setMapping2, msgSender,
+        Contract.runState, Verity.bind, Bind.bind]
+    · simp [Specs.sameContext, approve, allowancesSlot, setMapping2, msgSender,
+        Contract.runState, Verity.bind, Bind.bind]
 
 /-- `balanceOf` returns the value stored in balances slot 2 for `addr`. -/
 theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :

--- a/Contracts/ERC20/Proofs/Correctness.lean
+++ b/Contracts/ERC20/Proofs/Correctness.lean
@@ -39,7 +39,8 @@ theorem getOwner_preserves_state (s : ContractState) :
 theorem approve_is_balance_neutral_holds (s : ContractState) (spender : Address) (amount : Uint256) :
     approve_is_balance_neutral s ((Contracts.MacroContracts.ERC20.approve spender amount).runState s) := by
   have h := approve_meets_spec s spender amount
-  rcases h with ⟨_, _, _, h_storage, _, h_storageMap, _⟩
+  rcases h with ⟨_, _, h_frame⟩
+  rcases h_frame with ⟨h_storage, _, h_storageMap, _⟩
   exact ⟨h_storage, h_storageMap⟩
 
 /-- `transfer` preserves total supply under successful-path preconditions. -/

--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -46,15 +46,14 @@ def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState
 
 /-- approve: updates the owner-spender allowance mapping entry -/
 def approve_spec (ownerAddr spender : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  s'.storageMap2 3 ownerAddr spender = amount ∧
-  (∀ o' : Address, ∀ sp' : Address,
-    o' ≠ ownerAddr → s'.storageMap2 3 o' sp' = s.storageMap2 3 o' sp') ∧
-  (∀ sp' : Address,
-    sp' ≠ spender → s'.storageMap2 3 ownerAddr sp' = s.storageMap2 3 ownerAddr sp') ∧
-  sameStorage s s' ∧
-  sameStorageAddr s s' ∧
-  sameStorageMap s s' ∧
-  sameContext s s'
+  storageMap2UpdateSpec
+    3 ownerAddr spender (fun _ => amount)
+    (fun st st' =>
+      sameStorage st st' ∧
+      sameStorageAddr st st' ∧
+      sameStorageMap st st' ∧
+      sameContext st st')
+    s s'
 
 /-- transferFrom: debits `fromAddr`, credits `to`, and updates allowance for spender -/
 def transferFrom_spec (spender fromAddr to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -166,6 +166,28 @@ def storageMapUnchangedExceptKeysAtSlot (slot : Nat) (addr1 addr2 : Address) (s 
   storageMapUnchangedExceptKeys slot addr1 addr2 s s' ∧
   storageMapUnchangedExceptSlot slot s s'
 
+/-- All mapping2 storage slots except `slot` are unchanged. -/
+def storageMap2UnchangedExceptSlot (slot : Nat) (s s' : ContractState) : Prop :=
+  ∀ other : Nat, other ≠ slot → ∀ addr1 addr2 : Address,
+    s'.storageMap2 other addr1 addr2 = s.storageMap2 other addr1 addr2
+
+/-- All mapping2 entries at `slot` except primary key `addr1` are unchanged. -/
+def storageMap2UnchangedExceptPrimaryKey (slot : Nat) (addr1 : Address) (s s' : ContractState) : Prop :=
+  ∀ other : Address, other ≠ addr1 → ∀ addr2 : Address,
+    s'.storageMap2 slot other addr2 = s.storageMap2 slot other addr2
+
+/-- All mapping2 entries at `slot` and primary key `addr1` except secondary key `addr2` are unchanged. -/
+def storageMap2UnchangedExceptSecondaryKey
+    (slot : Nat) (addr1 addr2 : Address) (s s' : ContractState) : Prop :=
+  ∀ other : Address, other ≠ addr2 →
+    s'.storageMap2 slot addr1 other = s.storageMap2 slot addr1 other
+
+/-- Mapping2 storage is unchanged except at `slot` for key pair (`addr1`, `addr2`). -/
+def storageMap2UnchangedExceptKeyAtSlot (slot : Nat) (addr1 addr2 : Address) (s s' : ContractState) : Prop :=
+  storageMap2UnchangedExceptPrimaryKey slot addr1 s s' ∧
+  storageMap2UnchangedExceptSecondaryKey slot addr1 addr2 s s' ∧
+  storageMap2UnchangedExceptSlot slot s s'
+
 /-- Canonical two-state spec shape for updating one `storageMap` slot/key entry. -/
 def storageMapUpdateSpec
     (slot : Nat)
@@ -190,6 +212,17 @@ def storageMapAndStorageUpdateSpec
   s'.storage storageSlot = storageValue s ∧
   storageMapUnchangedExceptKeyAtSlot mapSlot key s s' ∧
   storageUnchangedExcept storageSlot s s' ∧
+  frame s s'
+
+/-- Canonical two-state spec shape for updating one `storageMap2` slot/key-pair entry. -/
+def storageMap2UpdateSpec
+    (slot : Nat)
+    (key1 key2 : Address)
+    (value : ContractState → Uint256)
+    (frame : ContractState → ContractState → Prop)
+    (s s' : ContractState) : Prop :=
+  s'.storageMap2 slot key1 key2 = value s ∧
+  storageMap2UnchangedExceptKeyAtSlot slot key1 key2 s s' ∧
   frame s s'
 
 /-- Canonical two-state spec shape for transfer-style updates on one mapping slot.


### PR DESCRIPTION
## Summary
- add reusable `storageMap2` frame/update combinators in `Verity.Specs.Common`
- migrate `Contracts.ERC20.Spec.approve_spec` to `storageMap2UpdateSpec`
- adapt `approve_meets_spec` and `approve_is_balance_neutral_holds` proof shape to the helper-based spec

## Why
`approve_spec` was still hand-writing the same mapping2 update/frame pattern. This increment reduces duplication and keeps proof scripts aligned with the shared combinator style under issue #1166.

## Validation
- `lake build Verity.Specs.Common Contracts.ERC20.Spec Contracts.ERC20.Proofs.Basic Contracts.ERC20.Proofs.Correctness`
- `make check`

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the formal `approve_spec` and related proofs to use a new shared `storageMap2` update/frame combinator; mistakes in the new framing predicates could cause subtle spec/proof mismatches.
> 
> **Overview**
> **Factors a reusable `storageMap2` update spec helper.** Adds `storageMap2UnchangedExcept*` predicates plus `storageMap2UpdateSpec` in `Verity.Specs.Common` to express “update one mapping2 entry, everything else unchanged”.
> 
> **Migrates ERC20 `approve` to the helper and reshapes proofs.** `Contracts.ERC20.Spec.approve_spec` is rewritten to use `storageMap2UpdateSpec`, and `approve_meets_spec` plus `approve_is_balance_neutral_holds` are updated to destructure the new nested spec/frame structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 427cba384779294e840517c760e630b1d70c4269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->