### PR TITLE
generator: fix mapping_uint invariant scaffolds

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -659,14 +659,19 @@ end Contracts.{cfg.name}.Spec
 def gen_invariants(cfg: ContractConfig) -> str:
     """Generate Contracts/{Name}/Invariants.lean"""
     # Build isolation predicates based on fields
-    # Address fields use storageAddr, uint256 fields use storage, mappings use storageMap
+    # Address fields use storageAddr, uint256 fields use storage, mappings use the
+    # storage accessor that matches their key type.
     slot_isolation = []
     for i, f in enumerate(cfg.fields):
         if f.is_mapping:
+            key_ty = "Uint256" if f.ty == "mapping_uint" else "Address"
+            key_name = "key" if f.ty == "mapping_uint" else "addr"
+            accessor = "storageMapUint" if f.ty == "mapping_uint" else "storageMap"
             slot_isolation.append(
                 f"-- Mapping storage isolation for {f.name} (slot {i})\n"
                 f"def {f.name}_mapping_isolated (s s' : ContractState) (slot : Nat) : Prop :=\n"
-                f"  slot ≠ {i} → ∀ addr : Address, s'.storageMap slot addr = s.storageMap slot addr"
+                f"  slot ≠ {i} → ∀ {key_name} : {key_ty}, "
+                f"s'.{accessor} slot {key_name} = s.{accessor} slot {key_name}"
             )
         elif f.ty == "address":
             slot_isolation.append(

--- a/scripts/test_generate_contract.py
+++ b/scripts/test_generate_contract.py
@@ -18,6 +18,7 @@ from generate_contract import (
     Param,
     gen_all_lean_imports,
     gen_basic_proofs,
+    gen_invariants,
     gen_example,
     gen_compiler_spec,
     gen_spec,
@@ -271,6 +272,35 @@ class GenerateContractSpecGetterTests(unittest.TestCase):
             out,
         )
         self.assertIn("result = s.storageMapUint 0 id", out)
+
+
+class GenerateContractInvariantScaffoldTests(unittest.TestCase):
+    def test_address_mapping_invariant_uses_address_keyed_storage_map(self) -> None:
+        cfg = ContractConfig(
+            name="AuditDemo",
+            fields=[Field(name="balances", ty="mapping")],
+            functions=[],
+        )
+
+        out = gen_invariants(cfg)
+        self.assertIn("def balances_mapping_isolated", out)
+        self.assertIn("∀ addr : Address, s'.storageMap slot addr = s.storageMap slot addr", out)
+
+    def test_uint_mapping_invariant_uses_uint_keyed_storage_map(self) -> None:
+        cfg = ContractConfig(
+            name="AuditDemo",
+            fields=[Field(name="values", ty="mapping_uint")],
+            functions=[],
+        )
+
+        out = gen_invariants(cfg)
+        self.assertIn("def values_mapping_isolated", out)
+        self.assertIn(
+            "∀ key : Uint256, s'.storageMapUint slot key = s.storageMapUint slot key",
+            out,
+        )
+        self.assertNotIn("storageMap slot", out)
+        self.assertNotIn("∀ addr : Address", out)
 
 
 class GenerateContractCompilerSpecGetterTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- fix `gen_invariants` so `mapping(uint256)` fields emit `storageMapUint` isolation lemmas with `Uint256` keys
- keep address-keyed mapping invariants unchanged
- add generator tests covering both mapping variants

## Why
Current `main` generates an incorrect invariant scaffold for `mapping(uint256)` fields:
- it quantifies over `Address`
- it reads `storageMap`

That contradicts the rest of the generated spec surface, which already distinguishes `mapping(address)` from `mapping(uint256)` via `storageMap` vs `storageMapUint`.

This is a small but concrete step toward `#1334`, because it keeps generated storage reasoning aligned with the typed storage shape instead of silently producing the wrong abstraction boundary.

## Testing
- `python3 scripts/test_generate_contract.py`
- `python3 scripts/generate_contract.py AuditDemo --fields 'values:mapping(uint256)' --functions 'getValue(uint256)' --dry-run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: generator-only change that corrects invariant scaffolding for `mapping(uint256)` and adds unit tests to prevent regressions.
> 
> **Overview**
> Fixes `gen_invariants` so isolation predicates for `mapping(uint256)` fields quantify over `Uint256` keys and use `storageMapUint` (instead of incorrectly using `Address`/`storageMap`).
> 
> Adds generator tests covering both address-keyed and uint256-keyed mapping invariant scaffolds, ensuring the correct storage accessor is emitted for each mapping variant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bec2dd1a5c5f97a25ff1903f1a5ac3c1be78de3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->