### PR TITLE
modules: add standard erc4626 totalAssets ECM

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -167,6 +167,7 @@ in `--verbose` output.
 | `ERC4626.previewRedeem` | `erc4626_previewRedeem_interface` | Target implements `previewRedeem(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.convertToAssets` | `erc4626_convertToAssets_interface` | Target implements `convertToAssets(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.convertToShares` | `erc4626_convertToShares_interface` | Target implements `convertToShares(uint256)` and returns one ABI-encoded `uint256` |
+| `ERC4626.totalAssets` | `erc4626_totalAssets_interface` | Target implements `totalAssets()` and returns one ABI-encoded `uint256` |
 | `Oracle.oracleReadUint256` | `oracle_read_uint256_interface` | Target implements the selected read-only oracle interface and returns one ABI-encoded `uint256` |
 | `Precompiles.ecrecover` | `evm_ecrecover_precompile` | EVM precompile at address 0x01 behaves per Yellow Paper |
 | `Callbacks.callback` | `callback_target_interface` | Callback target processes ABI-encoded arguments correctly |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -706,6 +706,25 @@ private def erc4626ConvertToSharesSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc4626TotalAssetsSmokeSpec : CompilationModel := {
+  name := "ERC4626TotalAssetsSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "totalAssets"
+      params := [{ name := "vault", ty := ParamType.address }]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.totalAssets
+          "assets"
+          (Expr.param "vault"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
 #eval! do
   let compiled :=
     match Compiler.CompilationModel.compile selectorSmokeSpec (selectorsFor selectorSmokeSpec) with
@@ -889,6 +908,16 @@ private def erc4626ConvertToSharesSmokeSpec : CompilationModel := {
     (contains erc4626ConvertToSharesYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "erc4626 convertToShares ECM ABI-encodes the selector"
     (contains erc4626ConvertToSharesYul "mstore(0, shl(224, 0xc6e6f592))")
+  let erc4626TotalAssetsYul ←
+    expectCompileToYul "erc4626 totalAssets smoke spec" erc4626TotalAssetsSmokeSpec
+  expectTrue "erc4626 totalAssets ECM lowers to staticcall"
+    (contains erc4626TotalAssetsYul "staticcall(gas(), vault, 0, 4, 0, 32)")
+  expectTrue "erc4626 totalAssets ECM forwards revert returndata"
+    (contains erc4626TotalAssetsYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 totalAssets ECM rejects non-32-byte returndata"
+    (contains erc4626TotalAssetsYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 totalAssets ECM ABI-encodes the selector"
+    (contains erc4626TotalAssetsYul "mstore(0, shl(224, 0x01e1d114))")
   let macroEcrecoverYul ←
     expectCompileToYul "macro ecrecover smoke spec" MacroEcrecoverSmoke.MacroEcrecover.spec
   expectTrue "macro ecrecover bind elaborates to the same ECM lowering"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -484,6 +484,25 @@ private def erc4626ConvertToSharesTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc4626TotalAssetsTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626TotalAssetsTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "totalAssets"
+      params := [{ name := "vault", ty := ParamType.address }]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.totalAssets
+          "assets"
+          (Expr.param "vault"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
 private def expectModuleArtifacts
     (labelPrefix : String)
     (modules : List String)
@@ -773,6 +792,16 @@ unsafe def runTests : IO Unit := do
   if !contains erc4626ConvertToSharesTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"convertToShares\"]}" then
     throw (IO.userError "✗ erc4626 convertToShares trust report emits assumed ECM proof-status bucket")
   IO.println "✓ erc4626 convertToShares trust report emits standard vault module assumption"
+
+  let erc4626TotalAssetsTrustReport := emitTrustReportJson [erc4626TotalAssetsTrustSurfaceSpec]
+  if !contains erc4626TotalAssetsTrustReport "\"contract\":\"ERC4626TotalAssetsTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 totalAssets trust report emits contract name")
+  if !contains erc4626TotalAssetsTrustReport "\"module\":\"totalAssets\"" ||
+      !contains erc4626TotalAssetsTrustReport "\"assumption\":\"erc4626_totalAssets_interface\"" then
+    throw (IO.userError "✗ erc4626 totalAssets trust report emits module assumption")
+  if !contains erc4626TotalAssetsTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"totalAssets\"]}" then
+    throw (IO.userError "✗ erc4626 totalAssets trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 totalAssets trust report emits standard vault module assumption"
 
   compileSpecsWithOptions [abiSmokeSpec] outDir false [] {} none (some trustReportPath) none
   let writtenTrustReport ← fileExists trustReportPath

--- a/Compiler/Modules/ERC4626.lean
+++ b/Compiler/Modules/ERC4626.lean
@@ -14,6 +14,8 @@
     exactly one 32-byte return word.
   - `convertToShares`: staticcall `convertToShares(uint256)` and require
     exactly one 32-byte return word.
+  - `totalAssets`: staticcall `totalAssets()` and require exactly one 32-byte
+    return word.
 
   Trust assumption: the target address implements the selected ERC-4626 read
   interface and returns one ABI-encoded `uint256` word.
@@ -28,33 +30,37 @@ open Compiler.Yul
 open Compiler.ECM
 open Compiler.CompilationModel (Stmt Expr)
 
-/-- Shared implementation for read-only ERC-4626 calls that take a single
-    `uint256` argument and return one ABI-encoded `uint256` word. -/
+/-- Shared implementation for read-only ERC-4626 calls that return one
+    ABI-encoded `uint256` word. -/
 private def readUint256Module
     (moduleName : String)
     (axiomName : String)
     (resultVar : String)
     (selector : Nat)
-    (argName : String) : ExternalCallModule where
+    (argNames : List String) : ExternalCallModule where
   name := moduleName
-  numArgs := 2
+  numArgs := 1 + argNames.length
   resultVars := [resultVar]
   writesState := false
   readsState := true
   axioms := [axiomName]
   compile := fun _ctx args => do
-    let (vaultExpr, argExpr) ← match args with
-      | [vault, value] => pure (vault, value)
-      | _ => throw s!"{moduleName} expects 2 arguments (vault, {argName})"
+    let vaultExpr ← match args.head? with
+      | some vault => pure vault
+      | none => throw s!"{moduleName} expects at least 1 argument (vault)"
+    let argExprs := args.drop 1
+    if argExprs.length != argNames.length then
+      throw s!"{moduleName} expects {1 + argNames.length} arguments (vault{if argNames.isEmpty then "" else s!", {String.intercalate ", " argNames}"})"
     let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
       YulExpr.lit 0,
       YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
     ])
-    let storeArg := YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 4, argExpr])
+    let storeArgs := argExprs.zipIdx.map fun (argExpr, idx) =>
+      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit (4 + idx * 32), argExpr])
     let callExpr := YulExpr.call "staticcall" [
       YulExpr.call "gas" [],
       vaultExpr,
-      YulExpr.lit 0, YulExpr.lit 36,
+      YulExpr.lit 0, YulExpr.lit (4 + argNames.length * 32),
       YulExpr.lit 0, YulExpr.lit 32
     ]
     let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__erc4626_success"]) [
@@ -70,13 +76,10 @@ private def readUint256Module
       YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
     ]
     let bindResult := YulStmt.let_ resultVar (YulExpr.call "mload" [YulExpr.lit 0])
