### PR TITLE
scripts: harden macro coverage contract parsing

### DIFF
--- a/scripts/check_macro_roundtrip_fuzz_coverage.py
+++ b/scripts/check_macro_roundtrip_fuzz_coverage.py
@@ -26,14 +26,26 @@ MACRO_SPECS_DEF_RE = re.compile(
 def _collect_contracts_from_text(text: str) -> list[str]:
     names: list[str] = []
     guard_pending = False
+    block_comment_depth = 0
     for line in text.splitlines():
         stripped = line.strip()
+        if block_comment_depth > 0:
+            block_comment_depth += stripped.count("/-")
+            block_comment_depth -= stripped.count("-/")
+            continue
+        if stripped.startswith("/-"):
+            block_comment_depth += stripped.count("/-")
+            block_comment_depth -= stripped.count("-/")
+            if block_comment_depth > 0 or stripped == "":
+                continue
+            if stripped.endswith("-/"):
+                continue
         if stripped == "#guard_msgs in":
             guard_pending = True
             continue
         match = CONTRACT_RE.search(line)
         if guard_pending:
-            if not stripped:
+            if not stripped or stripped.startswith("--"):
                 continue
             if match is not None:
                 guard_pending = False

--- a/scripts/check_macro_translate_invariant_coverage.py
+++ b/scripts/check_macro_translate_invariant_coverage.py
@@ -26,14 +26,26 @@ MACRO_SPECS_DEF_RE = re.compile(
 def _collect_contracts_from_text(text: str) -> list[str]:
     names: list[str] = []
     guard_pending = False
+    block_comment_depth = 0
     for line in text.splitlines():
         stripped = line.strip()
+        if block_comment_depth > 0:
+            block_comment_depth += stripped.count("/-")
+            block_comment_depth -= stripped.count("-/")
+            continue
+        if stripped.startswith("/-"):
+            block_comment_depth += stripped.count("/-")
+            block_comment_depth -= stripped.count("-/")
+            if block_comment_depth > 0 or stripped == "":
+                continue
+            if stripped.endswith("-/"):
+                continue
         if stripped == "#guard_msgs in":
             guard_pending = True
             continue
         match = CONTRACT_RE.search(line)
         if guard_pending:
-            if not stripped:
+            if not stripped or stripped.startswith("--"):
                 continue
             if match is not None:
                 guard_pending = False

--- a/scripts/test_check_macro_roundtrip_fuzz_coverage.py
+++ b/scripts/test_check_macro_roundtrip_fuzz_coverage.py
@@ -72,6 +72,31 @@ class MacroRoundTripFuzzCoverageTests(unittest.TestCase):
             ["Duplicate", "Duplicate"],
         )
 
+    def test_collect_contracts_keeps_guard_through_comments(self) -> None:
+        text = """
+        #guard_msgs in
+        -- keep guarding the next contract
+        /-
+        multi-line comment
+        -/
+        verity_contract NegativeFixture where
+          storage
+            counter : Uint256 := slot 0
+          function read () : Uint256 := do
+            return 0
+
+        verity_contract HappyPath where
+          storage
+            counter : Uint256 := slot 1
+          function readAgain () : Uint256 := do
+            return 1
+        """
+
+        self.assertEqual(
+            check_macro_roundtrip_fuzz_coverage._collect_contracts_from_text(text),
+            ["HappyPath"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_check_macro_translate_invariant_coverage.py
+++ b/scripts/test_check_macro_translate_invariant_coverage.py
@@ -55,6 +55,31 @@ class MacroTranslateInvariantCoverageTests(unittest.TestCase):
             ["HappyPath"],
         )
 
+    def test_collect_contracts_keeps_guard_through_comments(self) -> None:
+        text = """
+        #guard_msgs in
+        -- keep guarding the next contract
+        /-
+        multi-line comment
+        -/
+        verity_contract NegativeFixture where
+          storage
+            counter : Uint256 := slot 0
+          function read () : Uint256 := do
+            return 0
+
+        verity_contract HappyPath where
+          storage
+            counter : Uint256 := slot 1
+          function readAgain () : Uint256 := do
+            return 1
+        """
+
+        self.assertEqual(
+            check_macro_translate_invariant_coverage._collect_contracts_from_text(text),
+            ["HappyPath"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fix macro coverage contract parsing so `#guard_msgs in` only suppresses the immediately guarded contract
- preserve repeated contract declarations within a file so duplicate-name checks still fire
- add regression tests for both parser edge cases in the invariant and fuzz coverage suites

## Why
PR #1399 taught the coverage scripts to ignore negative `#guard_msgs` fixtures, but the new parser kept guard state alive until it saw a `verity_contract` line and collapsed matches into a `set` too early.

That caused two correctness gaps:
- a guarded non-contract command like `#check` could make the next unrelated contract disappear from coverage accounting
- duplicate `verity_contract` names in one file stopped surfacing in the round-trip fuzz duplicate-declaration check

This follow-up restores the intended behavior and closes the review feedback left on #1399.

## Testing
- `python3 -m unittest scripts.test_check_macro_translate_invariant_coverage -v`
- `python3 -m unittest scripts.test_check_macro_roundtrip_fuzz_coverage -v`
- `python3 scripts/check_macro_translate_invariant_coverage.py`
- `python3 scripts/check_macro_roundtrip_fuzz_coverage.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Python coverage-check scripts and their unit tests, though parsing tweaks may cause CI coverage checks to start flagging previously-missed contracts or duplicates.
> 
> **Overview**
> Tightens contract-name extraction in the macro invariant and round-trip fuzz coverage scripts so `#guard_msgs in` only suppresses the *immediately guarded* `verity_contract`, resets when a different command appears, and properly skips over Lean block comments.
> 
> Switches `_collect_contracts_from_text` to return an ordered `list` (not a `set`) so repeated `verity_contract` declarations in the same file are preserved and duplicate-name checks can trigger. Adds/updates unit tests for the new guard/comment and duplicate-declaration behaviors in both suites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85db1e86365852f911475df2eba19beaabbf8bb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->