### PR TITLE
cleanup: drop dead EDSL compiler imports

### DIFF
--- a/Verity/Macro.lean
+++ b/Verity/Macro.lean
@@ -1,4 +1,3 @@
-import Compiler.CompilationModel
 import Verity.Macro.Syntax
 import Verity.Macro.Translate
 import Verity.Macro.Bridge

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -27,12 +27,10 @@ import Verity.Core
 import Verity.Specs.Common
 import Verity.Stdlib.Math
 import Verity.EVM.Uint256
-import Compiler.CompilationModel
 
 namespace Verity.Proofs.Stdlib.Automation
 
 open Verity
-open Compiler.CompilationModel
 open Lean Parser.Tactic
 
 /-!


### PR DESCRIPTION
## Summary
- remove the unused `Compiler.CompilationModel` import from `Verity.Macro`
- remove the unused `Compiler.CompilationModel` import/open from `Verity.Proofs.Stdlib.Automation`
- reduce the remaining source-level `Verity -> Compiler` imports for `#1313` down to the one live consumer in `Verity/Macro/Check.lean`

## Why
`main` still had a few EDSL-side source files importing `Compiler`, but two of them were dead dependencies: both modules build without referencing any `Compiler.CompilationModel` names directly.

This patch does not claim to complete `#1313`; it removes the unnecessary edges first so the remaining live coupling is smaller and easier to reason about.

## Verification
- `lake build Verity.Macro Verity.Proofs.Stdlib.Automation`
- `make check`
- `rg -n "^import Compiler" Verity -g '*.lean'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes unused `Compiler.CompilationModel` imports/opens, reducing build dependencies without changing logic or proofs.
> 
> **Overview**
> Removes unused `Compiler.CompilationModel` dependencies from `Verity/Macro.lean` and `Verity/Proofs/Stdlib/Automation.lean` (including an `open`), reducing unnecessary coupling between `Verity` modules and the EDSL compiler.
> 
> Leaves `Compiler.CompilationModel` referenced only where it is still actively used (e.g., `Verity/Macro/Check.lean` for `#check_contract`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f6f8550e64c30c3f20f5f52e743ca5909871e0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->