-    pure [YulStmt.block [
-      storeSelector,
-      storeArg,
-      YulStmt.let_ "__erc4626_success" callExpr,
-      revertOnFailure,
-      requireSingleWord
-    ], bindResult]
+    pure [YulStmt.block (
+      [storeSelector] ++ storeArgs ++
+      [YulStmt.let_ "__erc4626_success" callExpr, revertOnFailure, requireSingleWord]
+    ), bindResult]
 
 /-- Read-only ERC-4626 `previewDeposit(uint256)` module.
 
@@ -91,7 +94,7 @@ def previewDepositModule (resultVar : String) : ExternalCallModule :=
     "erc4626_previewDeposit_interface"
     resultVar
     0xef8b30f7
-    "assets"
+    ["assets"]
 
 /-- Convenience: create a `Stmt.ecm` for a read-only `previewDeposit(uint256)`
     call. -/
@@ -111,7 +114,7 @@ def previewMintModule (resultVar : String) : ExternalCallModule :=
     "erc4626_previewMint_interface"
     resultVar
     0xb3d7f6b9
-    "shares"
+    ["shares"]
 
 /-- Convenience: create a `Stmt.ecm` for a read-only `previewMint(uint256)`
     call. -/
@@ -131,7 +134,7 @@ def previewWithdrawModule (resultVar : String) : ExternalCallModule :=
     "erc4626_previewWithdraw_interface"
     resultVar
     0x0a28a477
-    "assets"
+    ["assets"]
 
 /-- Convenience: create a `Stmt.ecm` for a read-only `previewWithdraw(uint256)`
     call. -/
@@ -151,7 +154,7 @@ def previewRedeemModule (resultVar : String) : ExternalCallModule :=
     "erc4626_previewRedeem_interface"
     resultVar
     0x4cdad506
-    "shares"
+    ["shares"]
 
 /-- Convenience: create a `Stmt.ecm` for a read-only `previewRedeem(uint256)`
     call. -/
@@ -171,7 +174,7 @@ def convertToAssetsModule (resultVar : String) : ExternalCallModule :=
     "erc4626_convertToAssets_interface"
     resultVar
     0x07a2d13a
