### PR TITLE
modules: add standard erc4626 max read ECMs

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -168,6 +168,10 @@ in `--verbose` output.
 | `ERC4626.convertToAssets` | `erc4626_convertToAssets_interface` | Target implements `convertToAssets(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.convertToShares` | `erc4626_convertToShares_interface` | Target implements `convertToShares(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.totalAssets` | `erc4626_totalAssets_interface` | Target implements `totalAssets()` and returns one ABI-encoded `uint256` |
+| `ERC4626.maxDeposit` | `erc4626_maxDeposit_interface` | Target implements `maxDeposit(address)` and returns one ABI-encoded `uint256` |
+| `ERC4626.maxMint` | `erc4626_maxMint_interface` | Target implements `maxMint(address)` and returns one ABI-encoded `uint256` |
+| `ERC4626.maxWithdraw` | `erc4626_maxWithdraw_interface` | Target implements `maxWithdraw(address)` and returns one ABI-encoded `uint256` |
+| `ERC4626.maxRedeem` | `erc4626_maxRedeem_interface` | Target implements `maxRedeem(address)` and returns one ABI-encoded `uint256` |
 | `Oracle.oracleReadUint256` | `oracle_read_uint256_interface` | Target implements the selected read-only oracle interface and returns one ABI-encoded `uint256` |
 | `Precompiles.ecrecover` | `evm_ecrecover_precompile` | EVM precompile at address 0x01 behaves per Yellow Paper |
 | `Callbacks.callback` | `callback_target_interface` | Callback target processes ABI-encoded arguments correctly |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -725,6 +725,98 @@ private def erc4626TotalAssetsSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc4626MaxDepositSmokeSpec : CompilationModel := {
+  name := "ERC4626MaxDepositSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "maxDeposit"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "receiver", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.maxDeposit
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "receiver"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
+private def erc4626MaxMintSmokeSpec : CompilationModel := {
+  name := "ERC4626MaxMintSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "maxMint"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "receiver", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.maxMint
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "receiver"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
+private def erc4626MaxWithdrawSmokeSpec : CompilationModel := {
+  name := "ERC4626MaxWithdrawSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "maxWithdraw"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "owner", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.maxWithdraw
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "owner"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
+private def erc4626MaxRedeemSmokeSpec : CompilationModel := {
+  name := "ERC4626MaxRedeemSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "maxRedeem"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "owner", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.maxRedeem
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "owner"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 #eval! do
   let compiled :=
     match Compiler.CompilationModel.compile selectorSmokeSpec (selectorsFor selectorSmokeSpec) with
@@ -918,6 +1010,46 @@ private def erc4626TotalAssetsSmokeSpec : CompilationModel := {
     (contains erc4626TotalAssetsYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "erc4626 totalAssets ECM ABI-encodes the selector"
     (contains erc4626TotalAssetsYul "mstore(0, shl(224, 0x01e1d114))")
+  let erc4626MaxDepositYul ←
+    expectCompileToYul "erc4626 maxDeposit smoke spec" erc4626MaxDepositSmokeSpec
+  expectTrue "erc4626 maxDeposit ECM lowers to staticcall"
+    (contains erc4626MaxDepositYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 maxDeposit ECM forwards revert returndata"
+    (contains erc4626MaxDepositYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 maxDeposit ECM rejects non-32-byte returndata"
+    (contains erc4626MaxDepositYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 maxDeposit ECM ABI-encodes the selector"
+    (contains erc4626MaxDepositYul "mstore(0, shl(224, 0x402d267d))")
+  let erc4626MaxMintYul ←
+    expectCompileToYul "erc4626 maxMint smoke spec" erc4626MaxMintSmokeSpec
+  expectTrue "erc4626 maxMint ECM lowers to staticcall"
+    (contains erc4626MaxMintYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 maxMint ECM forwards revert returndata"
+    (contains erc4626MaxMintYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 maxMint ECM rejects non-32-byte returndata"
+    (contains erc4626MaxMintYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 maxMint ECM ABI-encodes the selector"
+    (contains erc4626MaxMintYul "mstore(0, shl(224, 0xc63d75b6))")
+  let erc4626MaxWithdrawYul ←
+    expectCompileToYul "erc4626 maxWithdraw smoke spec" erc4626MaxWithdrawSmokeSpec
+  expectTrue "erc4626 maxWithdraw ECM lowers to staticcall"
+    (contains erc4626MaxWithdrawYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 maxWithdraw ECM forwards revert returndata"
+    (contains erc4626MaxWithdrawYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 maxWithdraw ECM rejects non-32-byte returndata"
+    (contains erc4626MaxWithdrawYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 maxWithdraw ECM ABI-encodes the selector"
+    (contains erc4626MaxWithdrawYul "mstore(0, shl(224, 0xce96cb77))")
+  let erc4626MaxRedeemYul ←
+    expectCompileToYul "erc4626 maxRedeem smoke spec" erc4626MaxRedeemSmokeSpec
+  expectTrue "erc4626 maxRedeem ECM lowers to staticcall"
+    (contains erc4626MaxRedeemYul "staticcall(gas(), vault, 0, 36, 0, 32)")
+  expectTrue "erc4626 maxRedeem ECM forwards revert returndata"
+    (contains erc4626MaxRedeemYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 maxRedeem ECM rejects non-32-byte returndata"
+    (contains erc4626MaxRedeemYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 maxRedeem ECM ABI-encodes the selector"
+    (contains erc4626MaxRedeemYul "mstore(0, shl(224, 0xd905777e))")
   let macroEcrecoverYul ←
     expectCompileToYul "macro ecrecover smoke spec" MacroEcrecoverSmoke.MacroEcrecover.spec
   expectTrue "macro ecrecover bind elaborates to the same ECM lowering"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -503,6 +503,98 @@ private def erc4626TotalAssetsTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc4626MaxDepositTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626MaxDepositTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "maxDeposit"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "receiver", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.maxDeposit
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "receiver"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
+private def erc4626MaxMintTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626MaxMintTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "maxMint"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "receiver", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.maxMint
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "receiver"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
+private def erc4626MaxWithdrawTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626MaxWithdrawTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "maxWithdraw"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "owner", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.maxWithdraw
+          "assets"
+          (Expr.param "vault")
+          (Expr.param "owner"),
+        Stmt.returnValues [Expr.localVar "assets"]
+      ]
+    }
+  ]
+}
+
+private def erc4626MaxRedeemTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626MaxRedeemTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "maxRedeem"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "owner", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.maxRedeem
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "owner"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 private def expectModuleArtifacts
     (labelPrefix : String)
     (modules : List String)
@@ -802,6 +894,46 @@ unsafe def runTests : IO Unit := do
   if !contains erc4626TotalAssetsTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"totalAssets\"]}" then
     throw (IO.userError "✗ erc4626 totalAssets trust report emits assumed ECM proof-status bucket")
   IO.println "✓ erc4626 totalAssets trust report emits standard vault module assumption"
+
+  let erc4626MaxDepositTrustReport := emitTrustReportJson [erc4626MaxDepositTrustSurfaceSpec]
+  if !contains erc4626MaxDepositTrustReport "\"contract\":\"ERC4626MaxDepositTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 maxDeposit trust report emits contract name")
+  if !contains erc4626MaxDepositTrustReport "\"module\":\"maxDeposit\"" ||
+      !contains erc4626MaxDepositTrustReport "\"assumption\":\"erc4626_maxDeposit_interface\"" then
+    throw (IO.userError "✗ erc4626 maxDeposit trust report emits module assumption")
+  if !contains erc4626MaxDepositTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"maxDeposit\"]}" then
+    throw (IO.userError "✗ erc4626 maxDeposit trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 maxDeposit trust report emits standard vault module assumption"
+
+  let erc4626MaxMintTrustReport := emitTrustReportJson [erc4626MaxMintTrustSurfaceSpec]
+  if !contains erc4626MaxMintTrustReport "\"contract\":\"ERC4626MaxMintTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 maxMint trust report emits contract name")
+  if !contains erc4626MaxMintTrustReport "\"module\":\"maxMint\"" ||
+      !contains erc4626MaxMintTrustReport "\"assumption\":\"erc4626_maxMint_interface\"" then
+    throw (IO.userError "✗ erc4626 maxMint trust report emits module assumption")
+  if !contains erc4626MaxMintTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"maxMint\"]}" then
+    throw (IO.userError "✗ erc4626 maxMint trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 maxMint trust report emits standard vault module assumption"
+
+  let erc4626MaxWithdrawTrustReport := emitTrustReportJson [erc4626MaxWithdrawTrustSurfaceSpec]
+  if !contains erc4626MaxWithdrawTrustReport "\"contract\":\"ERC4626MaxWithdrawTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 maxWithdraw trust report emits contract name")
+  if !contains erc4626MaxWithdrawTrustReport "\"module\":\"maxWithdraw\"" ||
+      !contains erc4626MaxWithdrawTrustReport "\"assumption\":\"erc4626_maxWithdraw_interface\"" then
+    throw (IO.userError "✗ erc4626 maxWithdraw trust report emits module assumption")
+  if !contains erc4626MaxWithdrawTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"maxWithdraw\"]}" then
+    throw (IO.userError "✗ erc4626 maxWithdraw trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 maxWithdraw trust report emits standard vault module assumption"
+
+  let erc4626MaxRedeemTrustReport := emitTrustReportJson [erc4626MaxRedeemTrustSurfaceSpec]
+  if !contains erc4626MaxRedeemTrustReport "\"contract\":\"ERC4626MaxRedeemTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 maxRedeem trust report emits contract name")
+  if !contains erc4626MaxRedeemTrustReport "\"module\":\"maxRedeem\"" ||
+      !contains erc4626MaxRedeemTrustReport "\"assumption\":\"erc4626_maxRedeem_interface\"" then
+    throw (IO.userError "✗ erc4626 maxRedeem trust report emits module assumption")
+  if !contains erc4626MaxRedeemTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"maxRedeem\"]}" then
+    throw (IO.userError "✗ erc4626 maxRedeem trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 maxRedeem trust report emits standard vault module assumption"
 
   compileSpecsWithOptions [abiSmokeSpec] outDir false [] {} none (some trustReportPath) none
   let writtenTrustReport ← fileExists trustReportPath

--- a/Compiler/Modules/ERC4626.lean
+++ b/Compiler/Modules/ERC4626.lean
@@ -16,6 +16,14 @@
     exactly one 32-byte return word.
   - `totalAssets`: staticcall `totalAssets()` and require exactly one 32-byte
     return word.
+  - `maxDeposit`: staticcall `maxDeposit(address)` and require exactly one
+    32-byte return word.
+  - `maxMint`: staticcall `maxMint(address)` and require exactly one 32-byte
+    return word.
+  - `maxWithdraw`: staticcall `maxWithdraw(address)` and require exactly one
+    32-byte return word.
+  - `maxRedeem`: staticcall `maxRedeem(address)` and require exactly one
+    32-byte return word.
 
   Trust assumption: the target address implements the selected ERC-4626 read
   interface and returns one ABI-encoded `uint256` word.
@@ -219,5 +227,85 @@ def totalAssetsModule (resultVar : String) : ExternalCallModule :=
 /-- Convenience: create a `Stmt.ecm` for a read-only `totalAssets()` call. -/
 def totalAssets (resultVar : String) (vault : Expr) : Stmt :=
   .ecm (totalAssetsModule resultVar) [vault]
+
+/-- Read-only ERC-4626 `maxDeposit(address)` module.
+
+    It ABI-encodes the canonical `maxDeposit(address)` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, receiver]`. -/
+def maxDepositModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "maxDeposit"
+    "erc4626_maxDeposit_interface"
+    resultVar
+    0x402d267d
+    ["receiver"]
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `maxDeposit(address)`
+    call. -/
+def maxDeposit (resultVar : String) (vault receiver : Expr) : Stmt :=
+  .ecm (maxDepositModule resultVar) [vault, receiver]
+
+/-- Read-only ERC-4626 `maxMint(address)` module.
+
+    It ABI-encodes the canonical `maxMint(address)` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, receiver]`. -/
+def maxMintModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "maxMint"
+    "erc4626_maxMint_interface"
+    resultVar
+    0xc63d75b6
+    ["receiver"]
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `maxMint(address)` call.
+    -/
+def maxMint (resultVar : String) (vault receiver : Expr) : Stmt :=
+  .ecm (maxMintModule resultVar) [vault, receiver]
+
+/-- Read-only ERC-4626 `maxWithdraw(address)` module.
+
+    It ABI-encodes the canonical `maxWithdraw(address)` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, owner]`. -/
+def maxWithdrawModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "maxWithdraw"
+    "erc4626_maxWithdraw_interface"
+    resultVar
+    0xce96cb77
+    ["owner"]
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `maxWithdraw(address)`
+    call. -/
+def maxWithdraw (resultVar : String) (vault owner : Expr) : Stmt :=
+  .ecm (maxWithdrawModule resultVar) [vault, owner]
+
+/-- Read-only ERC-4626 `maxRedeem(address)` module.
+
+    It ABI-encodes the canonical `maxRedeem(address)` selector, performs a
+    `staticcall`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, owner]`. -/
+def maxRedeemModule (resultVar : String) : ExternalCallModule :=
+  readUint256Module
+    "maxRedeem"
+    "erc4626_maxRedeem_interface"
+    resultVar
+    0xd905777e
+    ["owner"]
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `maxRedeem(address)`
+    call. -/
+def maxRedeem (resultVar : String) (vault owner : Expr) : Stmt :=
+  .ecm (maxRedeemModule resultVar) [vault, owner]
 
 end Compiler.Modules.ERC4626

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -9,7 +9,7 @@ structure that the compiler can plug in without modification.
 | File | Modules | Replaces |
 |------|---------|----------|
 | `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove`, `balanceOf`, `allowance`, `totalSupply` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom`, canonical ERC-20 read wrappers |
-| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`, `convertToAssets`, `convertToShares`, `totalAssets` | canonical vault preview/conversion wrappers |
+| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`, `convertToAssets`, `convertToShares`, `totalAssets`, `maxDeposit`, `maxMint`, `maxWithdraw`, `maxRedeem` | canonical vault preview/conversion wrappers |
 | `Oracle.lean` | `oracleReadUint256` | canonical oracle read wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |
 | `Callbacks.lean` | `callback` | `Stmt.callback` |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview/conversion helpers plus `totalAssets`, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview/conversion helpers plus `totalAssets` and `max*` limit reads, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -343,6 +343,14 @@ def Compiler.Modules.ERC4626.convertToShares
   (resultVar : String) (vault assets : Expr) : Stmt
 def Compiler.Modules.ERC4626.totalAssets
   (resultVar : String) (vault : Expr) : Stmt
+def Compiler.Modules.ERC4626.maxDeposit
+  (resultVar : String) (vault receiver : Expr) : Stmt
+def Compiler.Modules.ERC4626.maxMint
+  (resultVar : String) (vault receiver : Expr) : Stmt
+def Compiler.Modules.ERC4626.maxWithdraw
+  (resultVar : String) (vault owner : Expr) : Stmt
+def Compiler.Modules.ERC4626.maxRedeem
+  (resultVar : String) (vault owner : Expr) : Stmt
 def Compiler.Modules.Oracle.oracleReadUint256
   (resultVar : String) (target : Expr) (selector : Nat)
   (staticArgs : List Expr) : Stmt
@@ -399,6 +407,14 @@ This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust 
 `Compiler.Modules.ERC4626.convertToShares` covers the canonical asset-to-share conversion case: it ABI-encodes `convertToShares(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share amount to a local result variable. The trust report records the explicit ECM assumption `erc4626_convertToShares_interface`.
 
 `Compiler.Modules.ERC4626.totalAssets` covers the canonical vault-assets aggregate case: it ABI-encodes `totalAssets()`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset total to a local result variable. The trust report records the explicit ECM assumption `erc4626_totalAssets_interface`.
+
+`Compiler.Modules.ERC4626.maxDeposit` covers the canonical receiver-scoped deposit ceiling case: it ABI-encodes `maxDeposit(address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset limit to a local result variable. The trust report records the explicit ECM assumption `erc4626_maxDeposit_interface`.
+
+`Compiler.Modules.ERC4626.maxMint` covers the canonical receiver-scoped mint ceiling case: it ABI-encodes `maxMint(address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share limit to a local result variable. The trust report records the explicit ECM assumption `erc4626_maxMint_interface`.
+
+`Compiler.Modules.ERC4626.maxWithdraw` covers the canonical owner-scoped withdrawal ceiling case: it ABI-encodes `maxWithdraw(address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset limit to a local result variable. The trust report records the explicit ECM assumption `erc4626_maxWithdraw_interface`.
+
+`Compiler.Modules.ERC4626.maxRedeem` covers the canonical owner-scoped redeem ceiling case: it ABI-encodes `maxRedeem(address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share limit to a local result variable. The trust report records the explicit ECM assumption `erc4626_maxRedeem_interface`.
 
 ### Low-level `call` / `staticcall` / `delegatecall`
 


### PR DESCRIPTION
## Summary
- add standard `ERC4626.maxDeposit`, `maxMint`, `maxWithdraw`, and `maxRedeem` ECMs for canonical per-account vault limit reads
- reuse the shared ERC-4626 read-only uint256 lowering path for the new address-parameter helpers
- extend smoke, trust-report, and docs/trust-surface coverage for the new module assumptions

## Testing
- `lake build Compiler.Modules.ERC4626`
- `lake build Compiler.CompilationModelFeatureTest`
- `lake build Compiler.CompileDriverTest`
- `make check`

Continues #1410

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new ERC-4626 external-call modules that affect generated Yul for contracts using them, so any selector/ABI or calldata sizing mistake would surface at runtime. Changes are additive and covered by new smoke and trust-report assertions, keeping overall risk moderate.
> 
> **Overview**
> Introduces new ERC-4626 read-only ECM helpers for per-account limit reads: `maxDeposit`, `maxMint`, `maxWithdraw`, and `maxRedeem`, each lowering to a `staticcall` that ABI-encodes the canonical selector, forwards revert returndata, and enforces a single 32-byte return word.
> 
> Extends verification surface by registering the new interface axioms in `AXIOMS.md`, adding compilation/Yul-lowering smoke tests and trust-report assertions, and updating module listings and EDSL API docs (`Compiler/Modules/README.md`, `TRUST_ASSUMPTIONS.md`, `docs-site/content/edsl-api-reference.mdx`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a11fcd40f44e6e9c87a276629af6820e0dbc7fe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->