### PR TITLE
Specs: extract ERC721 constructor update shape into shared helpers

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -19,7 +19,7 @@ def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
     0 1
     (fun _ => initialOwner)
     (fun _ => 0)
-    (fun st st' => sameStorageMap st st' ∧ sameStorageMap2 st st' ∧ sameContext st st')
+    sameStorageMap2Context
     s s'
 
 /-- mint: increases recipient balance and total supply by amount -/

--- a/Contracts/ERC721/Proofs/Basic.lean
+++ b/Contracts/ERC721/Proofs/Basic.lean
@@ -33,12 +33,8 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   · simp [Specs.sameStorageMap, Contracts.MacroContracts.ERC721Addressed.constructor, Contracts.MacroContracts.ERC721Addressed.owner,
       Contracts.MacroContracts.ERC721Addressed.totalSupply, Contracts.MacroContracts.ERC721Addressed.nextTokenId,
       setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMap2, Contracts.MacroContracts.ERC721Addressed.constructor, Contracts.MacroContracts.ERC721Addressed.owner,
-      Contracts.MacroContracts.ERC721Addressed.totalSupply, Contracts.MacroContracts.ERC721Addressed.nextTokenId,
-      setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
-  · simp [Specs.sameStorageMapUint, Contracts.MacroContracts.ERC721Addressed.constructor, Contracts.MacroContracts.ERC721Addressed.owner,
-      Contracts.MacroContracts.ERC721Addressed.totalSupply, Contracts.MacroContracts.ERC721Addressed.nextTokenId,
-      setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
+  · rfl
+  · rfl
   · simp [Specs.sameContext, Contracts.MacroContracts.ERC721Addressed.constructor, Contracts.MacroContracts.ERC721Addressed.owner,
       Contracts.MacroContracts.ERC721Addressed.totalSupply, Contracts.MacroContracts.ERC721Addressed.nextTokenId,
       setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]

--- a/Contracts/ERC721/Spec.lean
+++ b/Contracts/ERC721/Spec.lean
@@ -26,7 +26,7 @@ def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
     (fun _ => initialOwner)
     (fun _ => 0)
     (fun _ => 0)
-    (fun st st' => sameStorageMap st st' ∧ sameStorageMap2 st st' ∧ sameStorageMapUint st st' ∧ sameContext st st')
+    sameStorageMapsContext
     s s'
 
 /-- balanceOf: returns current balance of `addr` -/

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -92,6 +92,25 @@ def sameStorageAddrContext (s s' : ContractState) : Prop :=
 @[simp] theorem sameStorageAddrContext_rfl (s : ContractState) : sameStorageAddrContext s s :=
   ⟨rfl, rfl, sameContext_rfl s⟩
 
+/-- Mapping storage, double-mapping storage, and context are unchanged. -/
+def sameStorageMap2Context (s s' : ContractState) : Prop :=
+  sameStorageMap s s' ∧
+  sameStorageMap2 s s' ∧
+  sameContext s s'
+
+@[simp] theorem sameStorageMap2Context_rfl (s : ContractState) : sameStorageMap2Context s s :=
+  ⟨rfl, rfl, sameContext_rfl s⟩
+
+/-- Mapping storage (word + uint-keyed + double), and context are unchanged. -/
+def sameStorageMapsContext (s s' : ContractState) : Prop :=
+  sameStorageMap s s' ∧
+  sameStorageMapUint s s' ∧
+  sameStorageMap2 s s' ∧
+  sameContext s s'
+
+@[simp] theorem sameStorageMapsContext_rfl (s : ContractState) : sameStorageMapsContext s s :=
+  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
+
 /-- All storage slots except `slot` are unchanged. -/
 def storageUnchangedExcept (slot : Nat) (s s' : ContractState) : Prop :=
   ∀ other : Nat, other ≠ slot → s'.storage other = s.storage other


### PR DESCRIPTION
## Summary
- add shared frame helpers in :
  - 
  - 
- add  combinator for constructor-style specs that update owner + two storage slots
- migrate   to the new combinator
- simplify   frame with 
- adjust  constructor proof to match the refactored spec shape

## Validation
- Build completed successfully.
- ⚠ [42/42] Replayed Contracts.ERC721.Proofs.Basic
warning: Contracts/ERC721/Proofs/Basic.lean:17:64: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.owner

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.constructor, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵w̵n̵e̵r̵,̵ ̵setStorageAddr, setStorage,
  ̲  ̲ ̲ ̲Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:19:64: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.totalSupply

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.constructor, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵t̵o̵t̵a̵l̵S̵u̵p̵p̵l̵y̵,̵ ̵setStorageAddr, setStorage,
  ̲  ̲ ̲ ̲Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:21:64: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.nextTokenId

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.constructor, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵n̵e̵x̵t̵T̵o̵k̵e̵n̵I̵d̵,̵ ̵setStorageAddr, setStorage,
  ̲  ̲ ̲ ̲Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:24:64: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.owner

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵w̵n̵e̵r̵,̵Contracts.MacroContracts.ERC721Addressed.totalSupply,
        Contracts.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr, setStorage,
        Contract.runState, Verity.bind, Bind.bind, h_neq]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:25:6: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.totalSupply

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲ ̲ ̲Contracts.MacroContracts.ERC721Addressed.owner,
        C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵t̵o̵t̵a̵l̵S̵u̵p̵p̵l̵y̵,̵ ̵Contracts.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr, setStorage,
        Contract.runState, Verity.bind, Bind.bind, h_neq]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:25:60: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.nextTokenId

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲ ̲ ̲Contracts.MacroContracts.ERC721Addressed.owner,
        Contracts.MacroContracts.ERC721Addressed.totalSupply, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵n̵e̵x̵t̵T̵o̵k̵e̵n̵I̵d̵,̵ ̵setStorageAddr, setStorage,
        Contract.runState, Verity.bind, Bind.bind, h_neq]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:29:64: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.owner

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵w̵n̵e̵r̵,̵Contracts.MacroContracts.ERC721Addressed.totalSupply,
        Contracts.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr, setStorage,
        Contract.runState, Verity.bind, Bind.bind, h_slot1, h_slot2]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:30:6: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.totalSupply

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲ ̲ ̲Contracts.MacroContracts.ERC721Addressed.owner,
        C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵t̵o̵t̵a̵l̵S̵u̵p̵p̵l̵y̵,̵ ̵Contracts.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr, setStorage,
        Contract.runState, Verity.bind, Bind.bind, h_slot1, h_slot2]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:30:60: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.nextTokenId

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲ ̲ ̲Contracts.MacroContracts.ERC721Addressed.owner,
        Contracts.MacroContracts.ERC721Addressed.totalSupply, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵n̵e̵x̵t̵T̵o̵k̵e̵n̵I̵d̵,̵ ̵setStorageAddr, setStorage,
        Contract.runState, Verity.bind, Bind.bind, h_slot1, h_slot2]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:33:86: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.owner

Hint: Omit it from the simp argument list.
  simp [Specs.sameStorageMap, Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵w̵n̵e̵r̵,̵Contracts.MacroContracts.ERC721Addressed.totalSupply,
      Contracts.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr, setStorage,
  ̲  ̲ ̲ ̲Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:34:6: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.totalSupply

Hint: Omit it from the simp argument list.
  simp [Specs.sameStorageMap, Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲Contracts.MacroContracts.ERC721Addressed.owner,
      C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵t̵o̵t̵a̵l̵S̵u̵p̵p̵l̵y̵,̵ ̵Contracts.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr, setStorage,
  ̲  ̲ ̲ ̲Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:34:60: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.nextTokenId

Hint: Omit it from the simp argument list.
  simp [Specs.sameStorageMap, Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲Contracts.MacroContracts.ERC721Addressed.owner,
      Contracts.MacroContracts.ERC721Addressed.totalSupply, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵n̵e̵x̵t̵T̵o̵k̵e̵n̵I̵d̵,̵setStorageAddr, setStorage,
  ̲  ̲ ̲ ̲Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:38:83: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.owner

Hint: Omit it from the simp argument list.
  simp [Specs.sameContext, Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵w̵n̵e̵r̵,̵Contracts.MacroContracts.ERC721Addressed.totalSupply,
      Contracts.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr, setStorage,
  ̲  ̲ ̲ ̲Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:39:6: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.totalSupply

Hint: Omit it from the simp argument list.
  simp [Specs.sameContext, Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲Contracts.MacroContracts.ERC721Addressed.owner,
      C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵t̵o̵t̵a̵l̵S̵u̵p̵p̵l̵y̵,̵ ̵Contracts.MacroContracts.ERC721Addressed.nextTokenId, setStorageAddr, setStorage,
  ̲  ̲ ̲ ̲Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:39:60: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.nextTokenId

Hint: Omit it from the simp argument list.
  simp [Specs.sameContext, Contracts.MacroContracts.ERC721Addressed.constructor,
  ̲  ̲ ̲ ̲Contracts.MacroContracts.ERC721Addressed.owner,
      Contracts.MacroContracts.ERC721Addressed.totalSupply, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵n̵e̵x̵t̵T̵o̵k̵e̵n̵I̵d̵,̵setStorageAddr, setStorage,
  ̲  ̲ ̲ ̲Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:46:4: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.balances

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.balanceOf, balanceOf_spec, getMapping,
  ̲  ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵.̵r̵u̵n̵V̵a̵l̵u̵e̵,̵
  ̵ ̵ ̵ ̵ ̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵b̵a̵l̵a̵n̵c̵e̵s̵]̵C̲o̲n̲t̲r̲a̲c̲t̲.̲r̲u̲n̲V̲a̲l̲u̲e̲]̲

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:53:22: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.owners

Hint: Omit it from the simp argument list.
  simp [ownerOf_spec, Contracts.MacroContracts.ERC721Addressed.ownerOf, Contract.run, Verity.bind,
  ̲  ̲ ̲ ̲ ̲ ̲Bind.bind, getMappingUint, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵w̵n̵e̵r̵s̵,̵ ̵Contracts.MacroContracts.ERC721Addressed.wordToAddress,
        Contracts.ERC721.Spec.wordToAddress, Pure.pure, Verity.pure, require, h_owner]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:62:22: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.owners

Hint: Omit it from the simp argument list.
  simp [getApproved_spec, Contracts.MacroContracts.ERC721Addressed.getApproved, Contract.run,
  ̲  ̲ ̲ ̲ ̲ ̲Verity.bind, Bind.bind, getMappingUint,
  ̲  ̲ ̲ ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵w̵n̵e̵r̵s̵,̵ ̵Contracts.MacroContracts.ERC721Addressed.tokenApprovals,
        Contracts.MacroContracts.ERC721Addressed.wordToAddress, Contracts.ERC721.Spec.wordToAddress,
  ̲  ̲ ̲ ̲ ̲ ̲Pure.pure, Verity.pure, require, h_owner]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:62:71: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.tokenApprovals

Hint: Omit it from the simp argument list.
  simp [getApproved_spec, Contracts.MacroContracts.ERC721Addressed.getApproved, Contract.run,
  ̲  ̲ ̲ ̲ ̲ ̲Verity.bind, Bind.bind, getMappingUint, Contracts.MacroContracts.ERC721Addressed.owners,
  ̲  ̲ ̲ ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵t̵o̵k̵e̵n̵A̵p̵p̵r̵o̵v̵a̵l̵s̵,̵Contracts.MacroContracts.ERC721Addressed.wordToAddress, Contracts.ERC721.Spec.wordToAddress,
  ̲  ̲ ̲ ̲ ̲ ̲Pure.pure, Verity.pure, require, h_owner]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:70:17: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.operatorApprovals

Hint: Omit it from the simp argument list.
  simp [isApprovedForAll_spec, Contracts.MacroContracts.ERC721Addressed.isApprovedForAll,
  ̲  ̲ ̲ ̲Contract.runValue, Verity.bind, Bind.bind, g̵e̵t̵M̵a̵p̵p̵i̵n̵g̵2̵,̵ ̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵p̵e̵r̵a̵t̵o̵r̵A̵p̵p̵r̵o̵v̵a̵l̵s̵]̵g̲e̲t̲M̲a̲p̲p̲i̲n̲g̲2̲]̲

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:78:72: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.operatorApprovals

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵p̵e̵r̵a̵t̵o̵r̵A̵p̵p̵r̵o̵v̵a̵l̵s̵,̵setMapping2,
          Contracts.MacroContracts.ERC721Addressed.boolToWord, Contracts.ERC721.Spec.boolToWord,
  ̲  ̲ ̲ ̲ ̲ ̲ ̲ ̲msgSender, Contract.runState, Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:82:70: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.operatorApprovals

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵p̵e̵r̵a̵t̵o̵r̵A̵p̵p̵r̵o̵v̵a̵l̵s̵,̵setMapping2,
        Contracts.MacroContracts.ERC721Addressed.boolToWord, msgSender, Contract.runState,
  ̲  ̲ ̲ ̲ ̲ ̲Verity.bind, Bind.bind, h_neq]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:86:70: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.operatorApprovals

Hint: Omit it from the simp argument list.
  simp [Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵p̵e̵r̵a̵t̵o̵r̵A̵p̵p̵r̵o̵v̵a̵l̵s̵,̵setMapping2,
        Contracts.MacroContracts.ERC721Addressed.boolToWord, msgSender, Contract.runState,
  ̲  ̲ ̲ ̲ ̲ ̲Verity.bind, Bind.bind, h_neq]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:89:89: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.operatorApprovals

Hint: Omit it from the simp argument list.
  simp [Specs.sameStorage, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll,
  ̲  ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵p̵e̵r̵a̵t̵o̵r̵A̵p̵p̵r̵o̵v̵a̵l̵s̵,̵setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord, msgSender, Contract.runState,
  ̲  ̲ ̲ ̲Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:92:93: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.operatorApprovals

Hint: Omit it from the simp argument list.
  simp [Specs.sameStorageAddr, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll,
  ̲  ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵p̵e̵r̵a̵t̵o̵r̵A̵p̵p̵r̵o̵v̵a̵l̵s̵,̵setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord, msgSender, Contract.runState,
  ̲  ̲ ̲ ̲Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:95:92: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.operatorApprovals

Hint: Omit it from the simp argument list.
  simp [Specs.sameStorageMap, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll,
  ̲  ̲ ̲ ̲C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵p̵e̵r̵a̵t̵o̵r̵A̵p̵p̵r̵o̵v̵a̵l̵s̵,̵setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord, msgSender, Contract.runState,
  ̲  ̲ ̲ ̲Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:99:6: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.operatorApprovals

Hint: Omit it from the simp argument list.
  simp [Specs.sameStorageMapUint, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll,
      C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵p̵e̵r̵a̵t̵o̵r̵A̵p̵p̵r̵o̵v̵a̵l̵s̵,̵ ̵setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord, msgSender, Contract.runState,
  ̲  ̲ ̲ ̲Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: Contracts/ERC721/Proofs/Basic.lean:103:6: This simp argument is unused:
  Contracts.MacroContracts.ERC721Addressed.operatorApprovals

Hint: Omit it from the simp argument list.
  simp [Specs.sameContext, Contracts.MacroContracts.ERC721Addressed.setApprovalForAll,
      C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵M̵a̵c̵r̵o̵C̵o̵n̵t̵r̵a̵c̵t̵s̵.̵E̵R̵C̵7̵2̵1̵A̵d̵d̵r̵e̵s̵s̵e̵d̵.̵o̵p̵e̵r̵a̵t̵o̵r̵A̵p̵p̵r̵o̵v̵a̵l̵s̵,̵ ̵setMapping2, Contracts.MacroContracts.ERC721Addressed.boolToWord, msgSender, Contract.runState,
  ̲  ̲ ̲ ̲Verity.bind, Bind.bind]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
Build completed successfully.
- [PASS] paths
[PASS] jobs
[PASS] python-commands
[PASS] multiseed
[PASS] foundry
[PASS] artifacts
[PASS] makefile
verify sync passed: 7 invariant groups
- Running CI-equivalent checks job...
python3 scripts/check_property_manifest.py
Property manifest check passed.
python3 scripts/check_property_coverage.py
Property coverage check passed.
python3 scripts/check_contract_structure.py
Checking 9 contracts for complete file structure...
  (Excluding: CryptoHash, MacroContracts, ReentrancyExample)

  OK Counter
  OK ERC20
  OK ERC721
  OK Ledger
  OK Owned
  OK OwnedCounter
  OK SafeCounter
  OK SimpleStorage
  OK SimpleToken

OK: All 9 contracts have complete file structure
python3 scripts/check_case_insensitive_path_conflicts.py
python3 scripts/check_axiom_locations.py
  OK keccak256_first_4_bytes at Compiler/Selectors.lean:41
  OK resultsMatch_switchCaseBody_of_resultsMatch_body at Compiler/Proofs/YulGeneration/Preservation.lean:300

OK: 2 documented axiom locations are accurate; registry is complete and synchronized with 2 source axioms
python3 scripts/generate_verification_status.py --check
Verification artifact is up to date: /workspaces/mission-3356d738/repo-run-20260306g/artifacts/verification_status.json
python3 scripts/check_doc_counts.py
Documentation count check passed (272 theorems, 10 categories, 2 axioms, 475 tests, 38 suites, 0 sorry, 250/272 covered, 22 exclusions).
python3 scripts/check_interop_matrix_sync.py
Interop matrix is synchronized across docs (6 feature rows checked).
python3 scripts/check_verify_sync.py
[PASS] paths
[PASS] jobs
[PASS] python-commands
[PASS] multiseed
[PASS] foundry
[PASS] artifacts
[PASS] makefile
verify sync passed: 7 invariant groups
python3 scripts/check_issue_template_forms.py
issue template forms OK (4 file(s))
python3 scripts/check_solc_pin.py
✓ solc pin is consistent (0.8.33+commit.64118f21)
python3 scripts/check_property_manifest_sync.py
Property manifest sync check passed.
python3 scripts/check_issue_templates.py
issue template contamination check passed
python3 scripts/check_macro_property_test_generation.py --check
macro property-test artifacts are up to date: artifacts/macro_property_tests
python3 scripts/check_macro_translate_invariant_coverage.py
macro invariant suite coverage OK
python3 scripts/check_macro_roundtrip_fuzz_coverage.py
macro round-trip fuzz coverage OK
python3 scripts/check_storage_layout.py
Storage layout validation passed.

============================================================
STORAGE LAYOUT REPORT
============================================================

  Counter
    Slot 0: count (Uint256)

  CryptoHash
    Slot 0: lastHash (Uint256)

  Ledger
    Slot 0: balances ((Address → Uint256))

  Owned
    Slot 0: owner (Address)

  OwnedCounter
    Slot 0: owner (Address)
    Slot 1: count (Uint256)

  ReentrancyExample
    Slot 0: reentrancyLock (Uint256)
    Slot 1: totalSupply (Uint256)
    Slot 2: balances ((Address → Uint256))

  SafeCounter
    Slot 0: count (Uint256)

  SimpleToken
    Slot 0: owner (Address)
    Slot 1: balances ((Address → Uint256))
    Slot 2: totalSupply (Uint256)
python3 scripts/check_manual_spec_quarantine.py
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
python3 scripts/check_spec_proof_migration_boundary.py
Spec-proof migration boundary check passed (16 allowlisted files; no out-of-bound legacy references).
python3 scripts/check_legacy_example_imports.py
Legacy migrated-contract import guard passed (170 Lean files scanned; 9 explicit exemption module(s)).
python3 scripts/check_layer2_universality.py
Layer-2 universality check passed (15 semantic bridge theorem headers validated).
python3 scripts/check_lean_hygiene.py
Lean hygiene check passed (0 debug commands in proofs, 1 allowUnsafeReducibility, 0 sorry (expected 0), 0 native_decide in proofs).
python3 scripts/check_gas_model_coverage.py
OK: static gas model covers all emitted Yul calls (26 names) across: artifacts/yul
python3 scripts/check_mapping_slot_boundary.py
✓ Mapping slot boundary is enforced
python3 scripts/check_yul_builtin_boundary.py
✓ Yul builtin boundary is enforced
python3 scripts/check_rewrite_proof_metadata.py
Rewrite proof metadata check passed (active object rewrite rules have non-empty proof refs).
python3 scripts/check_builtin_list_sync.py
✓ Builtin lists in sync (85 Linker, 78+4 CompilationModel)
python3 scripts/check_evmyullean_capability_boundary.py
✓ EVMYulLean capability boundary is enforced
python3 scripts/generate_evmyullean_capability_report.py --check
EVMYulLean capability report is up to date: /workspaces/mission-3356d738/repo-run-20260306g/artifacts/evmyullean_capability_report.json
EVMYulLean unsupported-node report is up to date: /workspaces/mission-3356d738/repo-run-20260306g/artifacts/evmyullean_unsupported_nodes.json
python3 scripts/generate_evmyullean_adapter_report.py --check
EVMYulLean adapter report is up to date: /workspaces/mission-3356d738/repo-run-20260306g/artifacts/evmyullean_adapter_report.json
python3 scripts/generate_print_axioms.py --check
OK: /workspaces/mission-3356d738/repo-run-20260306g/PrintAxioms.lean is up to date.
python3 scripts/check_proof_length.py
Proof length check: 952 proofs scanned.
  896 under 30 lines (good)
  42 between 30-50 lines (acceptable)
  14 over 50 lines (allowlisted)

Proof length check passed. No new proofs exceed the 50-line hard limit.
python3 scripts/check_issue_1060_integrity.py
issue #1060 integrity check passed
python3 -m unittest discover -s scripts -p 'test_*.py' -v
  OK documented_axiom at Compiler/A.lean:1
✓ Builtin lists in sync (3 Linker, 1+1 CompilationModel)
Documentation count check passed (272 theorems, 10 categories, 2 axioms, 475 tests, 38 suites, 0 sorry, 250/272 covered, 22 exclusions).
Interop matrix is synchronized across docs (1 feature rows checked).
issue #1060 integrity check passed
issue template forms OK (1 file(s))
Legacy migrated-contract import guard passed (1 Lean files scanned; 1 explicit exemption module(s)).
Legacy migrated-contract import guard passed (1 Lean files scanned; 0 explicit exemption module(s)).
wrote macro property-test artifacts (1 file(s)): tmpe58kpu6k/artifacts
wrote macro property-test artifacts (1 file(s)): tmpm_d67zod/artifacts
wrote macro property-test artifacts (1 file(s)): tmpxz6xbq25/artifacts
macro property-test artifacts are up to date: tmpxz6xbq25/artifacts
macro round-trip fuzz coverage OK
macro round-trip fuzz coverage OK
macro round-trip fuzz coverage OK
macro invariant suite coverage OK
macro invariant suite coverage OK
macro invariant suite coverage OK
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Spec-proof migration boundary check passed (1 allowlisted files; no out-of-bound legacy references).
Spec-proof migration boundary check passed (0 allowlisted files; no out-of-bound legacy references).
✓ Yul builtin boundary is enforced
Wrote Lean warning baseline to /tmp/tmpof_kmcx0/baseline.json
Wrote Yul identity report: /tmp/tmpzdge_b1e/r1.json
Status: non_identical (1 mismatches)
Wrote Yul identity report: /tmp/tmpzdge_b1e/r2.json
Status: non_identical (1 mismatches)
All checks passed.

Related to #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that factors repeated “unchanged” frame clauses into shared helpers; behavior should be equivalent but could affect downstream proofs/spec consumers if any relied on the previous tuple shape.
> 
> **Overview**
> **Refactors constructor spec frames to use shared “unchanged” helpers.** Adds `sameStorageMap2Context` and `sameStorageMapsContext` in `Verity/Specs/Common.lean`, then rewires the ERC20 and ERC721 constructor specs to reference these helpers instead of repeating conjunctions.
> 
> Updates the ERC721 constructor proof (`Contracts/ERC721/Proofs/Basic.lean`) to match the new spec shape, simplifying two frame subgoals to `rfl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5446a5d60f7dba6187ae4eb50690349e4d2e5afb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->