-    "shares"
+    ["shares"]
 
 /-- Convenience: create a `Stmt.ecm` for a read-only `convertToAssets(uint256)`
     call. -/
@@ -191,11 +194,30 @@ def convertToSharesModule (resultVar : String) : ExternalCallModule :=
     "erc4626_convertToShares_interface"
     resultVar
     0xc6e6f592
-    "assets"
+    ["assets"]
 
 /-- Convenience: create a `Stmt.ecm` for a read-only `convertToShares(uint256)`
     call. -/
 def convertToShares (resultVar : String) (vault assets : Expr) : Stmt :=
   .ecm (convertToSharesModule resultVar) [vault, assets]
+
+/-- Read-only ERC-4626 `totalAssets()` module.
+
+    It ABI-encodes the canonical `totalAssets()` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault]`. -/
+def totalAssetsModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "totalAssets"
+    "erc4626_totalAssets_interface"
+    resultVar
+    0x01e1d114
+    []
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `totalAssets()` call. -/
+def totalAssets (resultVar : String) (vault : Expr) : Stmt :=
+  .ecm (totalAssetsModule resultVar) [vault]
 
 end Compiler.Modules.ERC4626

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -9,7 +9,7 @@ structure that the compiler can plug in without modification.
 | File | Modules | Replaces |
 |------|---------|----------|
 | `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove`, `balanceOf`, `allowance`, `totalSupply` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom`, canonical ERC-20 read wrappers |
-| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`, `convertToAssets`, `convertToShares` | canonical vault preview/conversion wrappers |
+| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`, `convertToAssets`, `convertToShares`, `totalAssets` | canonical vault preview/conversion wrappers |
 | `Oracle.lean` | `oracleReadUint256` | canonical oracle read wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |
 | `Callbacks.lean` | `callback` | `Stmt.callback` |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview/conversion helpers, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview/conversion helpers plus `totalAssets`, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -341,6 +341,8 @@ def Compiler.Modules.ERC4626.convertToAssets
   (resultVar : String) (vault shares : Expr) : Stmt
 def Compiler.Modules.ERC4626.convertToShares
   (resultVar : String) (vault assets : Expr) : Stmt
+def Compiler.Modules.ERC4626.totalAssets
+  (resultVar : String) (vault : Expr) : Stmt
 def Compiler.Modules.Oracle.oracleReadUint256
   (resultVar : String) (target : Expr) (selector : Nat)
   (staticArgs : List Expr) : Stmt
@@ -395,6 +397,8 @@ This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust 
 `Compiler.Modules.ERC4626.convertToAssets` covers the canonical share-to-asset conversion case: it ABI-encodes `convertToAssets(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset amount to a local result variable. The trust report records the explicit ECM assumption `erc4626_convertToAssets_interface`.
 
 `Compiler.Modules.ERC4626.convertToShares` covers the canonical asset-to-share conversion case: it ABI-encodes `convertToShares(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share amount to a local result variable. The trust report records the explicit ECM assumption `erc4626_convertToShares_interface`.
+
+`Compiler.Modules.ERC4626.totalAssets` covers the canonical vault-assets aggregate case: it ABI-encodes `totalAssets()`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset total to a local result variable. The trust report records the explicit ECM assumption `erc4626_totalAssets_interface`.
 
 ### Low-level `call` / `staticcall` / `delegatecall`
 


### PR DESCRIPTION
## Summary
- add a standard `ERC4626.totalAssets()` ECM for canonical zero-arg vault asset reads
- generalize the shared ERC-4626 read-only uint256 lowering path so preview/conversion helpers and `totalAssets()` share one implementation
- extend smoke, trust-report, and docs/trust-surface coverage for the new module

## Testing
- `lake build Compiler.Modules.ERC4626 Compiler.CompilationModelFeatureTest Compiler.CompileDriverTest`
- `make check`

Closes #1413

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared ERC-4626 ECM lowering used by existing preview/conversion helpers, so a bug could change calldata sizing/encoding for multiple modules; coverage is mitigated by added Yul and trust-report smoke tests.
> 
> **Overview**
> Adds a standard `ERC4626.totalAssets()` external call module (selector `0x01e1d114`) for zero-arg vault asset reads.
> 
> Refactors the shared ERC-4626 `readUint256Module` lowering to accept a variable argument list (including zero args), updating existing preview/conversion modules to use the generalized path.
> 
> Extends compilation-model feature tests and compile-driver trust-report checks for the new module, and updates the axiom registry plus docs (`Modules/README.md`, `TRUST_ASSUMPTIONS.md`, and EDSL API reference) to list the new assumption `erc4626_totalAssets_interface`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 588aa9c19e84eb0c741d704cfe4a0aeb8559790f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->