### PR TITLE
Extend spec-gen with transfer and transferFrom templates

### DIFF
--- a/Contracts/ERC20/Spec.lean
+++ b/Contracts/ERC20/Spec.lean
@@ -22,24 +22,17 @@ open Verity.Specs
 #gen_spec_map_storage mint_spec for (to : Address) (amount : Uint256)
   (2, to, (fun st => add (st.storageMap 2 to) amount), 1, (fun st => add (st.storage 1) amount), sameStorageAddrSlotMap2Context 0)
 
-/-- transfer: sender balance decreases and recipient balance increases by amount -/
-def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  s.storageMap 2 sender ≥ amount ∧
-  storageMapTransferSpec 2 sender to amount
-    (sameStorageSlotAddrSlotMap2Context 1 0)
-    s s'
+#gen_spec_transfer transfer_spec for3
+  (sender : Address) (to : Address) (amount : Uint256)
+  (2, sameStorageSlotAddrSlotMap2Context 1 0)
 
 -- approve: updates the owner-spender allowance mapping entry
 #gen_spec_map2 approve_spec for3 (ownerAddr : Address) (spender : Address) (amount : Uint256)
   (3, ownerAddr, spender, (fun _ => amount), sameStorageAddrMapContext)
 
-/-- transferFrom: debits `fromAddr`, credits `to`, and updates allowance for spender -/
-def transferFrom_spec (spender fromAddr to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  s.storageMap2 3 fromAddr spender ≥ amount ∧
-  s.storageMap 2 fromAddr ≥ amount ∧
-  storageMapTransferFromSpec 2 3 fromAddr to spender amount
-    sameStorageAddrContext
-    s s'
+#gen_spec_transfer_from transferFrom_spec for4
+  (spender : Address) (fromAddr : Address) (to : Address) (amount : Uint256)
+  (2, 3, sameStorageAddrContext)
 
 /-- balanceOf: returns current balance of `addr` -/
 def balanceOf_spec (addr : Address) (result : Uint256) (s : ContractState) : Prop :=

--- a/Contracts/SimpleToken/Spec.lean
+++ b/Contracts/SimpleToken/Spec.lean
@@ -22,14 +22,11 @@ open Verity.Specs
 #gen_spec_map_storage mint_spec for (to : Address) (amount : Uint256)
   (1, to, (fun st => add (st.storageMap 1 to) amount), 2, (fun st => add (st.storage 2) amount), sameStorageAddrSlotContext 0)
 
-/-- Transfer: moves amount from sender to recipient, preserves total supply -/
-def transfer_spec (sender to : Address) (amount : Uint256) (s s' : ContractState) : Prop :=
-  s.storageMap 1 sender ≥ amount ∧
-  storageMapTransferSpec 1 sender to amount
-    (fun st st' =>
-      sameStorageAddrSlot 0 st st' ∧
-      sameStorageAddrContext st st')
-    s s'
+#gen_spec_transfer transfer_spec for3
+  (sender : Address) (to : Address) (amount : Uint256)
+  (1, (fun st st' =>
+    sameStorageAddrSlot 0 st st' ∧
+    sameStorageAddrContext st st'))
 
 /-- balanceOf: returns the balance of the given address -/
 def balanceOf_spec (addr : Address) (result : Uint256) (s : ContractState) : Prop :=

--- a/Verity/Macro/SpecGen.lean
+++ b/Verity/Macro/SpecGen.lean
@@ -149,6 +149,16 @@ syntax (name := genSpecMap2CmdFor3Extra)
     "(" ident " : " term ")" " (" ident " : " term ")" " (" ident " : " term ")"
     " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
 
+syntax (name := genSpecTransferCmdFor3)
+  "#gen_spec_transfer " ident " for3 "
+    "(" ident " : " term ")" " (" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ")" : command
+
+syntax (name := genSpecTransferFromCmdFor4)
+  "#gen_spec_transfer_from " ident " for4 "
+    "(" ident " : " term ")" " (" ident " : " term ")" " (" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ")" : command
+
 macro_rules
   | `(#gen_spec $name:ident ($slot:term, $value:term, $frame:term)) =>
       `(def $name (s s' : Verity.ContractState) : Prop :=
@@ -362,5 +372,20 @@ macro_rules
           Verity.Specs.storageMap2UpdateSpec
             $slot $key1 $key2 $value
             (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_transfer $name:ident for3
+      ($fromAddr:ident : $fromTy:term) ($toAddr:ident : $toTy:term) ($amount:ident : $amountTy:term)
+      ($slot:term, $frame:term)) =>
+      `(def $name ($fromAddr : $fromTy) ($toAddr : $toTy) ($amount : $amountTy) (s s' : Verity.ContractState) : Prop :=
+          s.storageMap $slot $fromAddr ≥ $amount ∧
+          Verity.Specs.storageMapTransferSpec
+            $slot $fromAddr $toAddr $amount $frame s s')
+  | `(#gen_spec_transfer_from $name:ident for4
+      ($spender:ident : $spenderTy:term) ($fromAddr:ident : $fromTy:term) ($toAddr:ident : $toTy:term) ($amount:ident : $amountTy:term)
+      ($balanceSlot:term, $allowanceSlot:term, $frame:term)) =>
+      `(def $name ($spender : $spenderTy) ($fromAddr : $fromTy) ($toAddr : $toTy) ($amount : $amountTy) (s s' : Verity.ContractState) : Prop :=
+          s.storageMap2 $allowanceSlot $fromAddr $spender ≥ $amount ∧
+          s.storageMap $balanceSlot $fromAddr ≥ $amount ∧
+          Verity.Specs.storageMapTransferFromSpec
+            $balanceSlot $allowanceSlot $fromAddr $toAddr $spender $amount $frame s s')
 
 end Verity.Macro


### PR DESCRIPTION
## Summary
- add `#gen_spec_transfer ... for3 (...) (slot, frame)` to generate transfer-shaped specs with sender-balance precondition
- add `#gen_spec_transfer_from ... for4 (...) (balanceSlot, allowanceSlot, frame)` for ERC20 `transferFrom` shape
- migrate manual transfer specs to macro-generated forms in:
  - `Contracts/ERC20/Spec.lean` (`transfer_spec`, `transferFrom_spec`)
  - `Contracts/SimpleToken/Spec.lean` (`transfer_spec`)

## Why
This is an incremental step on #1166 to reduce repeated spec boilerplate for common transfer patterns while preserving the existing proof surface.

## Validation
- `lake build Verity.Macro.SpecGen Contracts.ERC20.Spec Contracts.SimpleToken.Spec Contracts.ERC20.Proofs.Basic Contracts.ERC20.Proofs.Correctness Contracts.SimpleToken.Proofs.Basic Contracts.SimpleToken.Proofs.Supply`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the macro expansion that defines core `transfer`/`transferFrom` specs, so any mismatch in generated preconditions/frames could invalidate or break downstream proofs.
> 
> **Overview**
> Introduces two new SpecGen macros, `#gen_spec_transfer ... for3` and `#gen_spec_transfer_from ... for4`, to generate common transfer-shaped specs with built-in balance/allowance preconditions and a caller-supplied frame.
> 
> Migrates manual `transfer_spec`/`transferFrom_spec` definitions in `Contracts/ERC20/Spec.lean` and `Contracts/SimpleToken/Spec.lean` to these macro-generated forms, reducing repeated boilerplate while keeping the same storage slots/frames.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a53c2ddea17dd069a0809f8fb76806ac2913aa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->