### PR TITLE
tests: cover ABI-level string smoke surface

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -245,6 +245,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.Bytes32Smoke.spec
   , Contracts.Smoke.MappingWordSmoke.spec
   , Contracts.Smoke.StorageWordsSmoke.spec
+  , Contracts.Smoke.StringSmoke.spec
   , Contracts.Smoke.TupleSmoke.spec
   , Contracts.Smoke.Uint8Smoke.spec
   , Contracts.Smoke.AddressHelpersSmoke.spec
@@ -279,6 +280,7 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("Bytes32Smoke", ["setDigest(bytes32)", "getDigest()"])
   , ("MappingWordSmoke", ["setWord1(uint256,uint256)", "getWord1(uint256)", "isWord1NonZero(uint256)"])
   , ("StorageWordsSmoke", ["extSloadsLike(bytes32[])"])
+  , ("StringSmoke", ["echoString(string)"])
   , ("TupleSmoke", ["setFromPair((uint256,uint256))", "getPair(uint256)", "processConfig((address,address,uint256))"])
   , ("Uint8Smoke", ["acceptSig((uint8,bytes32,bytes32))", "sigV()"])
   , ("AddressHelpersSmoke", ["setDelegate(address,address)", "getDelegate(address)", "clearDelegate(address)",
@@ -306,6 +308,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("Bytes32Smoke", ["0xed9fdc05", "0xae0d3e27"])
   , ("MappingWordSmoke", ["0x60ab11c4", "0x8f8a322f", "0xea3aded7"])
   , ("StorageWordsSmoke", ["0x764fa434"])
+  , ("StringSmoke", ["0x0d7e2fce"])
   , ("TupleSmoke", ["0x712ea680", "0xbdf391cc", "0x01b427d2"])
   , ("Uint8Smoke", ["0xc233eaa7", "0x62fc458b"])
   , ("AddressHelpersSmoke", ["0x5c873849", "0x544d8564", "0xcc21cc2a", "0x480005cd", "0x67129177",

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -69,6 +69,18 @@ verity_contract StringSmoke where
   function echoString (message : String) : String := do
     returnBytes message
 
+/--
+error: storage field cannot be String; use Uint256 encoding
+-/
+#guard_msgs in
+verity_contract StringStorageUnsupported where
+  storage
+    label : String := slot 0
+
+  function echoString () : Unit := do
+    pure ()
+end StringStorageUnsupported
+
 verity_contract TupleSmoke where
   storage
     values : Uint256 → Uint256 := slot 0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,6 +92,10 @@ Recent progress for custom errors (`#586`):
 Recent progress for ABI JSON artifact generation (`#688`):
 - `verity-compiler --abi-output <dir>` emits one `<Contract>.abi.json` file per compiled CompilationModel in the supported compilation path.
 
+Recent progress for ABI-level string support (`#1159`):
+- `ParamType.string` now compiles through the existing dynamic-bytes ABI path for macro parsing/lowering, calldata loading, ABI JSON/signature rendering, `Stmt.returnBytes`, event emission, and custom errors.
+- This support is intentionally ABI-only for now: Solidity-style string storage/layout and typed-IR string lowering remain unsupported and should continue to fail fast with explicit diagnostics.
+
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.
 2. Error text must suggest the nearest currently-supported pattern.


### PR DESCRIPTION
## Summary
- add `StringSmoke` to the pinned macro-translation snapshot suite so selector and ABI coverage includes the new ABI-level string surface
- add a `#guard_msgs` regression that keeps `String` storage declarations fail-fast in the macro path
- document the new ABI-only `string` support boundary in the roadmap

## Why
PR #1406 merged ABI-level `string` support, but one important regression net was still missing: the macro invariant suite did not include `StringSmoke`, so selector snapshots, ABI snapshots, and randomized IR↔Yul checks were not covering that newly supported surface.

At the same time, the repo docs did not clearly state that this support is intentionally ABI-only for now, with string storage/layout still unsupported. This PR closes both gaps without expanding scope.

## Validation
- `lake build Contracts.Smoke Contracts.MacroTranslateInvariantTest`

Advances #1159.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to smoke-test coverage, pinned selector/signature snapshots, and documentation, with no production compiler/runtime logic modified.
> 
> **Overview**
> Adds `StringSmoke` to the pinned macro-translation invariant suite, including expected ABI signatures and function selector snapshots for `echoString(string)`.
> 
> Introduces a `#guard_msgs` regression test ensuring `verity_contract` still fails fast when a storage field is declared as `String`, and updates `docs/ROADMAP.md` to clarify that current `string` support is **ABI-only** (storage/layout and typed-IR lowering remain unsupported).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cec6dbc504bee9891865e302499759e114444912. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->