### PR TITLE
Extend #gen_spec with #gen_spec_map2 variants

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -29,12 +29,9 @@ def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState
     (sameStorageSlotAddrSlotMap2Context 1 0)
     s s'
 
-/-- approve: updates the owner-spender allowance mapping entry -/
-def approve_spec (ownerAddr spender : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  storageMap2UpdateSpec
-    3 ownerAddr spender (fun _ => amount)
-    sameStorageAddrMapContext
-    s s'
+-- approve: updates the owner-spender allowance mapping entry
+#gen_spec_map2 approve_spec for3 (ownerAddr : Address) (spender : Address) (amount : Uint256)
+  (3, ownerAddr, spender, (fun _ => amount), sameStorageAddrMapContext)
 
 /-- transferFrom: debits `fromAddr`, credits `to`, and updates allowance for spender -/
 def transferFrom_spec (spender fromAddr to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=

--- a/Contracts/ERC721/Spec.lean
+++ b/Contracts/ERC721/Spec.lean
@@ -3,6 +3,7 @@
 -/
 
 import Verity.Specs.Common
+import Verity.Macro
 import Verity.EVM.Uint256
 
 namespace Contracts.ERC721.Spec
@@ -53,13 +54,9 @@ def getApproved_spec (tokenId : Uint256) (result : ContractResult Address) (s : 
 def isApprovedForAll_spec (ownerAddr operator : Address) (result : Bool) (s : ContractState) : Prop :=
   result = (s.storageMap2 6 ownerAddr operator != 0)
 
-/-- setApprovalForAll: updates only sender->operator flag in slot 6 -/
-def setApprovalForAll_spec
-    (sender operator : Address) (approved : Bool) (s s' : ContractState) : Prop :=
-  storageMap2UpdateSpec
-    6 sender operator
-    (fun _ => boolToWord approved)
-    sameStorageAddrMapUintContext
-    s s'
+-- setApprovalForAll: updates only sender->operator flag in slot 6
+#gen_spec_map2 setApprovalForAll_spec for3
+  (sender : Address) (operator : Address) (approved : Bool)
+  (6, sender, operator, (fun _ => boolToWord approved), sameStorageAddrMapUintContext)
 
 end Contracts.ERC721.Spec

--- a/Verity/Macro/SpecGen.lean
+++ b/Verity/Macro/SpecGen.lean
@@ -115,6 +115,40 @@ syntax (name := genSpecMapStorageCmdFor2Extra)
     "(" ident " : " term ")" " (" ident " : " term ")"
     " (" term ", " term ", " term ", " term ", " term ", " term ", " term ")" : command
 
+syntax (name := genSpecMap2Cmd)
+  "#gen_spec_map2 " ident
+    " (" term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecMap2CmdExtra)
+  "#gen_spec_map2 " ident
+    " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecMap2CmdFor)
+  "#gen_spec_map2 " ident " for " "(" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecMap2CmdForExtra)
+  "#gen_spec_map2 " ident " for " "(" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecMap2CmdFor2)
+  "#gen_spec_map2 " ident " for2 " "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecMap2CmdFor2Extra)
+  "#gen_spec_map2 " ident " for2 " "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecMap2CmdFor3)
+  "#gen_spec_map2 " ident " for3 "
+    "(" ident " : " term ")" " (" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecMap2CmdFor3Extra)
+  "#gen_spec_map2 " ident " for3 "
+    "(" ident " : " term ")" " (" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
+
 macro_rules
   | `(#gen_spec $name:ident ($slot:term, $value:term, $frame:term)) =>
       `(def $name (s s' : Verity.ContractState) : Prop :=
@@ -281,6 +315,52 @@ macro_rules
           Verity.Specs.storageMapAndStorageUpdateSpec
             $mapSlot $key $mapValue
             $storageSlot $storageValue
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_map2 $name:ident
+      ($slot:term, $key1:term, $key2:term, $value:term, $frame:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMap2UpdateSpec
+            $slot $key1 $key2 $value $frame s s')
+  | `(#gen_spec_map2 $name:ident
+      ($slot:term, $key1:term, $key2:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMap2UpdateSpec
+            $slot $key1 $key2 $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_map2 $name:ident for ($arg:ident : $argTy:term)
+      ($slot:term, $key1:term, $key2:term, $value:term, $frame:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMap2UpdateSpec
+            $slot $key1 $key2 $value $frame s s')
+  | `(#gen_spec_map2 $name:ident for ($arg:ident : $argTy:term)
+      ($slot:term, $key1:term, $key2:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMap2UpdateSpec
+            $slot $key1 $key2 $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_map2 $name:ident for2 ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($slot:term, $key1:term, $key2:term, $value:term, $frame:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMap2UpdateSpec
+            $slot $key1 $key2 $value $frame s s')
+  | `(#gen_spec_map2 $name:ident for2 ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($slot:term, $key1:term, $key2:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMap2UpdateSpec
+            $slot $key1 $key2 $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_map2 $name:ident for3
+      ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term) ($arg3:ident : $argTy3:term)
+      ($slot:term, $key1:term, $key2:term, $value:term, $frame:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) ($arg3 : $argTy3) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMap2UpdateSpec
+            $slot $key1 $key2 $value $frame s s')
+  | `(#gen_spec_map2 $name:ident for3
+      ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term) ($arg3:ident : $argTy3:term)
+      ($slot:term, $key1:term, $key2:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) ($arg3 : $argTy3) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageMap2UpdateSpec
+            $slot $key1 $key2 $value
             (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
 
 end Verity.Macro


### PR DESCRIPTION
## Summary
- add `#gen_spec_map2` command family in `Verity/Macro/SpecGen.lean`
  - no-arg form
  - `for` / `for2` / `for3` typed-argument forms
  - optional extra-frame variants for each form
- migrate manual map2-update specs to macro-generated form:
  - `Contracts/ERC20/Spec.lean`: `approve_spec`
  - `Contracts/ERC721/Spec.lean`: `setApprovalForAll_spec`

## Why
This is another incremental step on #1166: it removes remaining hand-written `storageMap2UpdateSpec` boilerplate and extends declarative spec generation coverage to multi-key mapping updates.

## Validation
- `lake build Verity.Macro.SpecGen Contracts.ERC20.Spec Contracts.ERC721.Spec Contracts.ERC20.Proofs.Basic Contracts.ERC20.Proofs.Correctness`
- `python3 scripts/check_verify_sync.py`
- `make check`

## Notes
`lake build Contracts.ERC721.Proofs.Basic Contracts.ERC721.Proofs.Correctness` remains blocked on the pre-existing unsolved-goal regression in `Contracts/ERC721/Proofs/Basic.lean` (constructor proof), unchanged by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it extends Lean macro syntax/expansion in `Verity/Macro/SpecGen.lean`, which can cause build or proof breakages if the generated `storageMap2UpdateSpec` wrappers differ from the prior hand-written specs.
> 
> **Overview**
> Adds a new `#gen_spec_map2` macro family to generate `storageMap2UpdateSpec`-based specs, including no-arg and typed `for`/`for2`/`for3` variants plus optional *extra-frame* conjunction forms.
> 
> Migrates remaining hand-written 2-key mapping update specs to the macro form: ERC20 `approve_spec` and ERC721 `setApprovalForAll_spec` (also adding `import Verity.Macro` to ERC721 specs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 121bf767af54d0c9bd57789b861453e1a16fa1c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->