### PR TITLE
macro: surface custom error declarations

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -275,6 +275,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.Bytes32Smoke.spec
   , Contracts.Smoke.MappingWordSmoke.spec
   , Contracts.Smoke.StorageWordsSmoke.spec
+  , Contracts.Smoke.CustomErrorSmoke.spec
   , Contracts.StringSmoke.spec
   , Contracts.Smoke.TupleSmoke.spec
   , Contracts.Smoke.Uint8Smoke.spec
@@ -310,6 +311,7 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("Bytes32Smoke", ["setDigest(bytes32)", "getDigest()"])
   , ("MappingWordSmoke", ["setWord1(uint256,uint256)", "getWord1(uint256)", "isWord1NonZero(uint256)"])
   , ("StorageWordsSmoke", ["extSloadsLike(bytes32[])"])
+  , ("CustomErrorSmoke", ["echo(uint256)"])
   , ("StringSmoke", ["echoString(string)"])
   , ("TupleSmoke", ["setFromPair((uint256,uint256))", "getPair(uint256)", "processConfig((address,address,uint256))"])
   , ("Uint8Smoke", ["acceptSig((uint8,bytes32,bytes32))", "sigV()"])
@@ -338,6 +340,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("Bytes32Smoke", ["0xed9fdc05", "0xae0d3e27"])
   , ("MappingWordSmoke", ["0x60ab11c4", "0x8f8a322f", "0xea3aded7"])
   , ("StorageWordsSmoke", ["0x764fa434"])
+  , ("CustomErrorSmoke", ["0x6279e43c"])
   , ("StringSmoke", ["0x0d7e2fce"])
   , ("TupleSmoke", ["0x712ea680", "0xbdf391cc", "0x01b427d2"])
   , ("Uint8Smoke", ["0xc233eaa7", "0x62fc458b"])
@@ -441,6 +444,18 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
   let allNamesPresent :=
     fnNames.all (fun fnName => contains abi s!"\"name\": \"{fnName}\"")
   expectTrue s!"{spec.name}: ABI contains every external function name" allNamesPresent
+
+  if spec.name == "CustomErrorSmoke" then
+    expectTrue
+      "CustomErrorSmoke: macro spec preserves custom error declarations"
+      (spec.errors.map (·.name) == ["NonPositive", "AmountTooLarge"])
+    expectTrue
+      "CustomErrorSmoke: ABI includes declared custom errors"
+      (contains abi "\"type\": \"error\"" &&
+        contains abi "\"name\": \"NonPositive\"" &&
+        contains abi "\"name\": \"AmountTooLarge\"")
+  else
+    pure ()
 
 #eval! do
   expectTrue "macro spec count matches pinned signature snapshot"

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -41,6 +41,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.Bytes32Smoke.spec
   , Contracts.Smoke.MappingWordSmoke.spec
   , Contracts.Smoke.StorageWordsSmoke.spec
+  , Contracts.Smoke.CustomErrorSmoke.spec
   , Contracts.Smoke.TupleSmoke.spec
   , Contracts.Smoke.Uint8Smoke.spec
   , Contracts.Smoke.AddressHelpersSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -62,6 +62,17 @@ verity_contract StorageWordsSmoke where
   function extSloadsLike (slots : Array Bytes32) : Array Uint256 := do
     returnStorageWords slots
 
+verity_contract CustomErrorSmoke where
+  storage
+    sentinel : Uint256 := slot 0
+
+  errors
+    error NonPositive(Uint256)
+    error AmountTooLarge(Uint256, Uint256)
+
+  function echo (amount : Uint256) : Uint256 := do
+    return amount
+
 verity_contract TupleSmoke where
   storage
     values : Uint256 → Uint256 := slot 0
@@ -301,6 +312,7 @@ end SpecGenSmoke
 #check_contract Bytes32Smoke
 #check_contract MappingWordSmoke
 #check_contract StorageWordsSmoke
+#check_contract CustomErrorSmoke
 #check_contract TupleSmoke
 #check_contract Uint8Smoke
 #check_contract AddressHelpersSmoke

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -13,7 +13,7 @@ set_option hygiene false
 
 @[command_elab verityContractCmd]
 def elabVerityContract : CommandElab := fun stx => do
