### PR TITLE
ERC20: adapt correctness proof to storageMap2 helper shape (#1166)

### DIFF
--- a/Contracts/ERC20/Proofs/Correctness.lean
+++ b/Contracts/ERC20/Proofs/Correctness.lean
@@ -39,7 +39,8 @@ theorem getOwner_preserves_state (s : ContractState) :
 theorem approve_is_balance_neutral_holds (s : ContractState) (spender : Address) (amount : Uint256) :
     approve_is_balance_neutral s ((Contracts.MacroContracts.ERC20.approve spender amount).runState s) := by
   have h := approve_meets_spec s spender amount
-  rcases h with ⟨_, _, _, h_storage, _, h_storageMap, _⟩
+  rcases h with ⟨_, _, h_frame⟩
+  rcases h_frame with ⟨h_storage, _, h_storageMap, _⟩
   exact ⟨h_storage, h_storageMap⟩
 
 /-- `transfer` preserves total supply under successful-path preconditions. -/


### PR DESCRIPTION
## Summary
- adapt  in  to the nested frame shape introduced by  helper migration

## Why
PR #1271 migrated  to , which changed conjunction nesting. This follow-up restores  build correctness.

## Validation
- Build completed successfully.
- Running CI-equivalent checks job...
python3 scripts/check_property_manifest.py
Property manifest check passed.
python3 scripts/check_property_coverage.py
Property coverage check passed.
python3 scripts/check_contract_structure.py
Checking 9 contracts for complete file structure...
  (Excluding: CryptoHash, MacroContracts, ReentrancyExample)

  OK Counter
  OK ERC20
  OK ERC721
  OK Ledger
  OK Owned
  OK OwnedCounter
  OK SafeCounter
  OK SimpleStorage
  OK SimpleToken

OK: All 9 contracts have complete file structure
python3 scripts/check_case_insensitive_path_conflicts.py
python3 scripts/check_axiom_locations.py
  OK keccak256_first_4_bytes at Compiler/Selectors.lean:41
  OK resultsMatch_switchCaseBody_of_resultsMatch_body at Compiler/Proofs/YulGeneration/Preservation.lean:300

OK: 2 documented axiom locations are accurate; registry is complete and synchronized with 2 source axioms
python3 scripts/generate_verification_status.py --check
Verification artifact is up to date: /workspaces/mission-3356d738/repo-run-20260306g/artifacts/verification_status.json
python3 scripts/check_doc_counts.py
Documentation count check passed (272 theorems, 10 categories, 2 axioms, 475 tests, 38 suites, 0 sorry, 250/272 covered, 22 exclusions).
python3 scripts/check_interop_matrix_sync.py
Interop matrix is synchronized across docs (6 feature rows checked).
python3 scripts/check_verify_sync.py
[PASS] paths
[PASS] jobs
[PASS] python-commands
[PASS] multiseed
[PASS] foundry
[PASS] artifacts
[PASS] makefile
verify sync passed: 7 invariant groups
python3 scripts/check_issue_template_forms.py
issue template forms OK (4 file(s))
python3 scripts/check_solc_pin.py
✓ solc pin is consistent (0.8.33+commit.64118f21)
python3 scripts/check_property_manifest_sync.py
Property manifest sync check passed.
python3 scripts/check_issue_templates.py
issue template contamination check passed
python3 scripts/check_macro_property_test_generation.py --check
macro property-test artifacts are up to date: artifacts/macro_property_tests
python3 scripts/check_macro_translate_invariant_coverage.py
macro invariant suite coverage OK
python3 scripts/check_macro_roundtrip_fuzz_coverage.py
macro round-trip fuzz coverage OK
python3 scripts/check_storage_layout.py
Storage layout validation passed.

============================================================
STORAGE LAYOUT REPORT
============================================================

  Counter
    Slot 0: count (Uint256)

  CryptoHash
    Slot 0: lastHash (Uint256)

  Ledger
    Slot 0: balances ((Address → Uint256))

  Owned
    Slot 0: owner (Address)

  OwnedCounter
    Slot 0: owner (Address)
    Slot 1: count (Uint256)

  ReentrancyExample
    Slot 0: reentrancyLock (Uint256)
    Slot 1: totalSupply (Uint256)
    Slot 2: balances ((Address → Uint256))

  SafeCounter
    Slot 0: count (Uint256)

  SimpleToken
    Slot 0: owner (Address)
    Slot 1: balances ((Address → Uint256))
    Slot 2: totalSupply (Uint256)
python3 scripts/check_manual_spec_quarantine.py
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
python3 scripts/check_spec_proof_migration_boundary.py
Spec-proof migration boundary check passed (16 allowlisted files; no out-of-bound legacy references).
python3 scripts/check_legacy_example_imports.py
Legacy migrated-contract import guard passed (170 Lean files scanned; 9 explicit exemption module(s)).
python3 scripts/check_layer2_universality.py
Layer-2 universality check passed (15 semantic bridge theorem headers validated).
python3 scripts/check_lean_hygiene.py
Lean hygiene check passed (0 debug commands in proofs, 1 allowUnsafeReducibility, 0 sorry (expected 0), 0 native_decide in proofs).
python3 scripts/check_gas_model_coverage.py
OK: static gas model covers all emitted Yul calls (26 names) across: artifacts/yul
python3 scripts/check_mapping_slot_boundary.py
✓ Mapping slot boundary is enforced
python3 scripts/check_yul_builtin_boundary.py
✓ Yul builtin boundary is enforced
python3 scripts/check_rewrite_proof_metadata.py
Rewrite proof metadata check passed (active object rewrite rules have non-empty proof refs).
python3 scripts/check_builtin_list_sync.py
✓ Builtin lists in sync (85 Linker, 78+4 CompilationModel)
python3 scripts/check_evmyullean_capability_boundary.py
✓ EVMYulLean capability boundary is enforced
python3 scripts/generate_evmyullean_capability_report.py --check
EVMYulLean capability report is up to date: /workspaces/mission-3356d738/repo-run-20260306g/artifacts/evmyullean_capability_report.json
EVMYulLean unsupported-node report is up to date: /workspaces/mission-3356d738/repo-run-20260306g/artifacts/evmyullean_unsupported_nodes.json
python3 scripts/generate_evmyullean_adapter_report.py --check
EVMYulLean adapter report is up to date: /workspaces/mission-3356d738/repo-run-20260306g/artifacts/evmyullean_adapter_report.json
python3 scripts/generate_print_axioms.py --check
OK: /workspaces/mission-3356d738/repo-run-20260306g/PrintAxioms.lean is up to date.
python3 scripts/check_proof_length.py
Proof length check: 952 proofs scanned.
  895 under 30 lines (good)
  43 between 30-50 lines (acceptable)
  14 over 50 lines (allowlisted)

Proof length check passed. No new proofs exceed the 50-line hard limit.
python3 scripts/check_issue_1060_integrity.py
issue #1060 integrity check passed
python3 -m unittest discover -s scripts -p 'test_*.py' -v
  OK documented_axiom at Compiler/A.lean:1
✓ Builtin lists in sync (3 Linker, 1+1 CompilationModel)
Documentation count check passed (272 theorems, 10 categories, 2 axioms, 475 tests, 38 suites, 0 sorry, 250/272 covered, 22 exclusions).
Interop matrix is synchronized across docs (1 feature rows checked).
issue #1060 integrity check passed
issue template forms OK (1 file(s))
Legacy migrated-contract import guard passed (1 Lean files scanned; 1 explicit exemption module(s)).
Legacy migrated-contract import guard passed (1 Lean files scanned; 0 explicit exemption module(s)).
wrote macro property-test artifacts (1 file(s)): tmpk44gvgrl/artifacts
wrote macro property-test artifacts (1 file(s)): tmpjndvou4u/artifacts
wrote macro property-test artifacts (1 file(s)): tmp8kyjlvhh/artifacts
macro property-test artifacts are up to date: tmp8kyjlvhh/artifacts
macro round-trip fuzz coverage OK
macro round-trip fuzz coverage OK
macro round-trip fuzz coverage OK
macro invariant suite coverage OK
macro invariant suite coverage OK
macro invariant suite coverage OK
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Spec-proof migration boundary check passed (1 allowlisted files; no out-of-bound legacy references).
Spec-proof migration boundary check passed (0 allowlisted files; no out-of-bound legacy references).
✓ Yul builtin boundary is enforced
Wrote Lean warning baseline to /tmp/tmpynlt5t2y/baseline.json
Wrote Yul identity report: /tmp/tmpp34h61op/r1.json
Status: non_identical (1 mismatches)
Wrote Yul identity report: /tmp/tmpp34h61op/r2.json
Status: non_identical (1 mismatches)
All checks passed.

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only change that adjusts destructuring to match an updated spec lemma shape; no contract logic or invariants are modified.
> 
> **Overview**
> Updates `Contracts/ERC20/Proofs/Correctness.lean` to **restructure the `rcases` destructuring** in `approve_is_balance_neutral_holds`, matching the new nested “frame” shape returned by `approve_meets_spec` after the `storageMap2` helper migration.
> 
> No contract behavior changes; this is purely a proof maintenance fix to restore the ERC20 correctness build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fc2fc68040a274c3baa055c40f4062e6cf4ef8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->