### PR TITLE
modules: add standard ERC20 totalSupply ECM

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -160,6 +160,7 @@ in `--verbose` output.
 | `ERC20.safeApprove` | `erc20_approve_interface` | Target implements ERC-20 `approve(address,uint256)` |
 | `ERC20.balanceOf` | `erc20_balanceOf_interface` | Target implements `balanceOf(address)` and returns one ABI-encoded `uint256` |
 | `ERC20.allowance` | `erc20_allowance_interface` | Target implements `allowance(address,address)` and returns one ABI-encoded `uint256` |
+| `ERC20.totalSupply` | `erc20_totalSupply_interface` | Target implements `totalSupply()` and returns one ABI-encoded `uint256` |
 | `ERC4626.previewDeposit` | `erc4626_previewDeposit_interface` | Target implements `previewDeposit(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.previewRedeem` | `erc4626_previewRedeem_interface` | Target implements `previewRedeem(uint256)` and returns one ABI-encoded `uint256` |
 | `Oracle.oracleReadUint256` | `oracle_read_uint256_interface` | Target implements the selected read-only oracle interface and returns one ABI-encoded `uint256` |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -549,6 +549,25 @@ private def erc20AllowanceSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc20TotalSupplySmokeSpec : CompilationModel := {
+  name := "ERC20TotalSupplySmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "totalSupply"
+      params := [{ name := "token", ty := ParamType.address }]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC20.totalSupply
+          "supply"
+          (Expr.param "token"),
+        Stmt.returnValues [Expr.localVar "supply"]
+      ]
+    }
+  ]
+}
+
 private def erc4626PreviewDepositSmokeSpec : CompilationModel := {
   name := "ERC4626PreviewDepositSmoke"
   fields := []
@@ -708,6 +727,16 @@ private def erc4626PreviewRedeemSmokeSpec : CompilationModel := {
     (contains erc20AllowanceYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "erc20 allowance ECM ABI-encodes the selector"
     (contains erc20AllowanceYul "mstore(0, shl(224, 0xdd62ed3e))")
+  let erc20TotalSupplyYul ←
+    expectCompileToYul "erc20 totalSupply smoke spec" erc20TotalSupplySmokeSpec
+  expectTrue "erc20 totalSupply ECM lowers to staticcall"
+    (contains erc20TotalSupplyYul "staticcall(gas(), token, 0, 4, 0, 32)")
+  expectTrue "erc20 totalSupply ECM forwards revert returndata"
+    (contains erc20TotalSupplyYul "returndatacopy(0, 0, __totalSupply_rds)")
+  expectTrue "erc20 totalSupply ECM rejects non-32-byte returndata"
+    (contains erc20TotalSupplyYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc20 totalSupply ECM ABI-encodes the selector"
+    (contains erc20TotalSupplyYul "mstore(0, shl(224, 0x18160ddd))")
   let erc4626PreviewDepositYul ←
     expectCompileToYul "erc4626 previewDeposit smoke spec" erc4626PreviewDepositSmokeSpec
   expectTrue "erc4626 previewDeposit ECM lowers to staticcall"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -327,6 +327,25 @@ private def erc20AllowanceTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc20TotalSupplyTrustSurfaceSpec : CompilationModel := {
+  name := "ERC20TotalSupplyTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "totalSupply"
+      params := [{ name := "token", ty := ParamType.address }]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC20.totalSupply
+          "supply"
+          (Expr.param "token"),
+        Stmt.returnValues [Expr.localVar "supply"]
+      ]
+    }
+  ]
+}
+
 private def erc4626TrustSurfaceSpec : CompilationModel := {
   name := "ERC4626TrustSurface"
   fields := []
@@ -592,6 +611,16 @@ unsafe def runTests : IO Unit := do
   if !contains erc20AllowanceTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"allowance\"]}" then
     throw (IO.userError "✗ erc20 allowance trust report emits assumed ECM proof-status bucket")
   IO.println "✓ erc20 allowance trust report emits standard token read module assumption"
+
+  let erc20TotalSupplyTrustReport := emitTrustReportJson [erc20TotalSupplyTrustSurfaceSpec]
+  if !contains erc20TotalSupplyTrustReport "\"contract\":\"ERC20TotalSupplyTrustSurface\"" then
+    throw (IO.userError "✗ erc20 totalSupply trust report emits contract name")
+  if !contains erc20TotalSupplyTrustReport "\"module\":\"totalSupply\"" ||
+      !contains erc20TotalSupplyTrustReport "\"assumption\":\"erc20_totalSupply_interface\"" then
+    throw (IO.userError "✗ erc20 totalSupply trust report emits module assumption")
+  if !contains erc20TotalSupplyTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"totalSupply\"]}" then
+    throw (IO.userError "✗ erc20 totalSupply trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc20 totalSupply trust report emits standard token read module assumption"
 
   let erc4626TrustReport := emitTrustReportJson [erc4626TrustSurfaceSpec]
   if !contains erc4626TrustReport "\"contract\":\"ERC4626TrustSurface\"" then

--- a/Compiler/Modules/ERC20.lean
+++ b/Compiler/Modules/ERC20.lean
@@ -7,6 +7,7 @@
   - `safeApprove`:      approve(address,uint256)        selector 0x095ea7b3
   - `balanceOf`:        balanceOf(address)              selector 0x70a08231
   - `allowance`:        allowance(address,address)      selector 0xdd62ed3e
+  - `totalSupply`:      totalSupply()                   selector 0x18160ddd
 
   All modules handle the ERC-20 optional-bool-return pattern: if the call
   succeeds but returndatasize == 32 and the returned word is zero, the
@@ -218,5 +219,24 @@ def allowanceModule (resultVar : String) : ExternalCallModule :=
 /-- Convenience: create a `Stmt.ecm` for a read-only `allowance(address,address)` call. -/
 def allowance (resultVar : String) (token owner spender : Expr) : Stmt :=
   .ecm (allowanceModule resultVar) [token, owner, spender]
+
+/-- Read-only ERC-20 `totalSupply()` module.
+
+    It ABI-encodes the canonical `totalSupply()` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[token]`. -/
+def totalSupplyModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "totalSupply"
+    "erc20_totalSupply_interface"
+    resultVar
+    0x18160ddd
+    []
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `totalSupply()` call. -/
+def totalSupply (resultVar : String) (token : Expr) : Stmt :=
+  .ecm (totalSupplyModule resultVar) [token]
 
 end Compiler.Modules.ERC20

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -8,7 +8,7 @@ structure that the compiler can plug in without modification.
 
 | File | Modules | Replaces |
 |------|---------|----------|
-| `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove`, `balanceOf`, `allowance` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom`, canonical ERC-20 read wrappers |
+| `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove`, `balanceOf`, `allowance`, `totalSupply` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom`, canonical ERC-20 read wrappers |
 | `ERC4626.lean` | `previewDeposit`, `previewRedeem` | canonical vault preview wrappers |
 | `Oracle.lean` | `oracleReadUint256` | canonical oracle read wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20 writes/reads, ERC-4626 previews/redeems, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 previews/redeems, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -327,6 +327,8 @@ def Compiler.Modules.ERC20.balanceOf
   (resultVar : String) (token owner : Expr) : Stmt
 def Compiler.Modules.ERC20.allowance
   (resultVar : String) (token owner spender : Expr) : Stmt
+def Compiler.Modules.ERC20.totalSupply
+  (resultVar : String) (token : Expr) : Stmt
 def Compiler.Modules.ERC4626.previewDeposit
   (resultVar : String) (vault assets : Expr) : Stmt
 def Compiler.Modules.ERC4626.previewRedeem
@@ -371,6 +373,8 @@ This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust 
 `Compiler.Modules.ERC20.balanceOf` covers the common token-balance read case: it ABI-encodes `balanceOf(address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned balance word to a local result variable. The trust report records the explicit ECM assumption `erc20_balanceOf_interface`.
 
 `Compiler.Modules.ERC20.allowance` covers the common ERC-20 allowance read case: it ABI-encodes `allowance(address,address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned allowance word to a local result variable. The trust report records the explicit ECM assumption `erc20_allowance_interface`.
+
+`Compiler.Modules.ERC20.totalSupply` covers the common ERC-20 aggregate-supply read case: it ABI-encodes `totalSupply()`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned supply word to a local result variable. The trust report records the explicit ECM assumption `erc20_totalSupply_interface`.
 
 `Compiler.Modules.ERC4626.previewDeposit` covers the common vault preview case: it ABI-encodes `previewDeposit(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewDeposit_interface`.
 


### PR DESCRIPTION
Refs #1413.

## Summary
- add a standard `Compiler.Modules.ERC20.totalSupply` read ECM
- reuse the existing shared ERC-20 read-only uint256 lowering path for the zero-arg `totalSupply()` case
- add compilation-model and trust-report regression coverage and sync the docs/trust registries

## Validation
- `lake build Compiler.Modules.ERC20`
- `lake build Compiler.CompilationModelFeatureTest`
- `lake build Compiler.CompileDriverTest`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated new read-only ECM built on the existing `readUint256Module` path, plus test/docs updates; primary risk is incorrect selector/ABI encoding affecting contracts that adopt the new module.
> 
> **Overview**
> Adds a new standard ERC-20 read ECM, `Compiler.Modules.ERC20.totalSupply`, which compiles a `staticcall` for `totalSupply()` (selector `0x18160ddd`) and binds a single `uint256` return value.
> 
> Extends regression coverage to assert the expected Yul lowering and that `--trust-report` surfaces the new `erc20_totalSupply_interface` assumption, and updates the axiom registry and public docs to list the new module/assumption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ca9c43ba6fbb0a6d7d2801930526d8603c0f4f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->