### PR TITLE
fix: restore CompilationModel facade trust-surface import

### DIFF
--- a/Compiler/CompilationModel.lean
+++ b/Compiler/CompilationModel.lean
@@ -19,6 +19,7 @@ import Compiler.CompilationModel.LogicalPurity
 import Compiler.CompilationModel.MappingWrites
 import Compiler.CompilationModel.ScopeValidation
 import Compiler.CompilationModel.StorageWrites
+import Compiler.CompilationModel.TrustSurface
 import Compiler.CompilationModel.UsageAnalysis
 import Compiler.CompilationModel.ValidationCalls
 import Compiler.CompilationModel.ValidationEvents


### PR DESCRIPTION
## Summary
- restore the missing `Compiler.CompilationModel.TrustSurface` re-export from the `Compiler/CompilationModel.lean` facade
- unbreak `scripts/check_compilationmodel_split.py` on clean `main`
- keep the CompilationModel facade aligned with the current architectural split guard

## Verification
- `python3 scripts/check_compilationmodel_split.py`
- `python3 scripts/check_verify_sync.py`
- `python3 -m unittest scripts.test_check_compilationmodel_split -v`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single import is restored in the `Compiler.CompilationModel` facade to re-export `TrustSurface`, with no behavioral/runtime logic changes beyond module visibility/build wiring.
> 
> **Overview**
> Restores the missing `import Compiler.CompilationModel.TrustSurface` in the top-level `Compiler/CompilationModel.lean` facade so `TrustSurface` is re-exported again.
> 
> This fixes downstream usages/tools that rely on the facade’s complete submodule export set (e.g., split/architecture guard scripts) when building from a clean checkout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d72b210ec69a7009ad6901219a03c8eb376583. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->