### PR TITLE
Add initial #gen_spec command and migrate SafeCounter specs

### DIFF
--- a/Contracts/SafeCounter/Spec.lean
+++ b/Contracts/SafeCounter/Spec.lean
@@ -3,6 +3,7 @@
 -/
 
 import Verity.Specs.Common
+import Verity.Macro
 import Verity.Stdlib.Math
 import Verity.EVM.Uint256
 import Contracts.MacroContracts.Core
@@ -17,13 +18,11 @@ open Contracts.MacroContracts.SafeCounter
 
 /-! ## Operation Specifications -/
 
-/-- increment: increases count by 1 (with overflow check) -/
-def increment_spec (s s' : ContractState) : Prop :=
-  storageUpdateSpec 0 (fun st => add (st.storage 0) 1) sameAddrMapContext s s'
+-- increment: increases count by 1 (with overflow check)
+#gen_spec increment_spec (0, (fun st => add (st.storage 0) 1), sameAddrMapContext)
 
-/-- decrement: decreases count by 1 (with underflow check) -/
-def decrement_spec (s s' : ContractState) : Prop :=
-  storageUpdateSpec 0 (fun st => sub (st.storage 0) 1) sameAddrMapContext s s'
+-- decrement: decreases count by 1 (with underflow check)
+#gen_spec decrement_spec (0, (fun st => sub (st.storage 0) 1), sameAddrMapContext)
 
 /-- getCount: returns current count -/
 def getCount_spec (result : Uint256) (s : ContractState) : Prop :=

--- a/Verity/Macro.lean
+++ b/Verity/Macro.lean
@@ -4,3 +4,4 @@ import Verity.Macro.Translate
 import Verity.Macro.Bridge
 import Verity.Macro.Elaborate
 import Verity.Macro.Check
+import Verity.Macro.SpecGen

--- a/Verity/Macro/SpecGen.lean
+++ b/Verity/Macro/SpecGen.lean
@@ -1,0 +1,22 @@
+import Verity.Specs.Common
+
+namespace Verity.Macro
+
+set_option hygiene false
+
+syntax (name := genSpecCmd)
+  "#gen_spec " ident " (" term ", " term ", " term ")" : command
+
+syntax (name := genSpecCmdExtra)
+  "#gen_spec " ident " (" term ", " term ", " term ", " term ")" : command
+
+macro_rules
+  | `(#gen_spec $name:ident ($slot:term, $value:term, $frame:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageUpdateSpec $slot $value $frame s s')
+  | `(#gen_spec $name:ident ($slot:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageUpdateSpec $slot $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+
+end Verity.Macro


### PR DESCRIPTION
## Summary
- add an initial `#gen_spec` command in `Verity/Macro/SpecGen.lean` for generating single-slot `storageUpdateSpec` declarations
- wire it through `Verity/Macro.lean`
- migrate `Contracts/SafeCounter/Spec.lean` `increment_spec` and `decrement_spec` to generated form

## Why
Incremental progress on #1166 toward declarative spec generation and reduced hand-written boilerplate.

## Validation
- `lake build Verity.Macro Contracts.SafeCounter.Spec Contracts.SafeCounter.Proofs.Basic Contracts.SafeCounter.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Lean macro command wired into `Verity.Macro`, which can affect spec elaboration/definition generation for any module importing it. While currently used only to refactor SafeCounter specs, macro hygiene/expansion mistakes could break downstream proofs or change definitional equality expectations.
> 
> **Overview**
> Introduces a new Lean command macro `#gen_spec` (in `Verity/Macro/SpecGen.lean`, re-exported via `Verity/Macro.lean`) to generate common single-slot `storageUpdateSpec` boilerplate, with an optional variant that conjoins an extra frame condition.
> 
> Migrates `Contracts/SafeCounter/Spec.lean` `increment_spec` and `decrement_spec` from hand-written `def` declarations to the new `#gen_spec` form, leaving `getCount_spec` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df6f70fe035ccef5134a4322ce869572a5d11163. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->