### PR TITLE
macro: expose ecrecover in verity_contract

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -3,11 +3,47 @@ import Compiler.ABI
 import Compiler.Codegen
 import Compiler.Modules.Precompiles
 import Compiler.Yul.PrettyPrint
+import Contracts.Common
 
 namespace Compiler.CompilationModelFeatureTest
 
 open Compiler
 open Compiler.CompilationModel
+
+namespace MacroEcrecoverSmoke
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract MacroEcrecover where
+  storage
+    lastSigner : Address := slot 0
+
+  function recoverSigner (digest : Bytes32, v : Uint256, r : Bytes32, s : Bytes32) : Address := do
+    let signer ← ecrecover digest v r s
+    return signer
+
+def recoverSignerModelUsesEcrecoverEcm : Bool :=
+  match MacroEcrecover.recoverSigner_modelBody with
+  | [Stmt.ecm mod [Expr.param "digest", Expr.param "v", Expr.param "r", Expr.param "s"],
+      Stmt.return (Expr.localVar "signer")] =>
+      mod.name == "ecrecover" &&
+      mod.resultVars == ["signer"] &&
+      mod.axioms == ["evm_ecrecover_precompile"]
+  | _ => false
+
+example : recoverSignerModelUsesEcrecoverEcm = true := by native_decide
+
+def recoverSignerExecutableUsesOracle : Bool :=
+  match MacroEcrecover.recoverSigner 10 27 30 40 Verity.defaultState with
+  | .success signer state =>
+      signer == Verity.wordToAddress 107 && state.sender == Verity.defaultState.sender
+  | .revert _ _ => false
+
+example : recoverSignerExecutableUsesOracle = true := by native_decide
+
+end MacroEcrecoverSmoke
 
 private def expectTrue (label : String) (ok : Bool) : IO Unit := do
   if !ok then
@@ -419,5 +455,13 @@ private def ecrecoverSmokeSpec : CompilationModel := {
     (contains ecrecoverYul "if iszero(returndatasize()) {")
   expectTrue "ecrecover ECM masks recovered address to 160 bits"
     (contains ecrecoverYul "let signer := and(mload(0), 0xffffffffffffffffffffffffffffffffffffffff)")
+  let macroEcrecoverYul ←
+    expectCompileToYul "macro ecrecover smoke spec" MacroEcrecoverSmoke.MacroEcrecover.spec
+  expectTrue "macro ecrecover bind elaborates to the same ECM lowering"
+    (contains macroEcrecoverYul "staticcall(gas(), 1, 0, 128, 0, 32)")
+  let macroTrustReport := emitTrustReportJson [MacroEcrecoverSmoke.MacroEcrecover.spec]
+  expectTrue "macro ecrecover trust report surfaces the precompile assumption"
+    (contains macroTrustReport "\"module\":\"ecrecover\"" &&
+      contains macroTrustReport "\"assumption\":\"evm_ecrecover_precompile\"")
 
 end Compiler.CompilationModelFeatureTest

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -1,5 +1,6 @@
 import Compiler.CompilationModel
 import Verity.Core
+import Verity.Core.Semantics
 import Verity.EVM.Uint256
 import Verity.Macro
 import Verity.Stdlib.Math
@@ -40,6 +41,10 @@ def staticcall (gas target inOffset inSize outOffset outSize : Uint256) : Uint25
   add gas (add target (add inOffset (add inSize (add outOffset outSize))))
 def delegatecall (gas target inOffset inSize outOffset outSize : Uint256) : Uint256 :=
   add gas (add target (add inOffset (add inSize (add outOffset outSize))))
+def ecrecover (hash v r sigS : Uint256) : Contract Address := fun state =>
+  ContractResult.success
+    (wordToAddress ((Verity.Env.ofWorld state).callOracle "ecrecover" [hash, v, r, sigS]))
+    state
 def calldatacopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def returndataCopy (_destOffset _sourceOffset _size : Uint256) : Contract Unit := pure ()
 def revertReturndata : Contract Unit := pure ()

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1,4 +1,5 @@
 import Lean
+import Compiler.Modules.Precompiles
 import Verity.Macro.Syntax
 
 namespace Verity.Macro
@@ -657,7 +658,7 @@ private def translateBindSource
   | `(term| msgSender) => `(Compiler.CompilationModel.Expr.caller)
   | _ =>
       throwErrorAt rhs
-        "unsupported bind source; expected getStorage/getStorageAddr/getMapping/getMappingAddr/getMappingUint/getMappingUintAddr/getMappingWord/getMapping2/structMember/structMember2/msgSender"
+        "unsupported bind source; expected getStorage/getStorageAddr/getMapping/getMappingAddr/getMappingUint/getMappingUintAddr/getMappingWord/getMapping2/structMember/structMember2/msgSender/ecrecover"
 
 private def translateSafeRequireBind
     (fields : Array StorageFieldDecl)
@@ -932,15 +933,28 @@ private partial def translateDoElem
       let varName := toString name.getId
       if locals.contains varName then
         throwErrorAt name s!"duplicate local variable '{varName}'"
-      let safeBind? ← translateSafeRequireBind fields params locals varName rhs
-      match safeBind? with
-      | some safeStmts => pure (safeStmts, locals.push varName, mutableLocals)
-      | none =>
-          let rhsExpr ← translateBindSource fields params locals rhs
+      match stripParens rhs with
+      | `(term| ecrecover $hash:term $v:term $r:term $s:term) =>
+          let hashExpr ← translatePureExpr fields params locals hash
+          let vExpr ← translatePureExpr fields params locals v
+          let rExpr ← translatePureExpr fields params locals r
+          let sExpr ← translatePureExpr fields params locals s
           pure
-            (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
+            (#[(← `(Compiler.CompilationModel.Stmt.ecm
+                    (Compiler.Modules.Precompiles.ecrecoverModule $(strTerm varName))
+                    [$hashExpr, $vExpr, $rExpr, $sExpr]))],
               locals.push varName,
               mutableLocals)
