### PR TITLE
refactor(specs): factor ERC20/ERC721 approval frame predicates

### DIFF
--- a/Contracts/ERC20/Proofs/Basic.lean
+++ b/Contracts/ERC20/Proofs/Basic.lean
@@ -43,6 +43,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
 theorem approve_meets_spec (s : ContractState) (spender : Address) (amount : Uint256) :
     approve_spec s.sender spender amount s ((approve spender amount).runState s) := by
   unfold approve_spec Specs.storageMap2UpdateSpec Specs.storageMap2UnchangedExceptKeyPair
+    Specs.sameStorageAddrMapContext
   refine ⟨?_, ?_, ?_⟩
   · simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind]
   · refine ⟨?_, ?_⟩

--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -48,11 +48,7 @@ def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState
 def approve_spec (ownerAddr spender : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
   storageMap2UpdateSpec
     3 ownerAddr spender (fun _ => amount)
-    (fun st st' =>
-      sameStorage st st' ∧
-      sameStorageAddr st st' ∧
-      sameStorageMap st st' ∧
-      sameContext st st')
+    sameStorageAddrMapContext
     s s'
 
 /-- transferFrom: debits `fromAddr`, credits `to`, and updates allowance for spender -/
@@ -60,10 +56,7 @@ def transferFrom_spec (spender fromAddr to : Address) (amount : Uint256) (s s' :
   s.storageMap2 3 fromAddr spender ≥ amount ∧
   s.storageMap 2 fromAddr ≥ amount ∧
   storageMapTransferFromSpec 2 3 fromAddr to spender amount
-    (fun st st' =>
-      sameStorage st st' ∧
-      sameStorageAddr st st' ∧
-      sameContext st st')
+    sameStorageAddrContext
     s s'
 
 /-- balanceOf: returns current balance of `addr` -/

--- a/Contracts/ERC721/Proofs/Basic.lean
+++ b/Contracts/ERC721/Proofs/Basic.lean
@@ -73,6 +73,8 @@ theorem isApprovedForAll_meets_spec (s : ContractState) (ownerAddr operator : Ad
 /-- `setApprovalForAll` writes sender/operator flag and leaves other state unchanged. -/
 theorem setApprovalForAll_meets_spec (s : ContractState) (operator : Address) (approved : Bool) :
     setApprovalForAll_spec s.sender operator approved s ((Contracts.MacroContracts.ERC721Addressed.setApprovalForAll operator approved).runState s) := by
+  unfold setApprovalForAll_spec Specs.storageMap2UpdateSpec Specs.storageMap2UnchangedExceptKeyPair
+    Specs.sameStorageAddrMapUintContext
   refine ⟨?_, ?_, ?_⟩
   · cases approved <;>
       simp [Contracts.MacroContracts.ERC721Addressed.setApprovalForAll, Contracts.MacroContracts.ERC721Addressed.operatorApprovals,

--- a/Contracts/ERC721/Spec.lean
+++ b/Contracts/ERC721/Spec.lean
@@ -59,12 +59,7 @@ def setApprovalForAll_spec
   storageMap2UpdateSpec
     6 sender operator
     (fun _ => boolToWord approved)
-    (fun st st' =>
-      sameStorage st st' ∧
-      sameStorageAddr st st' ∧
-      sameStorageMap st st' ∧
-      sameStorageMapUint st st' ∧
-      sameContext st st')
+    sameStorageAddrMapUintContext
     s s'
 
 end Contracts.ERC721.Spec

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -115,6 +115,27 @@ def sameStorageMap2Context (s s' : ContractState) : Prop :=
 @[simp] theorem sameStorageMap2Context_rfl (s : ContractState) : sameStorageMap2Context s s :=
   ⟨rfl, rfl, sameContext_rfl s⟩
 
+/-- Uint256 storage, address storage, mapping storage, and context are unchanged. -/
+def sameStorageAddrMapContext (s s' : ContractState) : Prop :=
+  sameStorage s s' ∧
+  sameStorageAddr s s' ∧
+  sameStorageMap s s' ∧
+  sameContext s s'
+
+@[simp] theorem sameStorageAddrMapContext_rfl (s : ContractState) : sameStorageAddrMapContext s s :=
+  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
+
+/-- Uint256/address storage, mapping storage (word+uint-keyed), and context are unchanged. -/
+def sameStorageAddrMapUintContext (s s' : ContractState) : Prop :=
+  sameStorage s s' ∧
+  sameStorageAddr s s' ∧
+  sameStorageMap s s' ∧
+  sameStorageMapUint s s' ∧
+  sameContext s s'
+
+@[simp] theorem sameStorageAddrMapUintContext_rfl (s : ContractState) : sameStorageAddrMapUintContext s s :=
+  ⟨rfl, rfl, rfl, rfl, sameContext_rfl s⟩
+
 /-- Mapping storage (word + uint-keyed + double), and context are unchanged. -/
 def sameStorageMapsContext (s s' : ContractState) : Prop :=
   sameStorageMap s s' ∧


### PR DESCRIPTION
## Summary
- add two shared frame helpers in `Verity/Specs/Common.lean`:
  - `sameStorageAddrMapContext`
  - `sameStorageAddrMapUintContext`
- migrate remaining manual frame conjunctions to shared helpers:
  - `Contracts/ERC20/Spec.lean`: `approve_spec`, `transferFrom_spec`
  - `Contracts/ERC721/Spec.lean`: `setApprovalForAll_spec`
- keep proof scripts aligned by unfolding helper aliases where needed:
  - `Contracts/ERC20/Proofs/Basic.lean`
  - `Contracts/ERC721/Proofs/Basic.lean`

## Why
This continues issue #1166 by removing repetitive hand-written frame clauses and centralizing canonical spec-shape predicates used by approval flows.

## Validation
- `lake build Verity.Specs.Common Contracts.ERC20.Spec Contracts.ERC20.Proofs.Basic Contracts.ERC20.Proofs.Correctness Contracts.ERC721.Spec Contracts.ERC721.Proofs.Basic Contracts.ERC721.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

Closes #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of specification frame predicates and associated proof scripts; no executable contract logic changes, but could affect downstream proofs if frame assumptions were incorrectly generalized.
> 
> **Overview**
> Refactors ERC20/ERC721 approval-related specs to reuse new shared “frame” predicates instead of repeating conjunctions of `sameStorage*`/`sameContext` clauses.
> 
> Adds `sameStorageAddrMapContext` and `sameStorageAddrMapUintContext` to `Verity/Specs/Common.lean`, updates `approve_spec`, `transferFrom_spec`, and `setApprovalForAll_spec` to use them, and adjusts the corresponding basic proofs to `unfold` the new helpers where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d1f95ff3bf579dff80835f962db943cf483e953. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->