### PR TITLE
compiler: report keccak trust boundary

### DIFF
--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -59,6 +59,58 @@ private partial def collectLowLevelExprMechanics : Expr → List String
   | _ =>
       []
 
+private partial def collectAxiomatizedExprPrimitives : Expr → List String
+  | .keccak256 offset size =>
+      ["keccak256"] ++ collectAxiomatizedExprPrimitives offset ++ collectAxiomatizedExprPrimitives size
+  | .call gas target value inOffset inSize outOffset outSize =>
+      collectAxiomatizedExprPrimitives gas ++ collectAxiomatizedExprPrimitives target ++
+        collectAxiomatizedExprPrimitives value ++ collectAxiomatizedExprPrimitives inOffset ++
+        collectAxiomatizedExprPrimitives inSize ++ collectAxiomatizedExprPrimitives outOffset ++
+        collectAxiomatizedExprPrimitives outSize
+  | .staticcall gas target inOffset inSize outOffset outSize =>
+      collectAxiomatizedExprPrimitives gas ++ collectAxiomatizedExprPrimitives target ++
+        collectAxiomatizedExprPrimitives inOffset ++ collectAxiomatizedExprPrimitives inSize ++
+        collectAxiomatizedExprPrimitives outOffset ++ collectAxiomatizedExprPrimitives outSize
+  | .delegatecall gas target inOffset inSize outOffset outSize =>
+      collectAxiomatizedExprPrimitives gas ++ collectAxiomatizedExprPrimitives target ++
+        collectAxiomatizedExprPrimitives inOffset ++ collectAxiomatizedExprPrimitives inSize ++
+        collectAxiomatizedExprPrimitives outOffset ++ collectAxiomatizedExprPrimitives outSize
+  | .returndataOptionalBoolAt outOffset
+  | .mload outOffset
+  | .calldataload outOffset
+  | .extcodesize outOffset =>
+      collectAxiomatizedExprPrimitives outOffset
+  | .mapping _ key
+  | .mappingWord _ key _
+  | .mappingPackedWord _ key _ _
+  | .structMember _ key _ =>
+      collectAxiomatizedExprPrimitives key
+  | .mapping2 _ key1 key2
+  | .mapping2Word _ key1 key2 _
+  | .structMember2 _ key1 key2 _ =>
+      collectAxiomatizedExprPrimitives key1 ++ collectAxiomatizedExprPrimitives key2
+  | .mappingUint _ key
+  | .arrayElement _ key =>
+      collectAxiomatizedExprPrimitives key
+  | .externalCall _ args
+  | .internalCall _ args =>
+      args.flatMap collectAxiomatizedExprPrimitives
+  | .add a b | .sub a b | .mul a b | .div a b | .mod a b
+  | .bitAnd a b | .bitOr a b | .bitXor a b | .shl a b | .shr a b
+  | .eq a b | .gt a b | .lt a b | .ge a b | .le a b
+  | .logicalAnd a b | .logicalOr a b
+  | .wMulDown a b | .wDivUp a b | .min a b | .max a b =>
+      collectAxiomatizedExprPrimitives a ++ collectAxiomatizedExprPrimitives b
+  | .mulDivDown a b c | .mulDivUp a b c =>
+      collectAxiomatizedExprPrimitives a ++ collectAxiomatizedExprPrimitives b ++ collectAxiomatizedExprPrimitives c
+  | .bitNot a | .logicalNot a =>
+      collectAxiomatizedExprPrimitives a
+  | .ite cond thenVal elseVal =>
+      collectAxiomatizedExprPrimitives cond ++ collectAxiomatizedExprPrimitives thenVal ++
+        collectAxiomatizedExprPrimitives elseVal
+  | _ =>
+      []
+
 private partial def collectLowLevelStmtMechanics : Stmt → List String
   | .letVar _ value
   | .assignVar _ value
@@ -108,6 +160,57 @@ private partial def collectLowLevelStmtMechanics : Stmt → List String
   | .stop =>
       []
 
