### PR TITLE
modules: add standard erc4626 preview mint/withdraw ECMs

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -162,6 +162,8 @@ in `--verbose` output.
 | `ERC20.allowance` | `erc20_allowance_interface` | Target implements `allowance(address,address)` and returns one ABI-encoded `uint256` |
 | `ERC20.totalSupply` | `erc20_totalSupply_interface` | Target implements `totalSupply()` and returns one ABI-encoded `uint256` |
 | `ERC4626.previewDeposit` | `erc4626_previewDeposit_interface` | Target implements `previewDeposit(uint256)` and returns one ABI-encoded `uint256` |
+| `ERC4626.previewMint` | `erc4626_previewMint_interface` | Target implements `previewMint(uint256)` and returns one ABI-encoded `uint256` |
+| `ERC4626.previewWithdraw` | `erc4626_previewWithdraw_interface` | Target implements `previewWithdraw(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.previewRedeem` | `erc4626_previewRedeem_interface` | Target implements `previewRedeem(uint256)` and returns one ABI-encoded `uint256` |
 | `Oracle.oracleReadUint256` | `oracle_read_uint256_interface` | Target implements the selected read-only oracle interface and returns one ABI-encoded `uint256` |
 | `Precompiles.ecrecover` | `evm_ecrecover_precompile` | EVM precompile at address 0x01 behaves per Yellow Paper |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -591,6 +591,52 @@ private def erc4626PreviewDepositSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc4626PreviewMintSmokeSpec : CompilationModel := {
+  name := "ERC4626PreviewMintSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "preview"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "shares", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.previewMint
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "shares"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
+private def erc4626PreviewWithdrawSmokeSpec : CompilationModel := {
+  name := "ERC4626PreviewWithdrawSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "preview"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "assets", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.previewWithdraw
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "assets"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 private def erc4626PreviewRedeemSmokeSpec : CompilationModel := {
   name := "ERC4626PreviewRedeemSmoke"
   fields := []
@@ -747,6 +793,26 @@ private def erc4626PreviewRedeemSmokeSpec : CompilationModel := {
     (contains erc4626PreviewDepositYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "erc4626 previewDeposit ECM ABI-encodes the selector"
     (contains erc4626PreviewDepositYul "mstore(0, shl(224, 0xef8b30f7))")
+  let erc4626PreviewMintYul ←
+    expectCompileToYul "erc4626 previewMint smoke spec" erc4626PreviewMintSmokeSpec
+  expectTrue "erc4626 previewMint ECM lowers to staticcall"
+    (contains erc4626PreviewMintYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 previewMint ECM forwards revert returndata"
+    (contains erc4626PreviewMintYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 previewMint ECM rejects non-32-byte returndata"
+    (contains erc4626PreviewMintYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 previewMint ECM ABI-encodes the selector"
+    (contains erc4626PreviewMintYul "mstore(0, shl(224, 0xb3d7f6b9))")
+  let erc4626PreviewWithdrawYul ←
+    expectCompileToYul "erc4626 previewWithdraw smoke spec" erc4626PreviewWithdrawSmokeSpec
+  expectTrue "erc4626 previewWithdraw ECM lowers to staticcall"
+    (contains erc4626PreviewWithdrawYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 previewWithdraw ECM forwards revert returndata"
+    (contains erc4626PreviewWithdrawYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 previewWithdraw ECM rejects non-32-byte returndata"
+    (contains erc4626PreviewWithdrawYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 previewWithdraw ECM ABI-encodes the selector"
+    (contains erc4626PreviewWithdrawYul "mstore(0, shl(224, 0x0a28a477))")
   let erc4626PreviewRedeemYul ←
     expectCompileToYul "erc4626 previewRedeem smoke spec" erc4626PreviewRedeemSmokeSpec
   expectTrue "erc4626 previewRedeem ECM lowers to staticcall"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -369,6 +369,52 @@ private def erc4626TrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc4626PreviewMintTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626PreviewMintTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "preview"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "shares", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.previewMint
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "shares"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
+private def erc4626PreviewWithdrawTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626PreviewWithdrawTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "preview"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "assets", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.previewWithdraw
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "assets"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 private def erc4626PreviewRedeemTrustSurfaceSpec : CompilationModel := {
   name := "ERC4626PreviewRedeemTrustSurface"
   fields := []
@@ -631,6 +677,26 @@ unsafe def runTests : IO Unit := do
   if !contains erc4626TrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"previewDeposit\"]}" then
     throw (IO.userError "✗ erc4626 trust report emits assumed ECM proof-status bucket")
   IO.println "✓ erc4626 trust report emits standard vault module assumption"
+
+  let erc4626PreviewMintTrustReport := emitTrustReportJson [erc4626PreviewMintTrustSurfaceSpec]
+  if !contains erc4626PreviewMintTrustReport "\"contract\":\"ERC4626PreviewMintTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 previewMint trust report emits contract name")
+  if !contains erc4626PreviewMintTrustReport "\"module\":\"previewMint\"" ||
+      !contains erc4626PreviewMintTrustReport "\"assumption\":\"erc4626_previewMint_interface\"" then
+    throw (IO.userError "✗ erc4626 previewMint trust report emits module assumption")
+  if !contains erc4626PreviewMintTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"previewMint\"]}" then
+    throw (IO.userError "✗ erc4626 previewMint trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 previewMint trust report emits standard vault module assumption"
+
+  let erc4626PreviewWithdrawTrustReport := emitTrustReportJson [erc4626PreviewWithdrawTrustSurfaceSpec]
+  if !contains erc4626PreviewWithdrawTrustReport "\"contract\":\"ERC4626PreviewWithdrawTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 previewWithdraw trust report emits contract name")
+  if !contains erc4626PreviewWithdrawTrustReport "\"module\":\"previewWithdraw\"" ||
+      !contains erc4626PreviewWithdrawTrustReport "\"assumption\":\"erc4626_previewWithdraw_interface\"" then
+    throw (IO.userError "✗ erc4626 previewWithdraw trust report emits module assumption")
+  if !contains erc4626PreviewWithdrawTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"previewWithdraw\"]}" then
+    throw (IO.userError "✗ erc4626 previewWithdraw trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 previewWithdraw trust report emits standard vault module assumption"
 
   let erc4626PreviewRedeemTrustReport := emitTrustReportJson [erc4626PreviewRedeemTrustSurfaceSpec]
   if !contains erc4626PreviewRedeemTrustReport "\"contract\":\"ERC4626PreviewRedeemTrustSurface\"" then

--- a/Compiler/Modules/ERC4626.lean
+++ b/Compiler/Modules/ERC4626.lean
@@ -4,6 +4,10 @@
   Standard ECMs for read-only ERC-4626 integrations:
   - `previewDeposit`: staticcall `previewDeposit(uint256)` and require exactly
     one 32-byte return word.
+  - `previewMint`: staticcall `previewMint(uint256)` and require exactly one
+    32-byte return word.
+  - `previewWithdraw`: staticcall `previewWithdraw(uint256)` and require
+    exactly one 32-byte return word.
   - `previewRedeem`: staticcall `previewRedeem(uint256)` and require exactly
     one 32-byte return word.
 
@@ -89,6 +93,46 @@ def previewDepositModule (resultVar : String) : ExternalCallModule :=
     call. -/
 def previewDeposit (resultVar : String) (vault assets : Expr) : Stmt :=
   .ecm (previewDepositModule resultVar) [vault, assets]
+
+/-- Read-only ERC-4626 `previewMint(uint256)` module.
+
+    It ABI-encodes the canonical `previewMint(uint256)` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, shares]`. -/
+def previewMintModule (resultVar : String) : ExternalCallModule :=
+  previewUint256Module
+    "previewMint"
+    "erc4626_previewMint_interface"
+    resultVar
+    0xb3d7f6b9
+    "shares"
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `previewMint(uint256)`
+    call. -/
+def previewMint (resultVar : String) (vault shares : Expr) : Stmt :=
+  .ecm (previewMintModule resultVar) [vault, shares]
+
+/-- Read-only ERC-4626 `previewWithdraw(uint256)` module.
+
+    It ABI-encodes the canonical `previewWithdraw(uint256)` selector, performs
+    a `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, assets]`. -/
+def previewWithdrawModule (resultVar : String) : ExternalCallModule :=
+  previewUint256Module
+    "previewWithdraw"
+    "erc4626_previewWithdraw_interface"
+    resultVar
+    0x0a28a477
+    "assets"
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `previewWithdraw(uint256)`
+    call. -/
+def previewWithdraw (resultVar : String) (vault assets : Expr) : Stmt :=
+  .ecm (previewWithdrawModule resultVar) [vault, assets]
 
 /-- Read-only ERC-4626 `previewRedeem(uint256)` module.
 

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -9,7 +9,7 @@ structure that the compiler can plug in without modification.
 | File | Modules | Replaces |
 |------|---------|----------|
 | `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove`, `balanceOf`, `allowance`, `totalSupply` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom`, canonical ERC-20 read wrappers |
-| `ERC4626.lean` | `previewDeposit`, `previewRedeem` | canonical vault preview wrappers |
+| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem` | canonical vault preview wrappers |
 | `Oracle.lean` | `oracleReadUint256` | canonical oracle read wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |
 | `Callbacks.lean` | `callback` | `Stmt.callback` |
@@ -56,7 +56,7 @@ body := [
 ## Standard vs. Third-Party
 
 Standard modules live here and ship with Verity. They cover widely-used patterns
-(ERC-20 writes and reads, ERC-4626 preview/redeem calls, oracle reads, EVM precompiles,
+(ERC-20 writes and reads, ERC-4626 preview calls, oracle reads, EVM precompiles,
 flash-loan callbacks, generic ABI calls).
 
 Protocol-specific modules (Uniswap, Chainlink, Aave) should live in external Lean

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 previews/redeems, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview helpers, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -331,6 +331,10 @@ def Compiler.Modules.ERC20.totalSupply
   (resultVar : String) (token : Expr) : Stmt
 def Compiler.Modules.ERC4626.previewDeposit
   (resultVar : String) (vault assets : Expr) : Stmt
+def Compiler.Modules.ERC4626.previewMint
+  (resultVar : String) (vault shares : Expr) : Stmt
+def Compiler.Modules.ERC4626.previewWithdraw
+  (resultVar : String) (vault assets : Expr) : Stmt
 def Compiler.Modules.ERC4626.previewRedeem
   (resultVar : String) (vault shares : Expr) : Stmt
 def Compiler.Modules.Oracle.oracleReadUint256
@@ -377,6 +381,10 @@ This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust 
 `Compiler.Modules.ERC20.totalSupply` covers the common ERC-20 aggregate-supply read case: it ABI-encodes `totalSupply()`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned supply word to a local result variable. The trust report records the explicit ECM assumption `erc20_totalSupply_interface`.
 
 `Compiler.Modules.ERC4626.previewDeposit` covers the common vault preview case: it ABI-encodes `previewDeposit(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewDeposit_interface`.
+
+`Compiler.Modules.ERC4626.previewMint` covers the complementary mint-quote case: it ABI-encodes `previewMint(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewMint_interface`.
+
+`Compiler.Modules.ERC4626.previewWithdraw` covers the asset-withdrawal quote case: it ABI-encodes `previewWithdraw(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewWithdraw_interface`.
 
 `Compiler.Modules.ERC4626.previewRedeem` covers the complementary redeem-quote case: it ABI-encodes `previewRedeem(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewRedeem_interface`.
 


### PR DESCRIPTION
## Summary
- add standard ERC-4626 `previewMint(uint256)` and `previewWithdraw(uint256)` ECMs on top of the shared read-only preview lowering
- extend smoke and trust-surface regression coverage for the new vault preview helpers
- document the new surfaced assumptions in the module README, axioms registry, trust assumptions, and EDSL API reference

## Testing
- `lake build Compiler.Modules.ERC4626 Compiler.CompilationModelFeatureTest Compiler.CompileDriverTest`
- `make check`

Refs #1413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, mostly additive ECM helpers plus smoke/trust-report tests and documentation updates; impact is limited to contracts that opt into the new modules.
> 
> **Overview**
> Adds new ERC-4626 vault preview ECM helpers `previewMint(uint256)` and `previewWithdraw(uint256)` (including new `erc4626_previewMint_interface` and `erc4626_previewWithdraw_interface` assumptions) alongside the existing preview modules.
> 
> Extends compiler regression coverage to assert correct Yul lowering (selectors/staticcall/returndata checks) and trust-report emission for the new modules, and updates the axiom registry and user-facing docs to list the new APIs and assumptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90403e7c25423f5264de493f92c8c028116dcc43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->