### PR TITLE
Extend #gen_spec with parameterized storage helpers

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -3,6 +3,7 @@
 -/
 
 import Verity.Specs.Common
+import Verity.Macro
 import Verity.EVM.Uint256
 
 namespace Contracts.ERC20.Spec
@@ -13,14 +14,9 @@ open Verity.Specs
 
 /-! ## Operation Specifications -/
 
-/-- constructor: sets owner and initializes total supply to zero -/
-def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
-  storageAddrStorageUpdateSpec
-    0 1
-    (fun _ => initialOwner)
-    (fun _ => 0)
-    sameStorageMap2Context
-    s s'
+-- constructor: sets owner and initializes total supply to zero
+#gen_spec_addr_storage constructor_spec for (initialOwner : Address)
+  (0, 1, (fun _ => initialOwner), (fun _ => 0), sameStorageMap2Context)
 
 /-- mint: increases recipient balance and total supply by amount -/
 def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Contracts/SimpleToken/Spec.lean
+++ b/Contracts/SimpleToken/Spec.lean
@@ -3,6 +3,7 @@
 -/
 
 import Verity.Specs.Common
+import Verity.Macro
 import Verity.EVM.Uint256
 
 namespace Contracts.SimpleToken.Spec
@@ -13,14 +14,9 @@ open Verity.Specs
 
 /-! ## Operation Specifications -/
 