-  let (contractName, fields, ctor, functions) ← parseContractSyntax stx
+  let (contractName, fields, errorDecls, ctor, functions) ← parseContractSyntax stx
 
   elabCommand (← `(namespace $contractName))
 
@@ -26,7 +26,7 @@ def elabVerityContract : CommandElab := fun stx => do
       elabCommand cmd
     elabCommand (← mkBridgeCommand fn.ident)
 
-  elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields ctor functions)
+  elabCommand (← mkSpecCommandPublic (toString contractName.getId) fields errorDecls ctor functions)
 
   let findIdxSimpCmds ← mkFindIdxFieldSimpCommandsPublic contractName fields
   for cmd in findIdxSimpCmds do

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -7,6 +7,7 @@ open Lean
 declare_syntax_cat verityStorageField
 declare_syntax_cat verityStructMember
 declare_syntax_cat verityParam
+declare_syntax_cat verityError
 declare_syntax_cat verityConstructor
 declare_syntax_cat verityFunction
 
@@ -16,12 +17,14 @@ syntax ident " @word " num " packed(" num "," num ")" : verityStructMember
 syntax "MappingStruct(" term "," "[" sepBy(verityStructMember, ",") "]" ")" : term
 syntax "MappingStruct2(" term "," term "," "[" sepBy(verityStructMember, ",") "]" ")" : term
 syntax ident " : " term : verityParam
+syntax "error " ident "(" sepBy(term, ",") ")" : verityError
 syntax "constructor " "(" sepBy(verityParam, ",") ")" " := " term : verityConstructor
 syntax "function " ident " (" sepBy(verityParam, ",") ")" " : " term " := " term : verityFunction
 
 syntax (name := verityContractCmd)
   "verity_contract " ident " where "
   "storage " verityStorageField+
+  ("errors " verityError+)?
   (verityConstructor)?
   verityFunction+ : command
 

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -59,6 +59,11 @@ structure ParamDecl where
   name : String
   ty : ValueType
 
+structure ErrorDecl where
+  ident : Ident
+  name : String
+  params : Array ValueType
+
 structure FunctionDecl where
   ident : Ident
   name : String
@@ -279,6 +284,16 @@ private def parseParam (stx : Syntax) : CommandElabM ParamDecl := do
         ty := ← valueTypeFromSyntax ty
       }
   | _ => throwErrorAt stx "invalid parameter declaration"
+
+private def parseError (stx : Syntax) : CommandElabM ErrorDecl := do
+  match stx with
+  | `(verityError| error $name:ident ($[$params:term],*)) =>
+      pure {
+        ident := name
+        name := toString name.getId
+        params := ← params.mapM valueTypeFromSyntax
+      }
+  | _ => throwErrorAt stx "invalid custom error declaration"
 
 private def parseFunction (stx : Syntax) : CommandElabM FunctionDecl := do
   match stx with
@@ -904,7 +919,9 @@ private def translateEffectStmt
           throwErrorAt stx s!"field '{f.name}' is a struct-valued mapping; use setStructMember"
       | _ => throwErrorAt stx s!"field '{f.name}' is not a double mapping"
   | `(term| require $cond $msg) =>
-      `(Compiler.CompilationModel.Stmt.require $(← translatePureExpr fields params locals cond) $(strTerm (← expectStringLiteral msg)))
+      `(Compiler.CompilationModel.Stmt.require
+          $(← translatePureExpr fields params locals cond)
+          $(strTerm (← expectStringLiteral msg)))
   | `(term| mstore $offset:term $value:term) =>
       `(Compiler.CompilationModel.Stmt.mstore
           $(← translatePureExpr fields params locals offset)
@@ -1069,98 +1086,98 @@ private partial def translateDoElem
   match tupleCase? with
   | some result => pure result
   | none => match elem with
-  | `(doElem| let mut $name:ident := $rhs:term) =>
-      let varName := toString name.getId
-      if locals.contains varName then
-        throwErrorAt name s!"duplicate local variable '{varName}'"
-      let rhsExpr ← translatePureExpr fields params locals rhs
-      pure
-        (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
-          locals.push varName,
-          mutableLocals.push varName)
-  | `(doElem| let $name:ident := $rhs:term) =>
-      let varName := toString name.getId
-      if locals.contains varName then
-        throwErrorAt name s!"duplicate local variable '{varName}'"
-      let rhsExpr ← translatePureExpr fields params locals rhs
-      pure
-        (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
-          locals.push varName,
-          mutableLocals)
-  | `(doElem| let $name:ident ← $rhs:term) =>
-      let varName := toString name.getId
-      if locals.contains varName then
-        throwErrorAt name s!"duplicate local variable '{varName}'"
-      match stripParens rhs with
-      | `(term| ecrecover $hash:term $v:term $r:term $s:term) =>
-          let hashExpr ← translatePureExpr fields params locals hash
-          let vExpr ← translatePureExpr fields params locals v
-          let rExpr ← translatePureExpr fields params locals r
-          let sExpr ← translatePureExpr fields params locals s
+      | `(doElem| let mut $name:ident := $rhs:term) =>
+          let varName := toString name.getId
+          if locals.contains varName then
+            throwErrorAt name s!"duplicate local variable '{varName}'"
+          let rhsExpr ← translatePureExpr fields params locals rhs
           pure
-            (#[(← `(Compiler.CompilationModel.Stmt.ecm
-                    (Compiler.Modules.Precompiles.ecrecoverModule $(strTerm varName))
-                    [$hashExpr, $vExpr, $rExpr, $sExpr]))],
+            (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
+              locals.push varName,
+              mutableLocals.push varName)
+      | `(doElem| let $name:ident := $rhs:term) =>
+          let varName := toString name.getId
+          if locals.contains varName then
+            throwErrorAt name s!"duplicate local variable '{varName}'"
+          let rhsExpr ← translatePureExpr fields params locals rhs
+          pure
+            (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
               locals.push varName,
               mutableLocals)
-      | _ =>
-          let safeBind? ← translateSafeRequireBind fields params locals varName rhs
-          match safeBind? with
-          | some safeStmts => pure (safeStmts, locals.push varName, mutableLocals)
-          | none =>
-              let rhsExpr ← translateBindSource fields params locals rhs
+      | `(doElem| let $name:ident ← $rhs:term) =>
+          let varName := toString name.getId
+          if locals.contains varName then
+            throwErrorAt name s!"duplicate local variable '{varName}'"
+          match stripParens rhs with
+          | `(term| ecrecover $hash:term $v:term $r:term $s:term) =>
+              let hashExpr ← translatePureExpr fields params locals hash
+              let vExpr ← translatePureExpr fields params locals v
+              let rExpr ← translatePureExpr fields params locals r
+              let sExpr ← translatePureExpr fields params locals s
               pure
-                (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
+                (#[(← `(Compiler.CompilationModel.Stmt.ecm
+                        (Compiler.Modules.Precompiles.ecrecoverModule $(strTerm varName))
+                        [$hashExpr, $vExpr, $rExpr, $sExpr]))],
                   locals.push varName,
                   mutableLocals)
