### PR TITLE
tests: infer mapping-backed macro property assertions

### DIFF
--- a/artifacts/macro_property_tests/PropertyAddressHelpersSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyAddressHelpersSmoke.t.sol
@@ -23,14 +23,16 @@ contract PropertyAddressHelpersSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("setDelegate(address,address)", alice, alice));
         require(ok, "setDelegate reverted unexpectedly");
     }
-    // Property 2: TODO decode and assert `getDelegate` result
-    function testTODO_GetDelegate_DecodeAndAssert() public {
+    // Property 2: getDelegate reads the configured mapping value
+    function testAuto_GetDelegate_ReadsConfiguredMapping() public {
+        address expected = alice;
+        vm.store(target, _mappingSlot(bytes32(uint256(uint160(alice))), 0), bytes32(uint256(uint160(expected))));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getDelegate(address)", alice));
         require(ok, "getDelegate reverted unexpectedly");
         assertEq(ret.length, 32, "getDelegate ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, expected, "getDelegate should decode the configured mapping value");
     }
     // Property 3: clearDelegate has no unexpected revert
     function testAuto_ClearDelegate_NoUnexpectedRevert() public {
@@ -38,23 +40,25 @@ contract PropertyAddressHelpersSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("clearDelegate(address)", alice));
         require(ok, "clearDelegate reverted unexpectedly");
     }
-    // Property 4: TODO decode and assert `hasDelegate` result
-    function testTODO_HasDelegate_DecodeAndAssert() public {
+    // Property 4: hasDelegate returns true for a non-zero configured mapping address
+    function testAuto_HasDelegate_DetectsNonZeroMappingAddress() public {
+        vm.store(target, _mappingSlot(bytes32(uint256(uint160(alice))), 0), bytes32(uint256(uint160(address(0xBEEF)))));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("hasDelegate(address)", alice));
         require(ok, "hasDelegate reverted unexpectedly");
         assertEq(ret.length, 32, "hasDelegate ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        bool actual = abi.decode(ret, (bool));
+        assertTrue(actual, "hasDelegate should return true when the configured address is non-zero");
     }
-    // Property 5: TODO decode and assert `isDelegateZero` result
-    function testTODO_IsDelegateZero_DecodeAndAssert() public {
+    // Property 5: isDelegateZero returns true for a zero configured mapping address
+    function testAuto_IsDelegateZero_DetectsZeroMappingAddress() public {
+        vm.store(target, _mappingSlot(bytes32(uint256(uint160(alice))), 0), bytes32(0));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("isDelegateZero(address)", alice));
         require(ok, "isDelegateZero reverted unexpectedly");
         assertEq(ret.length, 32, "isDelegateZero ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        bool actual = abi.decode(ret, (bool));
+        assertTrue(actual, "isDelegateZero should return true when the configured address is zero");
     }
     // Property 6: setOwnerForId has no unexpected revert
     function testAuto_SetOwnerForId_NoUnexpectedRevert() public {
@@ -62,13 +66,15 @@ contract PropertyAddressHelpersSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("setOwnerForId(uint256,address)", uint256(1), alice));
         require(ok, "setOwnerForId reverted unexpectedly");
     }
-    // Property 7: TODO decode and assert `getOwnerForId` result
-    function testTODO_GetOwnerForId_DecodeAndAssert() public {
+    // Property 7: getOwnerForId reads the configured mapping value
+    function testAuto_GetOwnerForId_ReadsConfiguredMapping() public {
+        address expected = alice;
+        vm.store(target, _mappingSlot(bytes32(uint256(uint256(1))), 1), bytes32(uint256(uint160(expected))));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getOwnerForId(uint256)", uint256(1)));
         require(ok, "getOwnerForId reverted unexpectedly");
         assertEq(ret.length, 32, "getOwnerForId ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, expected, "getOwnerForId should decode the configured mapping value");
     }
 }

--- a/artifacts/macro_property_tests/PropertyERC20.t.sol
+++ b/artifacts/macro_property_tests/PropertyERC20.t.sol
@@ -41,23 +41,27 @@ contract PropertyERC20Test is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("transferFrom(address,address,uint256)", alice, alice, uint256(1)));
         require(ok, "transferFrom reverted unexpectedly");
     }
-    // Property 5: TODO decode and assert `balanceOf` result
-    function testTODO_BalanceOf_DecodeAndAssert() public {
+    // Property 5: balanceOf reads the configured mapping value
+    function testAuto_BalanceOf_ReadsConfiguredMapping() public {
+        uint256 expected = uint256(1);
+        vm.store(target, _mappingSlot(bytes32(uint256(uint160(alice))), 2), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("balanceOf(address)", alice));
         require(ok, "balanceOf reverted unexpectedly");
         assertEq(ret.length, 32, "balanceOf ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "balanceOf should decode the configured mapping value");
     }
-    // Property 6: TODO decode and assert `allowanceOf` result
-    function testTODO_AllowanceOf_DecodeAndAssert() public {
+    // Property 6: allowanceOf reads the configured mapping value
+    function testAuto_AllowanceOf_ReadsConfiguredMapping() public {
+        uint256 expected = uint256(1);
+        vm.store(target, _nestedMappingSlot(bytes32(uint256(uint160(alice))), bytes32(uint256(uint160(alice))), 3), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("allowanceOf(address,address)", alice, alice));
         require(ok, "allowanceOf reverted unexpectedly");
         assertEq(ret.length, 32, "allowanceOf ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "allowanceOf should decode the configured mapping value");
     }
     // Property 7: totalSupply reads storage slot 1 and decodes the result
     function testAuto_TotalSupply_ReadsConfiguredStorage() public {

--- a/artifacts/macro_property_tests/PropertyERC721.t.sol
+++ b/artifacts/macro_property_tests/PropertyERC721.t.sol
@@ -17,41 +17,50 @@ contract PropertyERC721Test is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: TODO decode and assert `balanceOf` result
-    function testTODO_BalanceOf_DecodeAndAssert() public {
+    // Property 1: balanceOf reads the configured mapping value
+    function testAuto_BalanceOf_ReadsConfiguredMapping() public {
+        uint256 expected = uint256(1);
+        vm.store(target, _mappingSlot(bytes32(uint256(uint160(alice))), 3), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("balanceOf(address)", alice));
         require(ok, "balanceOf reverted unexpectedly");
         assertEq(ret.length, 32, "balanceOf ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "balanceOf should decode the configured mapping value");
     }
-    // Property 2: TODO decode and assert `ownerOf` result
-    function testTODO_OwnerOf_DecodeAndAssert() public {
+    // Property 2: ownerOf decodes a non-zero configured owner word
+    function testAuto_OwnerOf_DecodesConfiguredOwnerWord() public {
+        address expected = address(0xBEEF);
+        vm.store(target, _mappingSlot(bytes32(uint256(uint256(1))), 4), bytes32(uint256(uint160(expected))));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("ownerOf(uint256)", uint256(1)));
         require(ok, "ownerOf reverted unexpectedly");
         assertEq(ret.length, 32, "ownerOf ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, expected, "ownerOf should decode the configured owner word");
     }
-    // Property 3: TODO decode and assert `getApproved` result
-    function testTODO_GetApproved_DecodeAndAssert() public {
+    // Property 3: getApproved decodes the configured secondary mapping value after the existence precondition
+    function testAuto_GetApproved_DecodesConfiguredSecondaryMapping() public {
+        address ownerWord = alice;
+        vm.store(target, _mappingSlot(bytes32(uint256(uint256(1))), 4), bytes32(uint256(uint160(ownerWord))));
+        address expected = alice;
+        vm.store(target, _mappingSlot(bytes32(uint256(uint256(1))), 5), bytes32(uint256(uint160(expected))));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getApproved(uint256)", uint256(1)));
         require(ok, "getApproved reverted unexpectedly");
         assertEq(ret.length, 32, "getApproved ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, expected, "getApproved should decode the configured secondary mapping value");
     }
-    // Property 4: TODO decode and assert `isApprovedForAll` result
-    function testTODO_IsApprovedForAll_DecodeAndAssert() public {
+    // Property 4: isApprovedForAll returns true for a non-zero configured mapping word
+    function testAuto_IsApprovedForAll_DetectsNonZeroMappingWord() public {
+        vm.store(target, _nestedMappingSlot(bytes32(uint256(uint160(alice))), bytes32(uint256(uint160(alice))), 6), bytes32(uint256(1)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("isApprovedForAll(address,address)", alice, alice));
         require(ok, "isApprovedForAll reverted unexpectedly");
         assertEq(ret.length, 32, "isApprovedForAll ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        bool actual = abi.decode(ret, (bool));
+        assertTrue(actual, "isApprovedForAll should return true when the configured word is non-zero");
     }
     // Property 5: approve has no unexpected revert
     function testAuto_Approve_NoUnexpectedRevert() public {

--- a/artifacts/macro_property_tests/PropertyLedger.t.sol
+++ b/artifacts/macro_property_tests/PropertyLedger.t.sol
@@ -35,13 +35,15 @@ contract PropertyLedgerTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("transfer(address,uint256)", alice, uint256(1)));
         require(ok, "transfer reverted unexpectedly");
     }
-    // Property 4: TODO decode and assert `getBalance` result
-    function testTODO_GetBalance_DecodeAndAssert() public {
+    // Property 4: getBalance reads the configured mapping value
+    function testAuto_GetBalance_ReadsConfiguredMapping() public {
+        uint256 expected = uint256(1);
+        vm.store(target, _mappingSlot(bytes32(uint256(uint160(alice))), 0), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getBalance(address)", alice));
         require(ok, "getBalance reverted unexpectedly");
         assertEq(ret.length, 32, "getBalance ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getBalance should decode the configured mapping value");
     }
 }

--- a/artifacts/macro_property_tests/PropertyMappingWordSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyMappingWordSmoke.t.sol
@@ -23,22 +23,25 @@ contract PropertyMappingWordSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("setWord1(uint256,uint256)", uint256(1), uint256(1)));
         require(ok, "setWord1 reverted unexpectedly");
     }
-    // Property 2: TODO decode and assert `getWord1` result
-    function testTODO_GetWord1_DecodeAndAssert() public {
+    // Property 2: getWord1 reads the configured mapping value
+    function testAuto_GetWord1_ReadsConfiguredMapping() public {
+        uint256 expected = uint256(1);
+        vm.store(target, _mappingWordSlot(bytes32(uint256(uint256(1))), 0, 1), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getWord1(uint256)", uint256(1)));
         require(ok, "getWord1 reverted unexpectedly");
         assertEq(ret.length, 32, "getWord1 ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getWord1 should decode the configured mapping value");
     }
-    // Property 3: TODO decode and assert `isWord1NonZero` result
-    function testTODO_IsWord1NonZero_DecodeAndAssert() public {
+    // Property 3: isWord1NonZero returns true for a non-zero configured mapping word
+    function testAuto_IsWord1NonZero_DetectsNonZeroMappingWord() public {
+        vm.store(target, _mappingWordSlot(bytes32(uint256(uint256(1))), 0, 1), bytes32(uint256(1)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("isWord1NonZero(uint256)", uint256(1)));
         require(ok, "isWord1NonZero reverted unexpectedly");
         assertEq(ret.length, 32, "isWord1NonZero ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        bool actual = abi.decode(ret, (bool));
+        assertTrue(actual, "isWord1NonZero should return true when the configured word is non-zero");
     }
 }

--- a/artifacts/macro_property_tests/PropertySimpleToken.t.sol
+++ b/artifacts/macro_property_tests/PropertySimpleToken.t.sol
@@ -29,14 +29,16 @@ contract PropertySimpleTokenTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("transfer(address,uint256)", alice, uint256(1)));
         require(ok, "transfer reverted unexpectedly");
     }
-    // Property 3: TODO decode and assert `balanceOf` result
-    function testTODO_BalanceOf_DecodeAndAssert() public {
+    // Property 3: balanceOf reads the configured mapping value
+    function testAuto_BalanceOf_ReadsConfiguredMapping() public {
+        uint256 expected = uint256(1);
+        vm.store(target, _mappingSlot(bytes32(uint256(uint160(alice))), 1), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("balanceOf(address)", alice));
         require(ok, "balanceOf reverted unexpectedly");
         assertEq(ret.length, 32, "balanceOf ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "balanceOf should decode the configured mapping value");
     }
     // Property 4: totalSupply reads storage slot 2 and decodes the result
     function testAuto_TotalSupply_ReadsConfiguredStorage() public {

--- a/artifacts/macro_property_tests/PropertyUintMapSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyUintMapSmoke.t.sol
@@ -23,13 +23,15 @@ contract PropertyUintMapSmokeTest is YulTestBase {
         (bool ok,) = target.call(abi.encodeWithSignature("setValue(uint256,uint256)", uint256(1), uint256(1)));
         require(ok, "setValue reverted unexpectedly");
     }
-    // Property 2: TODO decode and assert `getValue` result
-    function testTODO_GetValue_DecodeAndAssert() public {
+    // Property 2: getValue reads the configured mapping value
+    function testAuto_GetValue_ReadsConfiguredMapping() public {
+        uint256 expected = uint256(1);
+        vm.store(target, _mappingSlot(bytes32(uint256(uint256(1))), 0), bytes32(uint256(expected)));
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getValue(uint256)", uint256(1)));
         require(ok, "getValue reverted unexpectedly");
         assertEq(ret.length, 32, "getValue ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getValue should decode the configured mapping value");
     }
 }

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -28,6 +28,25 @@ PARAM_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$")
 STORAGE_RE = re.compile(
     r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*:=\s*slot\s+([0-9]+)\s*$",
 )
+STORAGE_READ_RE = re.compile(
+    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*(getStorage|getStorageAddr)\s+([A-Za-z_][A-Za-z0-9_]*)$"
+)
+MAPPING_READ_RE = re.compile(
+    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*"
+    r"(getMapping|getMappingUint|getMappingAddr|getMappingUintAddr)\s+"
+    r"([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)$"
+)
+MAPPING2_READ_RE = re.compile(
+    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*getMapping2\s+"
+    r"([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)$"
+)
+MAPPING_WORD_READ_RE = re.compile(
+    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*getMappingWord\s+"
+    r"([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)\s+([0-9]+)$"
+)
+NON_ZERO_REQUIRE_RE = re.compile(
+    r'require\s+\(([A-Za-z_][A-Za-z0-9_]*)\s*!=\s*0\)\s+"[^"]+"$'
+)
 
 
 @dataclass(frozen=True)
@@ -56,6 +75,15 @@ class ContractDecl:
     functions: tuple[FunctionDecl, ...]
     storage_slots: dict[str, int]
     source: Path
+
+
+@dataclass(frozen=True)
+class ReadAccessor:
+    var_name: str
+    accessor: str
+    storage_name: str
+    key_names: tuple[str, ...]
+    word_offset: int = 0
 
 
 def _normalize_type(type_src: str) -> str:
@@ -359,6 +387,118 @@ def _split_return_values(exprs_src: str) -> list[str]:
     return [part.strip() for part in exprs_src.split(",") if part.strip()]
 
 
+def _matches_return_expr(line: str, expr: str) -> bool:
+    return line in {f"return {expr}", f"return ({expr})"}
+
+
+def _parse_read_accessor(line: str) -> ReadAccessor | None:
+    storage_match = STORAGE_READ_RE.fullmatch(line)
+    if storage_match:
+        return ReadAccessor(
+            var_name=storage_match.group(1),
+            accessor=storage_match.group(2),
+            storage_name=storage_match.group(3),
+            key_names=(),
+        )
+
+    mapping_match = MAPPING_READ_RE.fullmatch(line)
+    if mapping_match:
+        return ReadAccessor(
+            var_name=mapping_match.group(1),
+            accessor=mapping_match.group(2),
+            storage_name=mapping_match.group(3),
+            key_names=(mapping_match.group(4),),
+        )
+
+    mapping2_match = MAPPING2_READ_RE.fullmatch(line)
+    if mapping2_match:
+        return ReadAccessor(
+            var_name=mapping2_match.group(1),
+            accessor="getMapping2",
+            storage_name=mapping2_match.group(2),
+            key_names=(mapping2_match.group(3), mapping2_match.group(4)),
+        )
+
+    mapping_word_match = MAPPING_WORD_READ_RE.fullmatch(line)
+    if mapping_word_match:
+        return ReadAccessor(
+            var_name=mapping_word_match.group(1),
+            accessor="getMappingWord",
+            storage_name=mapping_word_match.group(2),
+            key_names=(mapping_word_match.group(3),),
+            word_offset=int(mapping_word_match.group(4)),
+        )
+
+    return None
+
+
+def _mapping_key_expr(param: ParamDecl, value_expr: str) -> str:
+    ty = _normalize_type(param.lean_type)
+    if ty == "Address":
+        return f"bytes32(uint256(uint160({value_expr})))"
+    if ty in {"Uint256", "Uint8", "Bytes32"}:
+        return f"bytes32(uint256({value_expr}))"
+    raise ValueError(f"unsupported Lean key type for generated mapping setup: {ty!r}")
+
+
+def _mapping_slot_expr(
+    contract: ContractDecl,
+    fn: FunctionDecl,
+    read: ReadAccessor,
+    param_examples: dict[str, str],
+) -> str:
+    slot = contract.storage_slots.get(read.storage_name)
+    if slot is None:
+        raise ValueError(f"unknown storage slot '{read.storage_name}' on contract '{contract.name}'")
+
+    params = {param.name: param for param in fn.params}
+    key_exprs = []
+    for key_name in read.key_names:
+        param = params.get(key_name)
+        if param is None:
+            raise ValueError(f"unknown parameter '{key_name}' in function '{fn.name}'")
+        value_expr = param_examples.get(key_name)
+        if value_expr is None:
+            raise ValueError(f"missing example value for parameter '{key_name}' in function '{fn.name}'")
+        key_exprs.append(_mapping_key_expr(param, value_expr))
+
+    if read.accessor == "getMapping2":
+        return f"_nestedMappingSlot({key_exprs[0]}, {key_exprs[1]}, {slot})"
+    if read.accessor == "getMappingWord":
+        return f"_mappingWordSlot({key_exprs[0]}, {slot}, {read.word_offset})"
+    if read.accessor in {"getMapping", "getMappingUint", "getMappingAddr", "getMappingUintAddr"}:
+        return f"_mappingSlot({key_exprs[0]}, {slot})"
+    raise ValueError(f"unsupported accessor for mapping slot generation: {read.accessor!r}")
+
+
+def _render_decoded_assertion(
+    fn: FunctionDecl,
+    idx: int,
+    encode_args: str,
+    ret_assert: str,
+    decoded_type: str,
+    setup_lines: list[str],
+    actual_decode: str,
+    assert_lines: list[str],
+    summary: str,
+    suffix: str,
+) -> str:
+    setup = "\n".join(f"        {line}" for line in setup_lines)
+    asserts = "\n".join(f"        {line}" for line in assert_lines)
+    if setup:
+        setup += "\n"
+    return f"""    // Property {idx}: {summary}
+    function testAuto_{_fn_camel(fn.name)}_{suffix}() public {{
+{setup}        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature({encode_args}));
+        require(ok, \"{fn.name} reverted unexpectedly\");
+{ret_assert}
+        {actual_decode}
+{asserts}
+    }}
+"""
+
+
 def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx: int, encode_args: str) -> str | None:
     fn_camel = _fn_camel(fn.name)
     body = list(fn.body)
@@ -416,19 +556,17 @@ def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx
 """
 
     if len(body) == 2:
-        getter_match = re.fullmatch(
-            r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*(getStorage|getStorageAddr)\s+([A-Za-z_][A-Za-z0-9_]*)",
-            body[0],
-        )
-        if getter_match and body[1] == f"return {getter_match.group(1)}":
-            storage_name = getter_match.group(3)
-            slot = contract.storage_slots.get(storage_name)
-            if slot is None:
-                return None
+        read = _parse_read_accessor(body[0])
+        if read and body[1] == f"return {read.var_name}":
             ret_assert = _return_shape_assertion(fn.return_type, fn.name)
-            return f"""    // Property {idx}: {fn.name} reads storage slot {slot} and decodes the result
+            expected_expr = _example_value(fn.return_type)
+            if read.accessor in {"getStorage", "getStorageAddr"}:
+                slot = contract.storage_slots.get(read.storage_name)
+                if slot is None:
+                    return None
+                return f"""    // Property {idx}: {fn.name} reads storage slot {slot} and decodes the result
     function testAuto_{fn_camel}_ReadsConfiguredStorage() public {{
-        {decoded_type} expected = {_example_value(fn.return_type)};
+        {decoded_type} expected = {expected_expr};
         vm.store(target, bytes32(uint256({slot})), {_storage_word_expr(fn.return_type, "expected")});
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature({encode_args}));
@@ -438,6 +576,135 @@ def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx
         assertEq(actual, expected, \"{fn.name} should return storage slot {slot}\");
     }}
 """
+            if read.accessor in {"getMapping", "getMappingUint", "getMappingAddr", "getMappingUintAddr", "getMapping2", "getMappingWord"}:
+                slot_expr = _mapping_slot_expr(contract, fn, read, param_examples)
+                return _render_decoded_assertion(
+                    fn,
+                    idx,
+                    encode_args,
+                    ret_assert,
+                    decoded_type,
+                    [
+                        f"{decoded_type} expected = {expected_expr};",
+                        f"vm.store(target, {slot_expr}, {_storage_word_expr(fn.return_type, 'expected')});",
+                    ],
+                    f"{decoded_type} actual = abi.decode(ret, ({decoded_type}));",
+                    [f'assertEq(actual, expected, "{fn.name} should decode the configured mapping value");'],
+                    f"{fn.name} reads the configured mapping value",
+                    "ReadsConfiguredMapping",
+                )
+
+        if read and ty == "Bool":
+            ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+            slot_expr = _mapping_slot_expr(contract, fn, read, param_examples)
+            if _matches_return_expr(body[1], f"{read.var_name} != 0"):
+                return _render_decoded_assertion(
+                    fn,
+                    idx,
+                    encode_args,
+                    ret_assert,
+                    decoded_type,
+                    [
+                        f"vm.store(target, {slot_expr}, bytes32(uint256(1)));",
+                    ],
+                    f"{decoded_type} actual = abi.decode(ret, ({decoded_type}));",
+                    [f'assertTrue(actual, "{fn.name} should return true when the configured word is non-zero");'],
+                    f"{fn.name} returns true for a non-zero configured mapping word",
+                    "DetectsNonZeroMappingWord",
+                )
+            if _matches_return_expr(body[1], f"{read.var_name} != zeroAddress"):
+                return _render_decoded_assertion(
+                    fn,
+                    idx,
+                    encode_args,
+                    ret_assert,
+                    decoded_type,
+                    [
+                        f"vm.store(target, {slot_expr}, bytes32(uint256(uint160(address(0xBEEF)))));",
+                    ],
+                    f"{decoded_type} actual = abi.decode(ret, ({decoded_type}));",
+                    [f'assertTrue(actual, "{fn.name} should return true when the configured address is non-zero");'],
+                    f"{fn.name} returns true for a non-zero configured mapping address",
+                    "DetectsNonZeroMappingAddress",
+                )
+            if body[1] == f"return isZeroAddress {read.var_name}":
+                return _render_decoded_assertion(
+                    fn,
+                    idx,
+                    encode_args,
+                    ret_assert,
+                    decoded_type,
+                    [
+                        f"vm.store(target, {slot_expr}, bytes32(0));",
+                    ],
+                    f"{decoded_type} actual = abi.decode(ret, ({decoded_type}));",
+                    [f'assertTrue(actual, "{fn.name} should return true when the configured address is zero");'],
+                    f"{fn.name} returns true for a zero configured mapping address",
+                    "DetectsZeroMappingAddress",
+                )
+
+    if len(body) == 3:
+        read = _parse_read_accessor(body[0])
+        require_match = NON_ZERO_REQUIRE_RE.fullmatch(body[1])
+        if (
+            read
+            and read.accessor == "getMappingUint"
+            and require_match
+            and require_match.group(1) == read.var_name
+            and body[2] == f"return wordToAddress {read.var_name}"
+            and ty == "Address"
+        ):
+            ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+            slot_expr = _mapping_slot_expr(contract, fn, read, param_examples)
+            return _render_decoded_assertion(
+                fn,
+                idx,
+                encode_args,
+                ret_assert,
+                decoded_type,
+                [
+                    f"{decoded_type} expected = address(0xBEEF);",
+                    f"vm.store(target, {slot_expr}, bytes32(uint256(uint160(expected))));",
+                ],
+                f"{decoded_type} actual = abi.decode(ret, ({decoded_type}));",
+                [f'assertEq(actual, expected, "{fn.name} should decode the configured owner word");'],
+                f"{fn.name} decodes a non-zero configured owner word",
+                "DecodesConfiguredOwnerWord",
+            )
+
+    if len(body) == 4:
+        precondition_read = _parse_read_accessor(body[0])
+        require_match = NON_ZERO_REQUIRE_RE.fullmatch(body[1])
+        result_read = _parse_read_accessor(body[2])
+        if (
+            precondition_read
+            and result_read
+            and precondition_read.accessor == "getMappingUint"
+            and require_match
+            and require_match.group(1) == precondition_read.var_name
+            and body[3] == f"return {result_read.var_name}"
+        ):
+            ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+            owner_slot_expr = _mapping_slot_expr(contract, fn, precondition_read, param_examples)
+            result_slot_expr = _mapping_slot_expr(contract, fn, result_read, param_examples)
+            expected_expr = _example_value(fn.return_type)
+            return _render_decoded_assertion(
+                fn,
+                idx,
+                encode_args,
+                ret_assert,
+                decoded_type,
+                [
+                    "address ownerWord = alice;",
+                    f"vm.store(target, {owner_slot_expr}, bytes32(uint256(uint160(ownerWord))));",
+                    f"{decoded_type} expected = {expected_expr};",
+                    f"vm.store(target, {result_slot_expr}, {_storage_word_expr(fn.return_type, 'expected')});",
+                ],
+                f"{decoded_type} actual = abi.decode(ret, ({decoded_type}));",
+                [f'assertEq(actual, expected, "{fn.name} should decode the configured secondary mapping value");'],
+                f"{fn.name} decodes the configured secondary mapping value after the existence precondition",
+                "DecodesConfiguredSecondaryMapping",
+            )
 
     return None
 

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -340,6 +340,131 @@ class RenderTests(unittest.TestCase):
         self.assertIn('assertEq(actual0, uint256(1), "getPair tuple element 0 mismatch");', rendered)
         self.assertIn('assertEq(actual1, uint256(1), "getPair tuple element 1 mismatch");', rendered)
 
+    def test_render_mapping_getter_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="UintMapSmoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "getValue",
+                    (gen.ParamDecl("key", "Uint256"),),
+                    "Uint256",
+                    body=("let current ← getMappingUint values key", "return current"),
+                ),
+            ),
+            storage_slots={"values": 0},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_GetValue_ReadsConfiguredMapping()", rendered)
+        self.assertIn("vm.store(target, _mappingSlot(bytes32(uint256(uint256(1))), 0), bytes32(uint256(expected)));", rendered)
+        self.assertIn('assertEq(actual, expected, "getValue should decode the configured mapping value");', rendered)
+
+    def test_render_mapping_predicate_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="MappingWordSmoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "isWord1NonZero",
+                    (gen.ParamDecl("key", "Uint256"),),
+                    "Bool",
+                    body=("let word ← getMappingWord words key 1", "return (word != 0)"),
+                ),
+            ),
+            storage_slots={"words": 0},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_IsWord1NonZero_DetectsNonZeroMappingWord()", rendered)
+        self.assertIn("vm.store(target, _mappingWordSlot(bytes32(uint256(uint256(1))), 0, 1), bytes32(uint256(1)));", rendered)
+        self.assertIn(
+            'assertTrue(actual, "isWord1NonZero should return true when the configured word is non-zero");',
+            rendered,
+        )
+
+    def test_render_nested_mapping_predicate_without_parentheses_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="ERC721",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "isApprovedForAll",
+                    (
+                        gen.ParamDecl("ownerAddr", "Address"),
+                        gen.ParamDecl("operator", "Address"),
+                    ),
+                    "Bool",
+                    body=("let flag ← getMapping2 operatorApprovals ownerAddr operator", "return flag != 0"),
+                ),
+            ),
+            storage_slots={"operatorApprovals": 6},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_IsApprovedForAll_DetectsNonZeroMappingWord()", rendered)
+        self.assertIn(
+            "vm.store(target, _nestedMappingSlot(bytes32(uint256(uint160(alice))), bytes32(uint256(uint160(alice))), 6), bytes32(uint256(1)));",
+            rendered,
+        )
+        self.assertIn(
+            'assertTrue(actual, "isApprovedForAll should return true when the configured word is non-zero");',
+            rendered,
+        )
+
+    def test_render_word_to_address_mapping_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="ERC721",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "ownerOf",
+                    (gen.ParamDecl("tokenId", "Uint256"),),
+                    "Address",
+                    body=(
+                        "let ownerWord ← getMappingUint owners tokenId",
+                        'require (ownerWord != 0) "Token does not exist"',
+                        "return wordToAddress ownerWord",
+                    ),
+                ),
+            ),
+            storage_slots={"owners": 4},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_OwnerOf_DecodesConfiguredOwnerWord()", rendered)
+        self.assertIn("vm.store(target, _mappingSlot(bytes32(uint256(uint256(1))), 4), bytes32(uint256(uint160(expected))));", rendered)
+        self.assertIn('assertEq(actual, expected, "ownerOf should decode the configured owner word");', rendered)
+
+    def test_render_secondary_mapping_after_precondition_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="ERC721",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "getApproved",
+                    (gen.ParamDecl("tokenId", "Uint256"),),
+                    "Address",
+                    body=(
+                        "let ownerWord ← getMappingUint owners tokenId",
+                        'require (ownerWord != 0) "Token does not exist"',
+                        "let approvedAddr ← getMappingUintAddr tokenApprovals tokenId",
+                        "return approvedAddr",
+                    ),
+                ),
+            ),
+            storage_slots={"owners": 4, "tokenApprovals": 5},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_GetApproved_DecodesConfiguredSecondaryMapping()", rendered)
+        self.assertIn("vm.store(target, _mappingSlot(bytes32(uint256(uint256(1))), 4), bytes32(uint256(uint160(ownerWord))));", rendered)
+        self.assertIn("vm.store(target, _mappingSlot(bytes32(uint256(uint256(1))), 5), bytes32(uint256(uint160(expected))));", rendered)
+        self.assertIn(
+            'assertEq(actual, expected, "getApproved should decode the configured secondary mapping value");',
+            rendered,
+        )
+
     def test_parse_tuple_params(self) -> None:
         out = gen._split_params("cfg : Tuple [Address, Uint256], amount : Uint256")
         self.assertEqual(

--- a/test/yul/YulTestBase.sol
+++ b/test/yul/YulTestBase.sol
@@ -103,4 +103,17 @@ abstract contract YulTestBase is Test {
     function readStorageAddr(address target, uint256 slot) internal view returns (address) {
         return address(uint160(uint256(vm.load(target, bytes32(slot)))));
     }
+
+    function _mappingSlot(bytes32 key, uint256 baseSlot) internal pure returns (bytes32) {
+        return keccak256(abi.encode(key, baseSlot));
+    }
+
+    function _nestedMappingSlot(bytes32 key0, bytes32 key1, uint256 baseSlot) internal pure returns (bytes32) {
+        bytes32 outer = _mappingSlot(key0, baseSlot);
+        return keccak256(abi.encode(key1, outer));
+    }
+
+    function _mappingWordSlot(bytes32 key, uint256 baseSlot, uint256 wordOffset) internal pure returns (bytes32) {
+        return bytes32(uint256(_mappingSlot(key, baseSlot)) + wordOffset);
+    }
 }


### PR DESCRIPTION
## Summary
- teach `generate_macro_property_tests.py` to infer concrete assertions for simple mapping-backed readers, mapping-word predicates, and guarded `wordToAddress`/secondary mapping reads
- add shared mapping slot helpers in `test/yul/YulTestBase.sol` so generated tests can seed mapping storage directly
- refresh the generated macro property artifacts, reducing manual `testTODO_...` stubs from 25 on `main` to 10

## Verification
- `python3 -m unittest scripts.test_generate_macro_property_tests -v`
- `pytest scripts -q`
- `python3 scripts/check_macro_property_test_generation.py --check`

## Notes
- `forge` is not installed in this environment, so I could not run a Foundry compile/test pass here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches test-generation logic and updates many generated property-test artifacts; incorrect inference or slot computation could yield flaky/incorrect tests, but no production/runtime code is affected.
> 
> **Overview**
> **Macro property-test generation now infers concrete assertions for common mapping-backed readers/predicates.** `generate_macro_property_tests.py` recognizes simple `getMapping*`/`getMapping2`/`getMappingWord` read patterns (plus `!= 0`/`!= zeroAddress`/`isZeroAddress` predicates) and guarded `wordToAddress` / secondary mapping reads, and emits tests that seed storage via `vm.store`, decode `ret`, and assert expected values.
> 
> Adds mapping slot helpers (`_mappingSlot`, `_nestedMappingSlot`, `_mappingWordSlot`) to `YulTestBase.sol`, expands unit coverage for the new inference paths, and refreshes generated `artifacts/macro_property_tests/*` to replace several `testTODO_*` stubs with asserted mapping-based tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b35b8c628aa8068a18fdba870daad7e1ab195e2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->