### PR TITLE
tests: infer macro getter assertions

### DIFF
--- a/artifacts/macro_property_tests/PropertyBytes32Smoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyBytes32Smoke.t.sol
@@ -23,13 +23,15 @@ contract PropertyBytes32SmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("setDigest(bytes32)", bytes32(uint256(0xBEEF))));
         require(ok, "setDigest reverted unexpectedly");
     }
-    // Property 2: TODO decode and assert `getDigest` result
-    function testTODO_GetDigest_DecodeAndAssert() public {
+    // Property 2: getDigest reads storage slot 0 and decodes the result
+    function testAuto_GetDigest_ReadsConfiguredStorage() public {
+        bytes32 expected = bytes32(uint256(0xBEEF));
+        vm.store(target, bytes32(uint256(0)), expected);
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getDigest()"));
         require(ok, "getDigest reverted unexpectedly");
         assertEq(ret.length, 32, "getDigest ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        bytes32 actual = abi.decode(ret, (bytes32));
+        assertEq(actual, expected, "getDigest should return storage slot 0");
     }
 }

--- a/artifacts/macro_property_tests/PropertyCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertyCounter.t.sol
@@ -29,14 +29,16 @@ contract PropertyCounterTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("decrement()"));
         require(ok, "decrement reverted unexpectedly");
     }
-    // Property 3: TODO decode and assert `getCount` result
-    function testTODO_GetCount_DecodeAndAssert() public {
+    // Property 3: getCount reads storage slot 0 and decodes the result
+    function testAuto_GetCount_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCount()"));
         require(ok, "getCount reverted unexpectedly");
         assertEq(ret.length, 32, "getCount ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCount should return storage slot 0");
     }
     // Property 4: TODO decode and assert `previewAddTwice` result
     function testTODO_PreviewAddTwice_DecodeAndAssert() public {

--- a/artifacts/macro_property_tests/PropertyERC20.t.sol
+++ b/artifacts/macro_property_tests/PropertyERC20.t.sol
@@ -59,22 +59,26 @@ contract PropertyERC20Test is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 7: TODO decode and assert `totalSupply` result
-    function testTODO_TotalSupply_DecodeAndAssert() public {
+    // Property 7: totalSupply reads storage slot 1 and decodes the result
+    function testAuto_TotalSupply_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(1)), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("totalSupply()"));
         require(ok, "totalSupply reverted unexpectedly");
         assertEq(ret.length, 32, "totalSupply ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "totalSupply should return storage slot 1");
     }
-    // Property 8: TODO decode and assert `owner` result
-    function testTODO_Owner_DecodeAndAssert() public {
+    // Property 8: owner reads storage slot 0 and decodes the result
+    function testAuto_Owner_ReadsConfiguredStorage() public {
+        address expected = alice;
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(uint160(expected))));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("owner()"));
         require(ok, "owner reverted unexpectedly");
         assertEq(ret.length, 32, "owner ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, expected, "owner should return storage slot 0");
     }
 }

--- a/artifacts/macro_property_tests/PropertyOwned.t.sol
+++ b/artifacts/macro_property_tests/PropertyOwned.t.sol
@@ -23,13 +23,15 @@ contract PropertyOwnedTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("transferOwnership(address)", alice));
         require(ok, "transferOwnership reverted unexpectedly");
     }
-    // Property 2: TODO decode and assert `getOwner` result
-    function testTODO_GetOwner_DecodeAndAssert() public {
+    // Property 2: getOwner reads storage slot 0 and decodes the result
+    function testAuto_GetOwner_ReadsConfiguredStorage() public {
+        address expected = alice;
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(uint160(expected))));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getOwner()"));
         require(ok, "getOwner reverted unexpectedly");
         assertEq(ret.length, 32, "getOwner ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, expected, "getOwner should return storage slot 0");
     }
 }

--- a/artifacts/macro_property_tests/PropertyOwnedCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertyOwnedCounter.t.sol
@@ -29,23 +29,27 @@ contract PropertyOwnedCounterTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("decrement()"));
         require(ok, "decrement reverted unexpectedly");
     }
