### PR TITLE
modules: add standard erc4626 previewRedeem ECM

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -159,6 +159,7 @@ in `--verbose` output.
 | `ERC20.safeTransferFrom` | `erc20_transferFrom_interface` | Target implements ERC-20 `transferFrom(address,address,uint256)` |
 | `ERC20.safeApprove` | `erc20_approve_interface` | Target implements ERC-20 `approve(address,uint256)` |
 | `ERC4626.previewDeposit` | `erc4626_previewDeposit_interface` | Target implements `previewDeposit(uint256)` and returns one ABI-encoded `uint256` |
+| `ERC4626.previewRedeem` | `erc4626_previewRedeem_interface` | Target implements `previewRedeem(uint256)` and returns one ABI-encoded `uint256` |
 | `Oracle.oracleReadUint256` | `oracle_read_uint256_interface` | Target implements the selected read-only oracle interface and returns one ABI-encoded `uint256` |
 | `Precompiles.ecrecover` | `evm_ecrecover_precompile` | EVM precompile at address 0x01 behaves per Yellow Paper |
 | `Callbacks.callback` | `callback_target_interface` | Callback target processes ABI-encoded arguments correctly |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -523,6 +523,29 @@ private def erc4626PreviewDepositSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc4626PreviewRedeemSmokeSpec : CompilationModel := {
+  name := "ERC4626PreviewRedeemSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "preview"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "shares", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.previewRedeem
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "shares"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
 #eval! do
   let compiled :=
     match Compiler.CompilationModel.compile selectorSmokeSpec (selectorsFor selectorSmokeSpec) with
@@ -626,6 +649,16 @@ private def erc4626PreviewDepositSmokeSpec : CompilationModel := {
     (contains erc4626PreviewDepositYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "erc4626 previewDeposit ECM ABI-encodes the selector"
     (contains erc4626PreviewDepositYul "mstore(0, shl(224, 0xef8b30f7))")
+  let erc4626PreviewRedeemYul ←
+    expectCompileToYul "erc4626 previewRedeem smoke spec" erc4626PreviewRedeemSmokeSpec
+  expectTrue "erc4626 previewRedeem ECM lowers to staticcall"
+    (contains erc4626PreviewRedeemYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 previewRedeem ECM forwards revert returndata"
+    (contains erc4626PreviewRedeemYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 previewRedeem ECM rejects non-32-byte returndata"
+    (contains erc4626PreviewRedeemYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 previewRedeem ECM ABI-encodes the selector"
+    (contains erc4626PreviewRedeemYul "mstore(0, shl(224, 0x4cdad506))")
   let macroEcrecoverYul ←
     expectCompileToYul "macro ecrecover smoke spec" MacroEcrecoverSmoke.MacroEcrecover.spec
   expectTrue "macro ecrecover bind elaborates to the same ECM lowering"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -301,6 +301,29 @@ private def erc4626TrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc4626PreviewRedeemTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626PreviewRedeemTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "preview"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "shares", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.previewRedeem
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "shares"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
 private def expectModuleArtifacts
     (labelPrefix : String)
     (modules : List String)
@@ -510,6 +533,16 @@ unsafe def runTests : IO Unit := do
   if !contains erc4626TrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"previewDeposit\"]}" then
     throw (IO.userError "✗ erc4626 trust report emits assumed ECM proof-status bucket")
   IO.println "✓ erc4626 trust report emits standard vault module assumption"
+
+  let erc4626PreviewRedeemTrustReport := emitTrustReportJson [erc4626PreviewRedeemTrustSurfaceSpec]
+  if !contains erc4626PreviewRedeemTrustReport "\"contract\":\"ERC4626PreviewRedeemTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 previewRedeem trust report emits contract name")
+  if !contains erc4626PreviewRedeemTrustReport "\"module\":\"previewRedeem\"" ||
+      !contains erc4626PreviewRedeemTrustReport "\"assumption\":\"erc4626_previewRedeem_interface\"" then
+    throw (IO.userError "✗ erc4626 previewRedeem trust report emits module assumption")
+  if !contains erc4626PreviewRedeemTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"previewRedeem\"]}" then
+    throw (IO.userError "✗ erc4626 previewRedeem trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 previewRedeem trust report emits standard vault module assumption"
 
   compileSpecsWithOptions [abiSmokeSpec] outDir false [] {} none (some trustReportPath) none
   let writtenTrustReport ← fileExists trustReportPath

--- a/Compiler/Modules/ERC4626.lean
+++ b/Compiler/Modules/ERC4626.lean
@@ -4,6 +4,8 @@
   Standard ECMs for read-only ERC-4626 integrations:
   - `previewDeposit`: staticcall `previewDeposit(uint256)` and require exactly
     one 32-byte return word.
+  - `previewRedeem`: staticcall `previewRedeem(uint256)` and require exactly
+    one 32-byte return word.
 
   Trust assumption: the target address implements the selected ERC-4626 read
   interface and returns one ABI-encoded `uint256` word.
@@ -18,30 +20,29 @@ open Compiler.Yul
 open Compiler.ECM
 open Compiler.CompilationModel (Stmt Expr)
 
-/-- Read-only ERC-4626 `previewDeposit(uint256)` module.
-
-    It ABI-encodes the canonical `previewDeposit(uint256)` selector, performs a
-    `staticcall`, forwards revert returndata on failure, requires exactly one
-    32-byte return word, and binds that word to `resultVar`.
-
-    Arguments passed to the module are `[vault, assets]`. -/
-def previewDepositModule (resultVar : String) : ExternalCallModule where
-  name := "previewDeposit"
+/-- Shared implementation for read-only ERC-4626 preview calls that take a
+    single `uint256` argument and return one ABI-encoded `uint256` word. -/
+private def previewUint256Module
+    (moduleName : String)
+    (axiomName : String)
+    (resultVar : String)
+    (selector : Nat)
+    (argName : String) : ExternalCallModule where
+  name := moduleName
   numArgs := 2
   resultVars := [resultVar]
   writesState := false
   readsState := true
-  axioms := ["erc4626_previewDeposit_interface"]
+  axioms := [axiomName]
   compile := fun _ctx args => do
-    let (vaultExpr, assetsExpr) ← match args with
-      | [vault, assets] => pure (vault, assets)
-      | _ => throw "previewDeposit expects 2 arguments (vault, assets)"
-    let selector := 0xef8b30f7
+    let (vaultExpr, argExpr) ← match args with
+      | [vault, value] => pure (vault, value)
+      | _ => throw s!"{moduleName} expects 2 arguments (vault, {argName})"
     let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
       YulExpr.lit 0,
       YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
     ])
-    let storeAssets := YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, assetsExpr])
+    let storeArg := YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, argExpr])
     let callExpr := YulExpr.call "staticcall" [
       YulExpr.call "gas" [],
       vaultExpr,
@@ -63,15 +64,50 @@ def previewDepositModule (resultVar : String) : ExternalCallModule where
     let bindResult := YulStmt.let_ resultVar (YulExpr.call "mload" [YulExpr.lit 0])
     pure [YulStmt.block [
       storeSelector,
-      storeAssets,
+      storeArg,
       YulStmt.let_ "__erc4626_success" callExpr,
       revertOnFailure,
       requireSingleWord
     ], bindResult]
 
+/-- Read-only ERC-4626 `previewDeposit(uint256)` module.
+
+    It ABI-encodes the canonical `previewDeposit(uint256)` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, assets]`. -/
+def previewDepositModule (resultVar : String) : ExternalCallModule :=
+  previewUint256Module
+    "previewDeposit"
+    "erc4626_previewDeposit_interface"
+    resultVar
+    0xef8b30f7
+    "assets"
+
 /-- Convenience: create a `Stmt.ecm` for a read-only `previewDeposit(uint256)`
     call. -/
 def previewDeposit (resultVar : String) (vault assets : Expr) : Stmt :=
   .ecm (previewDepositModule resultVar) [vault, assets]
+
+/-- Read-only ERC-4626 `previewRedeem(uint256)` module.
+
+    It ABI-encodes the canonical `previewRedeem(uint256)` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, shares]`. -/
+def previewRedeemModule (resultVar : String) : ExternalCallModule :=
+  previewUint256Module
+    "previewRedeem"
+    "erc4626_previewRedeem_interface"
+    resultVar
+    0x4cdad506
+    "shares"
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `previewRedeem(uint256)`
+    call. -/
+def previewRedeem (resultVar : String) (vault shares : Expr) : Stmt :=
+  .ecm (previewRedeemModule resultVar) [vault, shares]
 
 end Compiler.Modules.ERC4626

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -9,7 +9,8 @@ structure that the compiler can plug in without modification.
 | File | Modules | Replaces |
 |------|---------|----------|
 | `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom` |
