### PR TITLE
modules: add standard erc20 read ECMs

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -158,6 +158,8 @@ in `--verbose` output.
 | `ERC20.safeTransfer` | `erc20_transfer_interface` | Target implements ERC-20 `transfer(address,uint256)` |
 | `ERC20.safeTransferFrom` | `erc20_transferFrom_interface` | Target implements ERC-20 `transferFrom(address,address,uint256)` |
 | `ERC20.safeApprove` | `erc20_approve_interface` | Target implements ERC-20 `approve(address,uint256)` |
+| `ERC20.balanceOf` | `erc20_balanceOf_interface` | Target implements `balanceOf(address)` and returns one ABI-encoded `uint256` |
+| `ERC20.allowance` | `erc20_allowance_interface` | Target implements `allowance(address,address)` and returns one ABI-encoded `uint256` |
 | `ERC4626.previewDeposit` | `erc4626_previewDeposit_interface` | Target implements `previewDeposit(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.previewRedeem` | `erc4626_previewRedeem_interface` | Target implements `previewRedeem(uint256)` and returns one ABI-encoded `uint256` |
 | `Oracle.oracleReadUint256` | `oracle_read_uint256_interface` | Target implements the selected read-only oracle interface and returns one ABI-encoded `uint256` |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -2,6 +2,7 @@ import Compiler.CompilationModel
 import Compiler.ABI
 import Compiler.Codegen
 import Compiler.Modules.ERC4626
+import Compiler.Modules.ERC20
 import Compiler.Modules.Oracle
 import Compiler.Modules.Precompiles
 import Compiler.Yul.PrettyPrint
