### PR TITLE
proofs: bridge shift builtins symbolically

### DIFF
--- a/Compiler/Proofs/ArithmeticProfile.lean
+++ b/Compiler/Proofs/ArithmeticProfile.lean
@@ -79,8 +79,8 @@ theorem mod_by_zero (a : Nat) :
 -- ============================================================================
 
 -- Arithmetic bridging is now universally proved for add/sub/mul/div/mod.
--- Bitwise `and`/`or`/`xor` now also have direct symbolic bridge lemmas.
--- `not` and the shift family still retain concrete bridge coverage here.
+-- Bitwise `and`/`or`/`xor` plus the shift family now also have direct symbolic bridge lemmas.
+-- `not` still retains concrete bridge coverage here.
 
 /-- Universal bridge theorem for addition. -/
 theorem add_bridge (a b : Nat) :
@@ -138,6 +138,20 @@ theorem xor_bridge (a b : Nat) :
   exact Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_xor_bridge
     s sender sel cd a b
 
+/-- Universal bridge theorem for shift-left. -/
+theorem shl_bridge (shift value : Nat) :
+    evalBuiltinCall s sender sel cd "shl" [shift, value] =
+      evalPureBuiltinViaEvmYulLean "shl" [shift, value] := by
+  exact Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_shl_bridge
+    s sender sel cd shift value
+
+/-- Universal bridge theorem for shift-right. -/
+theorem shr_bridge (shift value : Nat) :
+    evalBuiltinCall s sender sel cd "shr" [shift, value] =
+      evalPureBuiltinViaEvmYulLean "shr" [shift, value] := by
+  exact Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_shr_bridge
+    s sender sel cd shift value
+
 -- ============================================================================
 -- § 4. Backend profile invariant
 -- ============================================================================
@@ -167,8 +181,9 @@ example : ∀ b : Compiler.Proofs.YulGeneration.BuiltinBackend,
 -- Cryptographic primitives: keccak256 is axiomatized (see AXIOMS.md).
 -- The mapping-slot derivation trusts the keccak FFI.
 --
--- Universal bridge equivalence: add/sub/mul/div/mod and bitwise and/or/xor now
--- have direct symbolic bridge lemmas in `Backends/EvmYulLeanBridgeLemmas.lean`.
--- `not` and the shift family still rely on concrete bridge coverage.
+-- Universal bridge equivalence: all pure arithmetic/comparison builtins plus
+-- bitwise and/or/xor and the shift family now have direct symbolic bridge lemmas
+-- in `Backends/EvmYulLeanBridgeLemmas.lean`.
+-- `not` still relies on concrete bridge coverage.
 
 end Compiler.Proofs.ArithmeticProfile

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean
@@ -177,6 +177,60 @@ private theorem bridge_eval_xor_normalized (a b : Nat) :
   rw [Nat.mod_eq_of_lt]
   exact Nat.xor_lt_two_pow (word_lt_uint256_size a) (word_lt_uint256_size b)
 
