### PR TITLE
refactor(erc721): migrate setApprovalForAll spec to storageMap2UpdateSpec

### DIFF
--- a/Contracts/ERC721/Proofs/Basic.lean
+++ b/Contracts/ERC721/Proofs/Basic.lean
@@ -77,33 +77,35 @@ theorem isApprovedForAll_meets_spec (s : ContractState) (ownerAddr operator : Ad
 /-- `setApprovalForAll` writes sender/operator flag and leaves other state unchanged. -/
 theorem setApprovalForAll_meets_spec (s : ContractState) (operator : Address) (approved : Bool) :
     setApprovalForAll_spec s.sender operator approved s ((Contracts.MacroContracts.ERC721Addressed.setApprovalForAll operator approved).runState s) := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_⟩
   · cases approved <;>
       simp [Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
         setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord, Contracts.ERC721.Spec.boolToWord,
         msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · intro o' op' h_neq
-    simp [Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
-      setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord,
-      msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq]
-  · intro op' h_neq
-    simp [Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
-      setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord,
-      msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq]
-  · simp [Specs.sameStorage, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
-      setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord,
-      msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageAddr, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
-      setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord,
-      msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMap, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
+  · refine ⟨?_, ?_⟩
+    · intro o' op' h_neq
+      simp [Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
+        setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord,
+        msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq]
+    · intro op' h_neq
+      simp [Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
+        setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord,
+        msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq]
+  · refine ⟨?_, ?_, ?_, ?_, ?_⟩
+    · simp [Specs.sameStorage, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
       setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMapUint, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll,
+    · simp [Specs.sameStorageAddr, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
+      setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord,
+      msgSender, Contract.runState, Verity.bind, Bind.bind]
+    · simp [Specs.sameStorageMap, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,
+      setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord,
+      msgSender, Contract.runState, Verity.bind, Bind.bind]
+    · simp [Specs.sameStorageMapUint, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll,
       Contracts.MacroContracts.ERC721Addressed.operatorApprovals, setMapping2,
       Contracts.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameContext, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll,
+    · simp [Specs.sameContext, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll,
       Contracts.MacroContracts.ERC721Addressed.operatorApprovals, setMapping2,
       Contracts.MacroContracts.ERC721Addressed.boolToWord,
       msgSender, Contract.runState, Verity.bind, Bind.bind]

--- a/Contracts/ERC721/Proofs/Correctness.lean
+++ b/Contracts/ERC721/Proofs/Correctness.lean
@@ -41,7 +41,8 @@ theorem setApprovalForAll_is_balance_neutral_holds
     (s : ContractState) (operator : Address) (approved : Bool) :
     setApprovalForAll_is_balance_neutral s ((Contracts.MacroContracts.ERC721Addressed.setApprovalForAll operator approved).runState s) := by
   have h := setApprovalForAll_meets_spec s operator approved
-  rcases h with ⟨_, _, _, h_storage, h_storageAddr, h_storageMap, h_storageMapUint, _⟩
+  rcases h with ⟨_, _, h_frame⟩
+  rcases h_frame with ⟨h_storage, h_storageAddr, h_storageMap, h_storageMapUint, _⟩
   exact ⟨h_storage, h_storageAddr, h_storageMap, h_storageMapUint⟩
 
 end Contracts.ERC721.Proofs

--- a/Contracts/ERC721/Spec.lean
+++ b/Contracts/ERC721/Spec.lean
@@ -57,15 +57,15 @@ def isApprovedForAll_spec (ownerAddr operator : Address) (result : Bool) (s : Co
 /-- setApprovalForAll: updates only sender->operator flag in slot 6 -/
 def setApprovalForAll_spec
     (sender operator : Address) (approved : Bool) (s s' : ContractState) : Prop :=
-  s'.storageMap2 6 sender operator = boolToWord approved ∧
-  (∀ o' : Address, ∀ op' : Address,
-    o' ≠ sender → s'.storageMap2 6 o' op' = s.storageMap2 6 o' op') ∧
-  (∀ op' : Address,
-    op' ≠ operator → s'.storageMap2 6 sender op' = s.storageMap2 6 sender op') ∧
-  sameStorage s s' ∧
-  sameStorageAddr s s' ∧
-  sameStorageMap s s' ∧
-  sameStorageMapUint s s' ∧
-  sameContext s s'
+  storageMap2UpdateSpec
+    6 sender operator
+    (fun _ => boolToWord approved)
+    (fun st st' =>
+      sameStorage st st' ∧
+      sameStorageAddr st st' ∧
+      sameStorageMap st st' ∧
+      sameStorageMapUint st st' ∧
+      sameContext st st')
+    s s'
 
 end Contracts.ERC721.Spec


### PR DESCRIPTION
## Summary
- migrate `Contracts/ERC721/Spec.lean` `setApprovalForAll_spec` from manual slot/key frame clauses to shared `storageMap2UpdateSpec`
- reshape the corresponding proof destructuring in `Contracts/ERC721/Proofs/Basic.lean` and `Contracts/ERC721/Proofs/Correctness.lean` to match the helper-based spec
- keep operational behavior unchanged while reducing bespoke spec boilerplate

## Why
Incremental progress on #1166 by replacing repeated manual spec-update patterns with reusable combinators.

## Validation
- `lake build Contracts.ERC721.Spec`
- `python3 scripts/check_verify_sync.py`
- `make check`

## Notes
- `lake build Contracts.ERC721.Proofs.Basic Contracts.ERC721.Proofs.Correctness` currently fails on clean `main` due a pre-existing unsolved-goal regression in `constructor_meets_spec` (`Contracts/ERC721/Proofs/Basic.lean`), unrelated to this refactor.

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of formal specifications/proofs only; no runtime contract code changes, but verification could be impacted if the helper-based framing is mis-specified.
> 
> **Overview**
> Refactors `setApprovalForAll_spec` to use the shared `storageMap2UpdateSpec` helper instead of manually stating per-key/per-slot frame conditions, while keeping the same intended “update slot 6 at (sender,operator) and frame everything else” behavior.
> 
> Updates the corresponding proof obligations in `Proofs/Basic.lean` and downstream destructuring in `Proofs/Correctness.lean` to match the new nested spec shape (separating the mapping-update frame from the broader storage/context invariants).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52f3c847317bb92561510a9212c716740d8ddb4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->