### PR TITLE
proofs: bridge mod builtin symbolically

### DIFF
--- a/Compiler/Proofs/ArithmeticProfile.lean
+++ b/Compiler/Proofs/ArithmeticProfile.lean
@@ -78,8 +78,8 @@ theorem mod_by_zero (a : Nat) :
 -- § 3. EVMYulLean bridge agreement for pure arithmetic
 -- ============================================================================
 
--- Arithmetic bridging is now universally proved for add/sub/mul/div.
--- `mod` and the bitwise family still retain concrete bridge coverage here.
+-- Arithmetic bridging is now universally proved for add/sub/mul/div/mod.
+-- The bitwise family still retains concrete bridge coverage here.
 
 /-- Universal bridge theorem for addition. -/
 theorem add_bridge (a b : Nat) :
@@ -109,9 +109,12 @@ theorem div_bridge (a b : Nat) :
   exact Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_div_bridge
     s sender sel cd a b
 
-/-- Bridge agrees on modulo by zero. -/
-example : evalBuiltinCall s sender sel cd "mod" [10, 0] =
-          evalPureBuiltinViaEvmYulLean "mod" [10, 0] := by native_decide
+/-- Universal bridge theorem for modulo. -/
+theorem mod_bridge (a b : Nat) :
+    evalBuiltinCall s sender sel cd "mod" [a, b] =
+      evalPureBuiltinViaEvmYulLean "mod" [a, b] := by
+  exact Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_mod_bridge
+    s sender sel cd a b
 
 -- ============================================================================
 -- § 4. Backend profile invariant
@@ -142,8 +145,8 @@ example : ∀ b : Compiler.Proofs.YulGeneration.BuiltinBackend,
 -- Cryptographic primitives: keccak256 is axiomatized (see AXIOMS.md).
 -- The mapping-slot derivation trusts the keccak FFI.
 --
--- Universal bridge equivalence: add/sub/mul/div now have direct symbolic
+-- Universal bridge equivalence: add/sub/mul/div/mod now have direct symbolic
 -- bridge lemmas in `Backends/EvmYulLeanBridgeLemmas.lean`.
--- `mod` plus the bitwise family still rely on concrete bridge coverage.
+-- The bitwise family still relies on concrete bridge coverage.
 
 end Compiler.Proofs.ArithmeticProfile

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean
@@ -63,6 +63,37 @@ private theorem bridge_eval_div_normalized (a b : Nat) :
   · simp [hb]
   · simp [hb]
 
