### PR TITLE
Extend #gen_spec_addr_storage2 with for2 variants

### DIFF
--- a/Verity/Macro/SpecGen.lean
+++ b/Verity/Macro/SpecGen.lean
@@ -60,6 +60,16 @@ syntax (name := genSpecAddrStorage2CmdForExtra)
   "#gen_spec_addr_storage2 " ident " for " "(" ident " : " term ")"
     " (" term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ")" : command
 
+syntax (name := genSpecAddrStorage2CmdFor2)
+  "#gen_spec_addr_storage2 " ident " for2 "
+    "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorage2CmdFor2Extra)
+  "#gen_spec_addr_storage2 " ident " for2 "
+    "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ", " term ", " term ")" : command
+
 syntax (name := genSpecMapCmd)
   "#gen_spec_map " ident
     " (" term ", " term ", " term ", " term ")" : command
@@ -236,6 +246,23 @@ macro_rules
       ($addrSlot:term, $storageSlot1:term, $storageSlot2:term,
        $addrValue:term, $storageValue1:term, $storageValue2:term, $frame:term, $extra:term)) =>
       `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorage2UpdateSpec
+            $addrSlot $storageSlot1 $storageSlot2
+            $addrValue $storageValue1 $storageValue2
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_addr_storage2 $name:ident for2
+      ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($addrSlot:term, $storageSlot1:term, $storageSlot2:term,
+       $addrValue:term, $storageValue1:term, $storageValue2:term, $frame:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorage2UpdateSpec
+            $addrSlot $storageSlot1 $storageSlot2
+            $addrValue $storageValue1 $storageValue2 $frame s s')
+  | `(#gen_spec_addr_storage2 $name:ident for2
+      ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($addrSlot:term, $storageSlot1:term, $storageSlot2:term,
+       $addrValue:term, $storageValue1:term, $storageValue2:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
           Verity.Specs.storageAddrStorage2UpdateSpec
             $addrSlot $storageSlot1 $storageSlot2
             $addrValue $storageValue1 $storageValue2


### PR DESCRIPTION
## Summary\n- add  parser forms for \n- add matching macro expansions for both standard and extra-frame variants\n- keep generated definitions aligned with existing  shape\n\n## Why\nThis extends  template coverage for multi-parameter constructor/update shapes and advances issue #1166 macro completeness incrementally.\n\nRefs #1166\n\n## Validation\n- Build completed successfully.\n- [PASS] paths
[PASS] jobs
[PASS] python-commands
[PASS] multiseed
[PASS] foundry
[PASS] artifacts
[PASS] makefile
verify sync passed: 7 invariant groups\n- Running CI-equivalent checks job...
python3 scripts/check_property_manifest.py
Property manifest check passed.
python3 scripts/check_property_coverage.py
Property coverage check passed.
python3 scripts/check_contract_structure.py
Checking 9 contracts for complete file structure...
  (Excluding: CryptoHash, MacroContracts, ReentrancyExample)

  OK Counter
  OK ERC20
  OK ERC721
  OK Ledger
  OK Owned
  OK OwnedCounter
  OK SafeCounter
  OK SimpleStorage
  OK SimpleToken

OK: All 9 contracts have complete file structure
python3 scripts/check_case_insensitive_path_conflicts.py
python3 scripts/check_axiom_locations.py
  OK keccak256_first_4_bytes at Compiler/Selectors.lean:41
  OK resultsMatch_switchCaseBody_of_resultsMatch_body at Compiler/Proofs/YulGeneration/Preservation.lean:300

OK: 2 documented axiom locations are accurate; registry is complete and synchronized with 2 source axioms
python3 scripts/generate_verification_status.py --check
Verification artifact is up to date: /workspaces/mission-3356d738/repo-run-20260306h/artifacts/verification_status.json
python3 scripts/check_doc_counts.py
Documentation count check passed (272 theorems, 10 categories, 2 axioms, 475 tests, 38 suites, 0 sorry, 250/272 covered, 22 exclusions).
python3 scripts/check_interop_matrix_sync.py
Interop matrix is synchronized across docs (6 feature rows checked).
python3 scripts/check_verify_sync.py
[PASS] paths
[PASS] jobs
[PASS] python-commands
[PASS] multiseed
[PASS] foundry
[PASS] artifacts
[PASS] makefile
verify sync passed: 7 invariant groups
python3 scripts/check_issue_template_forms.py
issue template forms OK (4 file(s))
python3 scripts/check_solc_pin.py
✓ solc pin is consistent (0.8.33+commit.64118f21)
python3 scripts/check_property_manifest_sync.py
Property manifest sync check passed.
python3 scripts/check_issue_templates.py
issue template contamination check passed
python3 scripts/check_macro_property_test_generation.py --check
macro property-test artifacts are up to date: artifacts/macro_property_tests
python3 scripts/check_macro_translate_invariant_coverage.py
macro invariant suite coverage OK
python3 scripts/check_macro_roundtrip_fuzz_coverage.py
macro round-trip fuzz coverage OK
python3 scripts/check_storage_layout.py
Storage layout validation passed.

============================================================
STORAGE LAYOUT REPORT
============================================================

  Counter
    Slot 0: count (Uint256)

  CryptoHash
    Slot 0: lastHash (Uint256)

  Ledger
    Slot 0: balances ((Address → Uint256))

  Owned
    Slot 0: owner (Address)

  OwnedCounter
    Slot 0: owner (Address)
    Slot 1: count (Uint256)

  ReentrancyExample
    Slot 0: reentrancyLock (Uint256)
    Slot 1: totalSupply (Uint256)
    Slot 2: balances ((Address → Uint256))

  SafeCounter
    Slot 0: count (Uint256)

  SimpleToken
    Slot 0: owner (Address)
    Slot 1: balances ((Address → Uint256))
    Slot 2: totalSupply (Uint256)
python3 scripts/check_manual_spec_quarantine.py
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
python3 scripts/check_spec_proof_migration_boundary.py
Spec-proof migration boundary check passed (16 allowlisted files; no out-of-bound legacy references).
python3 scripts/check_legacy_example_imports.py
Legacy migrated-contract import guard passed (171 Lean files scanned; 9 explicit exemption module(s)).
python3 scripts/check_layer2_universality.py
Layer-2 universality check passed (15 semantic bridge theorem headers validated).
python3 scripts/check_lean_hygiene.py
Lean hygiene check passed (0 debug commands in proofs, 1 allowUnsafeReducibility, 0 sorry (expected 0), 0 native_decide in proofs).
python3 scripts/check_gas_model_coverage.py
OK: static gas model covers all emitted Yul calls (26 names) across: artifacts/yul
python3 scripts/check_mapping_slot_boundary.py
✓ Mapping slot boundary is enforced
python3 scripts/check_yul_builtin_boundary.py
✓ Yul builtin boundary is enforced
python3 scripts/check_rewrite_proof_metadata.py
Rewrite proof metadata check passed (active object rewrite rules have non-empty proof refs).
python3 scripts/check_builtin_list_sync.py
✓ Builtin lists in sync (85 Linker, 78+4 CompilationModel)
python3 scripts/check_evmyullean_capability_boundary.py
✓ EVMYulLean capability boundary is enforced
python3 scripts/generate_evmyullean_capability_report.py --check
EVMYulLean capability report is up to date: /workspaces/mission-3356d738/repo-run-20260306h/artifacts/evmyullean_capability_report.json
EVMYulLean unsupported-node report is up to date: /workspaces/mission-3356d738/repo-run-20260306h/artifacts/evmyullean_unsupported_nodes.json
python3 scripts/generate_evmyullean_adapter_report.py --check
EVMYulLean adapter report is up to date: /workspaces/mission-3356d738/repo-run-20260306h/artifacts/evmyullean_adapter_report.json
python3 scripts/generate_print_axioms.py --check
OK: /workspaces/mission-3356d738/repo-run-20260306h/PrintAxioms.lean is up to date.
python3 scripts/check_proof_length.py
Proof length check: 953 proofs scanned.
  897 under 30 lines (good)
  42 between 30-50 lines (acceptable)
  14 over 50 lines (allowlisted)

Proof length check passed. No new proofs exceed the 50-line hard limit.
python3 scripts/check_issue_1060_integrity.py
issue #1060 integrity check passed
python3 -m unittest discover -s scripts -p 'test_*.py' -v
  OK documented_axiom at Compiler/A.lean:1
✓ Builtin lists in sync (3 Linker, 1+1 CompilationModel)
Documentation count check passed (272 theorems, 10 categories, 2 axioms, 475 tests, 38 suites, 0 sorry, 250/272 covered, 22 exclusions).
Interop matrix is synchronized across docs (1 feature rows checked).
issue #1060 integrity check passed
issue template forms OK (1 file(s))
Legacy migrated-contract import guard passed (1 Lean files scanned; 1 explicit exemption module(s)).
Legacy migrated-contract import guard passed (1 Lean files scanned; 0 explicit exemption module(s)).
wrote macro property-test artifacts (1 file(s)): tmpyneqn7h8/artifacts
wrote macro property-test artifacts (1 file(s)): tmp1g44cpc7/artifacts
wrote macro property-test artifacts (1 file(s)): tmpcfi56vq8/artifacts
macro property-test artifacts are up to date: tmpcfi56vq8/artifacts
macro round-trip fuzz coverage OK
macro round-trip fuzz coverage OK
macro round-trip fuzz coverage OK
macro invariant suite coverage OK
macro invariant suite coverage OK
macro invariant suite coverage OK
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Manual-artifact quarantine check passed (5 canonical files; only allowlisted compatibility specs used).
Spec-proof migration boundary check passed (1 allowlisted files; no out-of-bound legacy references).
Spec-proof migration boundary check passed (0 allowlisted files; no out-of-bound legacy references).
✓ Yul builtin boundary is enforced
Wrote Lean warning baseline to /tmp/tmpv9gufl2m/baseline.json
Wrote Yul identity report: /tmp/tmpav7qwk2t/r1.json
Status: non_identical (1 mismatches)
Wrote Yul identity report: /tmp/tmpav7qwk2t/r2.json
Status: non_identical (1 mismatches)
All checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive macro syntax/expansion changes only; main risk is introducing parser/macro-rule ambiguity or incorrect spec generation for the new `for2` form.
> 
> **Overview**
> Extends `#gen_spec_addr_storage2` with new `for2` command forms that accept **two typed arguments**, matching existing `for`/non-`for` variants.
> 
> Adds corresponding macro expansions to generate `def` specifications that thread both arguments into `Verity.Specs.storageAddrStorage2UpdateSpec`, including an *extra-frame* variant that conjoins `frame` and `extra`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e6e12e12e68fb1a369937e0c7d735ccb8a684d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->