-    // Property 3: TODO decode and assert `getCount` result
-    function testTODO_GetCount_DecodeAndAssert() public {
+    // Property 3: getCount reads storage slot 1 and decodes the result
+    function testAuto_GetCount_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(1)), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCount()"));
         require(ok, "getCount reverted unexpectedly");
         assertEq(ret.length, 32, "getCount ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCount should return storage slot 1");
     }
-    // Property 4: TODO decode and assert `getOwner` result
-    function testTODO_GetOwner_DecodeAndAssert() public {
+    // Property 4: getOwner reads storage slot 0 and decodes the result
+    function testAuto_GetOwner_ReadsConfiguredStorage() public {
+        address expected = alice;
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(uint160(expected))));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getOwner()"));
         require(ok, "getOwner reverted unexpectedly");
         assertEq(ret.length, 32, "getOwner ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, expected, "getOwner should return storage slot 0");
     }
     // Property 5: transferOwnership has no unexpected revert
     function testAuto_TransferOwnership_NoUnexpectedRevert() public {

--- a/artifacts/macro_property_tests/PropertySafeCounter.t.sol
+++ b/artifacts/macro_property_tests/PropertySafeCounter.t.sol
@@ -29,13 +29,15 @@ contract PropertySafeCounterTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("decrement()"));
         require(ok, "decrement reverted unexpectedly");
     }
-    // Property 3: TODO decode and assert `getCount` result
-    function testTODO_GetCount_DecodeAndAssert() public {
+    // Property 3: getCount reads storage slot 0 and decodes the result
+    function testAuto_GetCount_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getCount()"));
         require(ok, "getCount reverted unexpectedly");
         assertEq(ret.length, 32, "getCount ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getCount should return storage slot 0");
     }
 }

--- a/artifacts/macro_property_tests/PropertySimpleStorage.t.sol
+++ b/artifacts/macro_property_tests/PropertySimpleStorage.t.sol
@@ -23,13 +23,15 @@ contract PropertySimpleStorageTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("store(uint256)", uint256(1)));
         require(ok, "store reverted unexpectedly");
     }
-    // Property 2: TODO decode and assert `retrieve` result
-    function testTODO_Retrieve_DecodeAndAssert() public {
+    // Property 2: retrieve reads storage slot 0 and decodes the result
+    function testAuto_Retrieve_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("retrieve()"));
         require(ok, "retrieve reverted unexpectedly");
         assertEq(ret.length, 32, "retrieve ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "retrieve should return storage slot 0");
     }
 }

--- a/artifacts/macro_property_tests/PropertySimpleToken.t.sol
+++ b/artifacts/macro_property_tests/PropertySimpleToken.t.sol
@@ -38,22 +38,26 @@ contract PropertySimpleTokenTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 4: TODO decode and assert `totalSupply` result
-    function testTODO_TotalSupply_DecodeAndAssert() public {
+    // Property 4: totalSupply reads storage slot 2 and decodes the result
+    function testAuto_TotalSupply_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(2)), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("totalSupply()"));
         require(ok, "totalSupply reverted unexpectedly");
         assertEq(ret.length, 32, "totalSupply ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "totalSupply should return storage slot 2");
     }
-    // Property 5: TODO decode and assert `owner` result
-    function testTODO_Owner_DecodeAndAssert() public {
+    // Property 5: owner reads storage slot 0 and decodes the result
+    function testAuto_Owner_ReadsConfiguredStorage() public {
+        address expected = alice;
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(uint160(expected))));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("owner()"));
         require(ok, "owner reverted unexpectedly");
         assertEq(ret.length, 32, "owner ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, expected, "owner should return storage slot 0");
     }
 }

--- a/artifacts/macro_property_tests/PropertyTupleSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyTupleSmoke.t.sol
@@ -23,14 +23,15 @@ contract PropertyTupleSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("setFromPair((uint256,uint256))", abi.encode(uint256(1), uint256(1))));
         require(ok, "setFromPair reverted unexpectedly");
     }
