### PR TITLE
macro: add custom error usage syntax

### DIFF
--- a/Compiler/MacroCustomErrorFeatureTest.lean
+++ b/Compiler/MacroCustomErrorFeatureTest.lean
@@ -1,0 +1,70 @@
+import Compiler.CompilationModel
+import Contracts.Common
+
+namespace Compiler.MacroCustomErrorFeatureTest
+
+open Compiler.CompilationModel
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+namespace MacroCustomErrorUsageSmoke
+
+verity_contract MacroCustomErrorUsage where
+  storage
+    sentinel : Uint256 := slot 0
+
+  errors
+    error NonPositive(Uint256)
+    error AmountTooLarge(Uint256, Uint256)
+
+  function requirePositive (amount : Uint256) : Unit := do
+    requireError (amount != 0) NonPositive(amount)
+
+  function rejectLarge (amount : Uint256) : Unit := do
+    if amount > 100 then
+      revert AmountTooLarge(amount, 100)
+    else
+      pure ()
+
+def requirePositiveModelUsesCustomErrorGuard : Bool :=
+  match MacroCustomErrorUsage.requirePositive_modelBody with
+  | [Stmt.requireError
+        (Expr.logicalNot (Expr.eq (Expr.param "amount") (Expr.literal 0)))
+        "NonPositive"
+        [Expr.param "amount"],
+      Stmt.stop] =>
+      true
+  | _ => false
+
+example : requirePositiveModelUsesCustomErrorGuard = true := by native_decide
+
+def rejectLargeModelUsesCustomErrorRevert : Bool :=
+  match MacroCustomErrorUsage.rejectLarge_modelBody with
+  | [Stmt.ite
+        (Expr.gt (Expr.param "amount") (Expr.literal 100))
+        [Stmt.revertError "AmountTooLarge" [Expr.param "amount", Expr.literal 100]]
+        [],
+      Stmt.stop] =>
+      true
+  | _ => false
+
+example : rejectLargeModelUsesCustomErrorRevert = true := by native_decide
+
+def requirePositiveExecutablePreservesSuccess : Bool :=
+  match MacroCustomErrorUsage.requirePositive 7 Verity.defaultState with
+  | .success () state => state.sender == Verity.defaultState.sender
+  | .revert _ _ => false
+
+example : requirePositiveExecutablePreservesSuccess = true := by native_decide
+
+def rejectLargeExecutableUsesRuntimeFallback : Bool :=
+  match MacroCustomErrorUsage.rejectLarge 101 Verity.defaultState with
+  | .revert msg state => msg == "AmountTooLarge" && state.sender == Verity.defaultState.sender
+  | .success _ _ => false
+
+example : rejectLargeExecutableUsesRuntimeFallback = true := by native_decide
+
+end MacroCustomErrorUsageSmoke
+
+end Compiler.MacroCustomErrorFeatureTest

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -11,6 +11,14 @@ open Verity hiding pure bind
 open Verity.EVM.Uint256
 open Verity.Stdlib.Math
 
+macro_rules
+  | `(doElem| revert $errorName:ident($_args,*)) =>
+      `(doElem| require false $(Lean.quote (toString errorName.getId)))
+  | `(doElem| revertError $errorName:ident($_args,*)) =>
+      `(doElem| require false $(Lean.quote (toString errorName.getId)))
+  | `(doElem| requireError $cond:term $errorName:ident($_args,*)) =>
+      `(doElem| if $cond then pure () else require false $(Lean.quote (toString errorName.getId)))
+
 
 def bitAnd (a b : Uint256) : Uint256 := Verity.Core.Uint256.and a b
 def bitOr (a b : Uint256) : Uint256 := Verity.Core.Uint256.or a b

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -18,6 +18,9 @@ syntax "MappingStruct(" term "," "[" sepBy(verityStructMember, ",") "]" ")" : te
 syntax "MappingStruct2(" term "," term "," "[" sepBy(verityStructMember, ",") "]" ")" : term
 syntax ident " : " term : verityParam
 syntax "error " ident "(" sepBy(term, ",") ")" : verityError
