### PR TITLE
modules: add standard erc4626 asset ECM

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -168,6 +168,7 @@ in `--verbose` output.
 | `ERC4626.convertToAssets` | `erc4626_convertToAssets_interface` | Target implements `convertToAssets(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.convertToShares` | `erc4626_convertToShares_interface` | Target implements `convertToShares(uint256)` and returns one ABI-encoded `uint256` |
 | `ERC4626.totalAssets` | `erc4626_totalAssets_interface` | Target implements `totalAssets()` and returns one ABI-encoded `uint256` |
+| `ERC4626.asset` | `erc4626_asset_interface` | Target implements `asset()` and returns one ABI-encoded `address` |
 | `ERC4626.maxDeposit` | `erc4626_maxDeposit_interface` | Target implements `maxDeposit(address)` and returns one ABI-encoded `uint256` |
 | `ERC4626.maxMint` | `erc4626_maxMint_interface` | Target implements `maxMint(address)` and returns one ABI-encoded `uint256` |
 | `ERC4626.maxWithdraw` | `erc4626_maxWithdraw_interface` | Target implements `maxWithdraw(address)` and returns one ABI-encoded `uint256` |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -725,6 +725,25 @@ private def erc4626TotalAssetsSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc4626AssetSmokeSpec : CompilationModel := {
+  name := "ERC4626AssetSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "asset"
+      params := [{ name := "vault", ty := ParamType.address }]
+      returnType := none
+      returns := [ParamType.address]
+      body := [
+        Compiler.Modules.ERC4626.asset
+          "assetAddr"
+          (Expr.param "vault"),
+        Stmt.returnValues [Expr.localVar "assetAddr"]
+      ]
+    }
+  ]
+}
+
 private def erc4626MaxDepositSmokeSpec : CompilationModel := {
   name := "ERC4626MaxDepositSmoke"
   fields := []
@@ -1010,6 +1029,18 @@ private def erc4626MaxRedeemSmokeSpec : CompilationModel := {
     (contains erc4626TotalAssetsYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "erc4626 totalAssets ECM ABI-encodes the selector"
     (contains erc4626TotalAssetsYul "mstore(0, shl(224, 0x01e1d114))")
+  let erc4626AssetYul ←
+    expectCompileToYul "erc4626 asset smoke spec" erc4626AssetSmokeSpec
+  expectTrue "erc4626 asset ECM lowers to staticcall"
+    (contains erc4626AssetYul "staticcall(gas(), vault, 0, 4, 0, 32)")
+  expectTrue "erc4626 asset ECM forwards revert returndata"
+    (contains erc4626AssetYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 asset ECM rejects non-32-byte returndata"
+    (contains erc4626AssetYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 asset ECM ABI-encodes the selector"
+    (contains erc4626AssetYul "mstore(0, shl(224, 0x38d52e0f))")
+  expectTrue "erc4626 asset ECM masks the returned address"
+    (contains erc4626AssetYul "let assetAddr := and(mload(0), 0xffffffffffffffffffffffffffffffffffffffff)")
   let erc4626MaxDepositYul ←
     expectCompileToYul "erc4626 maxDeposit smoke spec" erc4626MaxDepositSmokeSpec
   expectTrue "erc4626 maxDeposit ECM lowers to staticcall"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -503,6 +503,25 @@ private def erc4626TotalAssetsTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc4626AssetTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626AssetTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "asset"
+      params := [{ name := "vault", ty := ParamType.address }]
+      returnType := none
+      returns := [ParamType.address]
+      body := [
+        Compiler.Modules.ERC4626.asset
+          "assetAddr"
+          (Expr.param "vault"),
+        Stmt.returnValues [Expr.localVar "assetAddr"]
+      ]
+    }
+  ]
+}
+
 private def erc4626MaxDepositTrustSurfaceSpec : CompilationModel := {
   name := "ERC4626MaxDepositTrustSurface"
   fields := []
@@ -894,6 +913,16 @@ unsafe def runTests : IO Unit := do
   if !contains erc4626TotalAssetsTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"totalAssets\"]}" then
     throw (IO.userError "✗ erc4626 totalAssets trust report emits assumed ECM proof-status bucket")
   IO.println "✓ erc4626 totalAssets trust report emits standard vault module assumption"
+
+  let erc4626AssetTrustReport := emitTrustReportJson [erc4626AssetTrustSurfaceSpec]
+  if !contains erc4626AssetTrustReport "\"contract\":\"ERC4626AssetTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 asset trust report emits contract name")
+  if !contains erc4626AssetTrustReport "\"module\":\"asset\"" ||
+      !contains erc4626AssetTrustReport "\"assumption\":\"erc4626_asset_interface\"" then
+    throw (IO.userError "✗ erc4626 asset trust report emits module assumption")
+  if !contains erc4626AssetTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"asset\"]}" then
+    throw (IO.userError "✗ erc4626 asset trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 asset trust report emits standard vault module assumption"
 
   let erc4626MaxDepositTrustReport := emitTrustReportJson [erc4626MaxDepositTrustSurfaceSpec]
   if !contains erc4626MaxDepositTrustReport "\"contract\":\"ERC4626MaxDepositTrustSurface\"" then

--- a/Compiler/Modules/ERC4626.lean
+++ b/Compiler/Modules/ERC4626.lean
@@ -16,6 +16,7 @@
     exactly one 32-byte return word.
   - `totalAssets`: staticcall `totalAssets()` and require exactly one 32-byte
     return word.
+  - `asset`: staticcall `asset()` and require exactly one 32-byte return word.
   - `maxDeposit`: staticcall `maxDeposit(address)` and require exactly one
     32-byte return word.
   - `maxMint`: staticcall `maxMint(address)` and require exactly one 32-byte
@@ -31,11 +32,13 @@
 
 import Compiler.ECM
 import Compiler.CompilationModel
+import Compiler.Constants
 
 namespace Compiler.Modules.ERC4626
 
 open Compiler.Yul
 open Compiler.ECM
+open Compiler.Constants (addressMask)
 open Compiler.CompilationModel (Stmt Expr)
 
 /-- Shared implementation for read-only ERC-4626 calls that return one
@@ -227,6 +230,56 @@ def totalAssetsModule (resultVar : String) : ExternalCallModule :=
 /-- Convenience: create a `Stmt.ecm` for a read-only `totalAssets()` call. -/
 def totalAssets (resultVar : String) (vault : Expr) : Stmt :=
   .ecm (totalAssetsModule resultVar) [vault]
+
+/-- Read-only ERC-4626 `asset()` module.
+
+    It ABI-encodes the canonical `asset()` selector, performs a `staticcall`,
+    forwards revert returndata on failure, requires exactly one 32-byte return
+    word, masks that word to 160 bits, and binds it to `resultVar`.
+
+    Arguments passed to the module are `[vault]`. -/
+def assetModule (resultVar : String) : ExternalCallModule where
+  name := "asset"
+  numArgs := 1
+  resultVars := [resultVar]
+  writesState := false
+  readsState := true
+  axioms := ["erc4626_asset_interface"]
+  compile := fun _ctx args => do
+    let vaultExpr ← match args with
+      | [vault] => pure vault
+      | _ => throw "asset expects 1 argument (vault)"
+    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
+      YulExpr.lit 0,
+      YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex 0x38d52e0f]
+    ])
+    let callExpr := YulExpr.call "staticcall" [
+      YulExpr.call "gas" [],
+      vaultExpr,
+      YulExpr.lit 0, YulExpr.lit 4,
+      YulExpr.lit 0, YulExpr.lit 32
+    ]
+    let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__erc4626_success"]) [
+      YulStmt.let_ "__erc4626_rds" (YulExpr.call "returndatasize" []),
+      YulStmt.expr (YulExpr.call "returndatacopy" [
+        YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__erc4626_rds"
+      ]),
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__erc4626_rds"])
+    ]
+    let requireSingleWord := YulStmt.if_ (YulExpr.call "iszero" [
+      YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32]
+    ]) [
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+    ]
+    let bindResult := YulStmt.let_ resultVar
+      (YulExpr.call "and" [YulExpr.call "mload" [YulExpr.lit 0], YulExpr.hex addressMask])
+    pure [YulStmt.block (
+      [storeSelector, YulStmt.let_ "__erc4626_success" callExpr, revertOnFailure, requireSingleWord]
+    ), bindResult]
+
+/-- Convenience: create a `Stmt.ecm` for a read-only `asset()` call. -/
+def asset (resultVar : String) (vault : Expr) : Stmt :=
+  .ecm (assetModule resultVar) [vault]
 
 /-- Read-only ERC-4626 `maxDeposit(address)` module.
 

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -9,7 +9,7 @@ structure that the compiler can plug in without modification.
 | File | Modules | Replaces |
 |------|---------|----------|
 | `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove`, `balanceOf`, `allowance`, `totalSupply` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom`, canonical ERC-20 read wrappers |
-| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`, `convertToAssets`, `convertToShares`, `totalAssets`, `maxDeposit`, `maxMint`, `maxWithdraw`, `maxRedeem` | canonical vault preview/conversion wrappers |
+| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`, `convertToAssets`, `convertToShares`, `totalAssets`, `asset`, `maxDeposit`, `maxMint`, `maxWithdraw`, `maxRedeem` | canonical vault preview/conversion wrappers |
 | `Oracle.lean` | `oracleReadUint256` | canonical oracle read wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |
 | `Callbacks.lean` | `callback` | `Stmt.callback` |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview/conversion helpers plus `totalAssets` and `max*` limit reads, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview/conversion helpers plus `totalAssets`, `asset`, and `max*` limit reads, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -343,6 +343,8 @@ def Compiler.Modules.ERC4626.convertToShares
   (resultVar : String) (vault assets : Expr) : Stmt
 def Compiler.Modules.ERC4626.totalAssets
   (resultVar : String) (vault : Expr) : Stmt
+def Compiler.Modules.ERC4626.asset
+  (resultVar : String) (vault : Expr) : Stmt
 def Compiler.Modules.ERC4626.maxDeposit
   (resultVar : String) (vault receiver : Expr) : Stmt
 def Compiler.Modules.ERC4626.maxMint
@@ -407,6 +409,8 @@ This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust 
 `Compiler.Modules.ERC4626.convertToShares` covers the canonical asset-to-share conversion case: it ABI-encodes `convertToShares(uint256)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share amount to a local result variable. The trust report records the explicit ECM assumption `erc4626_convertToShares_interface`.
 
 `Compiler.Modules.ERC4626.totalAssets` covers the canonical vault-assets aggregate case: it ABI-encodes `totalAssets()`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset total to a local result variable. The trust report records the explicit ECM assumption `erc4626_totalAssets_interface`.
