### PR TITLE
refactor: extract CompilationModel storage write lowering

### DIFF
--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -12,6 +12,7 @@ import Compiler.CompilationModel.EcmAxiomCollection
 import Compiler.CompilationModel.InternalNaming
 import Compiler.CompilationModel.LayoutValidation
 import Compiler.CompilationModel.MappingWrites
+import Compiler.CompilationModel.StorageWrites
 import Compiler.CompilationModel.UsageAnalysis
 import Compiler.CompilationModel.ValidationHelpers
 import Compiler.CompilationModel.SelectorInteropHelpers

--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -32,6 +32,7 @@ import Compiler.CompilationModel.UsageAnalysis
 import Compiler.CompilationModel.ValidationHelpers
 import Compiler.CompilationModel.SelectorInteropHelpers
 import Compiler.CompilationModel.ExpressionCompile
+import Compiler.CompilationModel.StorageWrites
 import Compiler.CompilationModel.Validation
 
 namespace Compiler.CompilationModel
@@ -69,76 +70,7 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
   | Stmt.assignVar name value => do
       pure [YulStmt.assign name (← compileExpr fields dynamicSource value)]
   | Stmt.setStorage field value =>
-    if isMapping fields field then
-      throw s!"Compilation error: field '{field}' is a mapping; use setMapping, setMappingWord, or setMappingPackedWord"
-    else
-      match findFieldWithResolvedSlot fields field with
-      | some (f, slot) => do
-          let slots := slot :: f.aliasSlots
-          let valueExpr ← compileExpr fields dynamicSource value
-          match slots with
-          | [] =>
-              throw s!"Compilation error: internal invariant failure: no write slots for field '{field}' in setStorage"
-          | [singleSlot] =>
-              match f.packedBits with
-              | none =>
-                  pure [YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit singleSlot, valueExpr])]
-              | some packed =>
-                  let maskNat := packedMaskNat packed
-                  let shiftedMaskNat := packedShiftedMaskNat packed
-                  pure [
-                    YulStmt.block [
-                      YulStmt.let_ "__compat_value" valueExpr,
-                      YulStmt.let_ "__compat_packed" (YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat]),
-                      YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [YulExpr.lit singleSlot]),
-                      YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
-                        YulExpr.ident "__compat_slot_word",
-                        YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
-                      ]),
-                      YulStmt.expr (YulExpr.call "sstore" [
-                        YulExpr.lit singleSlot,
-                        YulExpr.call "or" [
-                          YulExpr.ident "__compat_slot_cleared",
-                          YulExpr.call "shl" [YulExpr.lit packed.offset, YulExpr.ident "__compat_packed"]
-                        ]
-                      ])
-                    ]
-                  ]
-          | _ =>
-              match f.packedBits with
-              | none =>
-                  pure [
-                    YulStmt.block (
-                      [YulStmt.let_ "__compat_value" valueExpr] ++
-                      slots.map (fun writeSlot =>
-                        YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit writeSlot, YulExpr.ident "__compat_value"]))
-                    )
-                  ]
-              | some packed =>
-                  let maskNat := packedMaskNat packed
-                  let shiftedMaskNat := packedShiftedMaskNat packed
-                  pure [
-                    YulStmt.block (
-                      [YulStmt.let_ "__compat_value" valueExpr,
-                       YulStmt.let_ "__compat_packed" (YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat])] ++
-                      slots.map (fun writeSlot =>
-                        YulStmt.block [
-                          YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [YulExpr.lit writeSlot]),
-                          YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
-                            YulExpr.ident "__compat_slot_word",
-                            YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
-                          ]),
-                          YulStmt.expr (YulExpr.call "sstore" [
-                            YulExpr.lit writeSlot,
-                            YulExpr.call "or" [
-                              YulExpr.ident "__compat_slot_cleared",
-                              YulExpr.call "shl" [YulExpr.lit packed.offset, YulExpr.ident "__compat_packed"]
-                            ]
-                          ])
-                        ])
-                    )
-                  ]
-      | none => throw s!"Compilation error: unknown storage field '{field}' in setStorage"
+      compileSetStorage fields dynamicSource field value
   | Stmt.setMapping field key value => do
       compileMappingSlotWrite fields field
         (← compileExpr fields dynamicSource key)