+private theorem bridge_eval_shl_normalized (shift value : Nat) :
+    evalPureBuiltinViaEvmYulLean "shl" [shift, value] =
+      (if shift % EvmYul.UInt256.size < 256 then
+        some (((value % EvmYul.UInt256.size) * 2 ^ (shift % EvmYul.UInt256.size)) %
+          EvmYul.UInt256.size)
+      else
+        some 0) := by
+  change some (EvmYul.UInt256.toNat
+      (EvmYul.UInt256.shiftLeft (EvmYul.UInt256.ofNat value) (EvmYul.UInt256.ofNat shift))) =
+      (if shift % EvmYul.UInt256.size < 256 then
+        some (((value % EvmYul.UInt256.size) * 2 ^ (shift % EvmYul.UInt256.size)) %
+          EvmYul.UInt256.size)
+      else
+        some 0)
+  by_cases hs : shift % EvmYul.UInt256.size < 256
+  · have hs' : ¬ 256 ≤ (EvmYul.UInt256.ofNat shift).val := by
+      change ¬ 256 ≤ shift % EvmYul.UInt256.size
+      exact Nat.not_le_of_lt hs
+    simp [hs, EvmYul.UInt256.shiftLeft, EvmYul.UInt256.toNat, hs', Nat.shiftLeft_eq]
+    change (value % EvmYul.UInt256.size) * 2 ^ (shift % EvmYul.UInt256.size) %
+        EvmYul.UInt256.size =
+      value * 2 ^ (shift % EvmYul.UInt256.size) % EvmYul.UInt256.size
+    rw [Nat.mul_mod, Nat.mul_mod]
+    simp
+  · have hs' : 256 ≤ (EvmYul.UInt256.ofNat shift).val := by
+      change 256 ≤ shift % EvmYul.UInt256.size
+      exact Nat.not_lt.mp hs
+    simp [hs, EvmYul.UInt256.shiftLeft, EvmYul.UInt256.toNat, hs']
+
+private theorem bridge_eval_shr_normalized (shift value : Nat) :
+    evalPureBuiltinViaEvmYulLean "shr" [shift, value] =
+      (if shift % EvmYul.UInt256.size < 256 then
+        some ((value % EvmYul.UInt256.size) / 2 ^ (shift % EvmYul.UInt256.size))
+      else
+        some 0) := by
+  change some (EvmYul.UInt256.toNat
+      (EvmYul.UInt256.shiftRight (EvmYul.UInt256.ofNat value) (EvmYul.UInt256.ofNat shift))) =
+      (if shift % EvmYul.UInt256.size < 256 then
+        some ((value % EvmYul.UInt256.size) / 2 ^ (shift % EvmYul.UInt256.size))
+      else
+        some 0)
+  by_cases hs : shift % EvmYul.UInt256.size < 256
+  · have hs' : ¬ 256 ≤ (EvmYul.UInt256.ofNat shift).val := by
+      change ¬ 256 ≤ shift % EvmYul.UInt256.size
+      exact Nat.not_le_of_lt hs
+    simp [hs, EvmYul.UInt256.shiftRight, EvmYul.UInt256.toNat, hs', Nat.shiftRight_eq_div_pow]
+    change value % EvmYul.UInt256.size / 2 ^ (shift % EvmYul.UInt256.size) =
+      value % EvmYul.UInt256.size / 2 ^ (shift % EvmYul.UInt256.size)
+    rfl
+  · have hs' : 256 ≤ (EvmYul.UInt256.ofNat shift).val := by
+      change 256 ≤ shift % EvmYul.UInt256.size
+      exact Nat.not_lt.mp hs
+    simp [hs, EvmYul.UInt256.shiftRight, EvmYul.UInt256.toNat, hs']
+
 @[simp] theorem evalBuiltinCall_add_bridge
     (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "add" [a, b] =
@@ -287,6 +341,34 @@ EVMYulLean UInt256 semantics on all inputs. -/
   simp [EvmYul.UInt256.size, evmModulus]
   rfl
 
+/-- Universal bridge theorem for `shl`: Verity builtin semantics agree with
+EVMYulLean UInt256 semantics on all inputs. -/
+@[simp] theorem evalBuiltinCall_shl_bridge
+    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    evalBuiltinCall storage sender selector calldata "shl" [shift, value] =
+      evalPureBuiltinViaEvmYulLean "shl" [shift, value] := by
+  rw [show evalBuiltinCall storage sender selector calldata "shl" [shift, value] =
+      (if shift % evmModulus < 256 then
+        some (((value % evmModulus) * 2 ^ (shift % evmModulus)) % evmModulus)
+      else
+        some 0) by simp [evalBuiltinCall]]
+  rw [bridge_eval_shl_normalized]
+  simp [EvmYul.UInt256.size, evmModulus]
+
+/-- Universal bridge theorem for `shr`: Verity builtin semantics agree with
+EVMYulLean UInt256 semantics on all inputs. -/
+@[simp] theorem evalBuiltinCall_shr_bridge
+    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    evalBuiltinCall storage sender selector calldata "shr" [shift, value] =
+      evalPureBuiltinViaEvmYulLean "shr" [shift, value] := by
+  rw [show evalBuiltinCall storage sender selector calldata "shr" [shift, value] =
+      (if shift % evmModulus < 256 then
+        some ((value % evmModulus) / 2 ^ (shift % evmModulus))
+      else
+        some 0) by simp [evalBuiltinCall]]
+  rw [bridge_eval_shr_normalized]
+  simp [EvmYul.UInt256.size, evmModulus]
+
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_add_bridge
     (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "add" [a, b] =
@@ -358,5 +440,17 @@ EVMYulLean UInt256 semantics on all inputs. -/
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "xor" [a, b] =
       evalBuiltinCall storage sender selector calldata "xor" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallViaEvmYulLean, evalBuiltinCall_xor_bridge]
+
+@[simp] theorem evalBuiltinCallWithBackend_evmYulLean_shl_bridge
+    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "shl" [shift, value] =
+      evalBuiltinCall storage sender selector calldata "shl" [shift, value] := by
+  simp [evalBuiltinCallWithBackend, evalBuiltinCallViaEvmYulLean, evalBuiltinCall_shl_bridge]
+
+@[simp] theorem evalBuiltinCallWithBackend_evmYulLean_shr_bridge
+    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "shr" [shift, value] =
+      evalBuiltinCall storage sender selector calldata "shr" [shift, value] := by
+  simp [evalBuiltinCallWithBackend, evalBuiltinCallViaEvmYulLean, evalBuiltinCall_shr_bridge]
 
 end Compiler.Proofs.YulGeneration.Backends

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
@@ -240,6 +240,12 @@ example : verityEval "shl" [Compiler.Constants.evmModulus, 3] =
 example : verityEval "shl" [Compiler.Constants.evmModulus - 1, 3] =
           bridgeEval "shl" [Compiler.Constants.evmModulus - 1, 3] := by native_decide
 
+/-- Universal bridge theorem for `shl` (symbolic, not vector-based). -/
+example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    evalBuiltinCall storage sender selector calldata "shl" [shift, value] =
+      evalPureBuiltinViaEvmYulLean "shl" [shift, value] := by
+  exact evalBuiltinCall_shl_bridge storage sender selector calldata shift value
+
 /-- shr: 256 >> 8 = 1 -/
 example : verityEval "shr" [8, 256] = bridgeEval "shr" [8, 256] := by native_decide
 
@@ -250,6 +256,12 @@ example : verityEval "shr" [Compiler.Constants.evmModulus, Compiler.Constants.ev
 /-- shr: very large uint256 shift (2^256 - 1) saturates to 0. -/
 example : verityEval "shr" [Compiler.Constants.evmModulus - 1, 12345] =
           bridgeEval "shr" [Compiler.Constants.evmModulus - 1, 12345] := by native_decide
+
+/-- Universal bridge theorem for `shr` (symbolic, not vector-based). -/
+example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    evalBuiltinCall storage sender selector calldata "shr" [shift, value] =
+      evalPureBuiltinViaEvmYulLean "shr" [shift, value] := by
+  exact evalBuiltinCall_shr_bridge storage sender selector calldata shift value
 
 -- ## Scope boundary: state-dependent builtins fall through to none
 
@@ -292,7 +304,8 @@ def main : IO Unit := do
   IO.println "✓ Arithmetic builtins: add, sub, mul, div — universally bridged"
   IO.println "✓ Arithmetic builtins: mod — universally bridged"
   IO.println "✓ Comparison builtins: lt, gt, eq, iszero — universally bridged"
-  IO.println "✓ Bitwise builtins: and, or, xor, not, shl, shr — Verity ≡ EVMYulLean"
+  IO.println "✓ Bitwise builtins: and, or, xor, shl, shr — universally bridged"
+  IO.println "✓ Bitwise builtin: not — concrete bridge coverage retained"
   IO.println "✓ State-dependent builtins: sload, caller, calldataload — correctly delegated"
   IO.println "✓ Verity-specific helpers: mappingSlot — correctly delegated"
   IO.println "✓ Adapter: all 11 statement types lower without error"

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -572,6 +572,8 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.ArithmeticProfile.and_bridge
 #print axioms Compiler.Proofs.ArithmeticProfile.or_bridge
 #print axioms Compiler.Proofs.ArithmeticProfile.xor_bridge
+#print axioms Compiler.Proofs.ArithmeticProfile.shl_bridge
+#print axioms Compiler.Proofs.ArithmeticProfile.shr_bridge
 
 -- Compiler/Proofs/EndToEnd.lean
 #print axioms Compiler.Proofs.EndToEnd.layer3_function_preserves_semantics
@@ -628,6 +630,8 @@ import Compiler.Proofs.YulGeneration.Equivalence
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.bridge_eval_and_normalized  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.bridge_eval_or_normalized  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.bridge_eval_xor_normalized  -- private
+-- #print axioms Compiler.Proofs.YulGeneration.Backends.bridge_eval_shl_normalized  -- private
+-- #print axioms Compiler.Proofs.YulGeneration.Backends.bridge_eval_shr_normalized  -- private
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_add_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_sub_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_mul_bridge
@@ -640,6 +644,8 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_and_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_or_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_xor_bridge
+#print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_shl_bridge
+#print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCall_shr_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_add_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_sub_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_mul_bridge
@@ -652,6 +658,8 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_and_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_or_bridge
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_xor_bridge
+#print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_shl_bridge
+#print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackend_evmYulLean_shr_bridge
 
 -- Compiler/Proofs/YulGeneration/Builtins.lean
 #print axioms Compiler.Proofs.YulGeneration.evalBuiltinCall_callvalue_nil
@@ -680,4 +688,4 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy
--- Total: 579 theorems/lemmas (533 public, 46 private)
+-- Total: 587 theorems/lemmas (539 public, 48 private)


### PR DESCRIPTION
## Summary
- add universal `shl`/`shr` bridge lemmas to `EvmYulLeanBridgeLemmas`
- expose backend-facing simp lemmas and wire the shift family into `ArithmeticProfile`
- extend bridge tests and regenerate `PrintAxioms.lean`

## Scope
This advances #1168 by removing vector-only coverage for the shift family.
`not` remains on concrete bridge coverage and is intentionally left for follow-up.

## Validation
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeLemmas Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeTest Compiler.Proofs.ArithmeticProfile`
- `python3 scripts/generate_print_axioms.py`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Lean proof/bridge lemma additions and test/axiom-print regeneration, with no impact on runtime compiler behavior. Main risk is proof automation or build breakage if the new simp lemmas interact unexpectedly with existing rewriting.
> 
> **Overview**
> Adds **universal (symbolic) EVMYulLean bridge proofs** for the shift builtins `shl` and `shr`, including new normalized bridge lemmas plus exported `[simp]` theorems (and corresponding `evalBuiltinCallWithBackend .evmYulLean` simp bridges).
> 
> Wires `shl_bridge`/`shr_bridge` into `ArithmeticProfile`, extends `EvmYulLeanBridgeTest` with symbolic examples for both shifts, and regenerates `PrintAxioms.lean` to include the new theorems and updated counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4064d4dfe7ab00a6b871414c4c5c4c8665c1c4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->