+syntax "revert " ident "(" sepBy(term, ",") ")" : doElem
+syntax "revertError " ident "(" sepBy(term, ",") ")" : doElem
+syntax "requireError " term:max ppSpace ident "(" sepBy(term, ",") ")" : doElem
 syntax "constructor " "(" sepBy(verityParam, ",") ")" " := " term : verityConstructor
 syntax "function " ident " (" sepBy(verityParam, ",") ")" " : " term " := " term : verityFunction
 

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1175,6 +1175,31 @@ private partial def translateDoElem
                 [ $[$bodyStmts],* ]))],
               locals,
               mutableLocals)
+      | `(doElem| requireError $cond:term $errorName:ident($args,*)) =>
+          let argExprs ← args.getElems.mapM (translatePureExpr fields params locals)
+          pure
+            (#[(← `(Compiler.CompilationModel.Stmt.requireError
+                    $(← translatePureExpr fields params locals cond)
+                    $(strTerm (toString errorName.getId))
+                    [ $[$argExprs],* ]))],
+              locals,
+              mutableLocals)
+      | `(doElem| revert $errorName:ident($args,*)) =>
+          let argExprs ← args.getElems.mapM (translatePureExpr fields params locals)
+          pure
+            (#[(← `(Compiler.CompilationModel.Stmt.revertError
+                    $(strTerm (toString errorName.getId))
+                    [ $[$argExprs],* ]))],
+              locals,
+              mutableLocals)
+      | `(doElem| revertError $errorName:ident($args,*)) =>
+          let argExprs ← args.getElems.mapM (translatePureExpr fields params locals)
+          pure
+            (#[(← `(Compiler.CompilationModel.Stmt.revertError
+                    $(strTerm (toString errorName.getId))
+                    [ $[$argExprs],* ]))],
+              locals,
+              mutableLocals)
       | `(doElem| $stmt:term) =>
           pure (#[(← translateEffectStmt fields params locals stmt)], locals, mutableLocals)
       | _ => throwErrorAt elem "unsupported do element"

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -321,9 +321,17 @@ Today this elaborates cleanly for tuple literals and tuple-typed parameters. `re
 ```lean
 errors
   error NonPositive(Uint256)
+  error AmountTooLarge(Uint256, Uint256)
+
+function requirePositive (amount : Uint256) : Unit := do
+  requireError (amount != 0) NonPositive(amount)
+
+function rejectLarge (amount : Uint256) : Unit := do
+  if amount > 100 then
+    revert AmountTooLarge(amount, 100)
 ```
 
-These declarations populate `CompilationModel.errors`, so `#check_contract` and ABI generation see the same custom error list authored in the macro contract.
+These declarations populate `CompilationModel.errors`, and the macro now lowers guarded and unconditional custom-error exits to `Stmt.requireError` / `Stmt.revertError`. That keeps `#check_contract`, ABI generation, and the Yul compiler on the same custom-error surface authored in the macro contract.
 
 ## External Calls (ECM)
 


### PR DESCRIPTION
## Summary
- add `do`-block custom-error usage syntax for `requireError cond ErrorName(args)` and `revert ErrorName(args)`
- lower those macro forms to `Stmt.requireError` / `Stmt.revertError`
- add a focused compiler regression module covering both model lowering and executable fallback behavior
- document the new macro surface in the EDSL API reference

## Testing
- `lake build Compiler.MacroCustomErrorFeatureTest`
- `lake build Verity.Macro.Syntax Verity.Macro.Translate Contracts.Common`
- `make check`

## Notes
- `lake build Compiler.CompilationModelFeatureTest` still fails on `origin/main` with the pre-existing parse error at `Compiler/CompilationModelFeatureTest.lean:389` (`unexpected token 'errors'; expected '}'`). This branch does not touch that file.

Closes #1422

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `verity_contract` macro syntax/translation, so it can change how existing contracts are lowered and compiled. Behavior is covered by a new regression test, but macro elaboration/lowering changes can have broad blast radius.
> 
> **Overview**
> Adds `do`-block syntax for custom-error exits (`requireError cond ErrorName(args)` and `revert`/`revertError ErrorName(args)`) and lowers them to `CompilationModel` statements `Stmt.requireError` and `Stmt.revertError`.
> 
> Introduces `Contracts.Common` macro fallbacks so these forms still execute in the Lean interpreter by translating them to `require false "ErrorName"` (and a guarded `if` for `requireError`).
> 
> Adds `Compiler/MacroCustomErrorFeatureTest.lean` to assert both the generated model bodies and the executable fallback behavior, and updates the EDSL API reference docs to describe the new surface.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 131343d9cd6869cd62b7a57ba401ccc5e33250d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->