-/-- Constructor: sets owner and initializes total supply to 0 -/
-def constructor_spec (initialOwner : Address) (s s' : ContractState) : Prop :=
-  storageAddrStorageUpdateSpec
-    0 2
-    (fun _ => initialOwner)
-    (fun _ => 0)
-    sameMapContext
-    s s'
+-- Constructor: sets owner and initializes total supply to 0
+#gen_spec_addr_storage constructor_spec for (initialOwner : Address)
+  (0, 2, (fun _ => initialOwner), (fun _ => 0), sameMapContext)
 
 /-- Mint: increases balance and total supply by amount (owner only) -/
 def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Verity/Macro/SpecGen.lean
+++ b/Verity/Macro/SpecGen.lean
@@ -28,6 +28,38 @@ syntax (name := genSpecAddrCmdFor)
 syntax (name := genSpecAddrCmdForExtra)
   "#gen_spec_addr " ident " for " "(" ident " : " term ")" " (" term ", " term ", " term ", " term ")" : command
 
+syntax (name := genSpecAddrStorageCmd)
+  "#gen_spec_addr_storage " ident
+    " (" term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorageCmdExtra)
+  "#gen_spec_addr_storage " ident
+    " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorageCmdFor)
+  "#gen_spec_addr_storage " ident " for " "(" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorageCmdForExtra)
+  "#gen_spec_addr_storage " ident " for " "(" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorage2Cmd)
+  "#gen_spec_addr_storage2 " ident
+    " (" term ", " term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorage2CmdExtra)
+  "#gen_spec_addr_storage2 " ident
+    " (" term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorage2CmdFor)
+  "#gen_spec_addr_storage2 " ident " for " "(" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorage2CmdForExtra)
+  "#gen_spec_addr_storage2 " ident " for " "(" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ")" : command
+
 macro_rules
   | `(#gen_spec $name:ident ($slot:term, $value:term, $frame:term)) =>
       `(def $name (s s' : Verity.ContractState) : Prop :=
@@ -56,6 +88,58 @@ macro_rules
   | `(#gen_spec_addr $name:ident for ($arg:ident : $argTy:term) ($slot:term, $value:term, $frame:term, $extra:term)) =>
       `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
           Verity.Specs.storageAddrUpdateSpec $slot $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_addr_storage $name:ident
+      ($addrSlot:term, $storageSlot:term, $addrValue:term, $storageValue:term, $frame:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorageUpdateSpec
+            $addrSlot $storageSlot $addrValue $storageValue $frame s s')
+  | `(#gen_spec_addr_storage $name:ident
+      ($addrSlot:term, $storageSlot:term, $addrValue:term, $storageValue:term, $frame:term, $extra:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorageUpdateSpec
+            $addrSlot $storageSlot $addrValue $storageValue
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_addr_storage $name:ident for ($arg:ident : $argTy:term)
+      ($addrSlot:term, $storageSlot:term, $addrValue:term, $storageValue:term, $frame:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorageUpdateSpec
+            $addrSlot $storageSlot $addrValue $storageValue $frame s s')
+  | `(#gen_spec_addr_storage $name:ident for ($arg:ident : $argTy:term)
+      ($addrSlot:term, $storageSlot:term, $addrValue:term, $storageValue:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorageUpdateSpec
+            $addrSlot $storageSlot $addrValue $storageValue
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_addr_storage2 $name:ident
+      ($addrSlot:term, $storageSlot1:term, $storageSlot2:term,
+       $addrValue:term, $storageValue1:term, $storageValue2:term, $frame:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorage2UpdateSpec
+            $addrSlot $storageSlot1 $storageSlot2
+            $addrValue $storageValue1 $storageValue2 $frame s s')
+  | `(#gen_spec_addr_storage2 $name:ident
+      ($addrSlot:term, $storageSlot1:term, $storageSlot2:term,
+       $addrValue:term, $storageValue1:term, $storageValue2:term, $frame:term, $extra:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorage2UpdateSpec
+            $addrSlot $storageSlot1 $storageSlot2
+            $addrValue $storageValue1 $storageValue2
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_addr_storage2 $name:ident for ($arg:ident : $argTy:term)
+      ($addrSlot:term, $storageSlot1:term, $storageSlot2:term,
+       $addrValue:term, $storageValue1:term, $storageValue2:term, $frame:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorage2UpdateSpec
+            $addrSlot $storageSlot1 $storageSlot2
+            $addrValue $storageValue1 $storageValue2 $frame s s')
+  | `(#gen_spec_addr_storage2 $name:ident for ($arg:ident : $argTy:term)
+      ($addrSlot:term, $storageSlot1:term, $storageSlot2:term,
+       $addrValue:term, $storageValue1:term, $storageValue2:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorage2UpdateSpec
+            $addrSlot $storageSlot1 $storageSlot2
+            $addrValue $storageValue1 $storageValue2
             (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
 
 end Verity.Macro


### PR DESCRIPTION
## Summary
- extend `Verity/Macro/SpecGen.lean` with parameterized command forms for:
  - `#gen_spec` (1 typed argument)
  - `#gen_spec_addr` (1 typed argument)
  - `#gen_spec_addr_storage` (0/1 typed argument + optional extra frame)
  - `#gen_spec_addr_storage2` (0/1 typed argument + optional extra frame)
- migrate constructor specs in:
  - `Contracts/ERC20/Spec.lean`
  - `Contracts/SimpleToken/Spec.lean`
  to `#gen_spec_addr_storage ... (initialOwner : Address) (...)`

## Why
This advances #1166 by enabling declarative generation of common parameterized storage-shape specs (especially constructor patterns) without hand-written boilerplate.

## Validation
- `lake build Verity.Macro.SpecGen Contracts.ERC20.Spec Contracts.SimpleToken.Spec Contracts.ERC20.Proofs.Basic Contracts.SimpleToken.Proofs.Basic`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new macro syntax/expansions that generate spec definitions, which could subtly change or break spec generation across contracts if the expansions differ from the prior handwritten defs. Scope is limited to macro layer plus two constructor-spec migrations.
> 
> **Overview**
> **Adds new SpecGen macros** for declaratively generating specs that update a `storageAddr` slot plus one or two `storage` slots: `#gen_spec_addr_storage` and `#gen_spec_addr_storage2`, each supporting optional extra frame conditions and an optional single typed parameter via `for (...)`.
> 
> **Refactors contract constructor specs** in `Contracts/ERC20/Spec.lean` and `Contracts/SimpleToken/Spec.lean` to use `#gen_spec_addr_storage ... for (initialOwner : Address) ...`, removing manual boilerplate while keeping the same underlying update shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d23e2b02db9d9ca51e5716b5925ac7fbd267240b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->