### PR TITLE
specs: extract ERC721 constructor update shape helper

### DIFF
--- a/Contracts/ERC721/Spec.lean
+++ b/Contracts/ERC721/Spec.lean
@@ -21,10 +21,9 @@ def boolToWord (b : Bool) : Uint256 :=
 
 /-- constructor: sets owner and initializes counters to zero -/
 def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
-  s'.storageAddr 0 = initialOwner ∧
-  storageAddrUnchangedExcept 0 s s' ∧
-  storage2UpdateSpec
-    1 2
+  storageAddrStorage2UpdateSpec
+    0 1 2
+    (fun _ => initialOwner)
     (fun _ => 0)
     (fun _ => 0)
     (fun st st' => sameStorageMap st st' ∧ sameStorageMap2 st st' ∧ sameStorageMapUint st st' ∧ sameContext st st')

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -133,6 +133,20 @@ def storageAddrStorageUpdateSpec
   storageUnchangedExcept storageSlot s s' ∧
   frame s s'
 
+/-- Canonical two-state spec shape for updating one `storageAddr` slot and two `storage` slots. -/
+def storageAddrStorage2UpdateSpec
+    (addrSlot storageSlot1 storageSlot2 : Nat)
+    (addrValue : ContractState → Address)
+    (storageValue1 storageValue2 : ContractState → Uint256)
+    (frame : ContractState → ContractState → Prop)
+    (s s' : ContractState) : Prop :=
+  s'.storageAddr addrSlot = addrValue s ∧
+  s'.storage storageSlot1 = storageValue1 s ∧
+  s'.storage storageSlot2 = storageValue2 s ∧
+  storageAddrUnchangedExcept addrSlot s s' ∧
+  (∀ other : Nat, other ≠ storageSlot1 → other ≠ storageSlot2 → s'.storage other = s.storage other) ∧
+  frame s s'
+
 /-- Canonical two-state spec shape for updating two `storage` slots. -/
 def storage2UpdateSpec
     (slot1 slot2 : Nat)


### PR DESCRIPTION
## Summary
- add `storageAddrStorage2UpdateSpec` in `Verity/Specs/Common.lean`
- migrate `Contracts/ERC721/Spec.lean` `constructor_spec` to the new helper
- keep behavior/proof shape unchanged while removing the remaining hand-written constructor update scaffold

## Why
This is another incremental step for #1166 to centralize spec boilerplate into reusable combinators.

## Validation
- `lake build Verity.Specs.Common Contracts.ERC721.Spec Contracts.ERC721.Proofs.Basic Contracts.ERC721.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of specification boilerplate: behavior should be unchanged, but it introduces a new common helper and rewires the ERC721 constructor spec to use it, which could affect downstream proofs if the helper shape is slightly off.
> 
> **Overview**
> **Refactors spec boilerplate** by introducing `storageAddrStorage2UpdateSpec` in `Verity/Specs/Common.lean` to capture the common pattern of updating one address slot and two uint256 storage slots while framing all other state as unchanged.
> 
> Updates `Contracts/ERC721/Spec.lean` `constructor_spec` to use this new helper instead of its inline update clauses, aiming to keep the constructor’s specified effects (owner set + counters zeroed) and framing identical.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 606f3bfac7ea8af16cd1feb6f47541e63c1f24ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->