@@ -500,6 +501,54 @@ private def oracleReadSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc20BalanceOfSmokeSpec : CompilationModel := {
+  name := "ERC20BalanceOfSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "balance"
+      params := [
+        { name := "token", ty := ParamType.address }
+        , { name := "owner", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC20.balanceOf
+          "balance"
+          (Expr.param "token")
+          (Expr.param "owner"),
+        Stmt.returnValues [Expr.localVar "balance"]
+      ]
+    }
+  ]
+}
+
+private def erc20AllowanceSmokeSpec : CompilationModel := {
+  name := "ERC20AllowanceSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "allowance"
+      params := [
+        { name := "token", ty := ParamType.address }
+        , { name := "owner", ty := ParamType.address }
+        , { name := "spender", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC20.allowance
+          "remaining"
+          (Expr.param "token")
+          (Expr.param "owner")
+          (Expr.param "spender"),
+        Stmt.returnValues [Expr.localVar "remaining"]
+      ]
+    }
+  ]
+}
+
 private def erc4626PreviewDepositSmokeSpec : CompilationModel := {
   name := "ERC4626PreviewDepositSmoke"
   fields := []
@@ -639,6 +688,26 @@ private def erc4626PreviewRedeemSmokeSpec : CompilationModel := {
     (contains oracleReadYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "oracle read ECM ABI-encodes the selector"
     (contains oracleReadYul "mstore(0, shl(224, 0xfeaf968c))")
+  let erc20BalanceOfYul ←
+    expectCompileToYul "erc20 balanceOf smoke spec" erc20BalanceOfSmokeSpec
+  expectTrue "erc20 balanceOf ECM lowers to staticcall"
+    (contains erc20BalanceOfYul "staticcall(gas(), token, 0, 36, 0, 32)")
+  expectTrue "erc20 balanceOf ECM forwards revert returndata"
+    (contains erc20BalanceOfYul "returndatacopy(0, 0, __balanceOf_rds)")
+  expectTrue "erc20 balanceOf ECM rejects non-32-byte returndata"
+    (contains erc20BalanceOfYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc20 balanceOf ECM ABI-encodes the selector"
+    (contains erc20BalanceOfYul "mstore(0, shl(224, 0x70a08231))")
+  let erc20AllowanceYul ←
+    expectCompileToYul "erc20 allowance smoke spec" erc20AllowanceSmokeSpec
+  expectTrue "erc20 allowance ECM lowers to staticcall"
+    (contains erc20AllowanceYul "staticcall(gas(), token, 0, 68, 0, 32)")
+  expectTrue "erc20 allowance ECM forwards revert returndata"
+    (contains erc20AllowanceYul "returndatacopy(0, 0, __allowance_rds)")
+  expectTrue "erc20 allowance ECM rejects non-32-byte returndata"
+    (contains erc20AllowanceYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc20 allowance ECM ABI-encodes the selector"
+    (contains erc20AllowanceYul "mstore(0, shl(224, 0xdd62ed3e))")
   let erc4626PreviewDepositYul ←
     expectCompileToYul "erc4626 previewDeposit smoke spec" erc4626PreviewDepositSmokeSpec
   expectTrue "erc4626 previewDeposit ECM lowers to staticcall"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -5,6 +5,7 @@ import Compiler.CompilationModel.TrustSurface
 import Compiler.ECM
 import Compiler.ModuleInput
 import Compiler.Modules.ERC4626
+import Compiler.Modules.ERC20
 import Compiler.Modules.Oracle
 import Compiler.Modules.Precompiles
 import Compiler.TestModules
@@ -278,6 +279,54 @@ private def oracleTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc20BalanceOfTrustSurfaceSpec : CompilationModel := {
+  name := "ERC20BalanceOfTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "balance"
+      params := [
+        { name := "token", ty := ParamType.address }
+        , { name := "owner", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC20.balanceOf
+          "balance"
+          (Expr.param "token")
+          (Expr.param "owner"),
+        Stmt.returnValues [Expr.localVar "balance"]
+      ]
+    }
+  ]
+}
+
+private def erc20AllowanceTrustSurfaceSpec : CompilationModel := {
+  name := "ERC20AllowanceTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "allowance"
+      params := [
+        { name := "token", ty := ParamType.address }
+        , { name := "owner", ty := ParamType.address }
+        , { name := "spender", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC20.allowance
+          "remaining"
+          (Expr.param "token")
+          (Expr.param "owner")
+          (Expr.param "spender"),
+        Stmt.returnValues [Expr.localVar "remaining"]
+      ]
+    }
+  ]
+}
+
 private def erc4626TrustSurfaceSpec : CompilationModel := {
   name := "ERC4626TrustSurface"
   fields := []
@@ -523,6 +572,26 @@ unsafe def runTests : IO Unit := do
   if !contains oracleTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"oracleReadUint256\"]}" then
     throw (IO.userError "✗ oracle trust report emits assumed ECM proof-status bucket")
   IO.println "✓ oracle trust report emits standard oracle module assumption"
+
+  let erc20BalanceOfTrustReport := emitTrustReportJson [erc20BalanceOfTrustSurfaceSpec]
+  if !contains erc20BalanceOfTrustReport "\"contract\":\"ERC20BalanceOfTrustSurface\"" then
+    throw (IO.userError "✗ erc20 balanceOf trust report emits contract name")
+  if !contains erc20BalanceOfTrustReport "\"module\":\"balanceOf\"" ||
+      !contains erc20BalanceOfTrustReport "\"assumption\":\"erc20_balanceOf_interface\"" then
+    throw (IO.userError "✗ erc20 balanceOf trust report emits module assumption")
+  if !contains erc20BalanceOfTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"balanceOf\"]}" then
+    throw (IO.userError "✗ erc20 balanceOf trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc20 balanceOf trust report emits standard token read module assumption"
+
+  let erc20AllowanceTrustReport := emitTrustReportJson [erc20AllowanceTrustSurfaceSpec]
+  if !contains erc20AllowanceTrustReport "\"contract\":\"ERC20AllowanceTrustSurface\"" then
+    throw (IO.userError "✗ erc20 allowance trust report emits contract name")
+  if !contains erc20AllowanceTrustReport "\"module\":\"allowance\"" ||
+      !contains erc20AllowanceTrustReport "\"assumption\":\"erc20_allowance_interface\"" then
+    throw (IO.userError "✗ erc20 allowance trust report emits module assumption")
+  if !contains erc20AllowanceTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"allowance\"]}" then
+    throw (IO.userError "✗ erc20 allowance trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc20 allowance trust report emits standard token read module assumption"
 
   let erc4626TrustReport := emitTrustReportJson [erc4626TrustSurfaceSpec]
   if !contains erc4626TrustReport "\"contract\":\"ERC4626TrustSurface\"" then

--- a/Compiler/Modules/ERC20.lean
+++ b/Compiler/Modules/ERC20.lean
@@ -5,6 +5,8 @@
   - `safeTransfer`:     transfer(address,uint256)       selector 0xa9059cbb
   - `safeTransferFrom`: transferFrom(address,address,uint256) selector 0x23b872dd
   - `safeApprove`:      approve(address,uint256)        selector 0x095ea7b3
+  - `balanceOf`:        balanceOf(address)              selector 0x70a08231
+  - `allowance`:        allowance(address,address)      selector 0xdd62ed3e
 
   All modules handle the ERC-20 optional-bool-return pattern: if the call
   succeeds but returndatasize == 32 and the returned word is zero, the
@@ -23,6 +25,58 @@ namespace Compiler.Modules.ERC20
 open Compiler.Yul
 open Compiler.ECM
 open Compiler.CompilationModel (Stmt Expr)
+
+/-- Shared implementation for read-only ERC-20 calls that return one
+    ABI-encoded `uint256` word. -/
+private def readUint256Module
+    (moduleName : String)
+    (axiomName : String)
+    (resultVar : String)
+    (selector : Nat)
+    (argNames : List String) : ExternalCallModule where
+  name := moduleName
+  numArgs := 1 + argNames.length
+  resultVars := [resultVar]
+  writesState := false
+  readsState := true
+  axioms := [axiomName]
+  compile := fun _ctx args => do
+    let tokenExpr ← match args.head? with
+      | some token => pure token
+      | none => throw s!"{moduleName} expects at least 1 argument (token)"
+    let argExprs := args.drop 1
+    if argExprs.length = argNames.length then
+      let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
+        YulExpr.lit 0,
+        YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
+      ])
+      let storeArgs := argExprs.zipIdx.map fun (argExpr, idx) =>
+        YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit (4 + idx * 32), argExpr])
+      let callExpr := YulExpr.call "staticcall" [
+        YulExpr.call "gas" [],
+        tokenExpr,
+        YulExpr.lit 0, YulExpr.lit (4 + argNames.length * 32),
+        YulExpr.lit 0, YulExpr.lit 32
+      ]
+      let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident s!"__{moduleName}_success"]) [
+        YulStmt.let_ s!"__{moduleName}_rds" (YulExpr.call "returndatasize" []),
+        YulStmt.expr (YulExpr.call "returndatacopy" [
+          YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident s!"__{moduleName}_rds"
+        ]),
+        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident s!"__{moduleName}_rds"])
+      ]
+      let requireSingleWord := YulStmt.if_ (YulExpr.call "iszero" [
+        YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32]
+      ]) [
+        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      ]
+      let bindResult := YulStmt.let_ resultVar (YulExpr.call "mload" [YulExpr.lit 0])
+      pure [YulStmt.block (
+        [storeSelector] ++ storeArgs ++
+        [YulStmt.let_ s!"__{moduleName}_success" callExpr, revertOnFailure, requireSingleWord]
+      ), bindResult]
+    else
+      throw s!"{moduleName} expects {1 + argNames.length} arguments (token, {String.intercalate ", " argNames})"
 
 /-- ERC-20 safeTransfer module.
     Calls `transfer(address to, uint256 amount)` with optional-bool-return handling.