-  | `(doElem| $name:ident := $rhs:term) =>
-      let varName := toString name.getId
-      if !locals.contains varName then
-        throwErrorAt name s!"cannot assign unknown variable '{varName}'"
-      if !mutableLocals.contains varName then
-        throwErrorAt name s!"cannot assign immutable variable '{varName}'; declare it with 'let mut'"
-      let rhsExpr ← translatePureExpr fields params locals rhs
-      pure
-        (#[(← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName) $rhsExpr))],
-          locals,
-          mutableLocals)
-  | `(doElem| return $value:term) =>
-      match (← tupleReturnValueExprs? fields params locals value) with
-      | some valueExprs =>
-          pure (#[(← `(Compiler.CompilationModel.Stmt.returnValues [ $[$valueExprs],* ]))], locals, mutableLocals)
-      | none =>
-          pure (#[(← `(Compiler.CompilationModel.Stmt.return $(← translatePureExpr fields params locals value)))], locals, mutableLocals)
-  | `(doElem| pure ()) =>
-      pure (#[], locals, mutableLocals)
-  | `(doElem| if $cond:term then $thenBranch:doSeq else $elseBranch:doSeq) =>
-      let condExpr ← translatePureExpr fields params locals cond
-      let thenStmts ← translateDoSeqToStmtTerms fields params locals mutableLocals thenBranch
-      let elseStmts ← translateDoSeqToStmtTerms fields params locals mutableLocals elseBranch
-      pure
-        (#[(← `(Compiler.CompilationModel.Stmt.ite
-          $condExpr
-          [ $[$thenStmts],* ]
-          [ $[$elseStmts],* ]))],
-          locals,
-          mutableLocals)
-  | `(doElem| forEach $name:term $count:term $body:term) =>
-      let loopVar := ← expectStringOrIdent name
-      let countExpr ← translatePureExpr fields params locals count
-      let bodyStmts ←
-        match stripParens body with
-        | `(term| do $[$inner:doElem]*) =>
-            pure (← (translateDoElems fields params (locals.push loopVar) mutableLocals inner)).1
-        | _ => throwErrorAt body "forEach body must be a do block"
-      pure
-        (#[(← `(Compiler.CompilationModel.Stmt.forEach
-            $(strTerm loopVar)
-            $countExpr
-            [ $[$bodyStmts],* ]))],
-          locals,
-          mutableLocals)
-  | `(doElem| $stmt:term) =>
-      pure (#[(← translateEffectStmt fields params locals stmt)], locals, mutableLocals)
-  | _ => throwErrorAt elem "unsupported do element"
+          | _ =>
+              let safeBind? ← translateSafeRequireBind fields params locals varName rhs
+              match safeBind? with
+              | some safeStmts => pure (safeStmts, locals.push varName, mutableLocals)
+              | none =>
+                  let rhsExpr ← translateBindSource fields params locals rhs
+                  pure
+                    (#[(← `(Compiler.CompilationModel.Stmt.letVar $(strTerm varName) $rhsExpr))],
+                      locals.push varName,
+                      mutableLocals)
+      | `(doElem| $name:ident := $rhs:term) =>
+          let varName := toString name.getId
+          if !locals.contains varName then
+            throwErrorAt name s!"cannot assign unknown variable '{varName}'"
+          if !mutableLocals.contains varName then
+            throwErrorAt name s!"cannot assign immutable variable '{varName}'; declare it with 'let mut'"
+          let rhsExpr ← translatePureExpr fields params locals rhs
+          pure
+            (#[(← `(Compiler.CompilationModel.Stmt.assignVar $(strTerm varName) $rhsExpr))],
+              locals,
+              mutableLocals)
+      | `(doElem| return $value:term) =>
+          match (← tupleReturnValueExprs? fields params locals value) with
+          | some valueExprs =>
+              pure (#[(← `(Compiler.CompilationModel.Stmt.returnValues [ $[$valueExprs],* ]))], locals, mutableLocals)
+          | none =>
+              pure (#[(← `(Compiler.CompilationModel.Stmt.return $(← translatePureExpr fields params locals value)))], locals, mutableLocals)
+      | `(doElem| pure ()) =>
+          pure (#[], locals, mutableLocals)
+      | `(doElem| if $cond:term then $thenBranch:doSeq else $elseBranch:doSeq) =>
+          let condExpr ← translatePureExpr fields params locals cond
+          let thenStmts ← translateDoSeqToStmtTerms fields params locals mutableLocals thenBranch
+          let elseStmts ← translateDoSeqToStmtTerms fields params locals mutableLocals elseBranch
+          pure
+            (#[(← `(Compiler.CompilationModel.Stmt.ite
+              $condExpr
+              [ $[$thenStmts],* ]
+              [ $[$elseStmts],* ]))],
+              locals,
+              mutableLocals)
+      | `(doElem| forEach $name:term $count:term $body:term) =>
+          let loopVar := ← expectStringOrIdent name
+          let countExpr ← translatePureExpr fields params locals count
+          let bodyStmts ←
+            match stripParens body with
+            | `(term| do $[$inner:doElem]*) =>
+                pure (← (translateDoElems fields params (locals.push loopVar) mutableLocals inner)).1
+            | _ => throwErrorAt body "forEach body must be a do block"
+          pure
+            (#[(← `(Compiler.CompilationModel.Stmt.forEach
+                $(strTerm loopVar)
+                $countExpr
+                [ $[$bodyStmts],* ]))],
+              locals,
+              mutableLocals)
+      | `(doElem| $stmt:term) =>
+          pure (#[(← translateEffectStmt fields params locals stmt)], locals, mutableLocals)
+      | _ => throwErrorAt elem "unsupported do element"
 end
 
 private def translateBodyToStmtTerms
@@ -1260,12 +1277,20 @@ private def mkFunctionCommands (fields : Array StorageFieldDecl) (fn : FunctionD
   })
   pure #[fnCmd, bodyCmd, modelCmd]
 
+private def mkModelErrorTerm (err : ErrorDecl) : CommandElabM Term := do
+  let paramTerms ← err.params.mapM modelParamTypeTerm
+  `(Compiler.CompilationModel.ErrorDef.mk
+      $(strTerm err.name)
+      [ $[$paramTerms],* ])
+
 private def mkSpecCommand
     (contractName : String)
     (fields : Array StorageFieldDecl)