+private partial def collectAxiomatizedStmtPrimitives : Stmt → List String
+  | .letVar _ value
+  | .assignVar _ value
+  | .setStorage _ value
+  | .setStorageAddr _ value
+  | .return value
+  | .require value _ =>
+      collectAxiomatizedExprPrimitives value
+  | .requireError cond _ args =>
+      collectAxiomatizedExprPrimitives cond ++ args.flatMap collectAxiomatizedExprPrimitives
+  | .revertError _ args =>
+      args.flatMap collectAxiomatizedExprPrimitives
+  | .mstore offset value =>
+      collectAxiomatizedExprPrimitives offset ++ collectAxiomatizedExprPrimitives value
+  | .calldatacopy destOffset sourceOffset size
+  | .returndataCopy destOffset sourceOffset size =>
+      collectAxiomatizedExprPrimitives destOffset ++ collectAxiomatizedExprPrimitives sourceOffset ++
+        collectAxiomatizedExprPrimitives size
+  | .setMapping _ key value
+  | .setMappingWord _ key _ value
+  | .setMappingPackedWord _ key _ _ value
+  | .setMappingUint _ key value
+  | .setStructMember _ key _ value =>
+      collectAxiomatizedExprPrimitives key ++ collectAxiomatizedExprPrimitives value
+  | .setMapping2 _ key1 key2 value
+  | .setMapping2Word _ key1 key2 _ value
+  | .setStructMember2 _ key1 key2 _ value =>
+      collectAxiomatizedExprPrimitives key1 ++ collectAxiomatizedExprPrimitives key2 ++
+        collectAxiomatizedExprPrimitives value
+  | .ite cond thenBr elseBr =>
+      collectAxiomatizedExprPrimitives cond ++ thenBr.flatMap collectAxiomatizedStmtPrimitives ++
+        elseBr.flatMap collectAxiomatizedStmtPrimitives
+  | .forEach _ count body =>
+      collectAxiomatizedExprPrimitives count ++ body.flatMap collectAxiomatizedStmtPrimitives
+  | .emit _ args
+  | .internalCall _ args
+  | .externalCallBind _ _ args
+  | .returnValues args
+  | .ecm _ args
+  | .internalCallAssign _ _ args =>
+      args.flatMap collectAxiomatizedExprPrimitives
+  | .rawLog topics dataOffset dataSize =>
+      topics.flatMap collectAxiomatizedExprPrimitives ++ collectAxiomatizedExprPrimitives dataOffset ++
+        collectAxiomatizedExprPrimitives dataSize
+  | .returnArray _
+  | .returnBytes _
+  | .returnStorageWords _
+  | .revertReturndata
+  | .stop =>
+      []
+
 /-- Collect unique low-level call and returndata mechanics used by a spec. -/
 def collectLowLevelMechanics (spec : CompilationModel) : List String :=
   let stmtsFromFn (fn : FunctionSpec) := fn.body
@@ -116,6 +219,15 @@ def collectLowLevelMechanics (spec : CompilationModel) : List String :=
     | none => []
   let allStmts := stmtsFromCtor ++ spec.functions.flatMap stmtsFromFn
   dedupPreserve (allStmts.flatMap collectLowLevelStmtMechanics)
+
+/-- Collect unique axiomatized primitives used directly by a spec. -/
+def collectAxiomatizedPrimitives (spec : CompilationModel) : List String :=
+  let stmtsFromFn (fn : FunctionSpec) := fn.body
+  let stmtsFromCtor : List Stmt := match spec.constructor with
+    | some ctor => ctor.body
+    | none => []
+  let allStmts := stmtsFromCtor ++ spec.functions.flatMap stmtsFromFn
+  dedupPreserve (allStmts.flatMap collectAxiomatizedStmtPrimitives)
 
 private partial def collectExternalExprNames : Expr → List String
   | .externalCall name args =>