-| `ERC4626.lean` | `previewDeposit` | canonical vault preview wrappers |
+| `ERC4626.lean` | `previewDeposit`, `previewRedeem` | canonical vault preview wrappers |
+| `Oracle.lean` | `oracleReadUint256` | canonical oracle read wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |
 | `Callbacks.lean` | `callback` | `Stmt.callback` |
 | `Calls.lean` | `withReturn` | `Stmt.externalCallWithReturn` |
@@ -55,7 +56,8 @@ body := [
 ## Standard vs. Third-Party
 
 Standard modules live here and ship with Verity. They cover widely-used patterns
-(ERC-20, EVM precompiles, flash-loan callbacks, generic ABI calls).
+(ERC-20, ERC-4626 preview/redeem calls, oracle reads, EVM precompiles,
+flash-loan callbacks, generic ABI calls).
 
 Protocol-specific modules (Uniswap, Chainlink, Aave) should live in external Lean
 packages that depend on `Compiler.ECM`. See `docs/EXTERNAL_CALL_MODULES.md` for

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20, ERC-4626 previews, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20, ERC-4626 previews/redeems, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -325,6 +325,8 @@ def Compiler.Modules.ERC20.safeTransfer (token to amount : Expr) : Stmt
 def Compiler.Modules.ERC20.safeTransferFrom (token fromAddr to amount : Expr) : Stmt
 def Compiler.Modules.ERC4626.previewDeposit
   (resultVar : String) (vault assets : Expr) : Stmt
+def Compiler.Modules.ERC4626.previewRedeem
+  (resultVar : String) (vault shares : Expr) : Stmt
 def Compiler.Modules.Oracle.oracleReadUint256
   (resultVar : String) (target : Expr) (selector : Nat)
   (staticArgs : List Expr) : Stmt
@@ -363,6 +365,8 @@ This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust 
 `Compiler.Modules.Oracle.oracleReadUint256` covers the common read-only oracle case: it ABI-encodes the selector plus static arguments, performs a `staticcall`, requires exactly one 32-byte return word, and binds that word to a local result variable. The trust report records the explicit ECM assumption `oracle_read_uint256_interface`.
 
 `Compiler.Modules.ERC4626.previewDeposit` covers the common vault preview case: it ABI-encodes `previewDeposit(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewDeposit_interface`.
+
+`Compiler.Modules.ERC4626.previewRedeem` covers the complementary redeem-quote case: it ABI-encodes `previewRedeem(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewRedeem_interface`.
 
 ### Low-level `call` / `staticcall` / `delegatecall`
 


### PR DESCRIPTION
## Summary
- add a standard `Compiler.Modules.ERC4626.previewRedeem` ECM for `previewRedeem(uint256)`
- refactor the ERC-4626 module file so `previewDeposit` and `previewRedeem` share one read-only uint256 preview implementation
- add compile/trust-report regression coverage and update the module/trust docs

## Testing
- `lake build Compiler.Modules.ERC4626 Compiler.CompilationModelFeatureTest Compiler.CompileDriverTest`
- `make check`

Refs #1413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new ERC-4626 ECM and refactors `previewDeposit` to share a common codegen path, so a mistake could subtly change Yul emission or trust-report surfacing for existing vault integrations. Coverage is improved via new compile/Yul and trust-report regression tests.
> 
> **Overview**
> Adds a standard `Compiler.Modules.ERC4626.previewRedeem` ECM that performs a `staticcall` to `previewRedeem(uint256)` and enforces a single 32-byte `uint256` return, with a new trust assumption `erc4626_previewRedeem_interface`.
> 
> Refactors the existing ERC-4626 `previewDeposit` ECM to use a shared `previewUint256Module` helper, and extends regression tests to assert the expected Yul lowering (including selector encoding) and that trust reports surface the new module/assumption. Updates the axiom registry and user docs/API reference to include `previewRedeem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf6e6e5c475da538db23d73b7acb4b2e37235aa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->