### PR TITLE
Specs: add storageMap2 update helper and migrate ERC20 approve (#1166)

### DIFF
--- a/Contracts/ERC20/Proofs/Basic.lean
+++ b/Contracts/ERC20/Proofs/Basic.lean
@@ -42,22 +42,21 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
 /-- `approve` writes allowance(sender, spender) and leaves other state unchanged. -/
 theorem approve_meets_spec (s : ContractState) (spender : Address) (amount : Uint256) :
     approve_spec s.sender spender amount s ((approve spender amount).runState s) := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  unfold approve_spec Specs.storageMap2UpdateSpec Specs.storageMap2UnchangedExceptKeyPair
+  refine ⟨?_, ?_, ?_⟩
   · simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · intro o' sp' h_neq
-    simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
-      h_neq]
-  · intro sp' h_neq
-    simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
-      h_neq]
-  · simp [Specs.sameStorage, approve, allowancesSlot, setMapping2, msgSender,
-      Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageAddr, approve, allowancesSlot, setMapping2, msgSender,
-      Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMap, approve, allowancesSlot, setMapping2, msgSender,
-      Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameContext, approve, allowancesSlot, setMapping2, msgSender,
-      Contract.runState, Verity.bind, Bind.bind]
+  · refine ⟨?_, ?_⟩
+    · intro o' sp' h_neq
+      simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
+        h_neq]
+    · intro sp' h_neq
+      simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
+        h_neq]
+  · refine ⟨?_, ?_, ?_, ?_⟩
+    · rfl
+    · rfl
+    · rfl
+    · exact Specs.sameContext_rfl _
 
 /-- `balanceOf` returns the value stored in balances slot 2 for `addr`. -/
 theorem balanceOf_meets_spec (s : ContractState) (addr : Address) :

--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -46,15 +46,14 @@ def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState
 
 /-- approve: updates the owner-spender allowance mapping entry -/
 def approve_spec (ownerAddr spender : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  s'.storageMap2 3 ownerAddr spender = amount ∧
-  (∀ o' : Address, ∀ sp' : Address,
-    o' ≠ ownerAddr → s'.storageMap2 3 o' sp' = s.storageMap2 3 o' sp') ∧
-  (∀ sp' : Address,
-    sp' ≠ spender → s'.storageMap2 3 ownerAddr sp' = s.storageMap2 3 ownerAddr sp') ∧
-  sameStorage s s' ∧
-  sameStorageAddr s s' ∧
-  sameStorageMap s s' ∧
-  sameContext s s'
+  storageMap2UpdateSpec
+    3 ownerAddr spender (fun _ => amount)
+    (fun st st' =>
+      sameStorage st st' ∧
+      sameStorageAddr st st' ∧
+      sameStorageMap st st' ∧
+      sameContext st st')
+    s s'
 
 /-- transferFrom: debits `fromAddr`, credits `to`, and updates allowance for spender -/
 def transferFrom_spec (spender fromAddr to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -166,6 +166,14 @@ def storageMapUnchangedExceptKeysAtSlot (slot : Nat) (addr1 addr2 : Address) (s 
   storageMapUnchangedExceptKeys slot addr1 addr2 s s' ∧
   storageMapUnchangedExceptSlot slot s s'
 
+/-- All double-mapping entries at `slot` are unchanged except possibly `(key1, key2)`. -/
+def storageMap2UnchangedExceptKeyPair
+    (slot : Nat) (key1 key2 : Address) (s s' : ContractState) : Prop :=
+  (∀ k1' : Address, ∀ k2' : Address,
+    k1' ≠ key1 → s'.storageMap2 slot k1' k2' = s.storageMap2 slot k1' k2') ∧
+  (∀ k2' : Address,
+    k2' ≠ key2 → s'.storageMap2 slot key1 k2' = s.storageMap2 slot key1 k2')
+
 /-- Canonical two-state spec shape for updating one `storageMap` slot/key entry. -/
 def storageMapUpdateSpec
     (slot : Nat)
@@ -190,6 +198,17 @@ def storageMapAndStorageUpdateSpec
   s'.storage storageSlot = storageValue s ∧
   storageMapUnchangedExceptKeyAtSlot mapSlot key s s' ∧
   storageUnchangedExcept storageSlot s s' ∧
+  frame s s'
+
+/-- Canonical two-state spec shape for updating one `storageMap2` slot/key pair. -/
+def storageMap2UpdateSpec
+    (slot : Nat)
+    (key1 key2 : Address)
+    (value : ContractState → Uint256)
+    (frame : ContractState → ContractState → Prop)
+    (s s' : ContractState) : Prop :=
+  s'.storageMap2 slot key1 key2 = value s ∧
+  storageMap2UnchangedExceptKeyPair slot key1 key2 s s' ∧
   frame s s'
 
 /-- Canonical two-state spec shape for transfer-style updates on one mapping slot.


### PR DESCRIPTION
## Summary
- add reusable `storageMap2` spec primitives in `Verity/Specs/Common.lean`:
  - `storageMap2UnchangedExceptKeyPair`
  - `storageMap2UpdateSpec`
- migrate `Contracts/ERC20/Spec.lean` `approve_spec` to `storageMap2UpdateSpec`
- update `Contracts/ERC20/Proofs/Basic.lean` `approve_meets_spec` proof shape to match the helper expansion

## Why
Issue #1166 tracks reducing repetitive hand-written spec templates and moving toward declarative/spec-generation-friendly forms. `storageMap2` single-entry updates were still duplicated in ERC20 allowance specs.

## Validation
- `lake build Verity.Specs.Common Contracts.ERC20.Spec Contracts.ERC20.Proofs.Basic`
- `python3 scripts/check_verify_sync.py`
- `make check`

Closes part of #1166.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the canonical shape of the ERC20 `approve_spec` to a new reusable `storageMap2` update helper, which could affect downstream proofs/spec consumers even though the intended semantics are equivalent.
> 
> **Overview**
> **Specs now include canonical helpers for double-mapping updates.** `Verity/Specs/Common.lean` adds `storageMap2UnchangedExceptKeyPair` and `storageMap2UpdateSpec` to standardize “update one `(key1,key2)` entry and frame everything else” specs.
> 
> **ERC20 `approve` is migrated to the helper.** `Contracts/ERC20/Spec.lean` rewrites `approve_spec` in terms of `storageMap2UpdateSpec`, and `Contracts/ERC20/Proofs/Basic.lean` updates `approve_meets_spec` to unfold and prove the new spec structure (with simplified `same*`/context clauses).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff95a4b79f5543d83cce74a71ed523a727edfe4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->