### PR TITLE
trust: surface keccak primitive assumptions

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -138,6 +138,7 @@ This remains the last contract-level proof gap between body-level Yul equivalenc
 **Operational trust assumptions**:
 - Keccak implementation correctness in the linked FFI path.
 - Standard collision-resistance assumptions for mapping-slot uniqueness/non-collision, matching Solidity/EVM assumptions.
+- Machine-readable trust reports surface this runtime boundary as `keccak256_memory_slice_matches_evm` when contracts use `Expr.keccak256`.
 
 **Soundness controls**:
 - Mapping-slot abstraction boundary checks in CI.

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -420,6 +420,19 @@ private def assumptionJson (entry : ExternalFunction) : String :=
     ("axioms", jsonArray (entry.axiomNames.map jsonString))
   ]
 
+/-- Stable machine-readable assumption name for a trusted primitive boundary. -/
+def primitiveAssumptionName (primitive : String) : String :=
+  match primitive with
+  | "keccak256" => "keccak256_memory_slice_matches_evm"
+  | other => s!"{other}_assumed"
+
+private def primitiveAssumptionJson (primitive : String) : String :=
+  jsonObject [
+    ("primitive", jsonString primitive),
+    ("status", proofStatusString .assumed),
+    ("assumption", jsonString (primitiveAssumptionName primitive))
+  ]
+
 private def ecmJson (entry : String × String) : String :=
   jsonObject [
     ("module", jsonString entry.1),
@@ -480,6 +493,8 @@ where
         ("calleeBehaviorRequiresAssumptions", "true")
       ]),
       ("externalAssumptions", jsonObject [
+        ("axiomatizedPrimitives",
+          jsonArray ((collectAxiomatizedPrimitives spec).map primitiveAssumptionJson)),
         ("linkedExternals", jsonArray ((collectUsedExternalAssumptions spec).map assumptionJson)),
         ("ecmAxioms", jsonArray ((collectEcmAxioms spec).map ecmJson)),
         ("ecmModules", jsonArray ((collectUsedEcmModules spec).map ecmModuleJson))

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -45,6 +45,39 @@ example : recoverSignerExecutableUsesOracle = true := by native_decide
 
 end MacroEcrecoverSmoke
 
+namespace MacroKeccakSmoke
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract MacroKeccak where
+  storage
+    lastDigest : Uint256 := slot 0
+
+  function hashSlice (offset : Uint256, size : Uint256) : Uint256 := do
+    let digest := keccak256 offset size
+    return digest
+
+def hashSliceModelUsesKeccak : Bool :=
+  match MacroKeccak.hashSlice_modelBody with
+  | [Stmt.letVar "digest" (Expr.keccak256 (Expr.param "offset") (Expr.param "size")),
+      Stmt.return (Expr.localVar "digest")] =>
+      true
+  | _ => false
+
+example : hashSliceModelUsesKeccak = true := by native_decide
+
+def hashSliceExecutableUsesRuntimeStub : Bool :=
+  match MacroKeccak.hashSlice 11 64 Verity.defaultState with
+  | .success digest state =>
+      digest == 75 && state.sender == Verity.defaultState.sender
+  | .revert _ _ => false
+
+example : hashSliceExecutableUsesRuntimeStub = true := by native_decide
+
+end MacroKeccakSmoke
+
 private def expectTrue (label : String) (ok : Bool) : IO Unit := do
   if !ok then
     throw (IO.userError s!"✗ {label}")
@@ -463,5 +496,13 @@ private def ecrecoverSmokeSpec : CompilationModel := {
   expectTrue "macro ecrecover trust report surfaces the precompile assumption"
     (contains macroTrustReport "\"module\":\"ecrecover\"" &&
       contains macroTrustReport "\"assumption\":\"evm_ecrecover_precompile\"")
+  let macroKeccakYul ←
+    expectCompileToYul "macro keccak smoke spec" MacroKeccakSmoke.MacroKeccak.spec
+  expectTrue "macro keccak primitive lowers to the Yul keccak256 builtin"
+    (contains macroKeccakYul "keccak256(offset, size)")
+  let macroKeccakTrustReport := emitTrustReportJson [MacroKeccakSmoke.MacroKeccak.spec]
+  expectTrue "macro keccak trust report surfaces the named primitive assumption"
+    (contains macroKeccakTrustReport "\"primitive\":\"keccak256\"" &&
+      contains macroKeccakTrustReport "\"assumption\":\"keccak256_memory_slice_matches_evm\"")
 
 end Compiler.CompilationModelFeatureTest

--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -219,11 +219,16 @@ def compileSpecsWithOptions
     IO.println "External assumption report:"
     let mut anyExternalAssumptions := false
     for spec in specs do
+      let primitiveAssumptions := collectAxiomatizedPrimitives spec
       let externals := collectUsedExternalAssumptions spec
       let ecmAxioms := collectEcmAxioms spec
-      if !externals.isEmpty || !ecmAxioms.isEmpty then
+      if !primitiveAssumptions.isEmpty || !externals.isEmpty || !ecmAxioms.isEmpty then
         anyExternalAssumptions := true
         IO.println s!"  {spec.name}:"
+        if !primitiveAssumptions.isEmpty then
+          for primitive in primitiveAssumptions do
+            IO.println
+              s!"    [primitive:{primitive}][assumed] {primitiveAssumptionName primitive}"
         if !externals.isEmpty then
           for ext in externals do
             let renderedAxioms :=
@@ -234,7 +239,7 @@ def compileSpecsWithOptions
           for (modName, assumption) in ecmAxioms do
             IO.println s!"    [ecm:{modName}] {assumption}"
     if !anyExternalAssumptions then
-      IO.println "  (no linked external assumptions or ECM axioms)"
+      IO.println "  (no primitive assumptions, linked external assumptions, or ECM axioms)"
     IO.println ""
     IO.println "ECM axiom report:"
     let mut anyAxioms := false

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -398,6 +398,8 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ trust report emits low-level mechanics")
   if !contains trustReport "\"axiomatizedPrimitives\":[\"keccak256\"]" then
     throw (IO.userError "✗ trust report emits axiomatized primitives")
+  if !contains trustReport "\"axiomatizedPrimitives\":[{\"primitive\":\"keccak256\",\"status\":\"assumed\",\"assumption\":\"keccak256_memory_slice_matches_evm\"}]" then
+    throw (IO.userError "✗ trust report emits structured primitive assumptions")
   if !contains trustReport "\"proofStatus\":{\"proved\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[]}" then
     throw (IO.userError "✗ trust report emits proved proof-status bucket")
   if !contains trustReport "\"assumed\":{\"axiomatizedPrimitives\":[\"keccak256\"],\"linkedExternals\":[\"PoseidonT3_hash\"],\"ecmModules\":[\"testCall\"]}" then
@@ -414,7 +416,7 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ trust report emits ECM axioms")
   if !contains trustReport "\"ecmModules\":[{\"module\":\"testCall\",\"status\":\"assumed\",\"axioms\":[\"test_call_interface\"]}]" then
     throw (IO.userError "✗ trust report emits ECM module status")
-  IO.println "✓ trust report emits low-level mechanics, proof-status buckets, axiomatized primitives, and external assumptions"
+  IO.println "✓ trust report emits low-level mechanics, proof-status buckets, structured primitive assumptions, and external assumptions"
 
   let uncheckedTrustReport := emitTrustReportJson [uncheckedTrustSurfaceSpec]
   if !contains uncheckedTrustReport "\"hasUncheckedDependencies\":true" then

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -52,6 +52,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Role**: `keccak256(abi.encode(key, baseSlot))` for Solidity-compatible storage (`activeMappingSlotBackend = .keccak`).
 - **Trust**: external keccak implementation (`ffi.KEC` via EVMYul FFI) + standard collision-resistance assumptions (same trust class as Solidity/EVM).
 - **Mitigation**: Abstraction-boundary CI, selector/hash cross-checks.
+- **Audit surface**: machine-readable trust reports now emit the explicit primitive assumption `keccak256_memory_slice_matches_evm` whenever a contract uses `Expr.keccak256`.
 
 ### 5. EVM/Yul Semantics and Gas
 - **Role**: Runtime execution model.
@@ -101,5 +102,5 @@ High-level semantics can expose intermediate state in reverted computations. EVM
 
 ---
 
-**Last Updated**: 2026-03-06
+**Last Updated**: 2026-03-08
 **Maintainer Rule**: Update on every trust-boundary-relevant code change.

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -323,6 +323,16 @@ def Compiler.Modules.Calls.withReturn
   (args : List Expr) (isStatic : Bool := false) : Stmt
 ```
 
+### `keccak256` primitive
+
+`verity_contract` can hash a memory slice directly:
+
+```lean
+let digest := keccak256 offset size
+```
+
+This elaborates to `Compiler.CompilationModel.Expr.keccak256` and lowers to the Yul `keccak256(offset, size)` builtin. The machine-readable trust report records the explicit primitive assumption `keccak256_memory_slice_matches_evm`.
+
 ### `ecrecover` precompile
 
 `verity_contract` can bind the standard `ecrecover` precompile directly:


### PR DESCRIPTION
## Summary
- add structured primitive assumptions to the machine-readable trust report so `keccak256` is surfaced as an explicit named boundary instead of only a raw string bucket
- extend compile-driver output, macro feature coverage, and trust-report regression tests around the `keccak256` primitive path
- document the `verity_contract` `keccak256` surface and sync the trust docs with the new report entry

## Testing
- `lake build Compiler.CompilationModelFeatureTest`
- `lake build Compiler.CompileDriverTest`
- `make check`

Closes #1416.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 914e0d561b73fc8b9d025c1e044ff3c76a51f7c4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->