### PR TITLE
modules: add standard erc4626 deposit ECM

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -173,6 +173,7 @@ in `--verbose` output.
 | `ERC4626.maxMint` | `erc4626_maxMint_interface` | Target implements `maxMint(address)` and returns one ABI-encoded `uint256` |
 | `ERC4626.maxWithdraw` | `erc4626_maxWithdraw_interface` | Target implements `maxWithdraw(address)` and returns one ABI-encoded `uint256` |
 | `ERC4626.maxRedeem` | `erc4626_maxRedeem_interface` | Target implements `maxRedeem(address)` and returns one ABI-encoded `uint256` |
+| `ERC4626.deposit` | `erc4626_deposit_interface` | Target implements `deposit(uint256,address)` and returns one ABI-encoded `uint256` |
 | `Oracle.oracleReadUint256` | `oracle_read_uint256_interface` | Target implements the selected read-only oracle interface and returns one ABI-encoded `uint256` |
 | `Precompiles.ecrecover` | `evm_ecrecover_precompile` | EVM precompile at address 0x01 behaves per Yellow Paper |
 | `Callbacks.callback` | `callback_target_interface` | Callback target processes ABI-encoded arguments correctly |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -836,6 +836,31 @@ private def erc4626MaxRedeemSmokeSpec : CompilationModel := {
   ]
 }
 
+private def erc4626DepositSmokeSpec : CompilationModel := {
+  name := "ERC4626DepositSmoke"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "deposit"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "assets", ty := ParamType.uint256 }
+        , { name := "receiver", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.deposit
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "assets")
+          (Expr.param "receiver"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 #eval! do
   let compiled :=
     match Compiler.CompilationModel.compile selectorSmokeSpec (selectorsFor selectorSmokeSpec) with
@@ -1081,6 +1106,16 @@ private def erc4626MaxRedeemSmokeSpec : CompilationModel := {
     (contains erc4626MaxRedeemYul "if iszero(eq(returndatasize(), 32)) {")
   expectTrue "erc4626 maxRedeem ECM ABI-encodes the selector"
     (contains erc4626MaxRedeemYul "mstore(0, shl(224, 0xd905777e))")
+  let erc4626DepositYul ←
+    expectCompileToYul "erc4626 deposit smoke spec" erc4626DepositSmokeSpec
+  expectTrue "erc4626 deposit ECM lowers to call"
+    (contains erc4626DepositYul "call(gas(), vault, 0, 0, 68, 0, 32)")
+  expectTrue "erc4626 deposit ECM forwards revert returndata"
+    (contains erc4626DepositYul "returndatacopy(0, 0, __erc4626_rds)")
+  expectTrue "erc4626 deposit ECM rejects non-32-byte returndata"
+    (contains erc4626DepositYul "if iszero(eq(returndatasize(), 32)) {")
+  expectTrue "erc4626 deposit ECM ABI-encodes the selector"
+    (contains erc4626DepositYul "mstore(0, shl(224, 0x6e553f65))")
   let macroEcrecoverYul ←
     expectCompileToYul "macro ecrecover smoke spec" MacroEcrecoverSmoke.MacroEcrecover.spec
   expectTrue "macro ecrecover bind elaborates to the same ECM lowering"

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -614,6 +614,31 @@ private def erc4626MaxRedeemTrustSurfaceSpec : CompilationModel := {
   ]
 }
 
+private def erc4626DepositTrustSurfaceSpec : CompilationModel := {
+  name := "ERC4626DepositTrustSurface"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "deposit"
+      params := [
+        { name := "vault", ty := ParamType.address }
+        , { name := "assets", ty := ParamType.uint256 }
+        , { name := "receiver", ty := ParamType.address }
+      ]
+      returnType := none
+      returns := [ParamType.uint256]
+      body := [
+        Compiler.Modules.ERC4626.deposit
+          "shares"
+          (Expr.param "vault")
+          (Expr.param "assets")
+          (Expr.param "receiver"),
+        Stmt.returnValues [Expr.localVar "shares"]
+      ]
+    }
+  ]
+}
+
 private def expectModuleArtifacts
     (labelPrefix : String)
     (modules : List String)