+    (errorDecls : Array ErrorDecl)
     (ctor : Option ConstructorDecl)
     (functions : Array FunctionDecl) : CommandElabM Cmd := do
   let fieldTerms ← fields.mapM mkModelFieldTerm
+  let errorTerms ← errorDecls.mapM mkModelErrorTerm
   let constructorTerm ←
     match ctor with
     | none => `(none)
@@ -1280,6 +1305,7 @@ private def mkSpecCommand
   `(command| def spec : Compiler.CompilationModel.CompilationModel := {
     name := $(strTerm contractName)
     fields := [ $[$fieldTerms],* ]
+    «errors» := [ $[$errorTerms],* ]
     «constructor» := $constructorTerm
     functions := [ $[$functionModelIds],* ]
   })
@@ -1364,12 +1390,18 @@ private def mkFindIdxParamSimpCommands
 
 def parseContractSyntax
     (stx : Syntax)
-    : CommandElabM (Ident × Array StorageFieldDecl × Option ConstructorDecl × Array FunctionDecl) := do
+    : CommandElabM
+        (Ident × Array StorageFieldDecl × Array ErrorDecl × Option ConstructorDecl × Array FunctionDecl) := do
   match stx with
-  | `(command| verity_contract $contractName:ident where storage $[$storageFields:verityStorageField]* $[$ctor:verityConstructor]? $[$functions:verityFunction]*) =>
+  | `(command| verity_contract $contractName:ident where storage $[$storageFields:verityStorageField]* $[errors $[$errorDecls:verityError]*]? $[$ctor:verityConstructor]? $[$functions:verityFunction]*) =>
+      let parsedErrors ←
+        match errorDecls with
+        | some decls => decls.mapM parseError
+        | none => pure #[]
       pure
         ( contractName
         , (← storageFields.mapM parseStorageField)
+        , parsedErrors
         , (← ctor.mapM parseConstructor)
         , (← functions.mapM parseFunction)
         )
