### PR TITLE
fix: restore explicit IR fixture imports

### DIFF
--- a/Compiler/Proofs/IRGeneration/Expr.lean
+++ b/Compiler/Proofs/IRGeneration/Expr.lean
@@ -3,12 +3,14 @@
 -/
 
 import Compiler.Constants
+import Compiler.IR
+import Compiler.Yul.Ast
 
 namespace Compiler.Proofs.IRGeneration
 
 open Compiler
-open Compiler.Yul
 open Compiler.Constants
+open Compiler.Yul
 
 /-- Concrete IR contract for SimpleStorage. -/
 def simpleStorageIRContract : IRContract :=


### PR DESCRIPTION
## Summary
- restore explicit `Compiler.IR` and `Compiler.Yul.Ast` imports in `Compiler/Proofs/IRGeneration/Expr.lean`
- stop relying on transitive imports that no longer provide `IRContract` and `Compiler.Yul` after the package split
- keep the change scoped to the broken fixture module rather than touching proof logic

## Verification
- `lake build Compiler.Proofs.IRGeneration.Expr`
- `python3 scripts/test_check_package_glob_surfaces.py`

## Notes
- A broader build still fails on current `main` in `Compiler/Proofs/YulGeneration/Preservation.lean` due pre-existing proof/syntax regressions unrelated to this diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts imports/`open` statements in a proof fixture module to stop relying on transitive dependencies; no IR fixture definitions or proof logic change.
> 
> **Overview**
> Restores explicit dependencies in `Compiler/Proofs/IRGeneration/Expr.lean` by importing `Compiler.IR` and `Compiler.Yul.Ast` and reopening `Compiler.Yul`, avoiding reliance on transitive imports after the package split.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e47becfb360a016accb91f1bb41cf3bc77468df0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->