-    // Property 2: TODO decode and assert `getPair` result
-    function testTODO_GetPair_DecodeAndAssert() public {
+    // Property 2: getPair decodes and matches the returned tuple elements
+    function testAuto_GetPair_DecodesTupleResult() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getPair(uint256)", uint256(1)));
         require(ok, "getPair reverted unexpectedly");
         require(ret.length >= 64, "getPair ABI tuple return payload unexpectedly short");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        (uint256 actual0, uint256 actual1) = abi.decode(ret, (uint256, uint256));
+        assertEq(actual0, uint256(1), "getPair tuple element 0 mismatch");
+        assertEq(actual1, uint256(1), "getPair tuple element 1 mismatch");
     }
     // Property 3: processConfig has no unexpected revert
     function testAuto_ProcessConfig_NoUnexpectedRevert() public {

--- a/artifacts/macro_property_tests/PropertyUint8Smoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyUint8Smoke.t.sol
@@ -23,13 +23,13 @@ contract PropertyUint8SmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("acceptSig((uint8,bytes32,bytes32))", abi.encode(uint8(27), bytes32(uint256(0xBEEF)), bytes32(uint256(0xBEEF)))));
         require(ok, "acceptSig reverted unexpectedly");
     }
-    // Property 2: TODO decode and assert `sigV` result
-    function testTODO_SigV_DecodeAndAssert() public {
+    // Property 2: sigV returns the declared constant result
+    function testAuto_SigV_ReturnsDeclaredConstant() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("sigV()"));
         require(ok, "sigV reverted unexpectedly");
         assertEq(ret.length, 32, "sigV ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint8 actual = abi.decode(ret, (uint8));
+        assertEq(actual, 27, "sigV should return the declared constant");
     }
 }

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -25,6 +25,9 @@ FUNCTION_RE = re.compile(
 )
 CONSTRUCTOR_RE = re.compile(r"^\s*constructor\s*\(([^)]*)\)\s*:=\s*")
 PARAM_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$")
+STORAGE_RE = re.compile(
+    r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*:=\s*slot\s+([0-9]+)\s*$",
+)
 
 
 @dataclass(frozen=True)
@@ -38,6 +41,7 @@ class FunctionDecl:
     name: str
     params: tuple[ParamDecl, ...]
     return_type: str
+    body: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -50,6 +54,7 @@ class ContractDecl:
     name: str
     constructor: ConstructorDecl | None
     functions: tuple[FunctionDecl, ...]
+    storage_slots: dict[str, int]
     source: Path
 
 
@@ -94,22 +99,45 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
     contracts: dict[str, ContractDecl] = {}
     current_name: str | None = None
     current_constructor: ConstructorDecl | None = None
+    current_storage_slots: dict[str, int] = {}
     current_functions: list[FunctionDecl] = []
+    current_function: FunctionDecl | None = None
+    current_body: list[str] = []
     guard_pending = False
+    in_storage_block = False
+
+    def flush_function() -> None:
+        nonlocal current_function, current_body
+        if current_function is None:
+            return
+        current_functions.append(
+            FunctionDecl(
+                name=current_function.name,
+                params=current_function.params,
+                return_type=current_function.return_type,
+                body=tuple(current_body),
+            )
+        )
+        current_function = None
+        current_body = []
 
     def flush_current() -> None:
-        nonlocal current_name, current_constructor, current_functions
+        nonlocal current_name, current_constructor, current_storage_slots, current_functions, in_storage_block
         if current_name is None:
             return
+        flush_function()
         contracts[current_name] = ContractDecl(
             name=current_name,
             constructor=current_constructor,
             functions=tuple(current_functions),
+            storage_slots=dict(current_storage_slots),
             source=source,
         )
         current_name = None
         current_constructor = None
+        current_storage_slots = {}
         current_functions = []
+        in_storage_block = False
 
     for line in text.splitlines():
         if line.strip() == "#guard_msgs in":
@@ -128,25 +156,45 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
         if current_name is None:
             continue
 
+        if line.strip() == "storage":
+            in_storage_block = True
+            continue
+
         ctor = CONSTRUCTOR_RE.match(line)
         if ctor:
