### PR TITLE
tests: tighten address storage invariant matcher

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -52,10 +52,10 @@ private def externalFunctions (spec : CompilationModel) : List FunctionSpec :=
   spec.functions.filter (fun fn => !fn.isInternal && !isInteropEntrypointName fn.name)
 
 private def bodyUsesAddressStorageRead (body : List Stmt) : Bool :=
-  contains (reprStr body) "storageAddr"
+  contains (reprStr body) "Expr.storageAddr"
 
 private def bodyUsesAddressStorageWrite (body : List Stmt) : Bool :=
-  contains (reprStr body) "setStorageAddr"
+  contains (reprStr body) "Stmt.setStorageAddr"
 
 private def canonicalFieldSlots (spec : CompilationModel) : List Nat :=
   let indexed := List.zip (List.range spec.fields.length) spec.fields


### PR DESCRIPTION
## Summary
- tighten the macro invariant matcher so address-storage reads only match `Expr.storageAddr`
- make the write matcher equally explicit with `Stmt.setStorageAddr`
- avoid false positives when a model body only performs address-storage writes

## Context
This is a follow-up to #1385. That PR added explicit address storage ops end-to-end, but the invariant helper was still using a broad substring search that could classify `setStorageAddr` as a read.

Part of #1331.

## Testing
- `lake build Contracts.MacroTranslateInvariantTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only test/invariant string matchers to be more specific, reducing false positives without affecting production compilation/runtime behavior.
> 
> **Overview**
> Tightens the macro invariant checks in `Contracts/MacroTranslateInvariantTest.lean` to detect address-storage reads/writes using explicit IR node names (`Expr.storageAddr` for reads and `Stmt.setStorageAddr` for writes) instead of broader substring matches.
> 
> This prevents address-storage writes from being misclassified as reads when validating macro-generated model bodies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85bfe2e71f15333751a530a5102d0e47d6fbcbae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->