### PR TITLE
refactor(specs): migrate Ledger deposit/withdraw to storageMapUpdateSpec

### DIFF
--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -69,16 +69,15 @@ theorem deposit_meets_spec (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd
   deposit_spec amount s s' := by
   rw [deposit_unfold]
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  unfold deposit_spec Specs.storageMapUpdateSpec
+  refine ⟨?_, ?_, ?_⟩
   · simp [ContractResult.snd, beq_iff_eq]
   · refine ⟨?_, ?_⟩
     · intro addr h_ne
       simp [ContractResult.snd, beq_iff_eq, h_ne]
     · intro slotIdx h_ne addr
       simp [ContractResult.snd, beq_iff_eq, h_ne]
-  · rfl
-  · rfl
-  · exact Specs.sameContext_rfl _
+  · exact ⟨rfl, rfl, Specs.sameContext_rfl _⟩
 
 theorem deposit_increases_balance (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd
@@ -120,16 +119,15 @@ theorem withdraw_meets_spec (s : ContractState) (amount : Uint256)
   let s' := ((withdraw amount).run s).snd
   withdraw_spec amount s s' := by
   rw [withdraw_unfold s amount h_balance]
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  unfold withdraw_spec Specs.storageMapUpdateSpec
+  refine ⟨?_, ?_, ?_⟩
   · simp [ContractResult.snd, beq_iff_eq]
   · refine ⟨?_, ?_⟩
     · intro addr h_ne
       simp [ContractResult.snd, beq_iff_eq, h_ne]
     · intro slotIdx h_ne addr
       simp [ContractResult.snd, beq_iff_eq, h_ne]
-  · rfl
-  · rfl
-  · exact Specs.sameContext_rfl _
+  · exact ⟨rfl, rfl, Specs.sameContext_rfl _⟩
 
 theorem withdraw_decreases_balance (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :

--- a/Contracts/Ledger/Spec.lean
+++ b/Contracts/Ledger/Spec.lean
@@ -19,15 +19,19 @@ open Verity.Specs.Common (sumBalances balancesFinite)
 
 /-- deposit: increases sender's balance by amount -/
 def deposit_spec (amount : Uint256) (s s' : ContractState) : Prop :=
-  s'.storageMap 0 s.sender = add (s.storageMap 0 s.sender) amount ∧
-  storageMapUnchangedExceptKeyAtSlot 0 s.sender s s' ∧
-  sameStorageAddrContext s s'
+  storageMapUpdateSpec
+    0 s.sender
+    (fun st => add (st.storageMap 0 st.sender) amount)
+    sameStorageAddrContext
+    s s'
 
 /-- withdraw (when sufficient balance): decreases sender's balance by amount -/
 def withdraw_spec (amount : Uint256) (s s' : ContractState) : Prop :=
-  s'.storageMap 0 s.sender = sub (s.storageMap 0 s.sender) amount ∧
-  storageMapUnchangedExceptKeyAtSlot 0 s.sender s s' ∧
-  sameStorageAddrContext s s'
+  storageMapUpdateSpec
+    0 s.sender
+    (fun st => sub (st.storageMap 0 st.sender) amount)
+    sameStorageAddrContext
+    s s'
 
 /-- transfer: moves amount from sender to recipient -/
 def transfer_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=


### PR DESCRIPTION
## Summary
- migrate `Contracts/Ledger/Spec.lean` `deposit_spec` and `withdraw_spec` to `storageMapUpdateSpec`
- update `Contracts/Ledger/Proofs/Basic.lean` to match the helper-shaped spec definitions
- keep behavior/proof obligations unchanged while reducing hand-written spec boilerplate

## Why
Incremental progress on #1166 by replacing repeated manual update/frame conjunctions with shared combinators.

## Validation
- `lake build Contracts.Ledger.Spec Contracts.Ledger.Proofs.Basic`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to formal spec/proof definitions for `deposit`/`withdraw`, with no changes to contract execution code. Main risk is mismatched spec framing if `storageMapUpdateSpec` is not equivalent to the prior conjunction, but proofs were updated to discharge the same obligations.
> 
> **Overview**
> Refactors Ledger `deposit_spec` and `withdraw_spec` to use the shared `Specs.storageMapUpdateSpec` combinator instead of manually conjoining the balance update, storage-map frame condition, and context preservation.
> 
> Updates the corresponding `deposit_meets_spec` and `withdraw_meets_spec` proofs in `Contracts/Ledger/Proofs/Basic.lean` to unfold `storageMapUpdateSpec` and provide the expected structured witness, keeping the proven behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 934749a6432d42214696548ee8bf8b34e10b99ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->