### PR TITLE
Fix sub builtin word-normalization mismatch

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
@@ -50,6 +50,10 @@ example : verityEval "sub" [10, 3] = bridgeEval "sub" [10, 3] := by native_decid
 /-- sub: underflow wraps -/
 example : verityEval "sub" [0, 1] = bridgeEval "sub" [0, 1] := by native_decide
 
+/-- sub: denominator operand wraps in uint256 domain (2^257 + 1 ≡ 1). -/
+example : verityEval "sub" [0, 2 * Compiler.Constants.evmModulus + 1] =
+          bridgeEval "sub" [0, 2 * Compiler.Constants.evmModulus + 1] := by native_decide
+
 /-- mul: 6 * 7 = 42 -/
 example : verityEval "mul" [6, 7] = bridgeEval "mul" [6, 7] := by native_decide
 

--- a/Compiler/Proofs/YulGeneration/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/Builtins.lean
@@ -45,7 +45,10 @@ def evalBuiltinCall
     | _ => none
   else if func = "sub" then
     match argVals with
-    | [a, b] => some ((evmModulus + a - b) % evmModulus)
+    | [a, b] =>
+        let a := toWord a
+        let b := toWord b
+        some ((evmModulus + a - b) % evmModulus)
     | _ => none
   else if func = "mul" then
     match argVals with


### PR DESCRIPTION
## Summary
- normalize `sub` operands to uint256 words in `evalBuiltinCall`
- keep subtraction semantics as uint256 modular subtraction after normalization
- add bridge regression for wrapped second operand (`2 * evmModulus + 1 ≡ 1`)

## Why
`sub` previously applied Nat subtraction directly on raw arguments. For wrapped inputs, Nat truncation could produce incorrect results before modulo reduction, diverging from EVMYulLean UInt256 behavior.

## Validation
- `lake build Compiler.Proofs.YulGeneration.Builtins Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeTest`
- `python3 scripts/check_verify_sync.py`
- `make check`

Refs #1168

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes arithmetic semantics for `sub` in `evalBuiltinCall`, which may affect any proofs/tests that rely on the previous (non-word-normalized) behavior. Scope is small and covered by a new bridge regression test for wrapped operands.
> 
> **Overview**
> Aligns Verity’s `evalBuiltinCall` implementation of `sub` with EVM word semantics by first reducing both operands with `toWord` before performing modular subtraction.
> 
> Adds a new `EvmYulLeanBridgeTest` example covering a wrapped second operand (`2 * evmModulus + 1 ≡ 1`) to prevent future divergence between the Verity and EVMYulLean evaluation paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e316e1334594453e00ae157b471de8c2c2cd9960. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->