@@ -126,5 +180,43 @@ def safeApproveModule : ExternalCallModule where
 /-- Convenience: create a `Stmt.ecm` for safeApprove. -/
 def safeApprove (token spender amount : Expr) : Stmt :=
   .ecm safeApproveModule [token, spender, amount]
+
+/-- Read-only ERC-20 `balanceOf(address)` module.
+
+    It ABI-encodes the canonical `balanceOf(address)` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[token, owner]`. -/
+def balanceOfModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "balanceOf"
+    "erc20_balanceOf_interface"
+    resultVar
+    0x70a08231
+    ["owner"]
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `balanceOf(address)` call. -/
+def balanceOf (resultVar : String) (token owner : Expr) : Stmt :=
+  .ecm (balanceOfModule resultVar) [token, owner]
+
+/-- Read-only ERC-20 `allowance(address,address)` module.
+
+    It ABI-encodes the canonical `allowance(address,address)` selector,
+    performs a `staticcall`, forwards revert returndata on failure, requires
+    exactly one 32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[token, owner, spender]`. -/
+def allowanceModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "allowance"
+    "erc20_allowance_interface"
+    resultVar
+    0xdd62ed3e
+    ["owner", "spender"]
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `allowance(address,address)` call. -/
+def allowance (resultVar : String) (token owner spender : Expr) : Stmt :=
+  .ecm (allowanceModule resultVar) [token, owner, spender]
 
 end Compiler.Modules.ERC20

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -8,7 +8,7 @@ structure that the compiler can plug in without modification.
 
 | File | Modules | Replaces |
 |------|---------|----------|
