### PR TITLE
ERC20: factor transferFrom spec into shared helper (#1166)

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -59,18 +59,12 @@ def approve_spec (ownerAddr spender : Address) (amount : Uint256) (s s' : Contra
 def transferFrom_spec (spender fromAddr to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
   s.storageMap2 3 fromAddr spender ≥ amount ∧
   s.storageMap 2 fromAddr ≥ amount ∧
-  (if fromAddr == to
-    then s'.storageMap 2 fromAddr = s.storageMap 2 fromAddr
-    else s'.storageMap 2 fromAddr = sub (s.storageMap 2 fromAddr) amount) ∧
-  (if fromAddr == to
-    then s'.storageMap 2 to = s.storageMap 2 to
-    else s'.storageMap 2 to = add (s.storageMap 2 to) amount) ∧
-  (if s.storageMap2 3 fromAddr spender == Verity.EVM.MAX_UINT256
-    then s'.storageMap2 3 fromAddr spender = Verity.EVM.MAX_UINT256
-    else s'.storageMap2 3 fromAddr spender = sub (s.storageMap2 3 fromAddr spender) amount) ∧
-  s'.storage 1 = s.storage 1 ∧
-  s'.storageAddr 0 = s.storageAddr 0 ∧
-  sameContext s s'
+  storageMapTransferFromSpec 2 3 fromAddr to spender amount
+    (fun st st' =>
+      sameStorage st st' ∧
+      sameStorageAddr st st' ∧
+      sameContext st st')
+    s s'
 
 /-- balanceOf: returns current balance of `addr` -/
 def balanceOf_spec (addr : Address) (result : Uint256) (s : ContractState) : Prop :=

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -231,6 +231,32 @@ def storageMapTransferSpec
     else storageMapUnchangedExceptKeysAtSlot slot fromAddr to s s') ∧
   frame s s'
 
+/-- Canonical two-state spec shape for ERC20-style `transferFrom` updates.
+When `from == to`, balances are unchanged; otherwise `from` is debited and `to` is credited.
+Allowance stays at `MAX_UINT256` or decreases by `amount` and all other allowance pairs are unchanged. -/
+@[simp]
+def storageMapTransferFromSpec
+    (balanceSlot allowanceSlot : Nat)
+    (fromAddr to spender : Address)
+    (amount : Uint256)
+    (frame : ContractState → ContractState → Prop)
+    (s s' : ContractState) : Prop :=
+  (if fromAddr == to
+    then s'.storageMap balanceSlot fromAddr = s.storageMap balanceSlot fromAddr
+    else s'.storageMap balanceSlot fromAddr = sub (s.storageMap balanceSlot fromAddr) amount) ∧
+  (if fromAddr == to
+    then s'.storageMap balanceSlot to = s.storageMap balanceSlot to
+    else s'.storageMap balanceSlot to = add (s.storageMap balanceSlot to) amount) ∧
+  (if fromAddr == to
+    then storageMapUnchangedExceptKeyAtSlot balanceSlot fromAddr s s'
+    else storageMapUnchangedExceptKeysAtSlot balanceSlot fromAddr to s s') ∧
+  (if s.storageMap2 allowanceSlot fromAddr spender == Verity.EVM.MAX_UINT256
+    then s'.storageMap2 allowanceSlot fromAddr spender = Verity.EVM.MAX_UINT256
+    else s'.storageMap2 allowanceSlot fromAddr spender =
+      sub (s.storageMap2 allowanceSlot fromAddr spender) amount) ∧
+  storageMap2UnchangedExceptKeyPair allowanceSlot fromAddr spender s s' ∧
+  frame s s'
+
 /-- All storage (uint256, addr, map, mapUint, map2) is unchanged. -/
 def sameAllStorage (s s' : ContractState) : Prop :=
   sameStorage s s' ∧


### PR DESCRIPTION
## Summary
- add a shared `storageMapTransferFromSpec` combinator in `Verity/Specs/Common.lean`
- migrate `Contracts/ERC20/Spec.lean:transferFrom_spec` to the helper
- strengthen frame shape for `transferFrom_spec` by explicitly requiring unchanged allowance pairs via `storageMap2UnchangedExceptKeyPair`

## Why
Issue #1166 is incrementally extracting common spec templates. `transferFrom_spec` still used a hand-written shape with duplicated logic and weaker explicit frame constraints than newer helper-based specs.

## Validation
- `lake build Verity.Specs.Common Contracts.ERC20.Spec Contracts.ERC20.Proofs.Basic Contracts.ERC20.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the formal `transferFrom` specification shape and strengthens its frame conditions, which may require proof updates or reveal previously-unconstrained behaviors. Scope is limited to spec helpers (no runtime code).
> 
> **Overview**
> Refactors `Contracts/ERC20/Spec.lean` so `transferFrom_spec` is defined via a new shared helper, `storageMapTransferFromSpec`, instead of an inlined conjunction.
> 
> Adds `storageMapTransferFromSpec` to `Verity/Specs/Common.lean`, capturing ERC20 `transferFrom` balance updates plus allowance handling (preserve `MAX_UINT256` sentinel or decrement by `amount`) and **tightens framing** by requiring all other allowance key-pairs remain unchanged via `storageMap2UnchangedExceptKeyPair`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ade043eeb725090488025bcca828d24ea3d54992. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->