+      | _ =>
+          let safeBind? ← translateSafeRequireBind fields params locals varName rhs
+          match safeBind? with
+          | some safeStmts => pure (safeStmts, locals.push varName, mutableLocals)
+          | none =>
+              let rhsExpr ← translateBindSource fields params locals rhs
+              pure
+                (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
+                  locals.push varName,
+                  mutableLocals)
   | `(doElem| let $name:ident := $rhs:term) =>
       let varName := toString name.getId
       if locals.contains varName then

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -323,6 +323,16 @@ def Compiler.Modules.Calls.withReturn
   (args : List Expr) (isStatic : Bool := false) : Stmt
 ```
 
+### `ecrecover` precompile
+
+`verity_contract` can bind the standard `ecrecover` precompile directly:
+
+```lean
+let signer <- ecrecover digest v r s
+```
+
+This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust report records the explicit assumption `evm_ecrecover_precompile`.
+
 ### Low-level `call` / `staticcall` / `delegatecall`
 
 First-class low-level forms exist in the compilation model (`Expr.call`, `Expr.staticcall`, `Expr.delegatecall`).


### PR DESCRIPTION
## Summary
- expose `ecrecover` directly in `verity_contract` bind syntax
- back the executable EDSL surface with an explicit oracle-modeled `Contracts.Common.ecrecover` helper
- add compile-time regression coverage and docs for the precompile trust boundary

## Testing
- `lake build Compiler.CompilationModelFeatureTest`
- `make check`

Closes #1417.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `verity_contract` macro translation and executable semantics by adding a new special-case bind that lowers to an ECM precompile call and an oracle-backed helper. Risk is mitigated by added compile/Yul/trust-report regression tests, but macro-expansion changes can affect contract compilation behavior.
> 
> **Overview**
> Adds first-class `ecrecover` support to `verity_contract` do-notation (`let x ← ecrecover ...`), elaborating directly to `Stmt.ecm` via `Compiler.Modules.Precompiles.ecrecoverModule` (and surfacing `evm_ecrecover_precompile` as an explicit trust assumption).
> 
> Introduces an oracle-backed `Contracts.Common.ecrecover` helper for executable EDSL runs, plus new smoke/regression checks that the macro lowering matches the existing Yul `staticcall` precompile sequence and that the trust report includes the precompile assumption. Documentation is updated to describe the new `ecrecover` binding and its trust boundary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ec2a83d2958a528b156148c61765bd2e9e2e2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->