### PR TITLE
refactor: factor composed SemanticBridge proof merge pattern

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -549,6 +549,23 @@ theorem ownedCounter_transferOwnership_semantic_bridge
 
 /-! ## Composed End-to-End: EDSL → IR → Yul -/
 
+private theorem compose_semantic_bridge_with_yul
+    {α : Type}
+    (edslResult : ContractResult α)
+    (P : α → ContractState → Prop)
+    (hBridge : match edslResult with
+      | .success val s' => P val s'
+      | .revert _ _ => True)
+    (hYul : Prop) :
+    match edslResult with
+    | .success val s' => P val s' ∧ hYul
+    | .revert _ _ => True := by
+  cases edslResult with
+  | success val s' =>
+      exact And.intro hBridge hYul
+  | revert _ _ =>
+      trivial
+
 theorem simpleStorage_store_edsl_to_yul
     (state : ContractState) (sender : Address) (value : Uint256) :
     let edslResult := Contract.run (Contracts.MacroContracts.SimpleStorage.store value)
@@ -567,22 +584,28 @@ theorem simpleStorage_store_edsl_to_yul
     := by
   let tx := mkIRTransaction sender 0x6057361d [value.val]
   let irState := mkIRState state sender 0x6057361d [value.val] encodeStorage
+  let edslResult := Contract.run (Contracts.MacroContracts.SimpleStorage.store value)
+    { state with sender := sender }
   have hBridge := simpleStorage_store_semantic_bridge state sender value
   have hYul : resultsMatch (interpretIR simpleStorageIRContract tx irState) (interpretYulFromIR simpleStorageIRContract tx irState) := by
     semantic_bridge_layer3_cases simpleStorageIRContract tx irState [hfn, hfn] with [encodeStorage]
