### PR TITLE
modules: add standard erc4626 preview ECM

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -158,6 +158,7 @@ in `--verbose` output.
 | `ERC20.safeTransfer` | `erc20_transfer_interface` | Target implements ERC-20 `transfer(address,uint256)` |
 | `ERC20.safeTransferFrom` | `erc20_transferFrom_interface` | Target implements ERC-20 `transferFrom(address,address,uint256)` |
 | `ERC20.safeApprove` | `erc20_approve_interface` | Target implements ERC-20 `approve(address,uint256)` |
+| `ERC4626.previewDeposit` | `erc4626_previewDeposit_interface` | Target implements `previewDeposit(uint256)` and returns one ABI-encoded `uint256` |
 | `Oracle.oracleReadUint256` | `oracle_read_uint256_interface` | Target implements the selected read-only oracle interface and returns one ABI-encoded `uint256` |
 | `Precompiles.ecrecover` | `evm_ecrecover_precompile` | EVM precompile at address 0x01 behaves per Yellow Paper |
 | `Callbacks.callback` | `callback_target_interface` | Callback target processes ABI-encoded arguments correctly |

--- a/Compiler.lean
+++ b/Compiler.lean
@@ -16,6 +16,7 @@ import Compiler.CompileDriver
 import Compiler.CheckContract
 import Compiler.Modules.Calls
 import Compiler.Modules.Callbacks
+import Compiler.Modules.ERC4626
 import Compiler.Modules.ERC20
 import Compiler.Modules.Oracle
 import Compiler.Modules.Precompiles

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -1,6 +1,7 @@
 import Compiler.CompilationModel
 import Compiler.ABI
 import Compiler.Codegen
+import Compiler.Modules.ERC4626
 import Compiler.Modules.Oracle
 import Compiler.Modules.Precompiles
 import Compiler.Yul.PrettyPrint
