### PR TITLE
macro: add static tuple destructuring sugar

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -78,6 +78,75 @@ example : hashSliceExecutableUsesRuntimeStub = true := by native_decide
 
 end MacroKeccakSmoke
 
+namespace MacroTupleDestructuringSmoke
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract MacroTupleDestructuring where
+  storage
+    firstSlot : Uint256 := slot 0
+    secondSlot : Uint256 := slot 1
+
+  function storePair (pair : Tuple [Uint256, Uint256]) : Unit := do
+    let (first, second) := pair
+    setStorage firstSlot first
+    setStorage secondSlot second
+
+  function storeLiteralPair (seed : Uint256) : Unit := do
+    let (first, second) := (seed, add seed 1)
+    setStorage firstSlot first
+    setStorage secondSlot second
+
+  function echoPair (pair : Tuple [Uint256, Uint256]) : Tuple [Uint256, Uint256] := do
+    let (first, second) := pair
+    return (first, second)
+
+def storePairModelDestructuresTupleParam : Bool :=
+  match MacroTupleDestructuring.storePair_modelBody with
+  | [Stmt.letVar "first" (Expr.param "pair_0"),
+      Stmt.letVar "second" (Expr.param "pair_1"),
+      Stmt.setStorage "firstSlot" (Expr.localVar "first"),
+      Stmt.setStorage "secondSlot" (Expr.localVar "second"),
+      Stmt.stop] =>
+      true
+  | _ => false
+
+example : storePairModelDestructuresTupleParam = true := by native_decide
+
+def storeLiteralPairModelDestructuresTupleExpr : Bool :=
+  match MacroTupleDestructuring.storeLiteralPair_modelBody with
+  | [Stmt.letVar "first" (Expr.param "seed"),
+      Stmt.letVar "second" (Expr.add (Expr.param "seed") (Expr.literal 1)),
+      Stmt.setStorage "firstSlot" (Expr.localVar "first"),
+      Stmt.setStorage "secondSlot" (Expr.localVar "second"),
+      Stmt.stop] =>
+      true
+  | _ => false
+
+example : storeLiteralPairModelDestructuresTupleExpr = true := by native_decide
+
+def echoPairModelReturnsMultipleWords : Bool :=
+  match MacroTupleDestructuring.echoPair_modelBody with
+  | [Stmt.letVar "first" (Expr.param "pair_0"),
+      Stmt.letVar "second" (Expr.param "pair_1"),
+      Stmt.returnValues [Expr.localVar "first", Expr.localVar "second"]] =>
+      true
+  | _ => false
+
+example : echoPairModelReturnsMultipleWords = true := by native_decide
+
+def echoPairExecutableKeepsTupleShape : Bool :=
+  match MacroTupleDestructuring.echoPair (11, 17) Verity.defaultState with
+  | .success (first, second) state =>
+      first == 11 && second == 17 && state.sender == Verity.defaultState.sender
+  | .revert _ _ => false
+
+example : echoPairExecutableKeepsTupleShape = true := by native_decide
+
+end MacroTupleDestructuringSmoke
+
 private def expectTrue (label : String) (ok : Bool) : IO Unit := do
   if !ok then
     throw (IO.userError s!"✗ {label}")

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -235,6 +235,15 @@ private partial def modelReturnsTerm (ty : ValueType) : CommandElabM Term :=
       let elemTerms ← elemTys.mapM modelParamTypeTerm
       `([ $[$elemTerms.toArray],* ])
 
+mutual
+private partial def mkTupleContractType (elemTys : List ValueType) : CommandElabM Term := do
+  let rec go : List ValueType → CommandElabM Term
+    | [] => throwError "tuple types must have at least 2 elements"
+    | [ty] => contractValueTypeTerm ty
+    | ty :: rest => do
+        `(($(← contractValueTypeTerm ty) × $(← go rest)))
+  go elemTys
+
 private partial def contractValueTypeTerm (ty : ValueType) : CommandElabM Term :=
   match ty with
   | .uint256 => `(Uint256)
@@ -246,8 +255,9 @@ private partial def contractValueTypeTerm (ty : ValueType) : CommandElabM Term :
   | .bytes => `(ByteArray)
   | .array elemTy => do
       `(Array $(← contractValueTypeTerm elemTy))
-  | .tuple _ => `(Unit)
+  | .tuple elemTys => mkTupleContractType elemTys
   | .unit => `(Unit)
+end
 
 private def parseStorageField (stx : Syntax) : CommandElabM StorageFieldDecl := do
   match stx with
@@ -342,6 +352,63 @@ private def expectStringList (stx : Term) : CommandElabM (Array String) := do
   | `(term| [ $[$xs],* ]) =>
       xs.mapM expectStringOrIdent
   | _ => throwErrorAt stx "expected list literal [..]"