+
+`Compiler.Modules.ERC4626.asset` covers the canonical underlying-asset getter case: it ABI-encodes `asset()`, performs a `staticcall`, requires exactly one 32-byte return word, masks the returned word to 160 bits, and binds the resulting asset address to a local result variable. The trust report records the explicit ECM assumption `erc4626_asset_interface`.
 
 `Compiler.Modules.ERC4626.maxDeposit` covers the canonical receiver-scoped deposit ceiling case: it ABI-encodes `maxDeposit(address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset limit to a local result variable. The trust report records the explicit ECM assumption `erc4626_maxDeposit_interface`.
 


### PR DESCRIPTION
## Summary
- add a standard `Compiler.Modules.ERC4626.asset` ECM for the canonical `asset()` getter
- mask the returned word to 160 bits so address-typed call sites get a normalized result
- extend smoke coverage, trust-report coverage, and trust-surface docs for the new module

## Testing
- `lake build Compiler.Modules.ERC4626`
- `lake build Compiler.CompilationModelFeatureTest`
- `lake build Compiler.CompileDriverTest`
- `make check`

Refs #1410.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new ERC-4626 read-only ECM and related tests/docs; existing call modules and compilation behavior are unchanged unless the new `asset` module is used.
> 
> **Overview**
> Adds a standard `Compiler.Modules.ERC4626.asset` ECM for the ERC-4626 `asset()` getter, implemented as a `staticcall` with revert/returndata-size checks and a 160-bit mask (`addressMask`) to normalize the returned address.
> 
> Extends coverage and surfaced trust metadata by registering the new `erc4626_asset_interface` assumption in `AXIOMS.md`, adding smoke Yul assertions and trust-report checks in compiler tests, and updating module/docs listings (Modules README, `TRUST_ASSUMPTIONS.md`, and the EDSL API reference).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d75a29e9a3f476539e184ee72dc96bf45cf8b069. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->