### PR TITLE
CI: surface Lean/compiler failures on draft PRs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -68,7 +68,6 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     outputs:
       code: ${{ steps.filter.outputs.code }}
       compiler: ${{ steps.filter.outputs.compiler }}
@@ -459,7 +458,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [changes, build-compiler]
-    if: needs.changes.outputs.compiler == 'true'
+    if: needs.changes.outputs.compiler == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4
         with:
@@ -489,7 +488,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [changes, build-compiler]
-    if: needs.changes.outputs.compiler == 'true'
+    if: needs.changes.outputs.compiler == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     strategy:
       fail-fast: false
       matrix:
@@ -525,7 +524,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [changes, build-compiler]
-    if: needs.changes.outputs.compiler == 'true'
+    if: needs.changes.outputs.compiler == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- run the `changes` job for draft PRs so core path filtering still happens
- allow draft PRs to execute the Lean/compiler build jobs that depend on `changes`
- keep the expensive Foundry matrix and gas-calibration jobs deferred until the PR leaves draft

## Why
PR #1382 currently shows green required checks while its key Lean targets do not build locally. The reason is workflow-level, not just proof-level: `changes` is skipped for draft PRs, which causes `build`, `build-compiler`, and every dependent job to skip transitively.

That hides exactly the class of problem that draft PRs are supposed to surface early: parser/typechecking/build breakage in Lean and compiler code.

This change keeps the fast signal on draft PRs without forcing the full Foundry matrix before the branch is ready.

## Verification
- Parsed `.github/workflows/verify.yml` successfully with `python3` + `yaml.safe_load`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts CI gating logic, changing which verification jobs run on draft PRs; misconfiguration could either hide failures or run expensive jobs unexpectedly.
> 
> **Overview**
> Draft PR behavior in `.github/workflows/verify.yml` is rebalanced so the `changes` path-filter job is no longer skipped for drafts, allowing dependent jobs like `build`/`build-compiler` to execute and surface Lean/compiler build failures earlier.
> 
> The expensive Foundry jobs (`foundry`, `foundry-patched`, `foundry-gas-calibration`) are now explicitly gated to run only when the PR is *not* a draft (or on non-PR events), keeping the test matrix deferred until review-ready.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42b4d64d836442c82adb74d4cbadbe50093f2d5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->