@@ -963,6 +988,16 @@ unsafe def runTests : IO Unit := do
   if !contains erc4626MaxRedeemTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"maxRedeem\"]}" then
     throw (IO.userError "✗ erc4626 maxRedeem trust report emits assumed ECM proof-status bucket")
   IO.println "✓ erc4626 maxRedeem trust report emits standard vault module assumption"
+
+  let erc4626DepositTrustReport := emitTrustReportJson [erc4626DepositTrustSurfaceSpec]
+  if !contains erc4626DepositTrustReport "\"contract\":\"ERC4626DepositTrustSurface\"" then
+    throw (IO.userError "✗ erc4626 deposit trust report emits contract name")
+  if !contains erc4626DepositTrustReport "\"module\":\"deposit\"" ||
+      !contains erc4626DepositTrustReport "\"assumption\":\"erc4626_deposit_interface\"" then
+    throw (IO.userError "✗ erc4626 deposit trust report emits module assumption")
+  if !contains erc4626DepositTrustReport "\"assumed\":{\"axiomatizedPrimitives\":[],\"linkedExternals\":[],\"ecmModules\":[\"deposit\"]}" then
+    throw (IO.userError "✗ erc4626 deposit trust report emits assumed ECM proof-status bucket")
+  IO.println "✓ erc4626 deposit trust report emits standard vault module assumption"
 
   compileSpecsWithOptions [abiSmokeSpec] outDir false [] {} none (some trustReportPath) none
   let writtenTrustReport ← fileExists trustReportPath

--- a/Compiler/Modules/ERC4626.lean
+++ b/Compiler/Modules/ERC4626.lean
@@ -25,9 +25,11 @@
     32-byte return word.
   - `maxRedeem`: staticcall `maxRedeem(address)` and require exactly one
     32-byte return word.
+  - `deposit`: call `deposit(uint256,address)` and require exactly one 32-byte
+    return word.
 
   Trust assumption: the target address implements the selected ERC-4626 read
-  interface and returns one ABI-encoded `uint256` word.
+  or write interface and returns one ABI-encoded result word where required.
 -/
 
 import Compiler.ECM
@@ -71,6 +73,58 @@ private def readUint256Module
     let callExpr := YulExpr.call "staticcall" [
       YulExpr.call "gas" [],
       vaultExpr,
+      YulExpr.lit 0, YulExpr.lit (4 + argNames.length * 32),
+      YulExpr.lit 0, YulExpr.lit 32
+    ]
+    let revertOnFailure := YulStmt.if_ (YulExpr.call "iszero" [YulExpr.ident "__erc4626_success"]) [
+      YulStmt.let_ "__erc4626_rds" (YulExpr.call "returndatasize" []),
+      YulStmt.expr (YulExpr.call "returndatacopy" [
+        YulExpr.lit 0, YulExpr.lit 0, YulExpr.ident "__erc4626_rds"
+      ]),
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.ident "__erc4626_rds"])
+    ]
+    let requireSingleWord := YulStmt.if_ (YulExpr.call "iszero" [
+      YulExpr.call "eq" [YulExpr.call "returndatasize" [], YulExpr.lit 32]
+    ]) [
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+    ]
+    let bindResult := YulStmt.let_ resultVar (YulExpr.call "mload" [YulExpr.lit 0])
+    pure [YulStmt.block (
+      [storeSelector] ++ storeArgs ++
+      [YulStmt.let_ "__erc4626_success" callExpr, revertOnFailure, requireSingleWord]
+    ), bindResult]
+
+/-- Shared implementation for state-changing ERC-4626 calls that return one
+    ABI-encoded `uint256` word. -/
+private def writeUint256Module
+    (moduleName : String)
+    (axiomName : String)
+    (resultVar : String)
+    (selector : Nat)
+    (argNames : List String) : ExternalCallModule where
+  name := moduleName
+  numArgs := 1 + argNames.length
+  resultVars := [resultVar]
+  writesState := true
+  readsState := false
+  axioms := [axiomName]
+  compile := fun _ctx args => do
+    let vaultExpr ← match args.head? with
+      | some vault => pure vault
+      | none => throw s!"{moduleName} expects at least 1 argument (vault)"
+    let argExprs := args.drop 1
+    if argExprs.length != argNames.length then
+      throw s!"{moduleName} expects {1 + argNames.length} arguments (vault{if argNames.isEmpty then "" else s!", {String.intercalate ", " argNames}"})"
+    let storeSelector := YulStmt.expr (YulExpr.call "mstore" [
+      YulExpr.lit 0,
+      YulExpr.call "shl" [YulExpr.lit 224, YulExpr.hex selector]
+    ])
+    let storeArgs := argExprs.zipIdx.map fun (argExpr, idx) =>
+      YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit (4 + idx * 32), argExpr])
+    let callExpr := YulExpr.call "call" [
+      YulExpr.call "gas" [],
+      vaultExpr,
+      YulExpr.lit 0,
       YulExpr.lit 0, YulExpr.lit (4 + argNames.length * 32),
       YulExpr.lit 0, YulExpr.lit 32
     ]
