### PR TITLE
Fix uint256 shift saturation in builtin bridge semantics

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
@@ -163,12 +163,20 @@ example : verityEval "shl" [8, 1] = bridgeEval "shl" [8, 1] := by native_decide
 example : verityEval "shl" [Compiler.Constants.evmModulus, 3] =
           bridgeEval "shl" [Compiler.Constants.evmModulus, 3] := by native_decide
 
+/-- shl: very large uint256 shift (2^256 - 1) saturates to 0. -/
+example : verityEval "shl" [Compiler.Constants.evmModulus - 1, 3] =
+          bridgeEval "shl" [Compiler.Constants.evmModulus - 1, 3] := by native_decide
+
 /-- shr: 256 >> 8 = 1 -/
 example : verityEval "shr" [8, 256] = bridgeEval "shr" [8, 256] := by native_decide
 
 /-- shr: both shift and value are interpreted as uint256 words. -/
 example : verityEval "shr" [Compiler.Constants.evmModulus, Compiler.Constants.evmModulus] =
           bridgeEval "shr" [Compiler.Constants.evmModulus, Compiler.Constants.evmModulus] := by native_decide
+
+/-- shr: very large uint256 shift (2^256 - 1) saturates to 0. -/
+example : verityEval "shr" [Compiler.Constants.evmModulus - 1, 12345] =
+          bridgeEval "shr" [Compiler.Constants.evmModulus - 1, 12345] := by native_decide
 
 -- ## Scope boundary: state-dependent builtins fall through to none
 

--- a/Compiler/Proofs/YulGeneration/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/Builtins.lean
@@ -104,14 +104,20 @@ def evalBuiltinCall
     match argVals with
     | [shift, value] =>
         let shift := toWord shift
-        some ((value * (2 ^ shift)) % evmModulus)
+        if shift < 256 then
+          some ((toWord value * (2 ^ shift)) % evmModulus)
+        else
+          some 0
     | _ => none
   else if func = "shr" then
     match argVals with
     | [shift, value] =>
         let shift := toWord shift
         let value := toWord value
-        some (value / (2 ^ shift))
+        if shift < 256 then
+          some (value / (2 ^ shift))
+        else
+          some 0
     | _ => none
   else if func = "caller" then
     match argVals with


### PR DESCRIPTION
## Summary
Fixes a reliability/semantics edge case in Layer-3 builtin bridge execution for `shl`/`shr`.

- Update `evalBuiltinCall` shift semantics to use EVM-style saturation:
  - `shift < 256` => evaluate with `2 ^ shift`
  - `shift >= 256` => result `0`
- Normalize `shl` value via `toWord` before shifting.
- Add bridge regressions for extreme uint256 shifts (`2^256 - 1`) in `EvmYulLeanBridgeTest`.

## Why
For very large valid uint256 shift operands (e.g. `2^256 - 1`), the previous implementation could attempt enormous `Nat.pow` exponents in the Verity builtin evaluator, causing runtime instability (`INTERNAL PANIC: Nat.pow exponent is too big`) during exhaustive checks.

This patch aligns behavior with EVM saturated shift semantics while preventing runaway exponentiation.

## Validation
- `lake build Compiler.Proofs.YulGeneration.Builtins Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeTest`
- `python3 scripts/check_verify_sync.py`
- `make check`

## Issue
Partial progress on #1168
