### PR TITLE
trust: add proof-status buckets to trust reports

### DIFF
--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -378,6 +378,24 @@ private def ecmJson (entry : String × String) : String :=
     ("assumption", jsonString entry.2)
   ]
 
+private def proofStatusBucketJson
+    (primitives externals modules : List String) : String :=
+  jsonObject [
+    ("axiomatizedPrimitives", jsonArray (primitives.map jsonString)),
+    ("linkedExternals", jsonArray (externals.map jsonString)),
+    ("ecmModules", jsonArray (modules.map jsonString))
+  ]
+
+private def proofStatusJson (spec : CompilationModel) : String :=
+  let axiomatizedPrimitives := collectAxiomatizedPrimitives spec
+  let linkedExternals := (collectUsedExternalAssumptions spec).map Prod.fst
+  let ecmModules := (collectEcmAxioms spec).map Prod.fst
+  jsonObject [
+    ("proved", proofStatusBucketJson [] [] []),
+    ("assumed", proofStatusBucketJson axiomatizedPrimitives linkedExternals ecmModules),
+    ("unchecked", proofStatusBucketJson [] [] [])
+  ]
+
 /-- Render the machine-readable trust report consumed by CLI/tests. -/
 def emitTrustReportJson (specs : List CompilationModel) : String :=
   jsonObject [
@@ -389,6 +407,7 @@ where
       ("contract", jsonString spec.name),
       ("modeledLowLevelMechanics", jsonArray ((collectLowLevelMechanics spec).map jsonString)),
       ("axiomatizedPrimitives", jsonArray ((collectAxiomatizedPrimitives spec).map jsonString)),
+      ("proofStatus", proofStatusJson spec),
       ("proofBoundary", jsonObject [
         ("compilerModelsMechanics", "true"),
         ("proofInterpretersModelMechanics", "false"),

--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -165,6 +165,29 @@ def compileSpecsWithOptions
       IO.println "  (no axiomatized primitives used)"
     IO.println "  Proof boundary: these primitives compile through explicit trusted boundaries (for example, keccak-backed hashing) and should be audited alongside AXIOMS.md/TRUST_ASSUMPTIONS.md."
     IO.println ""
+    IO.println "Proof-status summary:"
+    let mut anyAssumedStatus := false
+    for spec in specs do
+      let primitives := collectAxiomatizedPrimitives spec
+      let externals := (collectUsedExternalAssumptions spec).map Prod.fst
+      let ecmModules := (collectEcmAxioms spec).map Prod.fst
+      if !primitives.isEmpty || !externals.isEmpty || !ecmModules.isEmpty then
+        anyAssumedStatus := true
+        IO.println s!"  {spec.name}:"
+        if !primitives.isEmpty then
+          IO.println s!"    assumed primitives: {String.intercalate ", " primitives}"
+        if !externals.isEmpty then
+          IO.println s!"    assumed linked externals: {String.intercalate ", " externals}"
+        if !ecmModules.isEmpty then
+          IO.println s!"    assumed ECM modules: {String.intercalate ", " ecmModules}"
+    if !anyAssumedStatus then
+      IO.println "  proved: none"
+      IO.println "  assumed: none"
+      IO.println "  unchecked: none"
+    else
+      IO.println "  proved: none reported yet for foreign surfaces"
+      IO.println "  unchecked: none reported"
+    IO.println ""
     IO.println "External assumption report:"
     let mut anyExternalAssumptions := false
     for spec in specs do

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -337,13 +337,19 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ trust report emits low-level mechanics")
   if !contains trustReport "\"axiomatizedPrimitives\":[\"keccak256\"]" then
     throw (IO.userError "✗ trust report emits axiomatized primitives")
+  if !contains trustReport "\"proofStatus\":{\"proved\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[]}" then
+    throw (IO.userError "✗ trust report emits proved proof-status bucket")
+  if !contains trustReport "\"assumed\":{\"axiomatizedPrimitives\":[\"keccak256\"],\"linkedExternals\":[\"PoseidonT3_hash\"],\"ecmModules\":[\"testCall\"]}" then
+    throw (IO.userError "✗ trust report emits assumed proof-status bucket")
+  if !contains trustReport "\"unchecked\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[]}" then
+    throw (IO.userError "✗ trust report emits unchecked proof-status bucket")
   if !contains trustReport "\"name\":\"PoseidonT3_hash\"" then
     throw (IO.userError "✗ trust report emits linked external name")
   if !contains trustReport "\"axioms\":[\"poseidon_t3_deterministic\"]" then
     throw (IO.userError "✗ trust report emits linked external axioms")
   if !contains trustReport "\"module\":\"testCall\"" || !contains trustReport "\"assumption\":\"test_call_interface\"" then
     throw (IO.userError "✗ trust report emits ECM axioms")
-  IO.println "✓ trust report emits low-level mechanics, axiomatized primitives, and external assumptions"
+  IO.println "✓ trust report emits low-level mechanics, proof-status buckets, axiomatized primitives, and external assumptions"
 
   let ecrecoverTrustReport := emitTrustReportJson [ecrecoverTrustSurfaceSpec]
   if !contains ecrecoverTrustReport "\"contract\":\"EcrecoverTrustSurface\"" then

--- a/docs/EXTERNAL_CALL_MODULES.md
+++ b/docs/EXTERNAL_CALL_MODULES.md
@@ -180,6 +180,9 @@ emits per-contract JSON that includes:
 - axiomatized primitives used directly by the spec (for example `keccak256`)
 - linked external assumptions (`spec.externals`)
 - ECM assumption entries (`module`, `assumption`)
+- explicit `proofStatus.proved` / `proofStatus.assumed` / `proofStatus.unchecked`
+  buckets for foreign trust surfaces; current linked externals, ECM modules, and
+  axiomatized primitives are reported under `assumed`
 
 ## Trust Model
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -81,7 +81,7 @@ Recent progress for low-level calls + returndata handling (`#622`):
 - `CompilationModel.Expr` now supports first-class low-level call primitives (`call`, `staticcall`, `delegatecall`) with explicit gas/value/target/input/output operands and deterministic Yul lowering.
 - `CompilationModel.Expr.returndataSize`, `Stmt.returndataCopy`, and `Stmt.revertReturndata` now provide first-class returndata access and revert-data forwarding without raw Yul builtin injection.
 - `CompilationModel.Expr.returndataOptionalBoolAt(outOffset)` now provides a first-class ERC20 compatibility helper for optional return-data bool decoding (`returndatasize()==0 || (returndatasize()==32 && mload(outOffset)==1)`), so low-level token call acceptance paths can be expressed without raw Yul builtins.
-- `verity-compiler --trust-report <path>` now emits a machine-readable per-contract trust surface covering low-level mechanics usage, linked external assumptions, and ECM axioms; `--verbose` mirrors the same boundary in human-readable form.
+- `verity-compiler --trust-report <path>` now emits a machine-readable per-contract trust surface covering low-level mechanics usage, linked external assumptions, ECM axioms, and explicit `proved` / `assumed` / `unchecked` proof-status buckets for foreign surfaces; `--verbose` mirrors the same boundary in human-readable form.
 - Raw `Expr.externalCall` interop names for low-level/builtin opcodes remain fail-fast rejected, preserving explicit migration diagnostics while the first-class surface continues to expand.
 - ABI artifact emission now reflects explicit function mutability markers (`isView`, `isPure`) as `stateMutability: "view" | "pure"` in generated JSON.
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -135,7 +135,7 @@ Diagnostics policy for unsupported constructs:
 1. Report the exact unsupported construct at compile time.
 2. Suggest the nearest supported migration pattern.
 3. Link to the owning tracking issue.
-4. When low-level mechanics, axiomatized primitives (for example `keccak256`), or external assumptions are in play, emit a machine-readable trust report via `verity-compiler --trust-report <path>`.
+4. When low-level mechanics, axiomatized primitives (for example `keccak256`), or external assumptions are in play, emit a machine-readable trust report via `verity-compiler --trust-report <path>`. The report now also groups foreign trust surfaces into explicit `proofStatus.proved`, `proofStatus.assumed`, and `proofStatus.unchecked` buckets.
 
 ## Trust Assumptions
 


### PR DESCRIPTION
## Summary
- add explicit `proofStatus.proved` / `proofStatus.assumed` / `proofStatus.unchecked` buckets to the machine-readable trust report
- mirror the new status grouping in verbose compiler output
- document the new trust-report shape and extend the trust-report regression

## Issue
- advances #1412

## Validation
- `lake build Compiler.CompileDriverTest` is still running in this fresh checkout because of a cold-cache Lean build, so I am not claiming it complete yet
- diff is intentionally narrow and centered on `emitTrustReportJson` / `CompileDriverTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the schema of the machine-readable `--trust-report` JSON by adding a new `proofStatus` object, which may break downstream tooling/tests that expect the previous shape. Functional compiler behavior is otherwise unaffected (reporting-only changes plus doc/test updates).
> 
> **Overview**
> Adds a new `proofStatus` section to the per-contract trust report JSON, splitting foreign trust surfaces into `proved` / `assumed` / `unchecked` buckets; currently, axiomatized primitives, referenced linked externals, and ECM module names are reported under `assumed` with empty `proved`/`unchecked` placeholders.
> 
> Updates `--verbose` output to print a proof-status summary aligned with the new buckets, extends `CompileDriverTest` to assert the new JSON fields, and refreshes related documentation to describe the updated trust-report shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04c3da83121be32144f574d93d77b8f917ee3c60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->