### PR TITLE
Extend core #gen_spec families with for2 variants

### DIFF
--- a/Contracts/MacroContracts/Smoke.lean
+++ b/Contracts/MacroContracts/Smoke.lean
@@ -81,6 +81,46 @@ verity_contract Uint8Smoke where
   function sigV () : Uint8 := do
     return 27
 
+namespace SpecGenSmoke
+
+#gen_spec storage_for2_spec for2 (x : Uint256) (y : Uint256)
+  (0, (fun st => add (st.storage 0) (add x y)), Verity.Specs.sameAddrMapContext)
+
+#gen_spec storage_for2_extra_spec for2 (x : Uint256) (y : Uint256)
+  (0, (fun st => add (st.storage 0) (add x y)), Verity.Specs.sameAddrMapContext,
+    (fun _ s' => s'.storage 0 >= x))
+
+#gen_spec_addr addr_for2_spec for2 (owner : Address) (_salt : Uint256)
+  (0, (fun _ => owner), Verity.Specs.sameStorageMapContext)
+
+#gen_spec_addr addr_for2_extra_spec for2 (owner : Address) (salt : Uint256)
+  (0, (fun _ => owner), Verity.Specs.sameStorageMapContext,
+    (fun _ s' => s'.storage 0 = owner.toNat ∧ salt = salt))
+
+#gen_spec_addr_storage addr_storage_for2_spec for2 (owner : Address) (value : Uint256)
+  (0, 2, (fun _ => owner), (fun _ => value), Verity.Specs.sameStorageMapsContext)
+
+#gen_spec_addr_storage addr_storage_for2_extra_spec for2 (owner : Address) (value : Uint256)
+  (0, 2, (fun _ => owner), (fun _ => value), Verity.Specs.sameStorageMapsContext,
+    (fun _ s' => s'.storage 2 = value))
+
+example (x y : Uint256) (s s' : ContractState) :
+    storage_for2_spec x y s s' =
+      Verity.Specs.storageUpdateSpec 0 (fun st => add (st.storage 0) (add x y))
+        Verity.Specs.sameAddrMapContext s s' := rfl
+
+example (owner : Address) (salt : Uint256) (s s' : ContractState) :
+    addr_for2_spec owner salt s s' =
+      Verity.Specs.storageAddrUpdateSpec 0 (fun _ => owner)
+        Verity.Specs.sameStorageMapContext s s' := rfl
+
+example (owner : Address) (value : Uint256) (s s' : ContractState) :
+    addr_storage_for2_spec owner value s s' =
+      Verity.Specs.storageAddrStorageUpdateSpec 0 2 (fun _ => owner) (fun _ => value)
+        Verity.Specs.sameStorageMapsContext s s' := rfl
+
+end SpecGenSmoke
+
 #check_contract Counter
 #check_contract UintMapSmoke
 #check_contract Bytes32Smoke

--- a/Verity/Macro/SpecGen.lean
+++ b/Verity/Macro/SpecGen.lean
@@ -16,6 +16,14 @@ syntax (name := genSpecCmdFor)
 syntax (name := genSpecCmdForExtra)
   "#gen_spec " ident " for " "(" ident " : " term ")" " (" term ", " term ", " term ", " term ")" : command
 
+syntax (name := genSpecCmdFor2)
+  "#gen_spec " ident " for2 " "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ")" : command
+
+syntax (name := genSpecCmdFor2Extra)
+  "#gen_spec " ident " for2 " "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ")" : command
+
 syntax (name := genSpecAddrCmd)
   "#gen_spec_addr " ident " (" term ", " term ", " term ")" : command
 
@@ -27,6 +35,14 @@ syntax (name := genSpecAddrCmdFor)
 
 syntax (name := genSpecAddrCmdForExtra)
   "#gen_spec_addr " ident " for " "(" ident " : " term ")" " (" term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrCmdFor2)
+  "#gen_spec_addr " ident " for2 " "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrCmdFor2Extra)
+  "#gen_spec_addr " ident " for2 " "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ")" : command
 
 syntax (name := genSpecAddrStorageCmd)
   "#gen_spec_addr_storage " ident
@@ -42,6 +58,14 @@ syntax (name := genSpecAddrStorageCmdFor)
 
 syntax (name := genSpecAddrStorageCmdForExtra)
   "#gen_spec_addr_storage " ident " for " "(" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorageCmdFor2)
