### PR TITLE
proofs: fix selectorExpr proof regression in Yul lemmas

### DIFF
--- a/Compiler/Proofs/YulGeneration/Lemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Lemmas.lean
@@ -15,12 +15,34 @@ set_option maxHeartbeats 1000000 in
 @[simp] theorem evalYulExpr_selectorExpr_semantics :
     ∀ state : YulState, evalYulExpr state selectorExpr = some (state.selector % selectorModulus) := by
   intro state
-  have hpow : 0 < (2 ^ selectorShift) := by
-    simpa using (Nat.pow_pos (a := 2) (n := selectorShift) (by decide : 0 < (2 : Nat)))
+  have hShiftModEq : selectorShift % evmModulus = selectorShift := by
+    have hShiftLtModulus : selectorShift < evmModulus := by
+      norm_num [selectorShift, evmModulus]
+    exact Nat.mod_eq_of_lt hShiftLtModulus
+  have hSelectorShiftLt256 : selectorShift < 256 := by
+    norm_num [selectorShift]
+  have hSelectorShiftNotGe256 : ¬ 256 ≤ selectorShift := Nat.not_le_of_lt hSelectorShiftLt256
+  have hSelectorWordLt :
+      (state.selector % selectorModulus) * 2 ^ selectorShift < evmModulus := by
+    have hModLt : state.selector % selectorModulus < selectorModulus := by
+      exact Nat.mod_lt _ (by decide)
+    have hPowPos : 0 < 2 ^ selectorShift := by
+      exact Nat.pow_pos (a := 2) (n := selectorShift) (by decide)
+    have hMulLt :
+        (state.selector % selectorModulus) * 2 ^ selectorShift <
+          selectorModulus * 2 ^ selectorShift := by
+      exact Nat.mul_lt_mul_of_pos_right hModLt hPowPos
+    have hModulusSplit : selectorModulus * 2 ^ selectorShift = evmModulus := by
+      norm_num [selectorModulus, selectorShift, evmModulus, Nat.pow_add, Nat.mul_comm, Nat.mul_left_comm,
+        Nat.mul_assoc]
+    simpa [hModulusSplit] using hMulLt
+  have hSelectorWordMod :
+      ((state.selector % selectorModulus) * 2 ^ selectorShift) % evmModulus =
+        (state.selector % selectorModulus) * 2 ^ selectorShift := by
+    exact Nat.mod_eq_of_lt hSelectorWordLt
   simp [selectorExpr, evalYulExpr, evalYulCall, evalYulExprs,
-    evalBuiltinCallWithBackend, defaultBuiltinBackend, evalBuiltinCall,
-    calldataloadWord, selectorWord, selectorModulus, selectorShift,
-    Nat.mul_div_right, hpow]
+    evalBuiltinCallWithBackend, evalBuiltinCall, calldataloadWord, selectorWord,
+    hShiftModEq, hSelectorWordMod, hSelectorShiftNotGe256]
 
 @[simp]
 theorem execYulStmtFuel_switch_match_semantics


### PR DESCRIPTION
## Summary
This PR fixes a concrete proof regression in `Compiler/Proofs/YulGeneration/Lemmas.lean`:
- repairs `evalYulExpr_selectorExpr_semantics` after uint256 normalization in builtin shift/compare semantics.
- replaces brittle one-shot simp with explicit arithmetic bounds/mod-equality steps.

## Why
`lake build Compiler.Proofs.YulGeneration.Lemmas` failed on `main` with an unsolved goal in selector extraction semantics. This theorem is a core dependency for Yul codegen proof paths.

## Validation
- `lake build Compiler.Proofs.YulGeneration.Lemmas`
- `lake build Compiler.Proofs.YulGeneration.Codegen`

## Notes
I investigated broader `Preservation.lean` failures as well; those appear to be pre-existing and orthogonal to this selector-lemma regression. This PR is intentionally scoped to the minimal safe unblock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low runtime risk since changes are limited to Lean proof scripts, but it touches a core selector-extraction lemma and could affect downstream proof compilation if the new arithmetic assumptions are wrong.
> 
> **Overview**
> Fixes a proof regression in `evalYulExpr_selectorExpr_semantics` by replacing a brittle `simp`-only argument with explicit arithmetic facts about `selectorShift` and EVM word bounds (mod-equality, shift < 256, and bounded selector-word multiplication).
> 
> Updates the final simplification to use these new lemmas (and drops older helper assumptions), restoring compilation of the selector-extraction semantics proof used by Yul codegen proofs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b303c75f324b68025bc4ef0db7a43e8e6d2639bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->