### PR TITLE
modules: add standard erc4626 conversion ECMs

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -165,6 +165,8 @@ in `--verbose` output.
 | `ERC4626.previewMint` | `erc4626_previewMint_interface` | Target implements `previewMint(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.previewWithdraw` | `erc4626_previewWithdraw_interface` | Target implements `previewWithdraw(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.previewRedeem` | `erc4626_previewRedeem_interface` | Target implements `previewRedeem(uint256)` and returns one ABI-encoded `uint256` |
+| `ERC4626.convertToAssets` | `erc4626_convertToAssets_interface` | Target implements `convertToAssets(uint256)` and returns one ABI-encoded `uint256` |
+| `ERC4626.convertToShares` | `erc4626_convertToShares_interface` | Target implements `convertToShares(uint256)` and returns one ABI-encoded `uint256` |
 | `Oracle.oracleReadUint256` | `oracle_read_uint256_interface` | Target implements the selected read-only oracle interface and returns one ABI-encoded `uint256` |
 | `Precompiles.ecrecover` | `evm_ecrecover_precompile` | EVM precompile at address 0x01 behaves per Yellow Paper |
 | `Callbacks.callback` | `callback_target_interface` | Callback target processes ABI-encoded arguments correctly |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -660,6 +660,52 @@ private def erc4626PreviewRedeemSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc4626ConvertToAssetsSmokeSpec : CompilationModel := {
+  name := "ERC4626ConvertToAssetsSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "convert"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "shares", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.convertToAssets
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "shares"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
+private def erc4626ConvertToSharesSmokeSpec : CompilationModel := {
+  name := "ERC4626ConvertToSharesSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "convert"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "assets", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.convertToShares
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "assets"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 #eval! do
   let compiled :=
     match Compiler.CompilationModel.compile selectorSmokeSpec (selectorsFor selectorSmokeSpec) with
@@ -823,6 +869,26 @@ private def erc4626PreviewRedeemSmokeSpec : CompilationModel := {
     (contains erc4626PreviewRedeemYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "erc4626 previewRedeem ECM ABI-encodes the selector"
     (contains erc4626PreviewRedeemYul "mstore(0, shl(224, 0x4cdad506))")
+  let erc4626ConvertToAssetsYul ←
+    expectCompileToYul "erc4626 convertToAssets smoke spec" erc4626ConvertToAssetsSmokeSpec
+  expectTrue "erc4626 convertToAssets ECM lowers to staticcall"
+    (contains erc4626ConvertToAssetsYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 convertToAssets ECM forwards revert returndata"
+    (contains erc4626ConvertToAssetsYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 convertToAssets ECM rejects non-32-byte returndata"
+    (contains erc4626ConvertToAssetsYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 convertToAssets ECM ABI-encodes the selector"
+    (contains erc4626ConvertToAssetsYul "mstore(0, shl(224, 0x07a2d13a))")
+  let erc4626ConvertToSharesYul ←
+    expectCompileToYul "erc4626 convertToShares smoke spec" erc4626ConvertToSharesSmokeSpec
+  expectTrue "erc4626 convertToShares ECM lowers to staticcall"
+    (contains erc4626ConvertToSharesYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 convertToShares ECM forwards revert returndata"
+    (contains erc4626ConvertToSharesYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 convertToShares ECM rejects non-32-byte returndata"
+    (contains erc4626ConvertToSharesYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 convertToShares ECM ABI-encodes the selector"
+    (contains erc4626ConvertToSharesYul "mstore(0, shl(224, 0xc6e6f592))")
   let macroEcrecoverYul ←
     expectCompileToYul "macro ecrecover smoke spec" MacroEcrecoverSmoke.MacroEcrecover.spec
   expectTrue "macro ecrecover bind elaborates to the same ECM lowering"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -438,6 +438,52 @@ private def erc4626PreviewRedeemTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc4626ConvertToAssetsTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626ConvertToAssetsTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "convert"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "shares", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.convertToAssets
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "shares"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
+private def erc4626ConvertToSharesTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626ConvertToSharesTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "convert"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "assets", ty := ParamType.uint256 }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.convertToShares
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "assets"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 private def expectModuleArtifacts
     (labelPrefix : String)
     (modules : List String)
@@ -707,6 +753,26 @@ unsafe def runTests : IO Unit := do
   if !contains erc4626PreviewRedeemTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"previewRedeem\"]}" then
     throw (IO.userError "✗ erc4626 previewRedeem trust report emits assumed ECM proof-status bucket")
   IO.println "✓ erc4626 previewRedeem trust report emits standard vault module assumption"
+
+  let erc4626ConvertToAssetsTrustReport := emitTrustReportJson [erc4626ConvertToAssetsTrustSurfaceSpec]
+  if !contains erc4626ConvertToAssetsTrustReport "\"contract\":\"ERC4626ConvertToAssetsTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 convertToAssets trust report emits contract name")
+  if !contains erc4626ConvertToAssetsTrustReport "\"module\":\"convertToAssets\"" ||
+      !contains erc4626ConvertToAssetsTrustReport "\"assumption\":\"erc4626_convertToAssets_interface\"" then
+    throw (IO.userError "✗ erc4626 convertToAssets trust report emits module assumption")
+  if !contains erc4626ConvertToAssetsTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"convertToAssets\"]}" then
+    throw (IO.userError "✗ erc4626 convertToAssets trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 convertToAssets trust report emits standard vault module assumption"
+
+  let erc4626ConvertToSharesTrustReport := emitTrustReportJson [erc4626ConvertToSharesTrustSurfaceSpec]
+  if !contains erc4626ConvertToSharesTrustReport "\"contract\":\"ERC4626ConvertToSharesTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 convertToShares trust report emits contract name")
+  if !contains erc4626ConvertToSharesTrustReport "\"module\":\"convertToShares\"" ||
+      !contains erc4626ConvertToSharesTrustReport "\"assumption\":\"erc4626_convertToShares_interface\"" then
+    throw (IO.userError "✗ erc4626 convertToShares trust report emits module assumption")
+  if !contains erc4626ConvertToSharesTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"convertToShares\"]}" then
+    throw (IO.userError "✗ erc4626 convertToShares trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 convertToShares trust report emits standard vault module assumption"
 
   compileSpecsWithOptions [abiSmokeSpec] outDir false [] {} none (some trustReportPath) none
   let writtenTrustReport ← fileExists trustReportPath

--- a/Compiler/Modules/ERC4626.lean
+++ b/Compiler/Modules/ERC4626.lean
@@ -10,6 +10,10 @@
     exactly one 32-byte return word.
   - `previewRedeem`: staticcall `previewRedeem(uint256)` and require exactly
     one 32-byte return word.
+  - `convertToAssets`: staticcall `convertToAssets(uint256)` and require
+    exactly one 32-byte return word.
+  - `convertToShares`: staticcall `convertToShares(uint256)` and require
+    exactly one 32-byte return word.
 
   Trust assumption: the target address implements the selected ERC-4626 read
   interface and returns one ABI-encoded `uint256` word.
@@ -24,9 +28,9 @@ open Compiler.Yul
 open Compiler.ECM
 open Compiler.CompilationModel (Stmt Expr)
 
-/-- Shared implementation for read-only ERC-4626 preview calls that take a
-    single `uint256` argument and return one ABI-encoded `uint256` word. -/
-private def previewUint256Module
+/-- Shared implementation for read-only ERC-4626 calls that take a single
+    `uint256` argument and return one ABI-encoded `uint256` word. -/
+private def readUint256Module
     (moduleName : String)
     (axiomName : String)
     (resultVar : String)
@@ -82,7 +86,7 @@ private def previewUint256Module
 
     Arguments passed to the module are `[vault, assets]`. -/
 def previewDepositModule (resultVar : String) : ExternalCallModule :=
-  previewUint256Module
+  readUint256Module
     "previewDeposit"
     "erc4626_previewDeposit_interface"
     resultVar
@@ -102,7 +106,7 @@ def previewDeposit (resultVar : String) (vault assets : Expr) : Stmt :=
 
     Arguments passed to the module are `[vault, shares]`. -/
 def previewMintModule (resultVar : String) : ExternalCallModule :=
-  previewUint256Module
+  readUint256Module
     "previewMint"
     "erc4626_previewMint_interface"
     resultVar
@@ -122,7 +126,7 @@ def previewMint (resultVar : String) (vault shares : Expr) : Stmt :=
 
     Arguments passed to the module are `[vault, assets]`. -/
 def previewWithdrawModule (resultVar : String) : ExternalCallModule :=
-  previewUint256Module
+  readUint256Module
     "previewWithdraw"
     "erc4626_previewWithdraw_interface"
     resultVar
@@ -142,7 +146,7 @@ def previewWithdraw (resultVar : String) (vault assets : Expr) : Stmt :=
 
     Arguments passed to the module are `[vault, shares]`. -/
 def previewRedeemModule (resultVar : String) : ExternalCallModule :=
-  previewUint256Module
+  readUint256Module
     "previewRedeem"
     "erc4626_previewRedeem_interface"
     resultVar
@@ -153,5 +157,45 @@ def previewRedeemModule (resultVar : String) : ExternalCallModule :=
     call. -/
 def previewRedeem (resultVar : String) (vault shares : Expr) : Stmt :=
   .ecm (previewRedeemModule resultVar) [vault, shares]
+
+/-- Read-only ERC-4626 `convertToAssets(uint256)` module.
+
+    It ABI-encodes the canonical `convertToAssets(uint256)` selector, performs
+    a `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, shares]`. -/
+def convertToAssetsModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "convertToAssets"
+    "erc4626_convertToAssets_interface"
+    resultVar
+    0x07a2d13a
+    "shares"
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `convertToAssets(uint256)`
+    call. -/
+def convertToAssets (resultVar : String) (vault shares : Expr) : Stmt :=
+  .ecm (convertToAssetsModule resultVar) [vault, shares]
+
+/-- Read-only ERC-4626 `convertToShares(uint256)` module.
+
+    It ABI-encodes the canonical `convertToShares(uint256)` selector, performs
+    a `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, assets]`. -/
+def convertToSharesModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "convertToShares"
+    "erc4626_convertToShares_interface"
+    resultVar
+    0xc6e6f592
+    "assets"
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `convertToShares(uint256)`
+    call. -/
+def convertToShares (resultVar : String) (vault assets : Expr) : Stmt :=
+  .ecm (convertToSharesModule resultVar) [vault, assets]
 
 end Compiler.Modules.ERC4626

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -9,7 +9,7 @@ structure that the compiler can plug in without modification.
 | File | Modules | Replaces |
 |------|---------|----------|
 | `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove`, `balanceOf`, `allowance`, `totalSupply` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom`, canonical ERC-20 read wrappers |
-| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem` | canonical vault preview wrappers |
+| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`, `convertToAssets`, `convertToShares` | canonical vault preview/conversion wrappers |
 | `Oracle.lean` | `oracleReadUint256` | canonical oracle read wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |
 | `Callbacks.lean` | `callback` | `Stmt.callback` |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview helpers, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview/conversion helpers, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -337,6 +337,10 @@ def Compiler.Modules.ERC4626.previewWithdraw
   (resultVar : String) (vault assets : Expr) : Stmt
 def Compiler.Modules.ERC4626.previewRedeem
   (resultVar : String) (vault shares : Expr) : Stmt
+def Compiler.Modules.ERC4626.convertToAssets
+  (resultVar : String) (vault shares : Expr) : Stmt
+def Compiler.Modules.ERC4626.convertToShares
+  (resultVar : String) (vault assets : Expr) : Stmt
 def Compiler.Modules.Oracle.oracleReadUint256
   (resultVar : String) (target : Expr) (selector : Nat)
   (staticArgs : List Expr) : Stmt
@@ -387,6 +391,10 @@ This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust 
 `Compiler.Modules.ERC4626.previewWithdraw` covers the asset-withdrawal quote case: it ABI-encodes `previewWithdraw(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewWithdraw_interface`.
 
 `Compiler.Modules.ERC4626.previewRedeem` covers the complementary redeem-quote case: it ABI-encodes `previewRedeem(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset quote to a local result variable. The trust report records the explicit ECM assumption `erc4626_previewRedeem_interface`.
+
+`Compiler.Modules.ERC4626.convertToAssets` covers the canonical share-to-asset conversion case: it ABI-encodes `convertToAssets(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset amount to a local result variable. The trust report records the explicit ECM assumption `erc4626_convertToAssets_interface`.
+
+`Compiler.Modules.ERC4626.convertToShares` covers the canonical asset-to-share conversion case: it ABI-encodes `convertToShares(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share amount to a local result variable. The trust report records the explicit ECM assumption `erc4626_convertToShares_interface`.
 
 ### Low-level `call` / `staticcall` / `delegatecall`
 


### PR DESCRIPTION
## Summary
- add standard ERC-4626 `convertToAssets` and `convertToShares` ECMs
- reuse one shared read-only uint256 ERC-4626 lowering path for previews and conversions
- extend smoke tests, trust-report checks, and docs/trust registries for the new modules

## Testing
- lake build Compiler.Modules.ERC4626 Compiler.CompilationModelFeatureTest Compiler.CompileDriverTest
- make check

## Issue
- part of #1413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds two new read-only ERC-4626 ECM wrappers and lightly refactors the existing ERC-4626 preview modules to share the same lowering path; behavior is covered by new smoke and trust-report tests plus selector string checks.
> 
> **Overview**
> Adds standard ERC-4626 conversion ECMs `convertToAssets` and `convertToShares`, mirroring the existing preview helpers (staticcall + 32-byte returndata enforcement) and surfacing new interface axioms for trust reporting.
> 
> Refactors ERC-4626 preview modules to reuse a single shared `readUint256Module` implementation, and extends compilation/Yul-lowering smoke tests, trust-report assertions, and documentation registries (`AXIOMS.md`, module README, API reference, trust assumptions) for the new modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e0b9ea576ebda8da9d66b3c9ad4705d21795bf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->