### PR TITLE
proofs: add checked-arithmetic automation helpers

### DIFF
--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -428,6 +428,8 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Verity.Proofs.Stdlib.Automation.safeAdd_some_iff_le
 #print axioms Verity.Proofs.Stdlib.Automation.safeAdd_none_iff_gt
 #print axioms Verity.Proofs.Stdlib.Automation.safeAdd_some_val
+#print axioms Verity.Proofs.Stdlib.Automation.safeMul_some_iff_le
+#print axioms Verity.Proofs.Stdlib.Automation.safeMul_none_iff_gt
 #print axioms Verity.Proofs.Stdlib.Automation.add_one_preserves_order_iff_no_overflow
 #print axioms Verity.Proofs.Stdlib.Automation.wf_of_state_eq
 #print axioms Verity.Proofs.Stdlib.Automation.wf_preservation_of_frame
@@ -692,4 +694,4 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy
--- Total: 591 theorems/lemmas (541 public, 50 private)
+-- Total: 593 theorems/lemmas (543 public, 50 private)

--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -100,6 +100,10 @@ syntax (name := verity_spec)
 syntax (name := verity_spec_with)
   "verity_spec " simpLemma " with " simpLemma : tactic
 
+/-- Discharge common checked-arithmetic reachability goals (`safeAdd`/`safeSub`/`safeMul`). -/
+syntax (name := verity_arith)
+  "verity_arith" : tactic
+
 macro_rules
   | `(tactic| verity_unfold $fn:simpLemma) =>
       `(tactic| simp only [
@@ -166,6 +170,20 @@ macro "verity_spec " spec:simpLemma " with " extra:simpLemma : tactic =>
     (simp [$spec, ContractResult.snd, Verity.Specs.sameAddrMapContext,
       Verity.Specs.sameStorageMapContext, Verity.Specs.sameContext, Verity.Specs.sameStorage,
       Verity.Specs.sameStorageAddr, Verity.Specs.sameStorageMap, $extra]))
+
+macro "verity_arith" : tactic =>
+  `(tactic|
+    first
+      | exact Verity.Proofs.Stdlib.Math.safeAdd_none _ _ (by first | assumption | omega)
+      | exact Verity.Proofs.Stdlib.Math.safeSub_none _ _ (by first | assumption | omega)
+      | exact Verity.Proofs.Stdlib.Math.safeMul_none _ _ (by first | assumption | omega)
+      | exact safeAdd_some_val _ _ (by first | assumption | omega)
+      | exact safeSub_some_val _ _ (by first | assumption | omega)
+      | exact Verity.Proofs.Stdlib.Math.safeMul_some _ _ (by first | assumption | omega)
+      | simpa [safeAdd_some_iff_le, safeAdd_none_iff_gt,
+          safeSub_some_iff_ge, safeSub_none_iff_lt,
+          safeMul_some_iff_le, safeMul_none_iff_gt]
+      | omega)
 
 /-!
 ## Index Normalization Helpers
@@ -658,6 +676,40 @@ theorem safeAdd_some_val (a b : Verity.Core.Uint256)
   unfold Verity.Stdlib.Math.safeAdd
   have h_not : ¬((a : Nat) + (b : Nat) > Verity.Stdlib.Math.MAX_UINT256) := by omega
   simp [h_not]
+
+-- safeMul returns Some iff no overflow
+theorem safeMul_some_iff_le (a b : Verity.Core.Uint256) :
+    (Verity.Stdlib.Math.safeMul a b).isSome ↔
+    (a : Nat) * (b : Nat) ≤ Verity.Stdlib.Math.MAX_UINT256 := by
+  unfold Verity.Stdlib.Math.safeMul
+  by_cases h : (a : Nat) * (b : Nat) > Verity.Stdlib.Math.MAX_UINT256
+  · constructor
+    · intro h_some
+      simp [h] at h_some
+    · intro h_le
+      omega
+  · constructor
+    · intro _
+      omega
+    · intro _
+      simp [h]
+
+-- safeMul returns None iff overflow
+theorem safeMul_none_iff_gt (a b : Verity.Core.Uint256) :
+    (Verity.Stdlib.Math.safeMul a b).isNone ↔
+    (a : Nat) * (b : Nat) > Verity.Stdlib.Math.MAX_UINT256 := by
+  unfold Verity.Stdlib.Math.safeMul
+  by_cases h : (a : Nat) * (b : Nat) > Verity.Stdlib.Math.MAX_UINT256
+  · constructor
+    · intro _
+      exact h
+    · intro _
+      simp [h]
+  · constructor
+    · intro h_none
+      simp [h] at h_none
+    · intro h_gt
+      exact absurd h_gt h
 
 /-!
 ## Modular Arithmetic Wraparound Lemmas


### PR DESCRIPTION
## Summary
- add `safeMul` overflow characterization lemmas to `Verity.Proofs.Stdlib.Automation`
- add a `verity_arith` tactic for common checked-arithmetic reachability goals across `safeAdd`/`safeSub`/`safeMul`
- regenerate `PrintAxioms.lean` so the theorem inventory stays in sync

## Why
Issue #1336 calls out the repeated proof burden around Solidity 0.8 checked arithmetic reachability. The repo already had reusable `safeAdd` / `safeSub` helper lemmas, but multiplication was missing from the automation surface, and there was no single tactic entry point for the common "prove the checked op succeeds/fails from arithmetic side conditions" flow.

This patch does not solve the whole VC-generation problem, but it tightens the upstream automation layer so proof scripts can depend on one place instead of hand-rolling the same arithmetic rewrites.

## Testing
- `lake build Verity.Proofs.Stdlib.Automation Contracts.SafeCounter.Proofs.Basic`
- `make check`

Toward #1336.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: proof-only additions (new lemmas and an optional tactic macro) with no impact on runtime semantics; main risk is minor proof-script brittleness if the new automation is adopted widely.
> 
> **Overview**
> Adds new proof automation for Solidity-style checked arithmetic by introducing `safeMul` overflow characterization lemmas (`safeMul_some_iff_le`, `safeMul_none_iff_gt`) alongside existing `safeAdd`/`safeSub` helpers.
> 
> Introduces a new `verity_arith` tactic macro that discharges common reachability goals for `safeAdd`/`safeSub`/`safeMul` using `omega` and the helper lemmas.
> 
> Regenerates `PrintAxioms.lean` to include the new theorems and update the theorem inventory counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 964f36fc80dcde492b480055604efbe1991b8059. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->