+  "#gen_spec_addr_storage " ident " for2 " "(" ident " : " term ")" " (" ident " : " term ")"
+    " (" term ", " term ", " term ", " term ", " term ")" : command
+
+syntax (name := genSpecAddrStorageCmdFor2Extra)
+  "#gen_spec_addr_storage " ident " for2 " "(" ident " : " term ")" " (" ident " : " term ")"
     " (" term ", " term ", " term ", " term ", " term ", " term ")" : command
 
 syntax (name := genSpecAddrStorage2Cmd)
@@ -191,11 +215,29 @@ macro_rules
       `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
           Verity.Specs.storageUpdateSpec $slot $value
             (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec $name:ident for2 ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($slot:term, $value:term, $frame:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageUpdateSpec $slot $value $frame s s')
+  | `(#gen_spec $name:ident for2 ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($slot:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageUpdateSpec $slot $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
   | `(#gen_spec_addr $name:ident for ($arg:ident : $argTy:term) ($slot:term, $value:term, $frame:term)) =>
       `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
           Verity.Specs.storageAddrUpdateSpec $slot $value $frame s s')
   | `(#gen_spec_addr $name:ident for ($arg:ident : $argTy:term) ($slot:term, $value:term, $frame:term, $extra:term)) =>
       `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrUpdateSpec $slot $value
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_addr $name:ident for2 ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($slot:term, $value:term, $frame:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrUpdateSpec $slot $value $frame s s')
+  | `(#gen_spec_addr $name:ident for2 ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($slot:term, $value:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
           Verity.Specs.storageAddrUpdateSpec $slot $value
             (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
   | `(#gen_spec_addr_storage $name:ident
@@ -217,6 +259,17 @@ macro_rules
   | `(#gen_spec_addr_storage $name:ident for ($arg:ident : $argTy:term)
       ($addrSlot:term, $storageSlot:term, $addrValue:term, $storageValue:term, $frame:term, $extra:term)) =>
       `(def $name ($arg : $argTy) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorageUpdateSpec
+            $addrSlot $storageSlot $addrValue $storageValue
+            (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')
+  | `(#gen_spec_addr_storage $name:ident for2 ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($addrSlot:term, $storageSlot:term, $addrValue:term, $storageValue:term, $frame:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
+          Verity.Specs.storageAddrStorageUpdateSpec
+            $addrSlot $storageSlot $addrValue $storageValue $frame s s')
+  | `(#gen_spec_addr_storage $name:ident for2 ($arg1:ident : $argTy1:term) ($arg2:ident : $argTy2:term)
+      ($addrSlot:term, $storageSlot:term, $addrValue:term, $storageValue:term, $frame:term, $extra:term)) =>
+      `(def $name ($arg1 : $argTy1) ($arg2 : $argTy2) (s s' : Verity.ContractState) : Prop :=
           Verity.Specs.storageAddrStorageUpdateSpec
             $addrSlot $storageSlot $addrValue $storageValue
             (fun s s' => ($frame) s s' ∧ ($extra) s s') s s')


### PR DESCRIPTION
## Summary
- add `for2` + `for2 ... extra` command forms for:
  - `#gen_spec`
  - `#gen_spec_addr`
  - `#gen_spec_addr_storage`
- add matching macro expansion rules that emit two-argument spec definitions
- add smoke coverage in `Contracts/MacroContracts/Smoke.lean` exercising each new form and proving expansion shape with `rfl` examples

## Why
Issue #1166 is moving toward declarative spec generation with less boilerplate. These three core generators still only accepted no-arg/one-arg forms, while newer generators already supported higher arity (`for2`/`for3`). This patch closes that consistency gap and unlocks two-argument specs without hand-written `def`s.

## Validation
- `lake build Verity.Macro.SpecGen Contracts.MacroContracts.Smoke`
- `python3 scripts/check_axiom_locations.py`
- `python3 scripts/check_doc_counts.py`

Closes #1166 (incremental macro coverage).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive macro/syntax extension; primary risk is parsing or macro-expansion regressions for spec generation commands.
> 
> **Overview**
> Adds new `for2` (and `for2 ... extra`) command forms for `#gen_spec`, `#gen_spec_addr`, and `#gen_spec_addr_storage`, expanding them into two-argument `def` specs with the same optional extra-conjunct behavior as existing arities.
> 
> Extends `Contracts/MacroContracts/Smoke.lean` with smoke usages of each new form plus `rfl` examples asserting the generated definitions match the expected `Verity.Specs.*UpdateSpec` shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a124c75946eeaf40f305fb3ecb4cfc8b2c39c0cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->