+            flush_function()
             if current_constructor is not None:
                 raise ValueError(f"duplicate constructor in contract '{current_name}'")
             current_constructor = ConstructorDecl(params=_split_params(ctor.group(1)))
+            in_storage_block = False
             continue
 
         fm = FUNCTION_RE.match(line)
         if fm:
+            flush_function()
             fn_name = fm.group(1)
             params_src = fm.group(2)
             ret_ty = _normalize_type(fm.group(3))
-            current_functions.append(
-                FunctionDecl(
-                    name=fn_name,
-                    params=_split_params(params_src),
-                    return_type=ret_ty,
-                )
+            current_function = FunctionDecl(
+                name=fn_name,
+                params=_split_params(params_src),
+                return_type=ret_ty,
             )
+            in_storage_block = False
+            continue
+
+        if in_storage_block:
+            sm = STORAGE_RE.match(line)
+            if sm:
+                current_storage_slots[sm.group(1)] = int(sm.group(3))
+                continue
+            if line.strip():
+                in_storage_block = False
+
+        if current_function is not None and line.startswith("    "):
+            stripped = line.strip()
+            if stripped:
+                current_body.append(stripped)
 
     flush_current()
     return contracts
@@ -283,6 +331,117 @@ def _return_shape_assertion(lean_ty: str, fn_name: str) -> str:
     raise ValueError(f"unsupported Lean return type for generated assertion: {ty!r}")
 
 
+def _storage_word_expr(lean_ty: str, value_expr: str) -> str:
+    ty = _normalize_type(lean_ty)
+    if ty in {"Uint256", "Uint8"}:
+        return f"bytes32(uint256({value_expr}))"
+    if ty == "Bool":
+        return f"bytes32(uint256({value_expr} ? 1 : 0))"
+    if ty == "Address":
+        return f"bytes32(uint256(uint160({value_expr})))"
+    if ty == "Bytes32":
+        return value_expr
+    raise ValueError(f"unsupported Lean type for generated storage write: {ty!r}")
+
+
+def _literal_expr(value: str, lean_ty: str) -> str | None:
+    ty = _normalize_type(lean_ty)
+    if ty in {"Uint256", "Uint8"} and re.fullmatch(r"(0x[0-9A-Fa-f]+|[0-9]+)", value):
+        return value
+    if ty == "Bool" and value in {"true", "false"}:
+        return value
+    if ty == "Bytes32" and re.fullmatch(r"(0x[0-9A-Fa-f]+|[0-9]+)", value):
+        return f"bytes32(uint256({value}))"
+    return None
+
+
+def _split_return_values(exprs_src: str) -> list[str]:
+    return [part.strip() for part in exprs_src.split(",") if part.strip()]
+
+
+def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx: int, encode_args: str) -> str | None:
+    fn_camel = _fn_camel(fn.name)
+    body = list(fn.body)
+    ty = _normalize_type(fn.return_type)
+    param_examples = {param.name: _example_value(param.lean_type) for param in fn.params}
+    decoded_type = _sol_type(fn.return_type)
+
+    if len(body) == 1:
+        literal_match = re.fullmatch(r"return\s+(.+)", body[0])
+        if literal_match:
+            literal_expr = _literal_expr(literal_match.group(1).strip(), ty)
+            if literal_expr is not None:
+                ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+                return f"""    // Property {idx}: {fn.name} returns the declared constant result
+    function testAuto_{fn_camel}_ReturnsDeclaredConstant() public {{
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature({encode_args}));
+        require(ok, \"{fn.name} reverted unexpectedly\");
+{ret_assert}
+        {decoded_type} actual = abi.decode(ret, ({decoded_type}));
+        assertEq(actual, {literal_expr}, \"{fn.name} should return the declared constant\");
+    }}
+"""
+        tuple_match = re.fullmatch(r"returnValues\s+\[(.+)\]", body[0])
+        if tuple_match and ty.startswith("Tuple [") and ty.endswith("]"):
+            elems = _parse_tuple_elements(ty[len("Tuple [") : -1])
+            exprs = _split_return_values(tuple_match.group(1))
+            if len(elems) != len(exprs):
+                return None
+            expected_exprs: list[str] = []
+            for elem_ty, expr in zip(elems, exprs):
+                if expr in param_examples:
+                    expected_exprs.append(param_examples[expr])
+                    continue
+                literal_expr = _literal_expr(expr, elem_ty)
+                if literal_expr is None:
+                    return None
+                expected_exprs.append(literal_expr)
+            typed_vars = ", ".join(f"{_sol_type(elem_ty)} actual{i}" for i, elem_ty in enumerate(elems))
+            raw_types = ", ".join(_sol_type(elem_ty) for elem_ty in elems)
+            assert_lines = "\n".join(
+                f'        assertEq(actual{i}, {expected_exprs[i]}, "{fn.name} tuple element {i} mismatch");'
+                for i in range(len(elems))
+            )
+            ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+            return f"""    // Property {idx}: {fn.name} decodes and matches the returned tuple elements
+    function testAuto_{fn_camel}_DecodesTupleResult() public {{
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature({encode_args}));
+        require(ok, \"{fn.name} reverted unexpectedly\");
+{ret_assert}
+        ({typed_vars}) = abi.decode(ret, ({raw_types}));
+{assert_lines}
+    }}
+"""
+
+    if len(body) == 2:
+        getter_match = re.fullmatch(
+            r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*(getStorage|getStorageAddr)\s+([A-Za-z_][A-Za-z0-9_]*)",
+            body[0],
+        )
+        if getter_match and body[1] == f"return {getter_match.group(1)}":
+            storage_name = getter_match.group(3)
+            slot = contract.storage_slots.get(storage_name)
+            if slot is None:
+                return None
+            ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+            return f"""    // Property {idx}: {fn.name} reads storage slot {slot} and decodes the result
+    function testAuto_{fn_camel}_ReadsConfiguredStorage() public {{
+        {decoded_type} expected = {_example_value(fn.return_type)};
+        vm.store(target, bytes32(uint256({slot})), {_storage_word_expr(fn.return_type, "expected")});
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature({encode_args}));
+        require(ok, \"{fn.name} reverted unexpectedly\");
+{ret_assert}
+        {decoded_type} actual = abi.decode(ret, ({decoded_type}));
+        assertEq(actual, expected, \"{fn.name} should return storage slot {slot}\");
+    }}
+"""
+
+    return None
+
+
 def render_contract_test(contract: ContractDecl) -> str:
     tests: list[str] = []
     need_uint_array_helper = False