+
+private partial def collectTupleElems (stx : Syntax) : Array Syntax :=
+  if stx.isAtom then
+    if stx.getAtomVal == "," then #[] else #[]
+  else if stx.getKind == `null then
+    stx.getArgs.foldl (fun acc child => acc ++ collectTupleElems child) #[]
+  else
+    #[stx]
+
+private def tupleElemsFromSyntax? (stx : Syntax) : Option (Array Syntax) :=
+  if stx.getKind == `Lean.Parser.Term.tuple then
+    some (collectTupleElems stx[1])
+  else
+    none
+
+private def tupleElemsFromTerm? (stx : Term) : Option (Array Term) :=
+  tupleElemsFromSyntax? (stripParens stx).raw |>.map (·.map (fun syn => ⟨syn⟩))
+
+private def tupleBinderNames? (stx : Syntax) : Option (Array String) := do
+  let elems ← tupleElemsFromSyntax? stx
+  elems.mapM fun elem =>
+    match elem with
+    | .ident _ raw _ _ => some raw.toString
+    | _ => none
+
+private def ensureFreshLocalNames
+    (locals : Array String)
+    (names : Array String)
+    (stx : Syntax) : CommandElabM Unit := do
+  let rec firstDuplicate (seen : Array String) (rest : Array String) (idx : Nat) : Option String :=
+    if h : idx < rest.size then
+      let name := rest[idx]
+      if seen.contains name then
+        some name
+      else
+        firstDuplicate (seen.push name) rest (idx + 1)
+    else
+      none
+  match firstDuplicate #[] names 0 with
+  | some dup => throwErrorAt stx s!"duplicate local variable '{dup}'"
+  | none => pure ()
+  for name in names do
+    if locals.contains name then
+      throwErrorAt stx s!"duplicate local variable '{name}'"
+
+private def tupleParamElemExprs?
+    (params : Array ParamDecl)
+    (name : String) : CommandElabM (Option (Array Term)) := do
+  match params.find? (fun p => p.name == name) with
+  | some p =>
+      match p.ty with
+      | .tuple elemTys => do
+          let exprs ← (elemTys.toArray.zipIdx).mapM fun (_ty, idx) =>
+            `(Compiler.CompilationModel.Expr.param $(strTerm s!"{name}_{idx}"))
+          pure (some exprs)
+      | _ => pure none
+  | none => pure none
 
 private def isTupleComponentRef (params : Array ParamDecl) (name : String) : Bool :=
   -- Check if `name` matches `<paramName>_<digit>` for a tuple-typed param
@@ -524,6 +591,23 @@ partial def translatePureExpr
           $(← translatePureExpr fields params locals key2)
           $(strTerm memberName))
   | _ => throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
+
+private def tupleValueExprs
+    (fields : Array StorageFieldDecl)
+    (params : Array ParamDecl)
+    (locals : Array String)
+    (rhs : Term) : CommandElabM (Array Term) := do
+  match tupleElemsFromTerm? rhs with
+  | some elems =>
+      elems.mapM (translatePureExpr fields params locals)
+  | none =>
+      match stripParens rhs with
+      | `(term| $id:ident) =>
+          match (← tupleParamElemExprs? params (toString id.getId)) with
+          | some exprs => pure exprs
+          | none => throwErrorAt rhs "tuple destructuring currently requires a tuple literal or tuple-typed parameter"
+      | _ =>
+          throwErrorAt rhs "tuple destructuring currently requires a tuple literal or tuple-typed parameter"
 
 private def expectExprList
     (fields : Array StorageFieldDecl)
