### PR TITLE
proofs: fail closed on short selector calldata

### DIFF
--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -382,12 +382,51 @@ noncomputable def interpretIR (contract : IRContract) (tx : IRTransaction) (init
 
   -- Find matching function by selector
   match contract.functions.find? (·.selector == tx.functionSelector) with
-  | some fn => execIRFunction fn tx.args initialState
+  | some fn =>
+    if _ : fn.params.length ≤ tx.args.length then
+      execIRFunction fn tx.args initialState
+    else
+      { success := false
+        returnValue := none
+        finalStorage := initialState.storage
+        finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
+        events := initialState.events }
   | none =>
     { success := false
       returnValue := none
       finalStorage := initialState.storage
       finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
       events := initialState.events }
+
+private def shortCalldataRegressionContract : IRContract :=
+  { name := "ShortCalldataRegression"
+    deploy := []
+    constructorPayable := false
+    functions := [
+      { name := "store"
+        selector := 0x12345678
+        params := [{ name := "value", ty := .uint256 }]
+        ret := .unit
+        payable := false
+        body := [
+          YulStmt.expr (YulExpr.call "sstore" [YulExpr.lit 0, YulExpr.ident "value"]),
+          YulStmt.expr (YulExpr.call "stop" [])
+        ] }
+    ]
+    usesMapping := false }
+
+example :
+    (interpretIR shortCalldataRegressionContract
+      { sender := 7, functionSelector := 0x12345678, args := [] }
+      (IRState.initial 0)).success = false := by
+  simp [interpretIR, shortCalldataRegressionContract, IRState.initial]
+
+example :
+    let result := interpretIR shortCalldataRegressionContract
+      { sender := 7, functionSelector := 0x12345678, args := [99] }
+      (IRState.initial 0)
+    result.success = true ∧ result.finalStorage 0 = 99 := by
+  simp [interpretIR, execIRFunction, execIRStmts, execIRStmt, evalIRExpr,
+    shortCalldataRegressionContract, IRState.initial, IRState.setVar, IRState.getVar]
 
 end Compiler.Proofs.IRGeneration


### PR DESCRIPTION
## Summary
- make `interpretIR` fail closed when a selector matches but `tx.args` is shorter than the function parameter list
- keep rollback semantics aligned with the existing selector-miss path instead of partially executing the IR body with missing params
- add focused Lean regression examples showing the short-calldata failure path and the still-successful exact-arity path

## Why
The generated Yul runtime already guards each selector case with `calldatasizeGuard`, so undersupplied calldata reverts before the function body runs. `interpretIR` did not mirror that behavior: it would execute the matched IR function anyway after silently dropping missing parameters during `zip`.

That mismatch is a real semantic bug, and it also makes issue #1301 harder than it should be because the current `SwitchCaseBodyBridge` gap is not purely proof plumbing while the IR side accepts states that the Yul dispatch rejects.

This patch does not discharge `#1301` by itself, but it removes one concrete IR/Yul divergence from the dispatch boundary.

Toward #1301.

## Testing
- `lake build Compiler.Proofs.IRGeneration.IRInterpreter`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes IR proof interpreter semantics for selector dispatch by rejecting undersupplied calldata, which may affect existing proof expectations and equivalence lemmas despite being a small, well-scoped change.
> 
> **Overview**
> `interpretIR` now **fails closed** when a selector matches but `tx.args` is shorter than the function’s parameter list, returning the same rollback-style failure result as the selector-miss path instead of executing with missing params.
> 
> Adds a small Lean regression contract plus examples proving the new short-calldata failure behavior and the still-successful exact-arity execution path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95cbc78fe8f4af8be5f5be6c16e687ceb96e5f58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->