### PR TITLE
Migrate Counter and OwnedCounter no-arg specs to #gen_spec

### DIFF
--- a/Contracts/Counter/Spec.lean
+++ b/Contracts/Counter/Spec.lean
@@ -3,6 +3,7 @@
 -/
 
 import Verity.Specs.Common
+import Verity.Macro
 import Verity.EVM.Uint256
 import Contracts.MacroContracts.Core
 
@@ -15,13 +16,11 @@ open Verity.EVM.Uint256
 
 /-! ## Operation Specifications -/
 
-/-- Increment: increases count by 1 -/
-def increment_spec (s s' : ContractState) : Prop :=
-  storageUpdateSpec 0 (fun st => add (st.storage 0) 1) sameAddrMapContext s s'
+-- Increment: increases count by 1
+#gen_spec increment_spec (0, (fun st => add (st.storage 0) 1), sameAddrMapContext)
 
-/-- Decrement: decreases count by 1 -/
-def decrement_spec (s s' : ContractState) : Prop :=
-  storageUpdateSpec 0 (fun st => sub (st.storage 0) 1) sameAddrMapContext s s'
+-- Decrement: decreases count by 1
+#gen_spec decrement_spec (0, (fun st => sub (st.storage 0) 1), sameAddrMapContext)
 
 /-- getCount: returns the current count -/
 def getCount_spec (result : Uint256) (s : ContractState) : Prop :=

--- a/Contracts/OwnedCounter/Spec.lean
+++ b/Contracts/OwnedCounter/Spec.lean
@@ -3,6 +3,7 @@
 -/
 
 import Verity.Specs.Common
+import Verity.Macro
 import Verity.EVM.Uint256
 import Contracts.MacroContracts.Core
 
@@ -27,13 +28,11 @@ def getCount_spec (result : Uint256) (s : ContractState) : Prop :=
 def getOwner_spec (result : Address) (s : ContractState) : Prop :=
   result = s.storageAddr 0
 
-/-- increment: increases count by 1 (owner only) -/
-def increment_spec (s s' : ContractState) : Prop :=
-  storageUpdateSpec 1 (fun st => add (st.storage 1) 1) sameAddrMapContext s s'
+-- increment: increases count by 1 (owner only)
+#gen_spec increment_spec (1, (fun st => add (st.storage 1) 1), sameAddrMapContext)
 
-/-- decrement: decreases count by 1 (owner only) -/
-def decrement_spec (s s' : ContractState) : Prop :=
-  storageUpdateSpec 1 (fun st => sub (st.storage 1) 1) sameAddrMapContext s s'
+-- decrement: decreases count by 1 (owner only)
+#gen_spec decrement_spec (1, (fun st => sub (st.storage 1) 1), sameAddrMapContext)
 
 /-- transferOwnership: changes owner (owner only) -/
 def transferOwnership_spec (newOwner : Address) (s s' : ContractState) : Prop :=


### PR DESCRIPTION
## Summary
- migrate `Contracts/Counter/Spec.lean` no-arg update specs to `#gen_spec`
- migrate `Contracts/OwnedCounter/Spec.lean` no-arg update specs to `#gen_spec`
- keep spec semantics unchanged while increasing declarative macro adoption for issue #1166

## Validation
- `lake build Contracts.Counter.Spec Contracts.OwnedCounter.Spec`
- `make check`

## Notes
- This is an incremental #1166 step; issue remains open for broader parameterized spec generation coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that should be semantics-preserving, but it does change how the specs are generated (macro expansion), so any macro issues would affect compilation/definitional equality.
> 
> **Overview**
> Migrates the `increment_spec`/`decrement_spec` definitions in `Contracts/Counter/Spec.lean` and `Contracts/OwnedCounter/Spec.lean` from handwritten `def`s using `storageUpdateSpec` to declarative `#gen_spec` macro invocations, adding the required `import Verity.Macro`.
> 
> No behavioral intent changes are introduced; this is a mechanical shift to macro-based spec generation for these no-arg storage-update specs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3804a080d2c1228e9beb5c6af35dce1f6bbc1ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->