@@ -360,5 +414,25 @@ def maxRedeemModule (resultVar : String) : ExternalCallModule :=
     call. -/
 def maxRedeem (resultVar : String) (vault owner : Expr) : Stmt :=
   .ecm (maxRedeemModule resultVar) [vault, owner]
+
+/-- State-changing ERC-4626 `deposit(uint256,address)` module.
+
+    It ABI-encodes the canonical `deposit(uint256,address)` selector, performs
+    a `call`, forwards revert returndata on failure, requires exactly one
+    32-byte return word, and binds that word to `resultVar`.
+
+    Arguments passed to the module are `[vault, assets, receiver]`. -/
+def depositModule (resultVar : String) : ExternalCallModule :=
+  writeUint256Module
+    "deposit"
+    "erc4626_deposit_interface"
+    resultVar
+    0x6e553f65
+    ["assets", "receiver"]
+
+/-- Convenience: create a `Stmt.ecm` for an ERC-4626 `deposit(uint256,address)`
+    call. -/
+def deposit (resultVar : String) (vault assets receiver : Expr) : Stmt :=
+  .ecm (depositModule resultVar) [vault, assets, receiver]
 
 end Compiler.Modules.ERC4626

--- a/Compiler/Modules/README.md
+++ b/Compiler/Modules/README.md
@@ -9,7 +9,7 @@ structure that the compiler can plug in without modification.
 | File | Modules | Replaces |
 |------|---------|----------|
 | `ERC20.lean` | `safeTransfer`, `safeTransferFrom`, `safeApprove`, `balanceOf`, `allowance`, `totalSupply` | `Stmt.safeTransfer`, `Stmt.safeTransferFrom`, canonical ERC-20 read wrappers |
-| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`, `convertToAssets`, `convertToShares`, `totalAssets`, `asset`, `maxDeposit`, `maxMint`, `maxWithdraw`, `maxRedeem` | canonical vault preview/conversion wrappers |
+| `ERC4626.lean` | `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`, `convertToAssets`, `convertToShares`, `totalAssets`, `asset`, `maxDeposit`, `maxMint`, `maxWithdraw`, `maxRedeem`, `deposit` | canonical vault preview/conversion wrappers plus a standard deposit wrapper |
 | `Oracle.lean` | `oracleReadUint256` | canonical oracle read wrappers |
 | `Precompiles.lean` | `ecrecover` | `Stmt.ecrecover` |
 | `Callbacks.lean` | `callback` | `Stmt.callback` |

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -60,7 +60,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 - **Implication**: Semantic correctness does not imply gas-safety.
 
 ### 6. External Call Modules (ECMs)
-- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview/conversion helpers plus `totalAssets`, `asset`, and `max*` limit reads, oracle reads, precompiles, callbacks).
+- **Role**: Reusable typed external call patterns (ERC-20 writes/reads including `totalSupply`, ERC-4626 preview/conversion helpers plus `totalAssets`, `asset`, `max*` limit reads, and `deposit`, oracle reads, precompiles, callbacks).
 - **Trust**: Each module's `compile` produces correct Yul. Bug in one module doesn't affect others.
 - **Mitigation**: Axiom aggregation at compile time (`--verbose`) and machine-readable trust-surface emission via `--trust-report <path>`. See [docs/EXTERNAL_CALL_MODULES.md](docs/EXTERNAL_CALL_MODULES.md).
 

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -353,6 +353,8 @@ def Compiler.Modules.ERC4626.maxWithdraw
   (resultVar : String) (vault owner : Expr) : Stmt
 def Compiler.Modules.ERC4626.maxRedeem
   (resultVar : String) (vault owner : Expr) : Stmt
+def Compiler.Modules.ERC4626.deposit
+  (resultVar : String) (vault assets receiver : Expr) : Stmt
 def Compiler.Modules.Oracle.oracleReadUint256
   (resultVar : String) (target : Expr) (selector : Nat)
   (staticArgs : List Expr) : Stmt
@@ -419,6 +421,8 @@ This elaborates to `Compiler.Modules.Precompiles.ecrecoverModule` and the trust 
 `Compiler.Modules.ERC4626.maxWithdraw` covers the canonical owner-scoped withdrawal ceiling case: it ABI-encodes `maxWithdraw(address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned asset limit to a local result variable. The trust report records the explicit ECM assumption `erc4626_maxWithdraw_interface`.
 
 `Compiler.Modules.ERC4626.maxRedeem` covers the canonical owner-scoped redeem ceiling case: it ABI-encodes `maxRedeem(address)`, performs a `staticcall`, requires exactly one 32-byte return word, and binds the returned share limit to a local result variable. The trust report records the explicit ECM assumption `erc4626_maxRedeem_interface`.
+
+`Compiler.Modules.ERC4626.deposit` covers the canonical vault deposit path: it ABI-encodes `deposit(uint256,address)`, performs a `call`, requires exactly one 32-byte return word, and binds the returned share amount to a local result variable. The trust report records the explicit ECM assumption `erc4626_deposit_interface`.
 
 ### Low-level `call` / `staticcall` / `delegatecall`
 


### PR DESCRIPTION
## Summary
- add a proof-aware `Compiler.Modules.ERC4626.deposit` ECM for `deposit(uint256,address)`
- reuse a shared ERC-4626 write-path helper that ABI-encodes args, bubbles revert returndata, and requires one 32-byte return word
- extend smoke coverage, trust-report coverage, and trust/docs registries for the new standard vault module assumption

## Testing
- lake build Compiler.Modules.ERC4626
- lake build Compiler.CompilationModelFeatureTest
- lake build Compiler.CompileDriverTest
- make check

Closes #1410

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive change introducing a new ERC-4626 `deposit` ECM and associated docs/tests; existing ECM behavior is unchanged and coverage asserts the generated Yul/trust-surface output.
> 
> **Overview**
> Adds a standard ERC-4626 `deposit(uint256,address)` External Call Module (`Compiler.Modules.ERC4626.deposit`) that lowers to a state-changing `call`, bubbles revert returndata, and requires a single 32-byte return word.
> 
> Extends compiler smoke tests and trust-report assertions to cover the new module, and updates the axiom/trust registries and EDSL API/docs to include the new `erc4626_deposit_interface` assumption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17acaffa065c710b5cea71a49d410fa7215c9c87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->