### PR TITLE
SemanticBridge: add reusable let-normalization helper

### DIFF
--- a/Compiler/Proofs/SemanticBridge.lean
+++ b/Compiler/Proofs/SemanticBridge.lean
@@ -81,6 +81,12 @@ syntax (name := semantic_bridge_layer3_cases)
   "semantic_bridge_layer3_cases " term " " term " " term
     " [" ident,* "] with [" term,* "]" : tactic
 
+/-- `semantic_bridge_have h := t with [...]` introduces `h` by normalizing
+    `t` with a local simp bundle (used to rewrite bridge theorems to local
+    `let`-bound fixtures). -/
+syntax (name := semantic_bridge_have)
+  "semantic_bridge_have " ident " := " term " with [" term,* "]" : tactic
+
 macro_rules
   | `(tactic| semantic_bridge_simp) =>
       `(tactic| simp [
@@ -132,6 +138,10 @@ macro_rules
       `(tactic|
         semantic_bridge_layer3 $contract $tx $irState
         semantic_bridge_fn_cases [$[$h],*] with [$[$extra],*])
+  | `(tactic| semantic_bridge_have $hnew:ident := $hsrc:term with [$[$extra:term],*]) =>
+      `(tactic|
+        have $hnew := by
+          simpa [$[$extra],*] using $hsrc)
 
 /-! ## State Encoding
 
@@ -589,14 +599,7 @@ theorem simpleStorage_store_edsl_to_yul
   have hBridge := simpleStorage_store_semantic_bridge state sender value
   have hYul : resultsMatch (interpretIR simpleStorageIRContract tx irState) (interpretYulFromIR simpleStorageIRContract tx irState) := by
     semantic_bridge_layer3_cases simpleStorageIRContract tx irState [hfn, hfn] with [encodeStorage]
-  have hBridge' : match edslResult with
-      | .success _ s' =>
-          let irResult := interpretIR simpleStorageIRContract tx irState
-          irResult.success = true ∧
-          (∀ «slot», (s'.storage «slot»).val = irResult.finalStorage «slot») ∧
-          encodeEvents s'.events = irResult.events
-      | .revert _ _ => True := by
-    simpa [edslResult, tx, irState] using hBridge
+  semantic_bridge_have hBridge' := hBridge with [edslResult, tx, irState]
   simpa [edslResult, tx, irState] using
     (compose_semantic_bridge_with_yul
       (edslResult := edslResult)
@@ -633,15 +636,7 @@ theorem simpleStorage_retrieve_edsl_to_yul
   have hYul : resultsMatch (interpretIR simpleStorageIRContract tx irState)
       (interpretYulFromIR simpleStorageIRContract tx irState) := by
     semantic_bridge_layer3_cases simpleStorageIRContract tx irState [hfn, hfn] with [encodeStorage]
-  have hBridge' : match edslResult with
-      | .success val s' =>
-          let irResult := interpretIR simpleStorageIRContract tx irState
-          irResult.success = true ∧
-          irResult.returnValue = some val.val ∧
-          (∀ «slot», (s'.storage «slot»).val = irResult.finalStorage «slot») ∧
-          encodeEvents s'.events = irResult.events
-      | .revert _ _ => True := by
-    simpa [edslResult, tx, irState] using hBridge
+  semantic_bridge_have hBridge' := hBridge with [edslResult, tx, irState]
   simpa [edslResult, tx, irState] using
     (compose_semantic_bridge_with_yul
       (edslResult := edslResult)
@@ -678,14 +673,7 @@ theorem counter_increment_edsl_to_yul
   have hYul : resultsMatch (interpretIR counterIRContract tx irState)
       (interpretYulFromIR counterIRContract tx irState) := by
     semantic_bridge_layer3_cases counterIRContract tx irState [hfn, hfn, hfn] with [encodeStorage]
-  have hBridge' : match edslResult with
-      | .success _ s' =>
-          let irResult := interpretIR counterIRContract tx irState
-          irResult.success = true ∧
-          (∀ «slot», (s'.storage «slot»).val = irResult.finalStorage «slot») ∧
-          encodeEvents s'.events = irResult.events
-      | .revert _ _ => True := by
-    simpa [edslResult, tx, irState] using hBridge
+  semantic_bridge_have hBridge' := hBridge with [edslResult, tx, irState]
   simpa [edslResult, tx, irState] using
     (compose_semantic_bridge_with_yul
       (edslResult := edslResult)


### PR DESCRIPTION
## Summary
- add a new tactic helper `semantic_bridge_have h := t with [...]` in `Compiler/Proofs/SemanticBridge.lean`
- use the helper to replace repeated let-normalization boilerplate in composed EDSL->IR->Yul bridge theorems
- migrate:
  - `simpleStorage_store_edsl_to_yul`
  - `simpleStorage_retrieve_edsl_to_yul`
  - `counter_increment_edsl_to_yul`

## Why
Issue #1165 tracks reducing repetitive SemanticBridge proof scaffolding. These theorems repeatedly used identical blocks:
- `have hBridge' : ... := by simpa [edslResult, tx, irState] using hBridge`

The helper makes that pattern a one-liner and keeps future bridge additions below the current boilerplate level.

## Validation
- `python3 scripts/check_verify_sync.py`
- `make check`
- attempted `lake build Compiler.Proofs.SemanticBridge` (still blocked by pre-existing unsolved goals in `Compiler/Proofs/YulGeneration/Preservation.lean`)

Closes #1165 (incremental progress).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: proof-only refactor that adds a small tactic macro and rewrites three theorems to use it, without changing theorem statements or runtime code paths.
> 
> **Overview**
> Introduces a new tactic helper `semantic_bridge_have h := t with [...]` in `SemanticBridge.lean` to encapsulate the common `have ... := by simpa [...] using ...` let-normalization pattern.
> 
> Updates the composed end-to-end bridge theorems (`simpleStorage_store_edsl_to_yul`, `simpleStorage_retrieve_edsl_to_yul`, `counter_increment_edsl_to_yul`) to use this helper, reducing repeated proof boilerplate while keeping the overall proof structure the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c39a1efe64fa7acf51609777186b90297eb3101b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->