@@ -499,6 +500,29 @@ private def oracleReadSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc4626PreviewDepositSmokeSpec : CompilationModel := {
+  name := "ERC4626PreviewDepositSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "preview"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "assets", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.previewDeposit
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "assets"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 #eval! do
   let compiled :=
     match Compiler.CompilationModel.compile selectorSmokeSpec (selectorsFor selectorSmokeSpec) with
@@ -592,6 +616,16 @@ private def oracleReadSmokeSpec : CompilationModel := {
     (contains oracleReadYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "oracle read ECM ABI-encodes the selector"
     (contains oracleReadYul "mstore(0, shl(224, 0xfeaf968c))")
+  let erc4626PreviewDepositYul ←
+    expectCompileToYul "erc4626 previewDeposit smoke spec" erc4626PreviewDepositSmokeSpec
+  expectTrue "erc4626 previewDeposit ECM lowers to staticcall"
+    (contains erc4626PreviewDepositYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 previewDeposit ECM forwards revert returndata"
+    (contains erc4626PreviewDepositYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 previewDeposit ECM rejects non-32-byte returndata"
+    (contains erc4626PreviewDepositYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 previewDeposit ECM ABI-encodes the selector"
+    (contains erc4626PreviewDepositYul "mstore(0, shl(224, 0xef8b30f7))")
   let macroEcrecoverYul ←
     expectCompileToYul "macro ecrecover smoke spec" MacroEcrecoverSmoke.MacroEcrecover.spec
   expectTrue "macro ecrecover bind elaborates to the same ECM lowering"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -4,6 +4,7 @@ import Compiler.CompilationModel
 import Compiler.CompilationModel.TrustSurface
 import Compiler.ECM
 import Compiler.ModuleInput
+import Compiler.Modules.ERC4626
 import Compiler.Modules.Oracle
 import Compiler.Modules.Precompiles
 import Compiler.TestModules
@@ -277,6 +278,29 @@ private def oracleTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc4626TrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626TrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "preview"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "assets", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.previewDeposit
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "assets"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 private def expectModuleArtifacts
     (labelPrefix : String)
     (modules : List String)
@@ -476,6 +500,16 @@ unsafe def runTests : IO Unit := do
   if !contains oracleTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"oracleReadUint256\"]}" then
     throw (IO.userError "✗ oracle trust report emits assumed ECM proof-status bucket")
   IO.println "✓ oracle trust report emits standard oracle module assumption"
+
+  let erc4626TrustReport := emitTrustReportJson [erc4626TrustSurfaceSpec]
+  if !contains erc4626TrustReport "\"contract\":\"ERC4626TrustSurface\"" then
+    throw (IO.userError "✗ erc4626 trust report emits contract name")
+  if !contains erc4626TrustReport "\"module\":\"previewDeposit\"" ||
+      !contains erc4626TrustReport "\"assumption\":\"erc4626_previewDeposit_interface\"" then
+    throw (IO.userError "✗ erc4626 trust report emits previewDeposit module assumption")
+  if !contains erc4626TrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"previewDeposit\"]}" then
+    throw (IO.userError "✗ erc4626 trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 trust report emits standard vault module assumption"
 
   compileSpecsWithOptions [abiSmokeSpec] outDir false [] {} none (some trustReportPath) none
   let writtenTrustReport ← fileExists trustReportPath

--- a/Compiler/Modules.lean
+++ b/Compiler/Modules.lean
@@ -1,5 +1,6 @@
 import Compiler.Modules.Calls
 import Compiler.Modules.Callbacks
+import Compiler.Modules.ERC4626
 import Compiler.Modules.ERC20
 import Compiler.Modules.Oracle
 import Compiler.Modules.Precompiles

--- a/Compiler/Modules/ERC4626.lean
+++ b/Compiler/Modules/ERC4626.lean
@@ -1,0 +1,77 @@
+/- 
+  Compiler.Modules.ERC4626: ERC-4626 Vault Interaction Modules
+
+  Standard ECMs for read-only ERC-4626 integrations:
+  - `previewDeposit`: staticcall `previewDeposit(uint256)` and require exactly
+    one 32-byte return word.
+
+  Trust assumption: the target address implements the selected ERC-4626 read
+  interface and returns one ABI-encoded `uint256` word.
+-/
+
+import Compiler.ECM
+import Compiler.CompilationModel
+
+namespace Compiler.Modules.ERC4626
+
+open Compiler.Yul
+open Compiler.ECM
+open Compiler.CompilationModel (Stmt Expr)
+
+/-- Read-only ERC-4626 `previewDeposit(uint256)` module.
+
+    It ABI-encodes the canonical `previewDeposit(uint256)` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, assets]`. -/
+def previewDepositModule (resultVar : String) : ExternalCallModule where
+  name := "previewDeposit"
+  numArgs := 2
+  resultVars := [resultVar]
+  writesState := false
+  readsState := true
+  axioms := ["erc4626_previewDeposit_interface"]
+  compile := fun _ctx args => do
+    let (vaultExpr, assetsExpr) ← match args with
+      | [vault, assets] => pure (vault, assets)
+      | _ => throw "previewDeposit expects 2 arguments (vault, assets)"
+    let selector := 0xef8b30f7
+    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
+      YulExpr.lit 0,
+      YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
+    ])
+    let storeAssets := YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, assetsExpr])
+    let callExpr := YulExpr.call "staticcall" [
+      YulExpr.call "gas" [],
+      vaultExpr,
+      YulExpr.lit 0, YulExpr.lit 36,
+      YulExpr.lit 0, YulExpr.lit 32
+    ]
+    let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__erc4626_success"]) [
+      YulStmt.let_ "__erc4626_rds" (YulExpr.call "returndatasize" []),
+      YulStmt.expr (YulExpr.call "returndatacopy" [
+        YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__erc4626_rds"
+      ]),
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__erc4626_rds"])
+    ]
+    let requireSingleWord := YulStmt.if_ (YulExpr.call "iszero" [
+      YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32]
+    ]) [
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+    ]
+    let bindResult := YulStmt.let_ resultVar (YulExpr.call "mload" [YulExpr.lit 0])
+    pure [YulStmt.block [
+      storeSelector,
+      storeAssets,
+      YulStmt.let_ "__erc4626_success" callExpr,
+      revertOnFailure,
+      requireSingleWord
+    ], bindResult]
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `previewDeposit(uint256)`
+    call. -/
+def previewDeposit (resultVar : String) (vault assets : Expr) : Stmt :=
+  .ecm (previewDepositModule resultVar) [vault, assets]
+
+end Compiler.Modules.ERC4626

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -9,6 +9,7 @@ structure that the compiler can plug in without modification.
 | File | Modules | Replaces |
 |------|---------|----------|
 | `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom` |
+| `ERC4626.lean` | `previewDeposit` | canonical vault preview wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |
 | `Callbacks.lean` | `callback` | `Stmt.callback` |
 | `Calls.lean` | `withReturn` | `Stmt.externalCallWithReturn` |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20, ERC-4626 previews, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -323,6 +323,8 @@ Today this elaborates cleanly for tuple literals and tuple-typed parameters. `re
 ```lean
 def Compiler.Modules.ERC20.safeTransfer (token to amount : Expr) : Stmt
 def Compiler.Modules.ERC20.safeTransferFrom (token fromAddr to amount : Expr) : Stmt
+def Compiler.Modules.ERC4626.previewDeposit
+  (resultVar : String) (vault assets : Expr) : Stmt
 def Compiler.Modules.Oracle.oracleReadUint256
   (resultVar : String) (target : Expr) (selector : Nat)
   (staticArgs : List Expr) : Stmt
@@ -359,6 +361,8 @@ let signer <- ecrecover digest v r s
 This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust report records the explicit assumption `evm_ecrecover_precompile`.
 
 `Compiler.Modules.Oracle.oracleReadUint256` covers the common read-only oracle case: it ABI-encodes the selector plus static arguments, performs a `staticcall`, requires exactly one 32-byte return word, and binds that word to a local result variable. The trust report records the explicit ECM assumption `oracle_read_uint256_interface`.
+
+`Compiler.Modules.ERC4626.previewDeposit` covers the common vault preview case: it ABI-encodes `previewDeposit(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewDeposit_interface`.
 
 ### Low-level `call` / `staticcall` / `delegatecall`
 


### PR DESCRIPTION
## Summary
- add a standard `Compiler.Modules.ERC4626.previewDeposit` ECM for read-only vault share quotes
- cover Yul lowering and trust-report emission with regression tests
- document the new ERC-4626 module assumption in the public module and trust docs

## Testing
- `lake build Compiler.Modules.ERC4626`
- `lake build Compiler.CompilationModelFeatureTest`
- `lake build Compiler.CompileDriverTest`
- `make check`

Refs #1413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new compiler-level External Call Module that generates Yul for ERC-4626 `previewDeposit`, so any bug would affect contracts that adopt this wrapper (call encoding, revert forwarding, returndata-size checks). Scope is otherwise additive and covered by new Yul-lowering and trust-report regression tests.
> 
> **Overview**
> Adds a standard ERC-4626 ECM wrapper `Compiler.Modules.ERC4626.previewDeposit` that performs a read-only `staticcall` to `previewDeposit(uint256)`, forwards revert returndata, and enforces a single 32-byte return word, introducing the new trust assumption `erc4626_previewDeposit_interface`.
> 
> Wires the module into the compiler/module import surface and extends regression tests to assert the expected Yul lowering and that trust reports include the new ECM module/assumption.
> 
> Updates public documentation (`AXIOMS.md`, `TRUST_ASSUMPTIONS.md`, module README, and EDSL API reference) to list the new module and its assumption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88205e8066c141f7dff546a26f498481c6d02fc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->