@@ -158,174 +90,18 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
         packed
         "setMappingPackedWord"
   | Stmt.setMapping2 field key1 key2 value =>
-    if !isMapping2 fields field then
-      throw s!"Compilation error: field '{field}' is not a double mapping"
-    else
-      match findFieldWriteSlots fields field with
-      | some slots => do
-          let key1Expr ← compileExpr fields dynamicSource key1
-          let key2Expr ← compileExpr fields dynamicSource key2
-          let valueExpr ← compileExpr fields dynamicSource value
-          match slots with
-          | [] =>
-              throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in setMapping2"
-          | [slot] =>
-              let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
-              pure [
-                YulStmt.expr (YulExpr.call "sstore" [
-                  YulExpr.call "mappingSlot" [innerSlot, key2Expr],
-                  valueExpr
-                ])
-              ]
-          | _ =>
-              pure [
-                YulStmt.block (
-                  [YulStmt.let_ "__compat_key1" key1Expr, YulStmt.let_ "__compat_key2" key2Expr, YulStmt.let_ "__compat_value" valueExpr] ++
-                  slots.map (fun slot =>
-                    let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
-                    YulStmt.expr (YulExpr.call "sstore" [
-                      YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"],
-                      YulExpr.ident "__compat_value"
-                    ]))
-                )
-              ]
-      | none => throw s!"Compilation error: unknown mapping field '{field}' in setMapping2"
+      compileSetMapping2 fields dynamicSource field key1 key2 value
   | Stmt.setMapping2Word field key1 key2 wordOffset value =>
-    if !isMapping2 fields field then
-      throw s!"Compilation error: field '{field}' is not a double mapping"
-    else
-      match findFieldWriteSlots fields field with
-      | some slots => do
-          let key1Expr ← compileExpr fields dynamicSource key1
-          let key2Expr ← compileExpr fields dynamicSource key2
-          let valueExpr ← compileExpr fields dynamicSource value
-          match slots with
-          | [] =>
-              throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in setMapping2Word"
-          | [slot] =>
-              let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
-              let outerSlot := YulExpr.call "mappingSlot" [innerSlot, key2Expr]
-              let finalSlot := if wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
-              pure [
-                YulStmt.expr (YulExpr.call "sstore" [finalSlot, valueExpr])
-              ]
-          | _ =>
-              pure [
-                YulStmt.block (
-                  [YulStmt.let_ "__compat_key1" key1Expr, YulStmt.let_ "__compat_key2" key2Expr, YulStmt.let_ "__compat_value" valueExpr] ++
-                  slots.map (fun slot =>
-                    let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
-                    let outerSlot := YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"]
-                    let finalSlot := if wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
-                    YulStmt.expr (YulExpr.call "sstore" [finalSlot, YulExpr.ident "__compat_value"])))
-              ]
-      | none => throw s!"Compilation error: unknown mapping field '{field}' in setMapping2Word"
+      compileSetMapping2Word fields dynamicSource field key1 key2 wordOffset value
   | Stmt.setMappingUint field key value => do
       compileMappingSlotWrite fields field
         (← compileExpr fields dynamicSource key)
         (← compileExpr fields dynamicSource value)
         "setMappingUint"
-  | Stmt.setStructMember field key memberName value => do
-      if isMapping2 fields field then
-        throw s!"Compilation error: field '{field}' is a double mapping; use Stmt.setStructMember2 instead of Stmt.setStructMember"
-      match findStructMembers fields field with
-      | none => throw s!"Compilation error: field '{field}' is not a mappingStruct"
-      | some members =>
-        match findStructMember members memberName with
-        | none => throw s!"Compilation error: struct field '{field}' has no member '{memberName}'"
-        | some member =>
-          match member.packed with
-          | none =>
-            compileMappingSlotWrite fields field
-              (← compileExpr fields dynamicSource key)
-              (← compileExpr fields dynamicSource value)
-              s!"setStructMember.{memberName}"
-              member.wordOffset
-          | some packed =>
-            compileMappingPackedSlotWrite fields field
-              (← compileExpr fields dynamicSource key)
-              (← compileExpr fields dynamicSource value)
-              member.wordOffset
-              packed
-              s!"setStructMember.{memberName}"
+  | Stmt.setStructMember field key memberName value =>
+      compileSetStructMember fields dynamicSource field key memberName value
   | Stmt.setStructMember2 field key1 key2 memberName value =>
