### PR TITLE
proofs: add checked-arithmetic automation helpers

### DIFF
--- a/Verity/Proofs/Stdlib/Automation.lean
+++ b/Verity/Proofs/Stdlib/Automation.lean
@@ -174,12 +174,18 @@ macro "verity_spec " spec:simpLemma " with " extra:simpLemma : tactic =>
 macro "verity_arith" : tactic =>
   `(tactic|
     first
-      | exact Verity.Proofs.Stdlib.Math.safeAdd_none _ _ (by first | assumption | omega)
-      | exact Verity.Proofs.Stdlib.Math.safeSub_none _ _ (by first | assumption | omega)
-      | exact Verity.Proofs.Stdlib.Math.safeMul_none _ _ (by first | assumption | omega)
-      | exact safeAdd_some_val _ _ (by first | assumption | omega)
-      | exact safeSub_some_val _ _ (by first | assumption | omega)
-      | exact Verity.Proofs.Stdlib.Math.safeMul_some _ _ (by first | assumption | omega)
+      | simpa using
+          (Verity.Proofs.Stdlib.Math.safeAdd_none _ _ (by first | assumption | omega))
+      | simpa using
+          (Verity.Proofs.Stdlib.Math.safeSub_none _ _ (by first | assumption | omega))
+      | simpa using
+          (Verity.Proofs.Stdlib.Math.safeMul_none _ _ (by first | assumption | omega))
+      | simpa using
+          (Verity.Proofs.Stdlib.Automation.safeAdd_some_val _ _ (by first | assumption | omega))
+      | simpa using
+          (Verity.Proofs.Stdlib.Automation.safeSub_some_val _ _ (by first | assumption | omega))
+      | simpa using
+          (Verity.Proofs.Stdlib.Math.safeMul_some _ _ (by first | assumption | omega))
       | simpa [safeAdd_some_iff_le, safeAdd_none_iff_gt,
           safeSub_some_iff_ge, safeSub_none_iff_lt,
           safeMul_some_iff_le, safeMul_none_iff_gt]


### PR DESCRIPTION
## Summary
- add a reusable `verity_arith` tactic entrypoint for checked-arithmetic reachability proofs
- cover checked multiplication with `safeMul_some_iff_le` and `safeMul_none_iff_gt`
- harden the tactic to use `simpa`-based theorem rewrites so theorem-shaped goals are handled more reliably

## Verification
- `lake build Verity.Proofs.Stdlib.Automation`

Closes #1336.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Lean proof automation (`verity_arith`) and only affect how checked-arithmetic goals are discharged in proofs; main risk is breaking existing proof scripts due to different rewriting behavior.
> 
> **Overview**
> Updates the `verity_arith` tactic in `Verity/Proofs/Stdlib/Automation.lean` to prove checked-arithmetic reachability goals via `simpa using …` (instead of `exact …`) and fully qualifies the `safeAdd_some_val`/`safeSub_some_val` lemmas.
> 
> This makes the tactic handle theorem-shaped goals more reliably while keeping the same set of supported `safeAdd`/`safeSub`/`safeMul` cases and fallback simp/`omega` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 222a5562b5e2266254ac6f89a5f6617d9df40f24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->