-  cases hrun : Contract.run (Contracts.MacroContracts.SimpleStorage.store value)
-      { state with sender := sender } with
-  | success _ s' =>
-      have hA : (let tx := mkIRTransaction sender 0x6057361d [value.val]
-          let irState := mkIRState state sender 0x6057361d [value.val] encodeStorage
+  have hBridge' : match edslResult with
+      | .success _ s' =>
           let irResult := interpretIR simpleStorageIRContract tx irState
           irResult.success = true ∧
-          (∀ slot, (s'.storage slot).val = irResult.finalStorage slot) ∧
-          encodeEvents s'.events = irResult.events) := by
-        simpa [hrun] using hBridge
-      rcases hA with ⟨hs, hst, he⟩
-      simpa [tx, irState, hrun] using And.intro hs (And.intro hst (And.intro he hYul))
-  | revert _ _ => simp [hrun]
+          (∀ «slot», (s'.storage «slot»).val = irResult.finalStorage «slot») ∧
+          encodeEvents s'.events = irResult.events
+      | .revert _ _ => True := by
+    simpa [edslResult, tx, irState] using hBridge
+  simpa [edslResult, tx, irState] using
+    (compose_semantic_bridge_with_yul
+      (edslResult := edslResult)
+      (P := fun _ s' =>
+        let irResult := interpretIR simpleStorageIRContract tx irState
+        irResult.success = true ∧
+        (∀ «slot», (s'.storage «slot»).val = irResult.finalStorage «slot») ∧
+        encodeEvents s'.events = irResult.events)
+      hBridge' hYul)
 
 theorem simpleStorage_retrieve_edsl_to_yul
     (state : ContractState) (sender : Address) :
@@ -604,24 +627,31 @@ theorem simpleStorage_retrieve_edsl_to_yul
     := by
   let tx := mkIRTransaction sender 0x2e64cec1 []
   let irState := mkIRState state sender 0x2e64cec1 [] encodeStorage
+  let edslResult := Contract.run Contracts.MacroContracts.SimpleStorage.retrieve
+    { state with sender := sender }
   have hBridge := simpleStorage_retrieve_semantic_bridge state sender
   have hYul : resultsMatch (interpretIR simpleStorageIRContract tx irState)
       (interpretYulFromIR simpleStorageIRContract tx irState) := by
     semantic_bridge_layer3_cases simpleStorageIRContract tx irState [hfn, hfn] with [encodeStorage]
-  cases hrun : Contract.run Contracts.MacroContracts.SimpleStorage.retrieve { state with sender := sender } with
-  | success val s' =>
-      have hA : (let tx := mkIRTransaction sender 0x2e64cec1 []
-          let irState := mkIRState state sender 0x2e64cec1 [] encodeStorage
+  have hBridge' : match edslResult with
+      | .success val s' =>
           let irResult := interpretIR simpleStorageIRContract tx irState
           irResult.success = true ∧
           irResult.returnValue = some val.val ∧
-          (∀ slot, (s'.storage slot).val = irResult.finalStorage slot) ∧
-          encodeEvents s'.events = irResult.events) := by
-        simpa [hrun] using hBridge
-      rcases hA with ⟨hs, hret, hst, he⟩
-      simpa [tx, irState, hrun] using And.intro hs (And.intro hret (And.intro hst (And.intro he hYul)))
-  | revert _ _ =>
-      simp [hrun]
+          (∀ «slot», (s'.storage «slot»).val = irResult.finalStorage «slot») ∧
+          encodeEvents s'.events = irResult.events
+      | .revert _ _ => True := by
+    simpa [edslResult, tx, irState] using hBridge
+  simpa [edslResult, tx, irState] using
+    (compose_semantic_bridge_with_yul
+      (edslResult := edslResult)
+      (P := fun val s' =>
+        let irResult := interpretIR simpleStorageIRContract tx irState
+        irResult.success = true ∧
+        irResult.returnValue = some val.val ∧
+        (∀ «slot», (s'.storage «slot»).val = irResult.finalStorage «slot») ∧
+        encodeEvents s'.events = irResult.events)
+      hBridge' hYul)
 
 theorem counter_increment_edsl_to_yul
     (state : ContractState) (sender : Address) :
@@ -642,23 +672,28 @@ theorem counter_increment_edsl_to_yul
     := by
   let tx := mkIRTransaction sender 0xd09de08a []
   let irState := mkIRState state sender 0xd09de08a [] encodeStorage
+  let edslResult := Contract.run (Contracts.MacroContracts.Counter.increment)
+    { state with sender := sender }
   have hBridge := counter_increment_semantic_bridge state sender
   have hYul : resultsMatch (interpretIR counterIRContract tx irState)
       (interpretYulFromIR counterIRContract tx irState) := by
     semantic_bridge_layer3_cases counterIRContract tx irState [hfn, hfn, hfn] with [encodeStorage]
-  cases hrun : Contract.run (Contracts.MacroContracts.Counter.increment)
-      { state with sender := sender } with
-  | success _ s' =>
-      have hA : (let tx := mkIRTransaction sender 0xd09de08a []
-          let irState := mkIRState state sender 0xd09de08a [] encodeStorage
+  have hBridge' : match edslResult with
+      | .success _ s' =>
           let irResult := interpretIR counterIRContract tx irState
           irResult.success = true ∧
-          (∀ slot, (s'.storage slot).val = irResult.finalStorage slot) ∧
-          encodeEvents s'.events = irResult.events) := by
-        simpa [hrun] using hBridge
-      rcases hA with ⟨hs, hst, he⟩
-      simpa [tx, irState, hrun] using And.intro hs (And.intro hst (And.intro he hYul))
-  | revert _ _ =>
-      simp [hrun]
+          (∀ «slot», (s'.storage «slot»).val = irResult.finalStorage «slot») ∧
+          encodeEvents s'.events = irResult.events
+      | .revert _ _ => True := by
+    simpa [edslResult, tx, irState] using hBridge
+  simpa [edslResult, tx, irState] using
+    (compose_semantic_bridge_with_yul
+      (edslResult := edslResult)
+      (P := fun _ s' =>
+        let irResult := interpretIR counterIRContract tx irState
+        irResult.success = true ∧
+        (∀ «slot», (s'.storage «slot»).val = irResult.finalStorage «slot») ∧
+        encodeEvents s'.events = irResult.events)
+      hBridge' hYul)
 
 end Compiler.Proofs.SemanticBridge

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -614,6 +614,7 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.SemanticBridge.ownedCounter_increment_semantic_bridge
 #print axioms Compiler.Proofs.SemanticBridge.ownedCounter_decrement_semantic_bridge
 #print axioms Compiler.Proofs.SemanticBridge.ownedCounter_transferOwnership_semantic_bridge
+-- #print axioms Compiler.Proofs.SemanticBridge.compose_semantic_bridge_with_yul  -- private
 #print axioms Compiler.Proofs.SemanticBridge.simpleStorage_store_edsl_to_yul
 #print axioms Compiler.Proofs.SemanticBridge.simpleStorage_retrieve_edsl_to_yul
 #print axioms Compiler.Proofs.SemanticBridge.counter_increment_edsl_to_yul
@@ -645,4 +646,4 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy
--- Total: 544 theorems/lemmas (520 public, 24 private)
+-- Total: 545 theorems/lemmas (520 public, 25 private)


### PR DESCRIPTION
## Summary
- add a generic helper lemma `compose_semantic_bridge_with_yul` in `Compiler/Proofs/SemanticBridge.lean`
- migrate the three composed EDSL→IR→Yul theorems to the helper:
  - `simpleStorage_store_edsl_to_yul`
  - `simpleStorage_retrieve_edsl_to_yul`
  - `counter_increment_edsl_to_yul`
- remove repeated `cases`/`rcases` merge scaffolding and keep the proof shape declarative
- regenerate `PrintAxioms.lean` after proof changes

## Why
Issue #1165 tracks reducing repetitive SemanticBridge proof boilerplate. The composed bridge proofs still repeated the same manual pattern:
1. case split on `Contract.run`
2. recover the IR-side conjunction from the bridge theorem
3. append the Layer-3 witness

This PR factors that into one reusable helper while preserving theorem statements and behavior.

## Validation
- `make check` ✅
- `lake build Compiler.Proofs.SemanticBridge` still blocked by the existing upstream `Compiler/Proofs/YulGeneration/Preservation.lean` unsolved-goal regression (unchanged by this PR)

Closes part of #1165.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to Lean proof scripts; it doesn’t change theorem statements or runtime code, but could break proof compilation if the new helper is misapplied.
> 
> **Overview**
> **Proof refactor:** introduces a private helper lemma `compose_semantic_bridge_with_yul` to abstract the common “match on `Contract.run` result then append `resultsMatch`” pattern used in composed EDSL→IR→Yul theorems.
> 
> Updates `simpleStorage_store_edsl_to_yul`, `simpleStorage_retrieve_edsl_to_yul`, and `counter_increment_edsl_to_yul` to use the helper (removing duplicated `cases`/`rcases` scaffolding) and regenerates `PrintAxioms.lean` to reflect the additional private lemma.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5eb888505c438e037608b766bfbb78afaa367c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->