### PR TITLE
Extend #gen_spec coverage for map update specs

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -18,13 +18,9 @@ open Verity.Specs
 #gen_spec_addr_storage constructor_spec for (initialOwner : Address)
   (0, 1, (fun _ => initialOwner), (fun _ => 0), sameStorageMap2Context)
 
-/-- mint: increases recipient balance and total supply by amount -/
-def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  storageMapAndStorageUpdateSpec
-    2 to (fun st => add (st.storageMap 2 to) amount)
-    1 (fun st => add (st.storage 1) amount)
-    (sameStorageAddrSlotMap2Context 0)
-    s s'
+-- mint: increases recipient balance and total supply by amount
+#gen_spec_map_storage mint_spec for (to : Address) (amount : Uint256)
+  (2, to, (fun st => add (st.storageMap 2 to) amount), 1, (fun st => add (st.storage 1) amount), sameStorageAddrSlotMap2Context 0)
 
 /-- transfer: sender balance decreases and recipient balance increases by amount -/
 def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Contracts/Ledger/Spec.lean
+++ b/Contracts/Ledger/Spec.lean
@@ -4,6 +4,7 @@
 
 import Verity.Specs.Common
 import Verity.Specs.Common.Sum
+import Verity.Macro
 import Verity.EVM.Uint256
 import Contracts.MacroContracts.Core
 
@@ -17,21 +18,13 @@ open Verity.Specs.Common (sumBalances balancesFinite)
 
 /-! ## Operation Specifications -/
 
-/-- deposit: increases sender's balance by amount -/
-def deposit_spec (amount : Uint256) (s s' : ContractState) : Prop :=
-  storageMapUpdateSpec
-    0 s.sender
-    (fun st => add (st.storageMap 0 st.sender) amount)
-    sameStorageAddrContext
-    s s'
+-- deposit: increases sender's balance by amount
+#gen_spec_map deposit_spec for (amount : Uint256)
+  (0, s.sender, (fun st => add (st.storageMap 0 st.sender) amount), sameStorageAddrContext)
 
-/-- withdraw (when sufficient balance): decreases sender's balance by amount -/
-def withdraw_spec (amount : Uint256) (s s' : ContractState) : Prop :=
-  storageMapUpdateSpec
-    0 s.sender
-    (fun st => sub (st.storageMap 0 st.sender) amount)
-    sameStorageAddrContext
-    s s'
+-- withdraw (when sufficient balance): decreases sender's balance by amount
+#gen_spec_map withdraw_spec for (amount : Uint256)
+  (0, s.sender, (fun st => sub (st.storageMap 0 st.sender) amount), sameStorageAddrContext)
 
 /-- transfer: moves amount from sender to recipient -/
 def transfer_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Contracts/SimpleToken/Spec.lean
+++ b/Contracts/SimpleToken/Spec.lean
@@ -18,13 +18,9 @@ open Verity.Specs
 #gen_spec_addr_storage constructor_spec for (initialOwner : Address)
   (0, 2, (fun _ => initialOwner), (fun _ => 0), sameMapContext)
 
-/-- Mint: increases balance and total supply by amount (owner only) -/
-def mint_spec (to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  storageMapAndStorageUpdateSpec
-    1 to (fun st => add (st.storageMap 1 to) amount)
-    2 (fun st => add (st.storage 2) amount)
-    (sameStorageAddrSlotContext 0)
-    s s'
+-- Mint: increases balance and total supply by amount (owner only)
+#gen_spec_map_storage mint_spec for (to : Address) (amount : Uint256)
+  (1, to, (fun st => add (st.storageMap 1 to) amount), 2, (fun st => add (st.storage 2) amount), sameStorageAddrSlotContext 0)
 
 /-- Transfer: moves amount from sender to recipient, preserves total supply -/
 def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Verity/Macro/SpecGen.lean
+++ b/Verity/Macro/SpecGen.lean
@@ -60,6 +60,15 @@ syntax (name := genSpecAddrStorage2CmdForExtra)
   "#gen_spec_addr_storage2 " ident " for " "(" ident " : " term ")"
     " (" term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ")" : command
 
+syntax (name := genSpecMapCmdFor)
+  "#gen_spec_map " ident " for " "(" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecMapStorageCmdFor2)
+  "#gen_spec_map_storage " ident " for "
+    "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
+
 macro_rules
   | `(#gen_spec $name:ident ($slot:term, $value:term, $frame:term)) =>
       `(def $name (s s' : Verity.ContractState) : Prop :=
@@ -141,5 +150,18 @@ macro_rules
             $addrSlot $storageSlot1 $storageSlot2
             $addrValue $storageValue1 $storageValue2
             (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_map $name:ident for ($arg:ident : $argTy:term)
+      ($mapSlot:term, $key:term, $value:term, $frame:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMapUpdateSpec
+            $mapSlot $key $value $frame s s')
+  | `(#gen_spec_map_storage $name:ident for
+      ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($mapSlot:term, $key:term, $mapValue:term, $storageSlot:term, $storageValue:term, $frame:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMapAndStorageUpdateSpec
+            $mapSlot $key $mapValue
+            $storageSlot $storageValue
+            $frame s s')
 
 end Verity.Macro


### PR DESCRIPTION
## Summary
- add `#gen_spec_map` for one-argument `storageMapUpdateSpec` generation
- add `#gen_spec_map_storage` for two-argument `storageMapAndStorageUpdateSpec` generation
- migrate remaining hand-written map update specs to macro forms in:
  - `Contracts/Ledger/Spec.lean` (`deposit_spec`, `withdraw_spec`)
  - `Contracts/SimpleToken/Spec.lean` (`mint_spec`)
  - `Contracts/ERC20/Spec.lean` (`mint_spec`)

## Validation
- `lake build Verity.Macro.SpecGen Contracts.Ledger.Spec Contracts.SimpleToken.Spec Contracts.ERC20.Spec Contracts.Ledger.Proofs.Basic Contracts.SimpleToken.Proofs.Basic Contracts.SimpleToken.Proofs.Supply Contracts.ERC20.Proofs.Basic Contracts.ERC20.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

Closes #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes macro expansion used to define formal specs, which could subtly alter generated propositions and downstream proofs even though runtime behavior is unaffected.
> 
> **Overview**
> **Extends spec-generation macros** by adding `#gen_spec_map` (1-arg `storageMapUpdateSpec`) and `#gen_spec_map_storage` (2-arg `storageMapAndStorageUpdateSpec`) to `Verity/Macro/SpecGen.lean`.
> 
> **Refactors contract specs** to use the new macros, replacing hand-written `deposit_spec`/`withdraw_spec` in `Contracts/Ledger/Spec.lean` and `mint_spec` in `Contracts/SimpleToken/Spec.lean` and `Contracts/ERC20/Spec.lean` with macro-generated equivalents (plus adding `import Verity.Macro` where needed).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e16a3fcd43d83ae55a2b6e02a09bcddd601209f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->