### PR TITLE
Issue #1166: add one-arg spec-gen forms and migrate Owned/SimpleStorage specs

### DIFF
--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -66,10 +66,12 @@ theorem setStorageAddr_preserves_context (s : ContractState) (addr : Address) :
 theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   constructor_spec initialOwner s s' := by
-  simp [constructor_spec, owner, setStorageAddr, Specs.sameStorageMapContext,
-    Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
-  intro slotIdx h_neq
-  simp [h_neq]
+  refine ⟨?_, ?_, ?_⟩
+  · simp [constructor_spec, owner, setStorageAddr]
+  · intro slotIdx h_neq
+    simp [constructor_spec, owner, setStorageAddr, h_neq]
+  · simp [constructor_spec, owner, setStorageAddr, Specs.sameStorageMapContext,
+      Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
@@ -140,10 +142,12 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   let s' := ((transferOwnership newOwner).run s).snd
   transferOwnership_spec newOwner s s' := by
   rw [transferOwnership_unfold s newOwner h_is_owner]
-  simp [transferOwnership_spec, ContractResult.snd, Specs.sameStorageMapContext,
-    Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
-  intro slotIdx h_neq
-  simp [h_neq]
+  refine ⟨?_, ?_, ?_⟩
+  · simp [transferOwnership_spec, ContractResult.snd]
+  · intro slotIdx h_neq
+    simp [transferOwnership_spec, ContractResult.snd, h_neq]
+  · simp [transferOwnership_spec, ContractResult.snd, Specs.sameStorageMapContext,
+      Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
 
 theorem transferOwnership_changes_owner_when_allowed (s : ContractState) (newOwner : Address)
   (h_is_owner : s.sender = s.storageAddr 0) :

--- a/Contracts/Owned/Spec.lean
+++ b/Contracts/Owned/Spec.lean
@@ -3,6 +3,7 @@
 -/
 
 import Verity.Specs.Common
+import Verity.Macro
 import Contracts.MacroContracts.Core
 
 namespace Contracts.Owned.Spec
@@ -13,17 +14,15 @@ open Contracts.MacroContracts.Owned
 
 /-! ## Operation Specifications -/
 
-/-- Constructor: sets the owner to the provided address -/
-def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
-  storageAddrUpdateSpec 0 (fun _ => initialOwner) sameStorageMapContext s s'
+-- Constructor: sets the owner to the provided address.
+#gen_spec_addr constructor_spec for (initialOwner : Address) (0, (fun _ => initialOwner), sameStorageMapContext)
 
 /-- getOwner: returns the current owner address -/
 def getOwner_spec (result : Address) (s : ContractState) : Prop :=
   result = s.storageAddr 0
 
-/-- transferOwnership: updates owner to new address (owner only) -/
-def transferOwnership_spec (newOwner : Address) (s s' : ContractState) : Prop :=
-  storageAddrUpdateSpec 0 (fun _ => newOwner) sameStorageMapContext s s'
+-- transferOwnership: updates owner to new address (owner only).
+#gen_spec_addr transferOwnership_spec for (newOwner : Address) (0, (fun _ => newOwner), sameStorageMapContext)
 
 /-- isOwner: returns true if sender equals current owner -/
 def isOwner_spec (result : Bool) (s : ContractState) : Prop :=

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -39,10 +39,12 @@ private theorem guarded_reverts (f : Unit → Contract α) (s : ContractState)
 theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
   constructor_spec initialOwner s s' := by
-  simp [setStorageAddr, owner, constructor_spec, Contract.run, ContractResult.snd,
-    Specs.sameStorageMapContext, Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
-  intro slotIdx h_neq
-  simp [h_neq]
+  refine ⟨?_, ?_, ?_⟩
+  · simp [setStorageAddr, owner, constructor_spec, Contract.run, ContractResult.snd]
+  · intro slotIdx h_neq
+    simp [setStorageAddr, owner, constructor_spec, Contract.run, ContractResult.snd, h_neq]
+  · simp [setStorageAddr, owner, constructor_spec, Contract.run, ContractResult.snd,
+      Specs.sameStorageMapContext, Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
@@ -128,9 +130,12 @@ theorem increment_meets_spec_when_owner (s : ContractState)
   let s' := (increment.run s).snd
   increment_spec s s' := by
   rw [increment_unfold s h_owner]
-  verity_spec increment_spec
-  intro slotIdx h_neq
-  simp [h_neq]
+  refine ⟨?_, ?_, ?_⟩
+  · simp [increment_spec, ContractResult.snd]
+  · intro slotIdx h_neq
+    simp [increment_spec, ContractResult.snd, h_neq]
+  · simp [increment_spec, ContractResult.snd, Specs.sameAddrMapContext, Specs.sameStorageAddr,
+      Specs.sameStorageMap, Specs.sameContext]
 
 theorem increment_adds_one_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -169,9 +174,12 @@ theorem decrement_meets_spec_when_owner (s : ContractState)
   let s' := (decrement.run s).snd
   decrement_spec s s' := by
   rw [decrement_unfold s h_owner]
-  verity_spec decrement_spec
-  intro slotIdx h_neq
-  simp [h_neq]
+  refine ⟨?_, ?_, ?_⟩
+  · simp [decrement_spec, ContractResult.snd]
+  · intro slotIdx h_neq
+    simp [decrement_spec, ContractResult.snd, h_neq]
+  · simp [decrement_spec, ContractResult.snd, Specs.sameAddrMapContext, Specs.sameStorageAddr,
+      Specs.sameStorageMap, Specs.sameContext]
 
 theorem decrement_subtracts_one_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -209,9 +217,12 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   let s' := ((transferOwnership newOwner).run s).snd
   transferOwnership_spec newOwner s s' := by
   rw [transferOwnership_unfold s newOwner h_owner]
-  verity_spec transferOwnership_spec
-  intro slotIdx h_neq
-  simp [h_neq]
+  refine ⟨?_, ?_, ?_⟩
+  · simp [transferOwnership_spec, ContractResult.snd]
+  · intro slotIdx h_neq
+    simp [transferOwnership_spec, ContractResult.snd, h_neq]
+  · simp [transferOwnership_spec, ContractResult.snd, Specs.sameStorageMapContext,
+      Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
 
 theorem transferOwnership_changes_owner (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :

--- a/Contracts/OwnedCounter/Spec.lean
+++ b/Contracts/OwnedCounter/Spec.lean
@@ -16,9 +16,8 @@ open Verity.EVM.Uint256
 
 /-! ## Operation Specifications -/
 
-/-- Constructor: sets owner -/
-def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
-  storageAddrUpdateSpec 0 (fun _ => initialOwner) sameStorageMapContext s s'
+-- Constructor: sets owner.
+#gen_spec_addr constructor_spec for (initialOwner : Address) (0, (fun _ => initialOwner), sameStorageMapContext)
 
 /-- getCount: returns current count -/
 def getCount_spec (result : Uint256) (s : ContractState) : Prop :=
@@ -34,8 +33,7 @@ def getOwner_spec (result : Address) (s : ContractState) : Prop :=
 -- decrement: decreases count by 1 (owner only)
 #gen_spec decrement_spec (1, (fun st => sub (st.storage 1) 1), sameAddrMapContext)
 
-/-- transferOwnership: changes owner (owner only) -/
-def transferOwnership_spec (newOwner : Address) (s s' : ContractState) : Prop :=
-  storageAddrUpdateSpec 0 (fun _ => newOwner) sameStorageMapContext s s'
+-- transferOwnership: changes owner (owner only).
+#gen_spec_addr transferOwnership_spec for (newOwner : Address) (0, (fun _ => newOwner), sameStorageMapContext)
 
 end Contracts.OwnedCounter.Spec

--- a/Contracts/SimpleStorage/Proofs/Basic.lean
+++ b/Contracts/SimpleStorage/Proofs/Basic.lean
@@ -74,9 +74,12 @@ theorem store_meets_spec (s : ContractState) (value : Uint256) :
   let s' := ((store value).run s).snd
   store_spec value s s' := by
   verity_unfold store
-  verity_spec store_spec with storedData
-  intro slotIdx h_neq
-  simp [h_neq]
+  refine ⟨?_, ?_, ?_⟩
+  · simp [store_spec, storedData]
+  · intro slotIdx h_neq
+    simp [store_spec, storedData, h_neq]
+  · simp [store_spec, storedData, Specs.sameAddrMapContext, Specs.sameStorageAddr,
+      Specs.sameStorageMap, Specs.sameContext]
 
 -- Main theorem: retrieve meets its specification
 theorem retrieve_meets_spec (s : ContractState) :

--- a/Contracts/SimpleStorage/Spec.lean
+++ b/Contracts/SimpleStorage/Spec.lean
@@ -3,6 +3,7 @@
 -/
 
 import Verity.Specs.Common
+import Verity.Macro
 import Contracts.MacroContracts.Core
 
 namespace Contracts.SimpleStorage.Spec
@@ -10,9 +11,8 @@ namespace Contracts.SimpleStorage.Spec
 open Verity
 open Verity.Specs
 
-/-- Store: updates the storage at slot 0 -/
-def store_spec (value : Uint256) (s s' : ContractState) : Prop :=
-  storageUpdateSpec 0 (fun _ => value) sameAddrMapContext s s'
+-- Store: updates the storage at slot 0.
+#gen_spec store_spec for (value : Uint256) (0, (fun _ => value), sameAddrMapContext)
 
 /-- Retrieve: returns the value at slot 0 -/
 def retrieve_spec (result : Uint256) (s : ContractState) : Prop :=

--- a/Verity/Macro/SpecGen.lean
+++ b/Verity/Macro/SpecGen.lean
@@ -10,11 +10,23 @@ syntax (name := genSpecCmd)
 syntax (name := genSpecCmdExtra)
   "#gen_spec " ident " (" term ", " term ", " term ", " term ")" : command
 
+syntax (name := genSpecCmdFor)
+  "#gen_spec " ident " for " "(" ident " : " term ")" " (" term ", " term ", " term ")" : command
+
+syntax (name := genSpecCmdForExtra)
+  "#gen_spec " ident " for " "(" ident " : " term ")" " (" term ", " term ", " term ", " term ")" : command
+
 syntax (name := genSpecAddrCmd)
   "#gen_spec_addr " ident " (" term ", " term ", " term ")" : command
 
 syntax (name := genSpecAddrCmdExtra)
   "#gen_spec_addr " ident " (" term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrCmdFor)
+  "#gen_spec_addr " ident " for " "(" ident " : " term ")" " (" term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrCmdForExtra)
+  "#gen_spec_addr " ident " for " "(" ident " : " term ")" " (" term ", " term ", " term ", " term ")" : command
 
 macro_rules
   | `(#gen_spec $name:ident ($slot:term, $value:term, $frame:term)) =>
@@ -29,6 +41,20 @@ macro_rules
           Verity.Specs.storageAddrUpdateSpec $slot $value $frame s s')
   | `(#gen_spec_addr $name:ident ($slot:term, $value:term, $frame:term, $extra:term)) =>
       `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrUpdateSpec $slot $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec $name:ident for ($arg:ident : $argTy:term) ($slot:term, $value:term, $frame:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageUpdateSpec $slot $value $frame s s')
+  | `(#gen_spec $name:ident for ($arg:ident : $argTy:term) ($slot:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageUpdateSpec $slot $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_addr $name:ident for ($arg:ident : $argTy:term) ($slot:term, $value:term, $frame:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrUpdateSpec $slot $value $frame s s')
+  | `(#gen_spec_addr $name:ident for ($arg:ident : $argTy:term) ($slot:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
           Verity.Specs.storageAddrUpdateSpec $slot $value
             (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
 


### PR DESCRIPTION
## Summary
- add one-argument command forms for spec generation macros:
  - `#gen_spec <name> for (<arg> : <Type>) (...)`
  - `#gen_spec_addr <name> for (<arg> : <Type>) (...)`
- migrate remaining repetitive one-arg specs to macro-generated forms:
  - `Contracts/Owned/Spec.lean`
  - `Contracts/OwnedCounter/Spec.lean`
  - `Contracts/SimpleStorage/Spec.lean`
- update affected proof scripts to explicit `storage*UpdateSpec` shape proofs so they remain stable under macro-generated defs

## Why
This advances #1166 by removing remaining manual one-argument spec boilerplate and extending macro coverage beyond no-arg cases.

## Validation
- `lake build Verity.Macro.SpecGen Contracts.Owned.Spec Contracts.OwnedCounter.Spec Contracts.SimpleStorage.Spec`
- `lake build Contracts.Owned.Proofs.Basic Contracts.OwnedCounter.Proofs.Basic Contracts.SimpleStorage.Proofs.Basic`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Lean macro expansion and rewrites multiple proofs to match the new generated spec shapes, so small macro mistakes could ripple into many theorems despite no runtime/contract logic changes.
> 
> **Overview**
> **Adds new one-argument forms** for the spec-generation commands in `Verity/Macro/SpecGen.lean` (e.g. `#gen_spec ... for (arg : Type)` and `#gen_spec_addr ... for (arg : Type)`).
> 
> **Migrates specs** in `Contracts/Owned/Spec.lean`, `Contracts/OwnedCounter/Spec.lean`, and `Contracts/SimpleStorage/Spec.lean` from hand-written `storage*UpdateSpec` definitions to the macro-generated equivalents (and adds the needed `Verity.Macro` imports).
> 
> **Updates affected proofs** in the corresponding `Proofs/Basic.lean` files to prove the explicit 3-field `storage*UpdateSpec` structure via `refine ⟨...⟩`/`simp`, keeping proofs stable under macro-generated defs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dab8a13023d5545205148c5c6f07d893730ea2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->