### PR TITLE
test: cover split package toml manifests

### DIFF
--- a/scripts/test_check_split_package_builds.py
+++ b/scripts/test_check_split_package_builds.py
@@ -133,6 +133,30 @@ class CheckSplitPackageBuildsTests(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), "")
         self.assertIn("does not contain a Lake manifest", stderr.getvalue())
 
+    def test_check_split_package_builds_accepts_toml_manifest(self) -> None:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as tmpdir:
+            root = Path(tmpdir)
+            package_dir = root / "packages" / "verity-edsl"
+            package_dir.mkdir(parents=True, exist_ok=True)
+            (package_dir / "lakefile.toml").write_text("name = \"test\"\n", encoding="utf-8")
+
+            with patch.object(check, "ROOT", root):
+                with patch.object(check, "run_lake_build") as run_lake_build:
+                    run_lake_build.return_value = check.subprocess.CompletedProcess(
+                        ["lake", "build"],
+                        0,
+                        "",
+                        "",
+                    )
+                    stdout = io.StringIO()
+                    stderr = io.StringIO()
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        rc = check.check_split_package_builds([package_dir])
+
+        self.assertEqual(rc, 0)
+        self.assertIn("Split package build check passed (1 package(s)).", stdout.getvalue())
+        self.assertEqual(stderr.getvalue(), "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `scripts/test_check_split_package_builds.py` with a regression test for `lakefile.toml`
- cover the alternate Lake manifest format already accepted by `check_split_package_builds.py`
- keep the change scoped to test coverage only

## Why
`check_split_package_builds.py` intentionally accepts both `lakefile.lean` and `lakefile.toml`, but the existing test suite only exercised the Lean manifest path. This follow-up keeps the CI guard honest if package manifests ever switch format.

## Verification
- `python3 scripts/test_check_split_package_builds.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds coverage for the already-supported `lakefile.toml` manifest path, with no production logic modifications.
> 
> **Overview**
> Adds a regression test to `scripts/test_check_split_package_builds.py` to ensure `check_split_package_builds` treats `lakefile.toml` as a valid Lake manifest and successfully runs the build check when it’s present.
> 
> This complements existing coverage that only exercised `lakefile.lean`, helping keep CI checks aligned with both supported manifest formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7c9032ef4c39ed9a51ce5a7cbdd08b32b9b532b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->