@@ -324,8 +483,10 @@ def render_contract_test(contract: ContractDecl) -> str:
     }}
 """
         else:
-            ret_assert = _return_shape_assertion(fn.return_type, fn.name)
-            body = f"""    // Property {idx}: TODO decode and assert `{fn.name}` result
+            body = _render_inferred_non_unit_test(contract, fn, idx, encode_args)
+            if body is None:
+                ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+                body = f"""    // Property {idx}: TODO decode and assert `{fn.name}` result
     function testTODO_{fn_camel}_DecodeAndAssert() public {{
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature({encode_args}));

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -41,6 +41,7 @@ class ParseContractsTests(unittest.TestCase):
         self.assertEqual(sorted(parsed.keys()), ["Counter", "Owned"])
         self.assertEqual([f.name for f in parsed["Counter"].functions], ["increment", "getCount"])
         self.assertEqual(parsed["Counter"].functions[1].return_type, "Uint256")
+        self.assertEqual(parsed["Counter"].storage_slots, {"count": 0})
 
     def test_parse_params(self) -> None:
         out = gen._split_params("to : Address, amount : Uint256")
@@ -64,6 +65,26 @@ class ParseContractsTests(unittest.TestCase):
         self.assertEqual(
             [(p.name, p.lean_type) for p in owned.constructor.params],
             [("initialOwner", "Address")],
+        )
+
+    def test_parse_function_body_and_storage_slots(self) -> None:
+        src = textwrap.dedent(
+            """
+            verity_contract SimpleStorage where
+              storage
+                storedData : Uint256 := slot 0
+
+              function retrieve () : Uint256 := do
+                let current ← getStorage storedData
+                return current
+            """
+        )
+        parsed = gen.parse_contracts(src, Path("dummy.lean"))
+        contract = parsed["SimpleStorage"]
+        self.assertEqual(contract.storage_slots, {"storedData": 0})
+        self.assertEqual(
+            contract.functions[0].body,
+            ("let current ← getStorage storedData", "return current"),
         )
 
     def test_parse_contracts_ignores_guard_msgs_negative_fixtures(self) -> None:
@@ -100,6 +121,7 @@ class RenderTests(unittest.TestCase):
                 gen.FunctionDecl("touch", (), "Unit"),
                 gen.FunctionDecl("read", (gen.ParamDecl("who", "Address"),), "Uint256"),
             ),
+            storage_slots={},
         )
         rendered = gen.render_contract_test(contract)
         self.assertIn("function testAuto_Touch_NoUnexpectedRevert()", rendered)
@@ -122,6 +144,7 @@ class RenderTests(unittest.TestCase):
                     "Unit",
                 ),
             ),
+            storage_slots={},
         )
         rendered = gen.render_contract_test(contract)
         self.assertIn("_singletonUintArray", rendered)
@@ -139,6 +162,7 @@ class RenderTests(unittest.TestCase):
                     "Unit",
                 ),
             ),
+            storage_slots={},
         )
         rendered = gen.render_contract_test(contract)
         self.assertIn("_singletonBytes32Array", rendered)
@@ -155,6 +179,7 @@ class RenderTests(unittest.TestCase):
             functions=(
                 gen.FunctionDecl("mystery", (gen.ParamDecl("x", "String"),), "Unit"),
             ),
+            storage_slots={},
         )
         with self.assertRaisesRegex(ValueError, "unsupported Lean type"):
             gen.render_contract_test(contract)
@@ -167,6 +192,7 @@ class RenderTests(unittest.TestCase):
             functions=(
                 gen.FunctionDecl("consume", (gen.ParamDecl("values", "Array Address"),), "Unit"),
             ),
+            storage_slots={},
         )
         with self.assertRaisesRegex(ValueError, "unsupported Lean array element type"):
             gen.render_contract_test(contract)
@@ -177,6 +203,7 @@ class RenderTests(unittest.TestCase):
             constructor=None,
             source=gen.ROOT / "Contracts/Sample/Sample.lean",
             functions=(gen.FunctionDecl("blob", (), "Bytes"),),
+            storage_slots={},
         )
         rendered = gen.render_contract_test(contract)
         self.assertIn(
@@ -190,6 +217,7 @@ class RenderTests(unittest.TestCase):
             constructor=None,
             source=gen.ROOT / "Contracts/Sample/Sample.lean",
             functions=(gen.FunctionDecl("isReady", (), "Bool"),),
+            storage_slots={},
         )
         rendered = gen.render_contract_test(contract)
         self.assertIn(
@@ -203,8 +231,9 @@ class RenderTests(unittest.TestCase):
             constructor=None,
             source=gen.ROOT / "Contracts/Sample/Sample.lean",
             functions=(gen.FunctionDecl("mystery", (), "String"),),
+            storage_slots={},
         )
-        with self.assertRaisesRegex(ValueError, "unsupported Lean return type"):
+        with self.assertRaisesRegex(ValueError, "unsupported Lean type"):
             gen.render_contract_test(contract)
 
     def test_render_constructor_uses_deploy_with_args(self) -> None:
@@ -213,6 +242,7 @@ class RenderTests(unittest.TestCase):
             constructor=gen.ConstructorDecl(params=(gen.ParamDecl("initialOwner", "Address"),)),
             source=gen.ROOT / "Contracts/Sample/Sample.lean",
             functions=(gen.FunctionDecl("owner", (), "Address"),),
+            storage_slots={},
         )
         rendered = gen.render_contract_test(contract)
         self.assertIn('target = deployYulWithArgs("Owned", abi.encode(alice));', rendered)
@@ -230,6 +260,7 @@ class RenderTests(unittest.TestCase):
                     "Unit",
                 ),
             ),
+            storage_slots={},
         )
         rendered = gen.render_contract_test(contract)
         self.assertIn('"submit((address,address,uint256))"', rendered)
@@ -247,12 +278,67 @@ class RenderTests(unittest.TestCase):
                     "Tuple [Uint256, Uint256]",
                 ),
             ),
+            storage_slots={},
         )
         rendered = gen.render_contract_test(contract)
         self.assertIn(
             'require(ret.length >= 64, "getPair ABI tuple return payload unexpectedly short");',
             rendered,
         )
+
+    def test_render_storage_getter_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="SimpleStorage",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "retrieve",
+                    (),
+                    "Uint256",
+                    body=("let current ← getStorage storedData", "return current"),
+                ),
+            ),
+            storage_slots={"storedData": 0},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_Retrieve_ReadsConfiguredStorage()", rendered)
+        self.assertIn("vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));", rendered)
+        self.assertIn('assertEq(actual, expected, "retrieve should return storage slot 0");', rendered)
+
+    def test_render_constant_return_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="Uint8Smoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(gen.FunctionDecl("sigV", (), "Uint8", body=("return 27",)),),
+            storage_slots={},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_SigV_ReturnsDeclaredConstant()", rendered)
+        self.assertIn("uint8 actual = abi.decode(ret, (uint8));", rendered)
+        self.assertIn('assertEq(actual, 27, "sigV should return the declared constant");', rendered)
+
+    def test_render_tuple_return_values_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="TupleSmoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "getPair",
+                    (gen.ParamDecl("key", "Uint256"),),
+                    "Tuple [Uint256, Uint256]",
+                    body=("returnValues [key, key]",),
+                ),
+            ),
+            storage_slots={},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_GetPair_DecodesTupleResult()", rendered)
+        self.assertIn("(uint256 actual0, uint256 actual1) = abi.decode(ret, (uint256, uint256));", rendered)
+        self.assertIn('assertEq(actual0, uint256(1), "getPair tuple element 0 mismatch");', rendered)
+        self.assertIn('assertEq(actual1, uint256(1), "getPair tuple element 1 mismatch");', rendered)
 
     def test_parse_tuple_params(self) -> None:
         out = gen._split_params("cfg : Tuple [Address, Uint256], amount : Uint256")


### PR DESCRIPTION
## Summary
- teach `generate_macro_property_tests.py` to retain storage slot metadata and simple function bodies
- auto-generate concrete assertions for direct storage getters, constant returns, and simple `returnValues [...]` tuple returns
- regenerate macro property-test artifacts and cover the new inference paths with focused Python tests

## Why this change
There were no open PRs to review or merge, and the remaining open issues are all marked `deferred` with multi-week scopes. The highest-leverage shippable improvement in the current repo state was to remove placeholder macro property tests that decode nothing and assert nothing.

This is a narrow follow-up to the property-test generation work around #1011: instead of trying to synthesize full theorem-aware properties, it upgrades the safest cases from TODO stubs into executable assertions.

## Impact
This converts generated placeholder tests into real checks for:
- direct storage-backed getters like `retrieve`, `getCount`, `getOwner`, `totalSupply`, and `owner`
- literal-return functions like `sigV`
- simple tuple passthroughs like `getPair`

The harder mapping-backed and dynamic-return cases still fail closed as explicit TODO stubs.

## Validation
- `python3 -m pytest scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py`

`forge` is not installed in this environment, so I could not run a local Foundry compile/test pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test-generation tooling and regenerated test artifacts, with no impact on deployed contract/runtime logic.
> 
> **Overview**
> **Macro property-test generation now produces real assertions for simple non-`Unit` functions.** The generator parses `storage` slot metadata and retains minimal Lean function bodies, then auto-emits tests that `vm.store` expected values and `abi.decode`/assert results for direct storage getters, literal `return` constants, and simple `returnValues [...]` tuple returns.
> 
> Regenerates several `artifacts/macro_property_tests/*.t.sol` to replace placeholder `testTODO_*` cases (e.g., `getOwner`, `getCount`, `totalSupply`, `retrieve`, `sigV`, `getPair`) with executable checks, and expands Python unit coverage to validate the new parsing and inference paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12422a39615b90a678cb19d0f55299f1e8c5499e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->