### PR TITLE
Fix uint256 normalization gaps in pure builtin bridge semantics

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
@@ -59,11 +59,23 @@ example : verityEval "div" [42, 7] = bridgeEval "div" [42, 7] := by native_decid
 /-- div: division by zero returns 0 -/
 example : verityEval "div" [42, 0] = bridgeEval "div" [42, 0] := by native_decide
 
+/-- div: operands are interpreted as uint256 words (2^256 ≡ 0). -/
+example : verityEval "div" [Compiler.Constants.evmModulus, 2] =
+          bridgeEval "div" [Compiler.Constants.evmModulus, 2] := by native_decide
+
+/-- div: denominator wraps (2^256 ≡ 0), so this is division by zero. -/
+example : verityEval "div" [7, Compiler.Constants.evmModulus] =
+          bridgeEval "div" [7, Compiler.Constants.evmModulus] := by native_decide
+
 /-- mod: 10 % 3 = 1 -/
 example : verityEval "mod" [10, 3] = bridgeEval "mod" [10, 3] := by native_decide
 
 /-- mod: modulo by zero returns 0 -/
 example : verityEval "mod" [10, 0] = bridgeEval "mod" [10, 0] := by native_decide
+
+/-- mod: operands are interpreted as uint256 words (2^256 ≡ 0). -/
+example : verityEval "mod" [Compiler.Constants.evmModulus, 3] =
+          bridgeEval "mod" [Compiler.Constants.evmModulus, 3] := by native_decide
 
 -- ## Comparison builtins
 
