### PR TITLE
docs: sync bridge coverage after shift proofs

### DIFF
--- a/docs/ARITHMETIC_PROFILE.md
+++ b/docs/ARITHMETIC_PROFILE.md
@@ -75,7 +75,7 @@ The arithmetic model is invariant across profiles. See [`docs/SOLIDITY_PARITY_PR
 - **Gas semantics**: proofs establish result correctness, not gas cost or bounded liveness.
 - **Compiler-layer overflow detection**: the compiler does not insert overflow checks. Use EDSL `safeAdd`/`safeSub`/`safeMul` for checked behavior.
 - **Cryptographic primitives**: keccak256 is axiomatized (see [`AXIOMS.md`](../AXIOMS.md)).
-- **Universal bridge equivalence**: 12/15 pure EVMYulLean-backed builtins have universal bridge lemmas; `not`, `shl`, and `shr` still rely on concrete smoke tests.
+- **Universal bridge equivalence**: 14/15 pure EVMYulLean-backed builtins have universal bridge lemmas; only `not` still relies on concrete smoke tests.
 
 ## Auditor Checklist
 

--- a/docs/INTERPRETER_FEATURE_MATRIX.md
+++ b/docs/INTERPRETER_FEATURE_MATRIX.md
@@ -127,7 +127,7 @@ Legend: **ok** = supported, **rev** = reverts (not modeled), **nop** = no-op (co
 
 Legend: **ok** = native evaluation, **del** = delegated to Verity path (bridge returns `none`).
 
-15/19 builtins have bridge agreement coverage between Verity and EVMYulLean evaluation paths. 12 are discharged by universal symbolic lemmas in `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean`, while `not`, `shl`, and `shr` are currently guarded by concrete regression checks in `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean`. The remaining 4 are state-dependent or Verity-specific helpers that remain on the Verity evaluation path.
+15/19 builtins have bridge agreement coverage between Verity and EVMYulLean evaluation paths. 14 pure builtins are discharged by universal symbolic lemmas in `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean`, while `not` is still guarded by concrete regression checks in `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean`. The remaining 4 are state-dependent or Verity-specific helpers that remain on the Verity evaluation path.
 
 ---
 


### PR DESCRIPTION
## Summary
- update the arithmetic profile docs to reflect that `shl` and `shr` now have universal symbolic bridge lemmas
- update the interpreter feature matrix from `12/15` to `14/15` pure builtins symbolically bridged
- leave `not` explicitly documented as the only remaining pure builtin on concrete bridge coverage

## Testing
- `lake build Compiler.Proofs.ArithmeticProfile`
- `python3 scripts/check_verify_sync.py`
- `make check`

Closes the documentation inconsistency around #1168 after #1373.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust stated proof/bridge coverage counts; no code or proof logic changes.
> 
> **Overview**
> Updates docs to reflect expanded **universal symbolic bridge lemma** coverage in the EVMYulLean bridge: `shl` and `shr` are now counted as universally proved, leaving only `not` on concrete smoke-test coverage.
> 
> Synchronizes the reported totals in `docs/ARITHMETIC_PROFILE.md` and `docs/INTERPRETER_FEATURE_MATRIX.md` (e.g., `12/15` -> `14/15` pure builtins).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bd2a2117fc59e15079dace7d003e2923b546651. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->