### PR TITLE
Specs: extract reusable frame-context helpers

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -27,21 +27,14 @@ def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
   storageMapAndStorageUpdateSpec
     2 to (fun st => add (st.storageMap 2 to) amount)
     1 (fun st => add (st.storage 1) amount)
-    (fun st st' =>
-      sameStorageAddrSlot 0 st st' ∧
-      sameStorageMap2 st st' ∧
-      sameContext st st')
+    (sameStorageAddrSlotMap2Context 0)
     s s'
 
 /-- transfer: sender balance decreases and recipient balance increases by amount -/
 def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
   s.storageMap 2 sender ≥ amount ∧
   storageMapTransferSpec 2 sender to amount
-    (fun st st' =>
-      sameStorageSlot 1 st st' ∧
-      sameStorageAddrSlot 0 st st' ∧
-      sameStorageMap2 st st' ∧
-      sameContext st st')
+    (sameStorageSlotAddrSlotMap2Context 1 0)
     s s'
 
 /-- approve: updates the owner-spender allowance mapping entry -/

--- a/Contracts/SimpleToken/Spec.lean
+++ b/Contracts/SimpleToken/Spec.lean
@@ -19,7 +19,7 @@ def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
     0 2
     (fun _ => initialOwner)
     (fun _ => 0)
-    (fun st st' => sameStorageMap st st' ∧ sameContext st st')
+    sameMapContext
     s s'
 
 /-- Mint: increases balance and total supply by amount (owner only) -/
@@ -27,9 +27,7 @@ def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
   storageMapAndStorageUpdateSpec
     1 to (fun st => add (st.storageMap 1 to) amount)
     2 (fun st => add (st.storage 2) amount)
-    (fun st st' =>
-      sameStorageAddrSlot 0 st st' ∧
-      sameContext st st')
+    (sameStorageAddrSlotContext 0)
     s s'
 
 /-- Transfer: moves amount from sender to recipient, preserves total supply -/

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -115,6 +115,46 @@ def sameStorageMap2Context (s s' : ContractState) : Prop :=
 @[simp] theorem sameStorageMap2Context_rfl (s : ContractState) : sameStorageMap2Context s s :=
   ⟨rfl, rfl, sameContext_rfl s⟩
 
+/-- Mapping storage and context are unchanged. -/
+def sameMapContext (s s' : ContractState) : Prop :=
+  sameStorageMap s s' ∧
+  sameContext s s'
+
+@[simp] theorem sameMapContext_rfl (s : ContractState) : sameMapContext s s :=
+  ⟨rfl, sameContext_rfl s⟩
+
+/-- One address slot and context are unchanged. -/
+def sameStorageAddrSlotContext (addrSlot : Nat) (s s' : ContractState) : Prop :=
+  sameStorageAddrSlot addrSlot s s' ∧
+  sameContext s s'
+
+@[simp] theorem sameStorageAddrSlotContext_rfl (addrSlot : Nat) (s : ContractState) :
+    sameStorageAddrSlotContext addrSlot s s :=
+  ⟨rfl, sameContext_rfl s⟩
+
+/-- One address slot, double-mapping storage, and context are unchanged. -/
+def sameStorageAddrSlotMap2Context (addrSlot : Nat) (s s' : ContractState) : Prop :=
+  sameStorageAddrSlot addrSlot s s' ∧
+  sameStorageMap2 s s' ∧
+  sameContext s s'
+
+@[simp] theorem sameStorageAddrSlotMap2Context_rfl (addrSlot : Nat) (s : ContractState) :
+    sameStorageAddrSlotMap2Context addrSlot s s :=
+  ⟨rfl, rfl, sameContext_rfl s⟩
+
+/-- One Uint256 slot, one address slot, double-mapping storage, and context are unchanged. -/
+def sameStorageSlotAddrSlotMap2Context
+    (storageSlot addrSlot : Nat) (s s' : ContractState) : Prop :=
+  sameStorageSlot storageSlot s s' ∧
+  sameStorageAddrSlot addrSlot s s' ∧
+  sameStorageMap2 s s' ∧
+  sameContext s s'
+
+@[simp] theorem sameStorageSlotAddrSlotMap2Context_rfl
+    (storageSlot addrSlot : Nat) (s : ContractState) :
+    sameStorageSlotAddrSlotMap2Context storageSlot addrSlot s s :=
+  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
+
 /-- Uint256 storage, address storage, mapping storage, and context are unchanged. -/
 def sameStorageAddrMapContext (s s' : ContractState) : Prop :=
   sameStorage s s' ∧


### PR DESCRIPTION
## Summary
- add reusable frame-context helper predicates in `Verity.Specs.Common`:
  - `sameMapContext`
  - `sameStorageAddrSlotContext`
  - `sameStorageAddrSlotMap2Context`
  - `sameStorageSlotAddrSlotMap2Context`
- migrate repeated inline frame conjunctions in:
  - `Contracts/SimpleToken/Spec.lean` (`constructor_spec`, `mint_spec`)
  - `Contracts/ERC20/Spec.lean` (`mint_spec`, `transfer_spec`)

## Why
This is an incremental step toward #1166: reducing repetitive handwritten spec boilerplate and making spec frame clauses more declarative/reusable.

## Validation
- `lake build Verity.Specs.Common Contracts.SimpleToken.Spec Contracts.ERC20.Spec Contracts.SimpleToken.Proofs.Basic Contracts.ERC20.Proofs.Basic Contracts.ERC20.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to spec-layer helper predicates and replacing equivalent inline frame conjunctions; main risk is accidentally strengthening/weakening a frame condition in updated specs.
> 
> **Overview**
> Introduces new reusable *frame/context* helper predicates in `Verity/Specs/Common.lean` (e.g., `sameMapContext`, `sameStorageAddrSlotContext`, `sameStorageAddrSlotMap2Context`, `sameStorageSlotAddrSlotMap2Context`) to encode common “unchanged” clauses.
> 
> Updates ERC20 and SimpleToken specs to use these helpers instead of repeating inline conjunctions, notably in `Contracts/ERC20/Spec.lean` (`mint_spec`, `transfer_spec`) and `Contracts/SimpleToken/Spec.lean` (`constructor_spec`, `mint_spec`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29f5898272d8835777f791e653becc239053064a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->