### PR TITLE
Specs: factor slot-level frame equalities into shared helpers

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -28,7 +28,7 @@ def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
     2 to (fun st => add (st.storageMap 2 to) amount)
     1 (fun st => add (st.storage 1) amount)
     (fun st st' =>
-      st'.storageAddr 0 = st.storageAddr 0 ∧
+      sameStorageAddrSlot 0 st st' ∧
       sameStorageMap2 st st' ∧
       sameContext st st')
     s s'
@@ -38,8 +38,8 @@ def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState
   s.storageMap 2 sender ≥ amount ∧
   storageMapTransferSpec 2 sender to amount
     (fun st st' =>
-      st'.storage 1 = st.storage 1 ∧
-      st'.storageAddr 0 = st.storageAddr 0 ∧
+      sameStorageSlot 1 st st' ∧
+      sameStorageAddrSlot 0 st st' ∧
       sameStorageMap2 st st' ∧
       sameContext st st')
     s s'

--- a/Contracts/SimpleToken/Spec.lean
+++ b/Contracts/SimpleToken/Spec.lean
@@ -28,7 +28,7 @@ def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
     1 to (fun st => add (st.storageMap 1 to) amount)
     2 (fun st => add (st.storage 2) amount)
     (fun st st' =>
-      st'.storageAddr 0 = st.storageAddr 0 ∧
+      sameStorageAddrSlot 0 st st' ∧
       sameContext st st')
     s s'
 
@@ -37,7 +37,7 @@ def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState
   s.storageMap 1 sender ≥ amount ∧
   storageMapTransferSpec 1 sender to amount
     (fun st st' =>
-      st'.storageAddr 0 = st.storageAddr 0 ∧
+      sameStorageAddrSlot 0 st st' ∧
       sameStorageAddrContext st st')
     s s'
 

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -29,11 +29,25 @@ def sameStorage (s s' : ContractState) : Prop :=
 
 @[simp] theorem sameStorage_rfl (s : ContractState) : sameStorage s s := rfl
 
+/-- One Uint256 storage slot is unchanged. -/
+def sameStorageSlot (slot : Nat) (s s' : ContractState) : Prop :=
+  s'.storage slot = s.storage slot
+
+@[simp] theorem sameStorageSlot_rfl (slot : Nat) (s : ContractState) :
+    sameStorageSlot slot s s := rfl
+
 /-- Address storage is unchanged. -/
 def sameStorageAddr (s s' : ContractState) : Prop :=
   s'.storageAddr = s.storageAddr
 
 @[simp] theorem sameStorageAddr_rfl (s : ContractState) : sameStorageAddr s s := rfl
+
+/-- One address storage slot is unchanged. -/
+def sameStorageAddrSlot (slot : Nat) (s s' : ContractState) : Prop :=
+  s'.storageAddr slot = s.storageAddr slot
+
+@[simp] theorem sameStorageAddrSlot_rfl (slot : Nat) (s : ContractState) :
+    sameStorageAddrSlot slot s s := rfl
 
 /-- Mapping storage is unchanged. -/
 def sameStorageMap (s s' : ContractState) : Prop :=


### PR DESCRIPTION
## Summary
- add shared slot-level frame helpers in `Verity/Specs/Common.lean`:
  - `sameStorageSlot`
  - `sameStorageAddrSlot`
- migrate repeated raw slot-equality frame clauses to the helpers in:
  - `Contracts/SimpleToken/Spec.lean` (`mint_spec`, `transfer_spec`)
  - `Contracts/ERC20/Spec.lean` (`mint_spec`, `transfer_spec`)

This is an incremental `#1166` cleanup toward declarative spec templates by reducing hand-written frame boilerplate and standardizing slot-equality predicates.

## Validation
- `lake build Verity.Specs.Common Contracts.SimpleToken.Spec Contracts.ERC20.Spec Contracts.SimpleToken.Proofs.Basic Contracts.SimpleToken.Proofs.Supply Contracts.ERC20.Proofs.Basic Contracts.ERC20.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of Lean spec predicates that should be behavior-preserving, but could break downstream proofs if any relied on the previous raw equalities.
> 
> **Overview**
> Adds shared slot-level frame helpers `sameStorageSlot` and `sameStorageAddrSlot` in `Verity/Specs/Common.lean`.
> 
> Updates `ERC20` and `SimpleToken` specs (`mint_spec`, `transfer_spec`) to replace repeated direct slot equality clauses (e.g. `st'.storageAddr 0 = st.storageAddr 0`, `st'.storage 1 = st.storage 1`) with these helpers, reducing boilerplate and standardizing framing expressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7edb5074b9b9522ac02f5b20c7981bc7cc40d4fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->