+private theorem verity_eval_mod_normalized
+    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    evalBuiltinCall storage sender selector calldata "mod" [a, b] =
+      (if b % evmModulus = 0 then some 0 else some ((a % evmModulus) % (b % evmModulus))) := by
+  simp [evalBuiltinCall]
+
+private theorem bridge_eval_mod_normalized (a b : Nat) :
+    evalPureBuiltinViaEvmYulLean "mod" [a, b] =
+      (if b % EvmYul.UInt256.size = 0 then some 0 else
+        some ((a % EvmYul.UInt256.size) % (b % EvmYul.UInt256.size))) := by
+  change some (EvmYul.UInt256.toNat (EvmYul.UInt256.mod (EvmYul.UInt256.ofNat a) (EvmYul.UInt256.ofNat b))) =
+      (if b % EvmYul.UInt256.size = 0 then some 0 else
+        some ((a % EvmYul.UInt256.size) % (b % EvmYul.UInt256.size)))
+  by_cases hb : b % EvmYul.UInt256.size = 0
+  · have hb0val : ((EvmYul.UInt256.ofNat b).val).val = 0 := by
+      change b % EvmYul.UInt256.size = 0
+      exact hb
+    have hb0 : (EvmYul.UInt256.ofNat b).val = 0 := Fin.ext hb0val
+    simp [EvmYul.UInt256.mod, EvmYul.UInt256.toNat, hb, hb0]
+  · have hb0 : ¬ (EvmYul.UInt256.ofNat b).val = 0 := by
+      intro h
+      apply hb
+      exact congrArg Fin.val h
+    rw [show EvmYul.UInt256.mod (EvmYul.UInt256.ofNat a) (EvmYul.UInt256.ofNat b) =
+          ⟨(EvmYul.UInt256.ofNat a).val % (EvmYul.UInt256.ofNat b).val⟩ by
+            simp [EvmYul.UInt256.mod, hb0]]
+    simp [hb, EvmYul.UInt256.toNat]
+    change (a % EvmYul.UInt256.size) % (b % EvmYul.UInt256.size) =
+      (a % EvmYul.UInt256.size) % (b % EvmYul.UInt256.size)
+    rfl
+
 private theorem verity_eval_eq_normalized
     (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "eq" [a, b] =
@@ -142,6 +173,13 @@ private theorem bridge_eval_gt_normalized (a b : Nat) :
   rw [verity_eval_div_normalized, bridge_eval_div_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
+@[simp] theorem evalBuiltinCall_mod_bridge
+    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    evalBuiltinCall storage sender selector calldata "mod" [a, b] =
+      evalPureBuiltinViaEvmYulLean "mod" [a, b] := by
+  rw [verity_eval_mod_normalized, bridge_eval_mod_normalized]
+  simp [EvmYul.UInt256.size, evmModulus]
+
 /-- Universal bridge theorem for `eq`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_eq_bridge
@@ -201,6 +239,12 @@ EVMYulLean UInt256 semantics on all inputs. -/
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "div" [a, b] =
       evalBuiltinCall storage sender selector calldata "div" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallViaEvmYulLean, evalBuiltinCall_div_bridge]
+
+@[simp] theorem evalBuiltinCallWithBackend_evmYulLean_mod_bridge
+    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "mod" [a, b] =
+      evalBuiltinCall storage sender selector calldata "mod" [a, b] := by
+  simp [evalBuiltinCallWithBackend, evalBuiltinCallViaEvmYulLean, evalBuiltinCall_mod_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_eq_bridge
     (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
@@ -143,6 +143,12 @@ example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a
       evalPureBuiltinViaEvmYulLean "div" [a, b] := by
   exact evalBuiltinCall_div_bridge storage sender selector calldata a b
 
+/-- Universal bridge theorem for `mod` (symbolic, not vector-based). -/
+example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    evalBuiltinCall storage sender selector calldata "mod" [a, b] =
+      evalPureBuiltinViaEvmYulLean "mod" [a, b] := by
+  exact evalBuiltinCall_mod_bridge storage sender selector calldata a b
+
 /-- Universal bridge theorem for `eq` (symbolic, not vector-based). -/
 example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "eq" [a, b] =
@@ -266,7 +272,7 @@ example : (lowerStmts adapterSmokeStmts).isOk = true := by native_decide
 -- ## Summary output
 def main : IO Unit := do
   IO.println "✓ Arithmetic builtins: add, sub, mul, div — universally bridged"
-  IO.println "✓ Arithmetic builtin mod: vector coverage retained"
+  IO.println "✓ Arithmetic builtins: mod — universally bridged"
   IO.println "✓ Comparison builtins: lt, gt, eq, iszero — universally bridged"
   IO.println "✓ Bitwise builtins: and, or, xor, not, shl, shr — Verity ≡ EVMYulLean"
   IO.println "✓ State-dependent builtins: sload, caller, calldataload — correctly delegated"

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -568,6 +568,7 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.ArithmeticProfile.sub_bridge
 #print axioms Compiler.Proofs.ArithmeticProfile.mul_bridge
 #print axioms Compiler.Proofs.ArithmeticProfile.div_bridge
+#print axioms Compiler.Proofs.ArithmeticProfile.mod_bridge
 
 -- Compiler/Proofs/EndToEnd.lean
 #print axioms Compiler.Proofs.EndToEnd.layer3_function_preserves_semantics
@@ -610,6 +611,8 @@ import Compiler.Proofs.YulGeneration.Equivalence
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.bridge_eval_mul_normalized  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.verity_eval_div_normalized  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.bridge_eval_div_normalized  -- private
+-- #print axioms Compiler.Proofs.YulGeneration.Backends.verity_eval_mod_normalized  -- private
+-- #print axioms Compiler.Proofs.YulGeneration.Backends.bridge_eval_mod_normalized  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.verity_eval_eq_normalized  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.bridge_eval_eq_normalized  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.verity_eval_iszero_normalized  -- private
@@ -622,6 +625,7 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_sub_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_mul_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_div_bridge
+#print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_mod_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_eq_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_iszero_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_lt_bridge
@@ -630,6 +634,7 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_sub_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_mul_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_div_bridge
+#print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_mod_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_eq_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_iszero_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_lt_bridge
@@ -662,4 +667,4 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy
--- Total: 561 theorems/lemmas (521 public, 40 private)
+-- Total: 566 theorems/lemmas (524 public, 42 private)


### PR DESCRIPTION
Refs #1168.

## Summary
- add a universal `mod` bridge theorem between Verity builtin evaluation and the EVMYulLean backend
- expose the backend-facing simp lemma for `.evmYulLean` on `mod`
- upgrade the arithmetic profile and bridge test modules from vector-only `mod` coverage to symbolic coverage
- regenerate `PrintAxioms.lean`

## Validation
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeLemmas Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeTest Compiler.Proofs.ArithmeticProfile`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only changes that extend existing arithmetic bridge coverage to `mod`; low runtime risk, but could affect downstream proof automation if the new simp lemmas rewrite differently.
> 
> **Overview**
> Upgrades the EVMYulLean bridge from *vector-only* coverage of the `mod` builtin to a **universal symbolic equivalence proof** between Verity `evalBuiltinCall` and `evalPureBuiltinViaEvmYulLean`.
> 
> Adds normalized `mod` semantics lemmas and exposes new `[simp]` bridge theorems (including `evalBuiltinCallWithBackend .evmYulLean` for `mod`), updates `ArithmeticProfile` and `EvmYulLeanBridgeTest` to use the new symbolic `mod` bridge, and regenerates `PrintAxioms.lean` to include the new theorems.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a7d742a8a84070b5ca7096f4baa1fc6e2e0fca7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->