-      if !isMapping2 fields field then
-        throw s!"Compilation error: field '{field}' is not a double mapping; use Stmt.setStructMember instead of Stmt.setStructMember2"
-      else
-        match findStructMembers fields field with
-        | none => throw s!"Compilation error: field '{field}' is not a mappingStruct"
-        | some members =>
-          match findStructMember members memberName with
-          | none => throw s!"Compilation error: struct field '{field}' has no member '{memberName}'"
-          | some member =>
-            match findFieldWriteSlots fields field with
-            | some slots => do
-                let key1Expr ← compileExpr fields dynamicSource key1
-                let key2Expr ← compileExpr fields dynamicSource key2
-                let valueExpr ← compileExpr fields dynamicSource value
-                match slots with
-                | [] =>
-                    throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in setStructMember2.{memberName}"
-                | [slot] =>
-                    let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
-                    let outerSlot := YulExpr.call "mappingSlot" [innerSlot, key2Expr]
-                    let finalSlot := if member.wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit member.wordOffset]
-                    match member.packed with
-                    | none =>
-                      pure [YulStmt.expr (YulExpr.call "sstore" [finalSlot, valueExpr])]
-                    | some packed =>
-                      let maskNat := packedMaskNat packed
-                      let shiftedMaskNat := packedShiftedMaskNat packed
-                      pure [
-                        YulStmt.block [
-                          YulStmt.let_ "__compat_value" valueExpr,
-                          YulStmt.let_ "__compat_packed" (YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat]),
-                          YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [finalSlot]),
-                          YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
-                            YulExpr.ident "__compat_slot_word",
-                            YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
-                          ]),
-                          YulStmt.expr (YulExpr.call "sstore" [
-                            finalSlot,
-                            YulExpr.call "or" [
-                              YulExpr.ident "__compat_slot_cleared",
-                              YulExpr.call "shl" [YulExpr.lit packed.offset, YulExpr.ident "__compat_packed"]
-                            ]
-                          ])
-                        ]
-                      ]
-                | _ =>
-                    pure [
-                      YulStmt.block (
-                        [YulStmt.let_ "__compat_key1" key1Expr, YulStmt.let_ "__compat_key2" key2Expr, YulStmt.let_ "__compat_value" valueExpr] ++
-                        slots.map (fun slot =>
-                          let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
-                          let outerSlot := YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"]
-                          let finalSlot := if member.wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit member.wordOffset]
-                          match member.packed with
-                          | none =>
-                            YulStmt.expr (YulExpr.call "sstore" [finalSlot, YulExpr.ident "__compat_value"])
-                          | some packed =>
-                            let maskNat := packedMaskNat packed
-                            let shiftedMaskNat := packedShiftedMaskNat packed
-                            YulStmt.block [
-                              YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [finalSlot]),
-                              YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
-                                YulExpr.ident "__compat_slot_word",
-                                YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
-                              ]),
-                              YulStmt.expr (YulExpr.call "sstore" [
-                                finalSlot,
-                                YulExpr.call "or" [
-                                  YulExpr.ident "__compat_slot_cleared",
-                                  YulExpr.call "shl" [YulExpr.lit packed.offset,
-                                    YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat]]
-                                ]
-                              ])
-                            ])
-                      )
-                    ]
-            | none => throw s!"Compilation error: unknown mapping field '{field}' in setStructMember2.{memberName}"
+      compileSetStructMember2 fields dynamicSource field key1 key2 memberName value
   | Stmt.require cond message =>
     do
       let failCond ← compileRequireFailCond fields dynamicSource cond

