### PR TITLE
macro: add #gen_spec_addr generator for address-slot specs

### DIFF
--- a/Verity/Macro/SpecGen.lean
+++ b/Verity/Macro/SpecGen.lean
@@ -10,6 +10,12 @@ syntax (name := genSpecCmd)
 syntax (name := genSpecCmdExtra)
   "#gen_spec " ident " (" term ", " term ", " term ", " term ")" : command
 
+syntax (name := genSpecAddrCmd)
+  "#gen_spec_addr " ident " (" term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrCmdExtra)
+  "#gen_spec_addr " ident " (" term ", " term ", " term ", " term ")" : command
+
 macro_rules
   | `(#gen_spec $name:ident ($slot:term, $value:term, $frame:term)) =>
       `(def $name (s s' : Verity.ContractState) : Prop :=
@@ -17,6 +23,13 @@ macro_rules
   | `(#gen_spec $name:ident ($slot:term, $value:term, $frame:term, $extra:term)) =>
       `(def $name (s s' : Verity.ContractState) : Prop :=
           Verity.Specs.storageUpdateSpec $slot $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_addr $name:ident ($slot:term, $value:term, $frame:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrUpdateSpec $slot $value $frame s s')
+  | `(#gen_spec_addr $name:ident ($slot:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrUpdateSpec $slot $value
             (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
 
 end Verity.Macro


### PR DESCRIPTION
## Summary
- add `#gen_spec_addr` command forms to `Verity/Macro/SpecGen.lean`
- mirror existing `#gen_spec` behavior for `storageAddrUpdateSpec`
  - base form: `(slot, value, frame)`
  - extended form: `(slot, value, frame, extra)`

## Why
Issue #1166 is about moving hand-written spec boilerplate toward declarative generation. This adds the address-slot counterpart to the existing storage-slot generator, so owner-style specs can be migrated with the same command-level workflow.

## Validation
- `lake build Verity.Macro.SpecGen Contracts.SafeCounter.Spec`
- `make check`

Closes #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds new macro command forms that expand to `storageAddrUpdateSpec`, with no runtime behavior changes outside generated spec definitions.
> 
> **Overview**
> Adds new `#gen_spec_addr` command macros in `Verity/Macro/SpecGen.lean` to generate boilerplate spec definitions for `storageAddr` slot updates.
> 
> Mirrors existing `#gen_spec` behavior with both a base `(slot, value, frame)` form and an extended `(slot, value, frame, extra)` form that conjoins `frame` and `extra` in the generated predicate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d3d8249e7ee354d2b7f07e2ecd8c8bafa9d5d75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->