### PR TITLE
Fix uint256 wrap semantics for comparison builtins

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
@@ -88,11 +88,27 @@ example : verityEval "eq" [42, 42] = bridgeEval "eq" [42, 42] := by native_decid
 /-- eq: 42 ≠ 43 -/
 example : verityEval "eq" [42, 43] = bridgeEval "eq" [42, 43] := by native_decide
 
+/-- eq: 2^256 ≡ 0 (word-size wraparound). -/
+example : verityEval "eq" [Compiler.Constants.evmModulus, 0] =
+          bridgeEval "eq" [Compiler.Constants.evmModulus, 0] := by native_decide
+
 /-- iszero: 0 is zero -/
 example : verityEval "iszero" [0] = bridgeEval "iszero" [0] := by native_decide
 
 /-- iszero: 1 is not zero -/
 example : verityEval "iszero" [1] = bridgeEval "iszero" [1] := by native_decide
+
+/-- iszero: 2^256 ≡ 0 (word-size wraparound). -/
+example : verityEval "iszero" [Compiler.Constants.evmModulus] =
+          bridgeEval "iszero" [Compiler.Constants.evmModulus] := by native_decide
+
+/-- lt: 2^256 wraps to 0, so 0 < 1. -/
+example : verityEval "lt" [Compiler.Constants.evmModulus, 1] =
+          bridgeEval "lt" [Compiler.Constants.evmModulus, 1] := by native_decide
+
+/-- gt: 2^256 wraps to 0, so 0 > 2^256-1 is false. -/
+example : verityEval "gt" [Compiler.Constants.evmModulus, Compiler.Constants.evmModulus - 1] =
+          bridgeEval "gt" [Compiler.Constants.evmModulus, Compiler.Constants.evmModulus - 1] := by native_decide
 
 -- ## Bitwise builtins
 

--- a/Compiler/Proofs/YulGeneration/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/Builtins.lean
@@ -60,19 +60,19 @@ def evalBuiltinCall
     | _ => none
   else if func = "lt" then
     match argVals with
-    | [a, b] => some (if a < b then 1 else 0)
+    | [a, b] => some (if a % evmModulus < b % evmModulus then 1 else 0)
     | _ => none
   else if func = "gt" then
     match argVals with
-    | [a, b] => some (if a > b then 1 else 0)
+    | [a, b] => some (if a % evmModulus > b % evmModulus then 1 else 0)
     | _ => none
   else if func = "eq" then
     match argVals with
-    | [a, b] => some (if a = b then 1 else 0)
+    | [a, b] => some (if a % evmModulus = b % evmModulus then 1 else 0)
     | _ => none
   else if func = "iszero" then
     match argVals with
-    | [a] => some (if a = 0 then 1 else 0)
+    | [a] => some (if a % evmModulus = 0 then 1 else 0)
     | _ => none
   else if func = "and" then
     match argVals with


### PR DESCRIPTION
## Summary
- normalize Verity builtin comparison semantics (`lt`, `gt`, `eq`, `iszero`) to the uint256 domain by reducing operands modulo `2^256`
- add wrap-boundary regression checks in `EvmYulLeanBridgeTest.lean`

## Why
Issue #1168 tracks trust-boundary hardening for Verity ↔ EVMYulLean arithmetic/logic agreement. I found and reproduced a concrete mismatch:
- before this change: `evalBuiltinCall ... "eq" [2^256, 0] = some 0`
- bridge path: `evalPureBuiltinViaEvmYulLean "eq" [2^256, 0] = some 1`

This patch removes that inconsistency for comparison operators by matching uint256 word semantics.

## Validation
- `lake build Compiler.Proofs.YulGeneration.Builtins Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeTest`
- `python3 scripts/check_verify_sync.py`
- `make check`

Closes part of #1168.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the semantics of core comparison builtins (`lt`, `gt`, `eq`, `iszero`) and could affect any proofs/tests that relied on unbounded `Nat` comparisons, though the change is narrowly scoped and covered by new boundary tests.
> 
> **Overview**
> **Normalizes comparison builtins to uint256 semantics.** `evalBuiltinCall` now reduces operands modulo `evmModulus` for `lt`, `gt`, `eq`, and `iszero`, matching EVM word-size wraparound behavior.
> 
> **Adds wrap-boundary regression coverage.** `EvmYulLeanBridgeTest.lean` includes new equivalence checks at `2^256` (e.g., `eq(2^256,0)`, `iszero(2^256)`, and `lt`/`gt` cases) to ensure Verity and the EVMYulLean bridge agree at the boundary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3d65239422725ebf45851fb2942b9b3def1aeef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->