-| `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom` |
+| `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove`, `balanceOf`, `allowance` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom`, canonical ERC-20 read wrappers |
 | `ERC4626.lean` | `previewDeposit`, `previewRedeem` | canonical vault preview wrappers |
 | `Oracle.lean` | `oracleReadUint256` | canonical oracle read wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |
@@ -56,7 +56,7 @@ body := [
 ## Standard vs. Third-Party
 
 Standard modules live here and ship with Verity. They cover widely-used patterns
-(ERC-20, ERC-4626 preview/redeem calls, oracle reads, EVM precompiles,
+(ERC-20 writes and reads, ERC-4626 preview/redeem calls, oracle reads, EVM precompiles,
 flash-loan callbacks, generic ABI calls).
 
 Protocol-specific modules (Uniswap, Chainlink, Aave) should live in external Lean

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20, ERC-4626 previews/redeems, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20 writes/reads, ERC-4626 previews/redeems, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -323,6 +323,10 @@ Today this elaborates cleanly for tuple literals and tuple-typed parameters. `re
 ```lean
 def Compiler.Modules.ERC20.safeTransfer (token to amount : Expr) : Stmt
 def Compiler.Modules.ERC20.safeTransferFrom (token fromAddr to amount : Expr) : Stmt
+def Compiler.Modules.ERC20.balanceOf
+  (resultVar : String) (token owner : Expr) : Stmt
+def Compiler.Modules.ERC20.allowance
+  (resultVar : String) (token owner spender : Expr) : Stmt
 def Compiler.Modules.ERC4626.previewDeposit
   (resultVar : String) (vault assets : Expr) : Stmt
 def Compiler.Modules.ERC4626.previewRedeem
@@ -363,6 +367,10 @@ let signer <- ecrecover digest v r s
 This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust report records the explicit assumption `evm_ecrecover_precompile`.
 
 `Compiler.Modules.Oracle.oracleReadUint256` covers the common read-only oracle case: it ABI-encodes the selector plus static arguments, performs a `staticcall`, requires exactly one 32-byte return word, and binds that word to a local result variable. The trust report records the explicit ECM assumption `oracle_read_uint256_interface`.
+
+`Compiler.Modules.ERC20.balanceOf` covers the common token-balance read case: it ABI-encodes `balanceOf(address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned balance word to a local result variable. The trust report records the explicit ECM assumption `erc20_balanceOf_interface`.
+
+`Compiler.Modules.ERC20.allowance` covers the common ERC-20 allowance read case: it ABI-encodes `allowance(address,address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned allowance word to a local result variable. The trust report records the explicit ECM assumption `erc20_allowance_interface`.
 
 `Compiler.Modules.ERC4626.previewDeposit` covers the common vault preview case: it ABI-encodes `previewDeposit(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewDeposit_interface`.
 


### PR DESCRIPTION
Refs #1413.

## Summary
- add standard `Compiler.Modules.ERC20.balanceOf` and `Compiler.Modules.ERC20.allowance` ECMs
- share the read-only ERC-20 uint256-return lowering path so the wrappers stay consistent
- cover lowering and trust-report output in regression tests and document the new assumptions

## Validation
- `lake build Compiler.Modules.ERC20`
- `lake build Compiler.CompilationModelFeatureTest`
- `lake build Compiler.CompileDriverTest`
- `lake build Compiler.Modules.ERC20 Compiler.CompilationModelFeatureTest Compiler.CompileDriverTest`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new Yul-lowering logic for ERC-20 read calls (selector/ABI encoding, `staticcall`, revert/returndata handling); mistakes would impact correctness of generated contracts that use these new modules, though coverage is added via smoke and trust-report tests.
> 
> **Overview**
> Adds standard ERC-20 read External Call Modules `Compiler.Modules.ERC20.balanceOf` and `Compiler.Modules.ERC20.allowance`, using a shared `readUint256Module` helper to ABI-encode selectors/args, emit `staticcall`, forward revert returndata, and require a single 32-byte `uint256` result.
> 
> Updates trust-surface plumbing and docs by registering new ECM assumptions (`erc20_balanceOf_interface`, `erc20_allowance_interface`) and adding regression tests that assert both Yul lowering behavior and trust-report JSON output for the new modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2df1e755f3efebff538d3ca6447934c290c000a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->