### PR TITLE
generator: infer y-to-ies getter field plurals

### DIFF
--- a/scripts/generate_contract.py
+++ b/scripts/generate_contract.py
@@ -443,7 +443,8 @@ def _getter_target_field(fn: Function, fields: List[Field]) -> Field | None:
 
     Matches the getter suffix (e.g., ``getTotalSupply`` → ``totalSupply``,
     ``getBalance`` → ``balances``) case-insensitively against field names.
-    Tries exact match first, then common plural suffix (``+s``/``+es``).
+    Tries exact match first, then common plural forms (``+s``, ``+es``,
+    ``y`` → ``ies``).
     Returns ``None`` if no match.
     """
     prefix = _getter_prefix(fn.name)
@@ -454,8 +455,12 @@ def _getter_target_field(fn: Function, fields: List[Field]) -> Field | None:
     for f in fields:
         if f.name.lower() == suffix:
             return f
-    # Try plural forms: getBalance → balances, getAddress → addresses
-    for plural in (suffix + "s", suffix + "es"):
+    # Try plural forms: getBalance → balances, getAddress → addresses,
+    # getCategory → categories.
+    plural_candidates = [suffix + "s", suffix + "es"]
+    if suffix.endswith("y") and len(suffix) > 1 and suffix[-2] not in "aeiou":
+        plural_candidates.append(suffix[:-1] + "ies")
+    for plural in plural_candidates:
         for f in fields:
             if f.name.lower() == plural:
                 return f

--- a/scripts/test_generate_contract.py
+++ b/scripts/test_generate_contract.py
@@ -308,6 +308,30 @@ class GenerateContractSpecGetterTests(unittest.TestCase):
         self.assertIn("result = s.storageMapUint 0 id", out)
 
 
+class GenerateContractGetterTargetInferenceTests(unittest.TestCase):
+    def test_infers_y_to_ies_plural_field_for_mapping_getter(self) -> None:
+        cfg = ContractConfig(
+            name="AuditDemo",
+            fields=[Field(name="categories", ty="mapping")],
+            functions=[Function(name="getCategory", params=[Param(name="account", ty="address")])],
+        )
+
+        out = gen_example(cfg)
+        self.assertIn("def getCategory (account : Address) : Contract Uint256 := do", out)
+        self.assertIn("let currentValue ← getMapping categories account", out)
+
+    def test_infers_y_to_ies_plural_field_for_scalar_getter(self) -> None:
+        cfg = ContractConfig(
+            name="AuditDemo",
+            fields=[Field(name="treasuries", ty="uint256")],
+            functions=[Function(name="getTreasury", params=[])],
+        )
+
+        out = gen_spec(cfg)
+        self.assertIn("def getTreasury_spec (result : Uint256) (s : ContractState) : Prop :=", out)
+        self.assertIn("result = s.storage 0", out)
+
+
 class GenerateContractInvariantScaffoldTests(unittest.TestCase):
     def test_address_mapping_invariant_uses_address_keyed_storage_map(self) -> None:
         cfg = ContractConfig(


### PR DESCRIPTION
## Summary
- teach getter target inference to recognize common `y -> ies` pluralization
- fix scaffold generation for getters like `getCategory` -> `categories` and `getTreasury` -> `treasuries`
- add regression tests covering both mapping-backed and scalar-backed cases

## Problem
`generate_contract.py` only tried exact matches plus `+s`/`+es` when mapping a getter name back to a field. That made common names like `categories`, `policies`, `proxies`, and `treasuries` fail closed even though they are natural storage names.

## Testing
- `make test-python`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to scaffold generation heuristics and adds tests to lock in behavior, with no runtime contract logic affected.
> 
> **Overview**
> Improves `scripts/generate_contract.py` getter target inference to also match common `y → ies` plural field names (e.g., `getCategory` → `categories`, `getTreasury` → `treasuries`) when generating inferred getter implementations/specs.
> 
> Adds unit tests covering the new pluralization for both mapping-backed and scalar-backed getters to prevent regressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c57037a452cf3bca46795cd91916dcc7f7b43ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->