### PR TITLE
chore: replace deprecated List.get? syntax

### DIFF
--- a/Compiler/RandomGen.lean
+++ b/Compiler/RandomGen.lean
@@ -87,7 +87,7 @@ private def gen256Bits (rng : RNG) : RNG × Nat :=
 def genUint256 (rng : RNG) : RNG × Nat :=
   let (rng, n) := rng.next
   let selector := n % 32
-  match edgeUint256Values.get? selector with
+  match edgeUint256Values[selector]? with
   | some v =>
     -- Deterministic edge case
     (rng, v)
@@ -124,7 +124,7 @@ private def addressPool : List Address :=
 -- Generate random address from an expanded pool that includes edge cases
 def genAddress (rng : RNG) : RNG × Address :=
   let (rng', n) := rng.next
-  let addr := match addressPool.get? (n % addressPool.length) with
+  let addr := match addressPool[n % addressPool.length]? with
     | some a => a
     | none   => (0 : Address)  -- fallback; unreachable when addressPool is non-empty
   (rng', addr)

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -364,7 +364,7 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
       let indexedFns := List.zip (List.range extFns.length) extFns
       let mappingSafeFns :=
         indexedFns.filterMap (fun (idx, fnSpec) =>
-          match irFns.get? idx, selectors.get? idx with
+          match irFns[idx]?, selectors[idx]? with
           | some irFn, some sel =>
               if functionUsesMappingSlot irFn then none else some (fnSpec, sel)
           | _, _ => none)


### PR DESCRIPTION
## Summary
- replace deprecated `List.get?` calls with the current `xs[i]?` syntax
- clear the warning emitted by `Contracts.MacroTranslateInvariantTest`
- update `Compiler.RandomGen` to the same indexing style for consistency

## Context
There were still a few deprecated `List.get?` calls in the repo. The most visible one was in `Contracts.MacroTranslateInvariantTest`, which made the test target build with warnings even on clean `main`.

This keeps the build output warning-free without changing behavior.

## Testing
- `lake build Contracts.MacroTranslateInvariantTest Compiler.RandomGen`
- `lake build Contracts.MacroTranslateInvariantTest Compiler.RandomGen 2>&1 | rg 'warning:' || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical syntax update: switches list indexing to the non-deprecated `xs[i]?` form, intended to remove compiler warnings without changing behavior.
> 
> **Overview**
> Replaces deprecated `List.get?` calls with the current `xs[i]?` indexing syntax in `Compiler/RandomGen.lean` and `Contracts/MacroTranslateInvariantTest.lean`.
> 
> This is a behavior-preserving cleanup aimed at clearing Lean deprecation warnings (including those emitted by `MacroTranslateInvariantTest`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86084a0f2dd21c5068f07f68875315ce92f9b739. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->