@@ -115,20 +127,44 @@ example : verityEval "gt" [Compiler.Constants.evmModulus, Compiler.Constants.evm
 /-- and: 0xFF & 0x0F = 0x0F -/
 example : verityEval "and" [255, 15] = bridgeEval "and" [255, 15] := by native_decide
 
+/-- and: uint256-wrap on operands (2^256 ≡ 0). -/
+example : verityEval "and" [Compiler.Constants.evmModulus, Compiler.Constants.evmModulus] =
+          bridgeEval "and" [Compiler.Constants.evmModulus, Compiler.Constants.evmModulus] := by native_decide
+
 /-- or: 0xF0 | 0x0F = 0xFF -/
 example : verityEval "or" [240, 15] = bridgeEval "or" [240, 15] := by native_decide
+
+/-- or: uint256-wrap on operands (2^256 ≡ 0). -/
+example : verityEval "or" [Compiler.Constants.evmModulus, 0] =
+          bridgeEval "or" [Compiler.Constants.evmModulus, 0] := by native_decide
 
 /-- xor: 0xFF ^ 0x0F = 0xF0 -/
 example : verityEval "xor" [255, 15] = bridgeEval "xor" [255, 15] := by native_decide
 
+/-- xor: uint256-wrap on operands (2^256 ≡ 0). -/
+example : verityEval "xor" [Compiler.Constants.evmModulus, 0] =
+          bridgeEval "xor" [Compiler.Constants.evmModulus, 0] := by native_decide
+
 /-- not: bitwise NOT of 0 -/
 example : verityEval "not" [0] = bridgeEval "not" [0] := by native_decide
+
+/-- not: uint256-wrap on operand (2^256 ≡ 0). -/
+example : verityEval "not" [Compiler.Constants.evmModulus] =
+          bridgeEval "not" [Compiler.Constants.evmModulus] := by native_decide
 
 /-- shl: 1 << 8 = 256 -/
 example : verityEval "shl" [8, 1] = bridgeEval "shl" [8, 1] := by native_decide
 
+/-- shl: shift operand wraps in uint256 domain (2^256 ≡ 0). -/
+example : verityEval "shl" [Compiler.Constants.evmModulus, 3] =
+          bridgeEval "shl" [Compiler.Constants.evmModulus, 3] := by native_decide
+
 /-- shr: 256 >> 8 = 1 -/
 example : verityEval "shr" [8, 256] = bridgeEval "shr" [8, 256] := by native_decide
+
+/-- shr: both shift and value are interpreted as uint256 words. -/
+example : verityEval "shr" [Compiler.Constants.evmModulus, Compiler.Constants.evmModulus] =
+          bridgeEval "shr" [Compiler.Constants.evmModulus, Compiler.Constants.evmModulus] := by native_decide
 
 -- ## Scope boundary: state-dependent builtins fall through to none
 

--- a/Compiler/Proofs/YulGeneration/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/Builtins.lean
@@ -30,6 +30,7 @@ def evalBuiltinCall
     (calldata : List Nat)
     (func : String)
     (argVals : List Nat) : Option Nat :=
+  let toWord (x : Nat) : Nat := x % evmModulus
   if func = "mappingSlot" then
     match argVals with
     | [base, key] => some (Compiler.Proofs.abstractMappingSlot base key)
@@ -52,11 +53,17 @@ def evalBuiltinCall
     | _ => none
   else if func = "div" then
     match argVals with
-    | [a, b] => if b = 0 then some 0 else some (a / b)
+    | [a, b] =>
+        let a := toWord a
+        let b := toWord b
+        if b = 0 then some 0 else some (a / b)
     | _ => none
   else if func = "mod" then
     match argVals with
-    | [a, b] => if b = 0 then some 0 else some (a % b)
+    | [a, b] =>
+        let a := toWord a
+        let b := toWord b
+        if b = 0 then some 0 else some (a % b)
     | _ => none
   else if func = "lt" then
     match argVals with
@@ -76,27 +83,32 @@ def evalBuiltinCall
     | _ => none
   else if func = "and" then
     match argVals with
-    | [a, b] => some (a &&& b)
+    | [a, b] => some (toWord a &&& toWord b)
     | _ => none
   else if func = "or" then
     match argVals with
-    | [a, b] => some (a ||| b)
+    | [a, b] => some (toWord a ||| toWord b)
     | _ => none
   else if func = "xor" then
     match argVals with
-    | [a, b] => some (Nat.xor a b)
+    | [a, b] => some (Nat.xor (toWord a) (toWord b))
     | _ => none
   else if func = "not" then
     match argVals with
-    | [a] => some (Nat.xor a (evmModulus - 1))
+    | [a] => some (Nat.xor (toWord a) (evmModulus - 1))
     | _ => none
   else if func = "shl" then
     match argVals with
-    | [shift, value] => some ((value * (2 ^ shift)) % evmModulus)
+    | [shift, value] =>
+        let shift := toWord shift
+        some ((value * (2 ^ shift)) % evmModulus)
     | _ => none
   else if func = "shr" then
     match argVals with
-    | [shift, value] => some (value / (2 ^ shift))
+    | [shift, value] =>
+        let shift := toWord shift
+        let value := toWord value
+        some (value / (2 ^ shift))
     | _ => none
   else if func = "caller" then
     match argVals with


### PR DESCRIPTION
## Summary
- normalize remaining pure-builtin operands to uint256 words in `evalBuiltinCall`
- apply normalization for `div`, `mod`, `and`, `or`, `xor`, `not`, `shl`, and `shr`
- add wrap-boundary bridge regression examples in `EvmYulLeanBridgeTest` for these operations

## Why
`#1168` tracks trust alignment between Verity-side builtin evaluation and EVMYulLean's UInt256 semantics. Comparison builtins were already normalized, but several other pure builtins still consumed raw `Nat` values. This could produce mismatches for values outside `[0, 2^256)`.

## Validation
- `lake build Compiler.Proofs.YulGeneration.Builtins Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeTest`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1168

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core builtin-evaluation semantics for several arithmetic/bitwise ops, which could affect proof outcomes and execution equivalence for out-of-range inputs. Scope is limited to pure builtins and is covered by new wrap-boundary bridge tests.
> 
> **Overview**
> Aligns Verity-side builtin evaluation with EVMYulLean `UInt256` semantics by normalizing operands into the `uint256` domain (`% evmModulus`) for `div`, `mod`, `and`, `or`, `xor`, `not`, `shl`, and `shr` in `evalBuiltinCall`.
> 
> Extends `EvmYulLeanBridgeTest` with additional wrap-boundary examples (notably `2^256 ≡ 0` and division/modulo by wrapped-to-zero denominators) to regression-test that `verityEval` and `bridgeEval` stay in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d6099673854646699df15246b17435a0946702. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->