@@ -276,6 +388,7 @@ where
     jsonObject [
       ("contract", jsonString spec.name),
       ("modeledLowLevelMechanics", jsonArray ((collectLowLevelMechanics spec).map jsonString)),
+      ("axiomatizedPrimitives", jsonArray ((collectAxiomatizedPrimitives spec).map jsonString)),
       ("proofBoundary", jsonObject [
         ("compilerModelsMechanics", "true"),
         ("proofInterpretersModelMechanics", "false"),

--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -154,6 +154,17 @@ def compileSpecsWithOptions
       IO.println "  (no first-class low-level call or returndata primitives used)"
     IO.println "  Proof boundary: mechanics are lowered natively by the compiler; current proof interpreters do not model these primitives, and callee behavior remains assumption-backed unless discharged separately."
     IO.println ""
+    IO.println "Axiomatized primitive report:"
+    let mut anyAxiomatized := false
+    for spec in specs do
+      let primitives := collectAxiomatizedPrimitives spec
+      if !primitives.isEmpty then
+        anyAxiomatized := true
+        IO.println s!"  {spec.name}: {String.intercalate ", " primitives}"
+    if !anyAxiomatized then
+      IO.println "  (no axiomatized primitives used)"
+    IO.println "  Proof boundary: these primitives compile through explicit trusted boundaries (for example, keccak-backed hashing) and should be audited alongside AXIOMS.md/TRUST_ASSUMPTIONS.md."
+    IO.println ""
     IO.println "External assumption report:"
     let mut anyExternalAssumptions := false
     for spec in specs do

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -145,6 +145,7 @@ private def trustSurfaceSpec : CompilationModel := {
             (Expr.literal 32)),
         Stmt.letVar "rd" Expr.returndataSize,
         Stmt.returndataCopy (Expr.literal 0) (Expr.literal 0) (Expr.localVar "rd"),
+        Stmt.letVar "digest" (Expr.keccak256 (Expr.literal 0) (Expr.literal 64)),
         Stmt.letVar "hash" (Expr.externalCall "PoseidonT3_hash" [Expr.literal 1, Expr.literal 2]),
         Stmt.ecm
           { name := "testCall"
@@ -155,7 +156,7 @@ private def trustSurfaceSpec : CompilationModel := {
             axioms := ["test_call_interface"]
             compile := fun _ _ => pure [] }
           [Expr.localVar "hash"],
-        Stmt.setStorage "value" (Expr.localVar "ok"),
+        Stmt.setStorage "value" (Expr.add (Expr.localVar "ok") (Expr.localVar "digest")),
         Stmt.stop
       ]
     }
@@ -306,13 +307,15 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ trust report emits contract name")
   if !contains trustReport "\"modeledLowLevelMechanics\":[\"staticcall\",\"returndataSize\",\"returndataCopy\"]" then
     throw (IO.userError "✗ trust report emits low-level mechanics")
+  if !contains trustReport "\"axiomatizedPrimitives\":[\"keccak256\"]" then
+    throw (IO.userError "✗ trust report emits axiomatized primitives")
   if !contains trustReport "\"name\":\"PoseidonT3_hash\"" then
     throw (IO.userError "✗ trust report emits linked external name")
   if !contains trustReport "\"axioms\":[\"poseidon_t3_deterministic\"]" then
     throw (IO.userError "✗ trust report emits linked external axioms")
   if !contains trustReport "\"module\":\"testCall\"" || !contains trustReport "\"assumption\":\"test_call_interface\"" then
     throw (IO.userError "✗ trust report emits ECM axioms")
-  IO.println "✓ trust report emits low-level mechanics and external assumptions"
+  IO.println "✓ trust report emits low-level mechanics, axiomatized primitives, and external assumptions"
 
   compileSpecsWithOptions [abiSmokeSpec] outDir false [] {} none (some trustReportPath) none
   let writtenTrustReport ← fileExists trustReportPath

--- a/docs/EXTERNAL_CALL_MODULES.md
+++ b/docs/EXTERNAL_CALL_MODULES.md
@@ -177,6 +177,7 @@ modules to use is choosing which trust assumptions to accept.
 For machine-readable audit trails, `verity-compiler --trust-report <path>` now
 emits per-contract JSON that includes:
 - first-class low-level call / returndata mechanics used by the spec
+- axiomatized primitives used directly by the spec (for example `keccak256`)
 - linked external assumptions (`spec.externals`)
 - ECM assumption entries (`module`, `assumption`)
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -135,7 +135,7 @@ Diagnostics policy for unsupported constructs:
 1. Report the exact unsupported construct at compile time.
 2. Suggest the nearest supported migration pattern.
 3. Link to the owning tracking issue.
-4. When low-level mechanics or external assumptions are in play, emit a machine-readable trust report via `verity-compiler --trust-report <path>`.
+4. When low-level mechanics, axiomatized primitives (for example `keccak256`), or external assumptions are in play, emit a machine-readable trust report via `verity-compiler --trust-report <path>`.
 
 ## Trust Assumptions
 


### PR DESCRIPTION
Advances #1416

## Summary
- report direct `keccak256` usage explicitly in the machine-readable trust surface as `axiomatizedPrimitives`
- surface the same boundary in verbose compiler output so hash assumptions are visible during normal audits
- document the new trust-report coverage in the verification/module docs

## Why
`Expr.keccak256` is already available as a first-class primitive, but the trust report only exposed low-level mechanics and external/module assumptions. That left a gap for auditing the hash trust boundary tracked in #1416.

## Validation
- `lake build Compiler.CompileDriverTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `axiomatizedPrimitives` field to the machine-readable trust report and verbose output, which can break downstream tooling that assumes the previous JSON schema. Logic is otherwise read-only analysis of specs, so behavioral risk is limited to reporting correctness/completeness.
> 
> **Overview**
> Extends the trust-surface reporting to explicitly surface *axiomatized primitives* used directly in a contract spec (currently `keccak256`).
> 
> The compiler now emits this list as `axiomatizedPrimitives` in `emitTrustReportJson`, and prints an “Axiomatized primitive report” section in verbose compilation output.
> 
> Tests and docs are updated to exercise/report `keccak256` and to document the expanded trust report coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a9ecce7961c55488e1fcd4e401c0be06f750a53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->