--- a/Compiler/CompilationModel/StorageWrites.lean
+++ b/Compiler/CompilationModel/StorageWrites.lean
@@ -1,0 +1,239 @@
+import Compiler.CompilationModel.ExpressionCompile
+import Compiler.CompilationModel.MappingWrites
+import Compiler.CompilationModel.ValidationHelpers
+
+namespace Compiler.CompilationModel
+
+open Compiler
+open Compiler.Yul
+
+private def compilePackedStorageWrite (writeSlot valueExpr : YulExpr) (packed : PackedBits) :
+    List YulStmt :=
+  let maskNat := packedMaskNat packed
+  let shiftedMaskNat := packedShiftedMaskNat packed
+  [
+    YulStmt.block [
+      YulStmt.let_ "__compat_value" valueExpr,
+      YulStmt.let_ "__compat_packed" (YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat]),
+      YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [writeSlot]),
+      YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
+        YulExpr.ident "__compat_slot_word",
+        YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
+      ]),
+      YulStmt.expr (YulExpr.call "sstore" [
+        writeSlot,
+        YulExpr.call "or" [
+          YulExpr.ident "__compat_slot_cleared",
+          YulExpr.call "shl" [YulExpr.lit packed.offset, YulExpr.ident "__compat_packed"]
+        ]
+      ])
+    ]
+  ]
+
+private def compileCompatPackedStorageWrites (writeSlots : List YulExpr) (valueExpr : YulExpr)
+    (packed : PackedBits) : List YulStmt :=
+  let maskNat := packedMaskNat packed
+  let shiftedMaskNat := packedShiftedMaskNat packed
+  [
+    YulStmt.block (
+      [YulStmt.let_ "__compat_value" valueExpr,
+       YulStmt.let_ "__compat_packed" (YulExpr.call "and" [YulExpr.ident "__compat_value", YulExpr.lit maskNat])] ++
+      writeSlots.map (fun writeSlot =>
+        YulStmt.block [
+          YulStmt.let_ "__compat_slot_word" (YulExpr.call "sload" [writeSlot]),
+          YulStmt.let_ "__compat_slot_cleared" (YulExpr.call "and" [
+            YulExpr.ident "__compat_slot_word",
+            YulExpr.call "not" [YulExpr.lit shiftedMaskNat]
+          ]),
+          YulStmt.expr (YulExpr.call "sstore" [
+            writeSlot,
+            YulExpr.call "or" [
+              YulExpr.ident "__compat_slot_cleared",
+              YulExpr.call "shl" [YulExpr.lit packed.offset, YulExpr.ident "__compat_packed"]
+            ]
+          ])
+        ])
+    )
+  ]
+
+def compileSetStorage (fields : List Field) (dynamicSource : DynamicDataSource)
+    (field : String) (value : Expr) : Except String (List YulStmt) := do
+  if isMapping fields field then
+    throw s!"Compilation error: field '{field}' is a mapping; use setMapping, setMappingWord, or setMappingPackedWord"
+  else
+    match findFieldWithResolvedSlot fields field with
+    | some (f, slot) => do
+        let slots := slot :: f.aliasSlots
+        let valueExpr ← compileExpr fields dynamicSource value
+        match slots with
+        | [] =>
+            throw s!"Compilation error: internal invariant failure: no write slots for field '{field}' in setStorage"
+        | [singleSlot] =>
+            match f.packedBits with
+            | none =>
+                pure [YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit singleSlot, valueExpr])]
+            | some packed =>
+                pure (compilePackedStorageWrite (YulExpr.lit singleSlot) valueExpr packed)
+        | _ =>
+            let writeSlots := slots.map YulExpr.lit
+            match f.packedBits with
+            | none =>
+                pure [
+                  YulStmt.block (
+                    [YulStmt.let_ "__compat_value" valueExpr] ++
+                    writeSlots.map (fun writeSlot =>
+                      YulStmt.expr (YulExpr.call "sstore" [writeSlot, YulExpr.ident "__compat_value"]))
+                  )
+                ]
+            | some packed =>
+                pure (compileCompatPackedStorageWrites writeSlots valueExpr packed)
+    | none => throw s!"Compilation error: unknown storage field '{field}' in setStorage"
+
+def compileSetMapping2 (fields : List Field) (dynamicSource : DynamicDataSource)
+    (field : String) (key1 key2 value : Expr) : Except String (List YulStmt) := do
+  if !isMapping2 fields field then
+    throw s!"Compilation error: field '{field}' is not a double mapping"
+  else
+    match findFieldWriteSlots fields field with
+    | some slots => do
+        let key1Expr ← compileExpr fields dynamicSource key1
+        let key2Expr ← compileExpr fields dynamicSource key2
+        let valueExpr ← compileExpr fields dynamicSource value
+        match slots with
+        | [] =>
+            throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in setMapping2"
+        | [slot] =>
+            let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
+            pure [
+              YulStmt.expr (YulExpr.call "sstore" [
+                YulExpr.call "mappingSlot" [innerSlot, key2Expr],
+                valueExpr
+              ])
+            ]
+        | _ =>
+            pure [
+              YulStmt.block (
+                [YulStmt.let_ "__compat_key1" key1Expr, YulStmt.let_ "__compat_key2" key2Expr,
+                  YulStmt.let_ "__compat_value" valueExpr] ++
+                slots.map (fun slot =>
+                  let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
+                  YulStmt.expr (YulExpr.call "sstore" [
+                    YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"],
+                    YulExpr.ident "__compat_value"
+                  ]))
+              )
+            ]
+    | none => throw s!"Compilation error: unknown mapping field '{field}' in setMapping2"
+
+def compileSetMapping2Word (fields : List Field) (dynamicSource : DynamicDataSource)
+    (field : String) (key1 key2 : Expr) (wordOffset : Nat) (value : Expr) :
+    Except String (List YulStmt) := do
+  if !isMapping2 fields field then
+    throw s!"Compilation error: field '{field}' is not a double mapping"
+  else
+    match findFieldWriteSlots fields field with
+    | some slots => do
+        let key1Expr ← compileExpr fields dynamicSource key1
+        let key2Expr ← compileExpr fields dynamicSource key2
+        let valueExpr ← compileExpr fields dynamicSource value
+        match slots with
+        | [] =>
+            throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in setMapping2Word"
+        | [slot] =>
+            let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
+            let outerSlot := YulExpr.call "mappingSlot" [innerSlot, key2Expr]
+            let finalSlot := if wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
+            pure [YulStmt.expr (YulExpr.call "sstore" [finalSlot, valueExpr])]
+        | _ =>
+            pure [
+              YulStmt.block (
+                [YulStmt.let_ "__compat_key1" key1Expr, YulStmt.let_ "__compat_key2" key2Expr,
+                  YulStmt.let_ "__compat_value" valueExpr] ++
+                slots.map (fun slot =>
+                  let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
+                  let outerSlot := YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"]
+                  let finalSlot := if wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit wordOffset]
+                  YulStmt.expr (YulExpr.call "sstore" [finalSlot, YulExpr.ident "__compat_value"])))
+            ]
+    | none => throw s!"Compilation error: unknown mapping field '{field}' in setMapping2Word"
+
+def compileSetStructMember (fields : List Field) (dynamicSource : DynamicDataSource)
+    (field : String) (key : Expr) (memberName : String) (value : Expr) :
+    Except String (List YulStmt) := do
+  if isMapping2 fields field then
+    throw s!"Compilation error: field '{field}' is a double mapping; use Stmt.setStructMember2 instead of Stmt.setStructMember"
+  match findStructMembers fields field with
+  | none => throw s!"Compilation error: field '{field}' is not a mappingStruct"
+  | some members =>
+      match findStructMember members memberName with
+      | none => throw s!"Compilation error: struct field '{field}' has no member '{memberName}'"
+      | some member =>
+          match member.packed with
+          | none =>
+              compileMappingSlotWrite fields field
+                (← compileExpr fields dynamicSource key)
+                (← compileExpr fields dynamicSource value)
+                s!"setStructMember.{memberName}"
+                member.wordOffset
+          | some packed =>
+              compileMappingPackedSlotWrite fields field
+                (← compileExpr fields dynamicSource key)
+                (← compileExpr fields dynamicSource value)
+                member.wordOffset
+                packed
+                s!"setStructMember.{memberName}"
+
+def compileSetStructMember2 (fields : List Field) (dynamicSource : DynamicDataSource)
+    (field : String) (key1 key2 : Expr) (memberName : String) (value : Expr) :
+    Except String (List YulStmt) := do
+  if !isMapping2 fields field then
+    throw s!"Compilation error: field '{field}' is not a double mapping; use Stmt.setStructMember instead of Stmt.setStructMember2"
+  else
+    match findStructMembers fields field with
+    | none => throw s!"Compilation error: field '{field}' is not a mappingStruct"
+    | some members =>
+        match findStructMember members memberName with
+        | none => throw s!"Compilation error: struct field '{field}' has no member '{memberName}'"
+        | some member =>
+            match findFieldWriteSlots fields field with
+            | some slots => do
+                let key1Expr ← compileExpr fields dynamicSource key1
+                let key2Expr ← compileExpr fields dynamicSource key2
+                let valueExpr ← compileExpr fields dynamicSource value
+                match slots with
+                | [] =>
+                    throw s!"Compilation error: internal invariant failure: no write slots for mapping field '{field}' in setStructMember2.{memberName}"
+                | [slot] =>
+                    let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, key1Expr]
+                    let outerSlot := YulExpr.call "mappingSlot" [innerSlot, key2Expr]
+                    let finalSlot := if member.wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit member.wordOffset]
+                    match member.packed with
+                    | none =>
+                        pure [YulStmt.expr (YulExpr.call "sstore" [finalSlot, valueExpr])]
+                    | some packed =>
+                        pure (compilePackedStorageWrite finalSlot valueExpr packed)
+                | _ =>
+                    let finalSlots := slots.map fun slot =>
+                      let innerSlot := YulExpr.call "mappingSlot" [YulExpr.lit slot, YulExpr.ident "__compat_key1"]
+                      let outerSlot := YulExpr.call "mappingSlot" [innerSlot, YulExpr.ident "__compat_key2"]
+                      if member.wordOffset == 0 then outerSlot else YulExpr.call "add" [outerSlot, YulExpr.lit member.wordOffset]
+                    match member.packed with
+                    | none =>
+                        pure [
+                          YulStmt.block (
+                            [YulStmt.let_ "__compat_key1" key1Expr, YulStmt.let_ "__compat_key2" key2Expr,
+                              YulStmt.let_ "__compat_value" valueExpr] ++
+                            finalSlots.map (fun finalSlot =>
+                              YulStmt.expr (YulExpr.call "sstore" [finalSlot, YulExpr.ident "__compat_value"]))
+                          )
+                        ]
+                    | some packed =>
+                        pure [
+                          YulStmt.block (
+                            [YulStmt.let_ "__compat_key1" key1Expr, YulStmt.let_ "__compat_key2" key2Expr] ++
+                            compileCompatPackedStorageWrites finalSlots valueExpr packed
+                          )
+                        ]
+            | none => throw s!"Compilation error: unknown mapping field '{field}' in setStructMember2.{memberName}"
+
+end Compiler.CompilationModel