@@ -1386,9 +1418,10 @@ def mkFunctionCommandsPublic
 def mkSpecCommandPublic
     (contractName : String)
     (fields : Array StorageFieldDecl)
+    (errorDecls : Array ErrorDecl)
     (ctor : Option ConstructorDecl)
     (functions : Array FunctionDecl) : CommandElabM Cmd :=
-  mkSpecCommand contractName fields ctor functions
+  mkSpecCommand contractName fields errorDecls ctor functions
 
 def mkFindIdxFieldSimpCommandsPublic
     (contractIdent : Ident)

--- a/artifacts/macro_property_tests/PropertyCustomErrorSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyCustomErrorSmoke.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyCustomErrorSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyCustomErrorSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("CustomErrorSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `echo` result
+    function testTODO_Echo_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("echo(uint256)", uint256(1)));
+        require(ok, "echo reverted unexpectedly");
+        assertEq(ret.length, 32, "echo ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -314,6 +314,17 @@ return (first, second)
 
 Today this elaborates cleanly for tuple literals and tuple-typed parameters. `return (..)` lowers to `Stmt.returnValues [...]`, and tuple-parameter destructuring maps onto the ABI-flattened component names (`pair_0`, `pair_1`, ...), so the generated model stays explicit for debugging and proofs.
 
+## Custom Errors
+
+`verity_contract` now accepts custom error declarations and threads them into the generated `CompilationModel`/ABI surface:
+
+```lean
+errors
+  error NonPositive(Uint256)
+```
+
+These declarations populate `CompilationModel.errors`, so `#check_contract` and ABI generation see the same custom error list authored in the macro contract.
+
 ## External Calls (ECM)
 
 ### ERC-20 safe wrappers


### PR DESCRIPTION
## Summary
- add `errors` declarations to `verity_contract`
- preserve declared custom errors in generated `CompilationModel` specs and ABI output
- add smoke, invariant, round-trip, and macro-property coverage for the new surface

## Scope
This is a narrow slice of #1422. It makes custom error declarations first-class in the macro path and keeps the generated `CompilationModel`/ABI synchronized with those declarations.

It does not add new statement syntax for typed custom-error reverts yet.

## Validation
- `lake build Contracts.Smoke Contracts.MacroTranslateInvariantTest Contracts.MacroTranslateRoundTripFuzz`
- `make check`

Related to #1422.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `verity_contract` macro parsing/elaboration and the generated `CompilationModel`/ABI surface; could affect downstream tooling that consumes specs/ABI even though the `errors` block is optional.
> 
> **Overview**
> `verity_contract` now accepts an optional `errors` block and carries those custom error declarations through macro translation into `CompilationModel.errors`, so ABI emission includes `"type": "error"` entries matching the macro source.
> 
> Adds a new `CustomErrorSmoke` contract plus expanded invariant and round-trip fuzz coverage to pin selectors/signatures and assert that declared errors are preserved in both the generated spec and ABI output. Also adds an auto-generated Solidity property-test stub and documents the new `errors` syntax in the EDSL API reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce4fc422dde490dfcf010eea4e4218fe52473071. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->