### PR TITLE
macro: clarify struct mapping setMapping2 errors

### DIFF
--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -206,6 +206,18 @@ verity_contract StructMappingWrongWriteAccessor where
 end StructMappingWrongWriteAccessor
 
 /--
+error: field 'positions' is a struct-valued mapping; use setStructMember
+-/
+#guard_msgs in
+verity_contract StructMappingWrongLegacyWriteAccessor where
+  storage
+    positions : MappingStruct(Address,[delegate @word 0]) := slot 0
+
+  function setDelegate (owner : Address, delegate_ : Address) : Unit := do
+    setMapping2 positions owner owner delegate_
+end StructMappingWrongLegacyWriteAccessor
+
+/--
 error: unknown struct member 'nonce' on field 'positions'
 -/
 #guard_msgs in

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -792,6 +792,8 @@ private def translateEffectStmt
               $(← translatePureExpr fields params locals value))
       | .mappingStruct2 _ _ _ =>
           throwErrorAt stx s!"field '{f.name}' is a nested struct mapping; use setStructMember2"
+      | .mappingStruct _ _ =>
+          throwErrorAt stx s!"field '{f.name}' is a struct-valued mapping; use setStructMember"
       | _ => throwErrorAt stx s!"field '{f.name}' is not a double mapping"
   | `(term| require $cond $msg) =>
       `(Compiler.CompilationModel.Stmt.require $(← translatePureExpr fields params locals cond) $(strTerm (← expectStringLiteral msg)))


### PR DESCRIPTION
## Summary
- fix `setMapping2` diagnostics for single-level `MappingStruct(...)` fields
- point users at `setStructMember` instead of the generic "not a double mapping" error
- add a `#guard_msgs` smoke contract that locks the regression down

## Why
PR #1399 made struct-valued mappings first-class in the macro surface, but one legacy write accessor path still fell through to the generic `setMapping2` error for `MappingStruct(...)` fields. That produced misleading guidance precisely in the workflow the new surface is meant to simplify.

This follow-up keeps the read/write accessor diagnostics consistent and removes a sharp edge for issue #1334's new storage surface.

## Testing
- `lake build Verity.Macro.Translate`
- `lake build Contracts.Smoke`

Advances #1334.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only macro error reporting and adds a compile-time `#guard_msgs` regression test, with no runtime/semantic behavior impact.
> 
> **Overview**
> Adjusts `Verity.Macro.Translate` so `setMapping2` used on `MappingStruct(...)` fields fails with a specific message pointing to `setStructMember`, instead of the generic *not a double mapping* error.
> 
> Adds a new `#guard_msgs` smoke contract (`StructMappingWrongLegacyWriteAccessor`) to lock in the improved diagnostic for the legacy `setMapping2` write path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d7f0fb82f1be463ae19e856ecc418f681533576. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->