### PR DESCRIPTION
## Summary
- extract the storage-write lowering cases from `Compiler/CompilationModel/Compile.lean` into a dedicated `Compiler/CompilationModel/StorageWrites.lean` module
- centralize packed slot write helpers so `setStorage`, `setMapping2*`, and `setStructMember*` share one lowering path
- continue shrinking the remaining `CompilationModel` compile monolith as part of #1311

## Testing
- `make check`
- `lake build Compiler.CompilationModel.StorageWrites Compiler.CompilationModel.Compile`

Refs #1311

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler lowering for `sstore` generation (including packed and nested mapping writes); while intended as a refactor, any subtle mismatch could change emitted Yul and on-chain storage behavior.
> 
> **Overview**
> **Extracts storage-write lowering out of `CompilationModel/Compile.lean` into a new `CompilationModel/StorageWrites.lean` module.** `Stmt.setStorage`, `Stmt.setMapping2*`, and `Stmt.setStructMember*` now delegate to `compileSetStorage`, `compileSetMapping2`, `compileSetMapping2Word`, `compileSetStructMember`, and `compileSetStructMember2`.
> 
> **Centralizes packed-slot write logic** via shared helpers so single-slot and multi-slot (alias) writes use a consistent path for masking/clearing/shifting. The new module is re-exported from `CompilationModel.lean` and imported by `Compile.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b53fc1ba64a06c3e7afbac8ed7b5ab35e1645a2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->