### PR TITLE
scripts: scaffold storage-backed getter property tests

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -893,19 +893,89 @@ def _gen_single_test(
         encode_args = f'"{sol_sig}"'
 
     if is_getter:
-        return f"""    //═══════════════════════════════════════════════════════════════════════
+        getter_prefix = _getter_prefix(fn.name)
+        if getter_prefix in ("is", "has"):
+            return f"""    //═══════════════════════════════════════════════════════════════════════
     // Property {idx + 1}: TODO_{fn.name}_meets_spec
-    // Getter theorem extraction requires manual return/storage assertions.
+    // Predicate getter extraction still needs manual boolean semantics.
     //═══════════════════════════════════════════════════════════════════════
 
     /// Property TODO: {fn.name}_meets_spec
     function testTODO_{camel}_GetterNeedsSpecAssertions() public {{
-        // TODO: Implement getter-specific checks:
+        // TODO: Implement predicate-specific checks:
         // 1) set up deterministic storage,
         // 2) decode return data from `{fn.name}`,
-        // 3) assert decoded value matches spec/state,
-        // 4) assert no unintended storage mutation (all relevant slots/mappings).
+        // 3) assert decoded boolean matches spec/state,
+        // 4) assert no unintended storage mutation.
         revert("TODO: implement getter property assertions");
+    }}
+"""
+
+        target = _require_getter_target_field(fn, cfg.fields)
+        target_slot = _field_slot(cfg.fields, target)
+        helper_field_name = f"{target.name[0].upper()}{target.name[1:]}"
+
+        setup_lines: list[str] = []
+        if target.is_mapping:
+            sample_key = "42" if target.ty == "mapping_uint" else "alice"
+            setup_lines.append(f"        set{helper_field_name}InStorage({sample_key}, 1337);")
+            decoded_ty = "uint256"
+            decode_assertion = '        assertEq(decoded, 1337, "getter should return seeded mapping entry");'
+        elif target.ty == "address":
+            setup_lines.append(
+                f"        vm.store(target, bytes32(uint256({target_slot})), bytes32(uint256(uint160(alice))));"
+            )
+            decoded_ty = "address"
+            decode_assertion = '        assertEq(decoded, alice, "getter should return seeded address slot");'
+        else:
+            setup_lines.append(
+                f"        vm.store(target, bytes32(uint256({target_slot})), bytes32(uint256(1337)));"
+            )
+            decoded_ty = "uint256"
+            decode_assertion = '        assertEq(decoded, 1337, "getter should return seeded uint256 slot");'
+
+        snapshot_lines: list[str] = []
+        assertion_lines: list[str] = []
+        for slot_idx, field in enumerate(cfg.fields):
+            if field.is_mapping:
+                helper_name = f"{field.name[0].upper()}{field.name[1:]}"
+                key_expr = "42" if field.ty == "mapping_uint" else "alice"
+                before_name = f"{field.name}Before"
+                snapshot_lines.append(
+                    f"        uint256 {before_name} = get{helper_name}FromStorage({key_expr});"
+                )
+                assertion_lines.append(
+                    f'        assertEq(get{helper_name}FromStorage({key_expr}), {before_name}, "{field.name} mapping entry unchanged by getter");'
+                )
+            else:
+                before_name = f"slot{slot_idx}Before"
+                snapshot_lines.append(
+                    f"        uint256 {before_name} = readStorage({slot_idx});"
+                )
+                assertion_lines.append(
+                    f'        assertEq(readStorage({slot_idx}), {before_name}, "slot {slot_idx} unchanged by getter");'
+                )
+
+        return f"""    //═══════════════════════════════════════════════════════════════════════
+    // Property {idx + 1}: {fn.name}_meets_spec
+    // Inferred getter scaffold seeds storage, decodes the return value, and
+    // checks that the getter does not mutate known storage slots.
+    //═══════════════════════════════════════════════════════════════════════
+
+    /// Property: {fn.name}_meets_spec
+    function testProperty_{camel}_MeetsSpec() public {{
+{chr(10).join(setup_lines)}
+{chr(10).join(snapshot_lines)}
+
+        (bool success, bytes memory ret) = target.call(
+            abi.encodeWithSignature({encode_args})
+        );
+        require(success, "{fn.name} call failed");
+
+        {decoded_ty} decoded = abi.decode(ret, ({decoded_ty}));
+{decode_assertion}
+
+{chr(10).join(assertion_lines)}
     }}
 """
     else:

--- a/scripts/test_generate_contract.py
+++ b/scripts/test_generate_contract.py
@@ -125,7 +125,7 @@ class GenerateContractFunctionSignatureValidationTests(unittest.TestCase):
 
 
 class GenerateContractGetterPropertyScaffoldTests(unittest.TestCase):
-    def test_getter_scaffold_is_explicit_todo_placeholder(self) -> None:
+    def test_scalar_getter_scaffold_reads_seeded_slot_and_preserves_storage(self) -> None:
         cfg = ContractConfig(
             name="Demo",
             fields=[Field(name="storedValue", ty="uint256")],
@@ -134,13 +134,47 @@ class GenerateContractGetterPropertyScaffoldTests(unittest.TestCase):
 
         out = gen_property_tests(cfg)
         self.assertIn(
-            "function testTODO_GetStoredValue_GetterNeedsSpecAssertions() public {",
+            "function testProperty_GetStoredValue_MeetsSpec() public {",
             out,
         )
-        self.assertIn("Property TODO: getStoredValue_meets_spec", out)
+        self.assertIn("Property: getStoredValue_meets_spec", out)
+        self.assertIn("vm.store(target, bytes32(uint256(0)), bytes32(uint256(1337)));", out)
+        self.assertIn("uint256 decoded = abi.decode(ret, (uint256));", out)
+        self.assertIn('assertEq(decoded, 1337, "getter should return seeded uint256 slot");', out)
+        self.assertIn('assertEq(readStorage(0), slot0Before, "slot 0 unchanged by getter");', out)
+
+    def test_mapping_getter_scaffold_reads_seeded_entry_and_preserves_storage(self) -> None:
+        cfg = ContractConfig(
+            name="Demo",
+            fields=[Field(name="balances", ty="mapping")],
+            functions=[Function(name="getBalance", params=[Param(name="account", ty="address")])],
+        )
+
+        out = gen_property_tests(cfg)
+        self.assertIn("function testProperty_GetBalance_MeetsSpec() public {", out)
+        self.assertIn("setBalancesInStorage(alice, 1337);", out)
+        self.assertIn("uint256 balancesBefore = getBalancesFromStorage(alice);", out)
+        self.assertIn("abi.encodeWithSignature(\"getBalance(address)\", alice)", out)
+        self.assertIn('assertEq(decoded, 1337, "getter should return seeded mapping entry");', out)
+        self.assertIn(
+            'assertEq(getBalancesFromStorage(alice), balancesBefore, "balances mapping entry unchanged by getter");',
+            out,
+        )
+
+    def test_predicate_getter_scaffold_stays_explicit_todo(self) -> None:
+        cfg = ContractConfig(
+            name="Demo",
+            fields=[Field(name="owner", ty="address")],
+            functions=[Function(name="isOwner", params=[])],
+        )
+
+        out = gen_property_tests(cfg)
+        self.assertIn(
+            "function testTODO_IsOwner_GetterNeedsSpecAssertions() public {",
+            out,
+        )
+        self.assertIn("Property TODO: isOwner_meets_spec", out)
         self.assertIn("revert(\"TODO: implement getter property assertions\");", out)
-        self.assertNotIn("bytes memory data", out)
-        self.assertNotIn("assertEq(readStorage(0), slot0Before", out)
 
     def test_non_getter_scaffold_keeps_meets_spec_template(self) -> None:
         cfg = ContractConfig(


### PR DESCRIPTION
## Summary
- replace reverting getter property-test placeholders with executable scaffolds for inferred storage-backed `get...` accessors
- seed deterministic storage for scalar and mapping getters, decode the returned value, and assert the getter preserves known storage slots
- keep `is...` / `has...` predicate getters on the explicit TODO path until boolean semantics can be inferred safely

## Testing
- `python3 -m unittest scripts.test_generate_contract -v`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes test scaffolding generation for getter functions to emit executable assertions based on inferred storage layout; incorrect inference or storage seeding assumptions could produce misleading or failing generated tests for new contracts.
> 
> **Overview**
> **Getter property tests are now generated as executable scaffolds instead of revert-only TODOs.** For inferred `get...` accessors, the generator seeds deterministic storage (scalar slots or a sample mapping entry), calls the getter, decodes the return value, and asserts it matches the seeded value.
> 
> It also snapshots all known storage slots/mapping entries before the call and asserts they are unchanged afterward to catch unintended getter mutations. `is...`/`has...` predicate getters remain on the explicit TODO path.
> 
> Unit tests were updated to validate the new scalar/mapping getter scaffolds and to ensure predicate getters still emit TODO placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 831620eeddc7a93cf43b73ccd9d8ce61562b6437. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->