@@ -919,7 +1003,57 @@ private partial def translateDoElem
     (locals : Array String)
     (mutableLocals : Array String)
     (elem : TSyntax `doElem) : CommandElabM (Array Term × Array String × Array String) := do
-  match elem with
+  let tupleCase? ← do
+    let stx := elem.raw
+    if stx.getKind == `Lean.Parser.Term.doLet then
+      let decl := stx[2]
+      let patDecl := decl[0]
+      match tupleBinderNames? patDecl[0] with
+      | some names =>
+          ensureFreshLocalNames locals names stx
+          let valueExprs ← tupleValueExprs fields params locals ⟨patDecl[4]⟩
+          if names.size != valueExprs.size then
+            throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueExprs.size} values"
+          let stmts ← (names.zip valueExprs).mapM fun (name, valueExpr) =>
+            `(Compiler.CompilationModel.Stmt.letVar $(strTerm name) $valueExpr)
+          pure (some (stmts, locals ++ names, mutableLocals))
+      | none => pure none
+    else if stx.getKind == `Lean.Parser.Term.doLetArrow then
+      let patDecl := stx[2]
+      match tupleBinderNames? patDecl[0] with
+      | some names =>
+          ensureFreshLocalNames locals names stx
+          let rhs : Term := ⟨patDecl[2][0]⟩
+          let rhs := stripParens rhs
+          match rhs.raw with
+          | .node _ `Lean.Parser.Term.app args =>
+              match args.getD 0 Syntax.missing with
+              | .ident _ raw _ _ =>
+                  let argExprs ← (args.getD 1 Syntax.missing).getArgs.mapM
+                    (translatePureExpr fields params locals ∘ fun syn => ⟨syn⟩)
+                  let resultNameTerms := names.map strTerm
+                  let stmt ← `(Compiler.CompilationModel.Stmt.internalCallAssign
+                    [ $[$resultNameTerms],* ]
+                    $(strTerm raw.toString)
+                    [ $[$argExprs],* ])
+                  pure (some (#[(stmt)], locals ++ names, mutableLocals))
+              | _ =>
+                  throwErrorAt rhs "tuple bind sources must be internal helper calls"
+          | .ident _ raw _ _ =>
+              let resultNameTerms := names.map strTerm
+              let stmt ← `(Compiler.CompilationModel.Stmt.internalCallAssign
+                [ $[$resultNameTerms],* ]
+                $(strTerm raw.toString)
+                [])
+              pure (some (#[(stmt)], locals ++ names, mutableLocals))
+          | _ =>
+              throwErrorAt rhs "tuple bind sources must be internal helper calls"
+      | none => pure none
+    else
+      pure none
+  match tupleCase? with
+  | some result => pure result
+  | none => match elem with
   | `(doElem| let mut $name:ident := $rhs:term) =>
       let varName := toString name.getId
       if locals.contains varName then
@@ -929,6 +1063,15 @@ private partial def translateDoElem
         (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
           locals.push varName,
           mutableLocals.push varName)
+  | `(doElem| let $name:ident := $rhs:term) =>
+      let varName := toString name.getId
+      if locals.contains varName then
+        throwErrorAt name s!"duplicate local variable '{varName}'"
+      let rhsExpr ← translatePureExpr fields params locals rhs
+      pure
+        (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
+          locals.push varName,
+          mutableLocals)
   | `(doElem| let $name:ident ← $rhs:term) =>
       let varName := toString name.getId
       if locals.contains varName then
@@ -955,15 +1098,6 @@ private partial def translateDoElem
                 (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
                   locals.push varName,
                   mutableLocals)
-  | `(doElem| let $name:ident := $rhs:term) =>
-      let varName := toString name.getId
-      if locals.contains varName then
-        throwErrorAt name s!"duplicate local variable '{varName}'"
-      let rhsExpr ← translatePureExpr fields params locals rhs
-      pure
-        (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
-          locals.push varName,
-          mutableLocals)
   | `(doElem| $name:ident := $rhs:term) =>
       let varName := toString name.getId
       if !locals.contains varName then
@@ -976,7 +1110,11 @@ private partial def translateDoElem
           locals,
           mutableLocals)
   | `(doElem| return $value:term) =>
-      pure (#[(← `(Compiler.CompilationModel.Stmt.return $(← translatePureExpr fields params locals value)))], locals, mutableLocals)
+      try
+        let valueExprs ← tupleValueExprs fields params locals value
+        pure (#[(← `(Compiler.CompilationModel.Stmt.returnValues [ $[$valueExprs],* ]))], locals, mutableLocals)
+      catch _ =>
+        pure (#[(← `(Compiler.CompilationModel.Stmt.return $(← translatePureExpr fields params locals value)))], locals, mutableLocals)
   | `(doElem| pure ()) =>
       pure (#[], locals, mutableLocals)
   | `(doElem| if $cond:term then $thenBranch:doSeq else $elseBranch:doSeq) =>

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -302,6 +302,18 @@ def mulDivUp (a b c : Uint256) : Uint256
 
 Location: `Contracts/Common.lean`
 
+## Tuple Surface
+
+`verity_contract` now accepts tuple-shaped local sugar for the static tuple cases already supported by the compilation model:
+
+```lean
+let (first, second) := pair
+let (lhs, rhs) := (seed, add seed 1)
+return (first, second)
+```
+
+Today this elaborates cleanly for tuple literals and tuple-typed parameters. `return (..)` lowers to `Stmt.returnValues [...]`, and tuple-parameter destructuring maps onto the ABI-flattened component names (`pair_0`, `pair_1`, ...), so the generated model stays explicit for debugging and proofs.
+
 ## External Calls (ECM)
 
 ### ERC-20 safe wrappers


### PR DESCRIPTION
Refs #1415.

## What changed
- teach `verity_contract` to elaborate static tuple destructuring from tuple-typed parameters and tuple literals
- lower `return (a, b, ...)` to explicit `Stmt.returnValues [...]`
- use real Lean product types for executable tuple-valued contract functions instead of erasing them to `Unit`
- add macro regression coverage and docs for the supported tuple surface

## Scope
This PR intentionally covers the static tuple slice of #1415:
- `let (a, b) := pair` when `pair` is a tuple-typed parameter
- `let (a, b) := (x, y)` for tuple literals
- `return (a, b)` for tuple returns

It does not claim struct destructuring yet.

## Validation
- `lake build Verity.Macro.Translate`
- `lake build Compiler.CompilationModelFeatureTest`
- `make check`