### PR TITLE
macro: destructure mapping structs into tuples

### DIFF
--- a/Compiler/ABITest.lean
+++ b/Compiler/ABITest.lean
@@ -81,7 +81,7 @@ private def abiSpec : CompilationModel := {
       ]
     }
   ]
-  errors := [
+  «errors» := [
     { name := "BadThing"
       params := [ParamType.address, ParamType.bytes]
     }
@@ -107,7 +107,7 @@ private def stringAbiSpec : CompilationModel := {
       ]
     }
   ]
-  errors := [
+  «errors» := [
     { name := "BadMessage"
       params := [ParamType.string]
     }

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -150,6 +150,70 @@ example : echoPairExecutableKeepsTupleShape = true := by native_decide
 
 end MacroTupleDestructuringSmoke
 
+namespace MacroStructDestructuringSmoke
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract MacroStructDestructuring where
+  storage
+    positions : MappingStruct(Address,[
+      supplyShares @word 0 packed(0,128),
+      borrowShares @word 0 packed(128,128),
+      delegate @word 1
+    ]) := slot 0
+    approvals : MappingStruct2(Address,Address,[
+      allowance @word 0 packed(0,128),
+      nonce @word 1
+    ]) := slot 1
+
+  function loadPosition (user : Address) : Tuple [Uint256, Uint256, Address] := do
+    let (supply, borrow, delegate_) := structMembers "positions" user ["supplyShares", "borrowShares", "delegate"]
+    return (supply, borrow, delegate_)
+
+  function loadApproval (owner : Address, spender : Address) : Tuple [Uint256, Uint256] := do
+    return structMembers2 "approvals" owner spender ["allowance", "nonce"]
+
+def loadPositionModelDestructuresStructMembers : Bool :=
+  match MacroStructDestructuring.loadPosition_modelBody with
+  | [Stmt.letVar "supply" (Expr.structMember "positions" (Expr.param "user") "supplyShares"),
+      Stmt.letVar "borrow" (Expr.structMember "positions" (Expr.param "user") "borrowShares"),
+      Stmt.letVar "delegate_" (Expr.structMember "positions" (Expr.param "user") "delegate"),
+      Stmt.returnValues [Expr.localVar "supply", Expr.localVar "borrow", Expr.localVar "delegate_"]] =>
+      true
+  | _ => false
+
+example : loadPositionModelDestructuresStructMembers = true := by native_decide
+
+def loadApprovalModelReturnsStructMembers2 : Bool :=
+  match MacroStructDestructuring.loadApproval_modelBody with
+  | [Stmt.returnValues
+      [Expr.structMember2 "approvals" (Expr.param "owner") (Expr.param "spender") "allowance",
+       Expr.structMember2 "approvals" (Expr.param "owner") (Expr.param "spender") "nonce"]] =>
+      true
+  | _ => false
+
+example : loadApprovalModelReturnsStructMembers2 = true := by native_decide
+
+def loadPositionExecutableKeepsTupleShape : Bool :=
+  match MacroStructDestructuring.loadPosition Verity.defaultState.sender Verity.defaultState with
+  | .success (supply, (borrow, delegate_)) state =>
+      supply == 0 && borrow == 0 && delegate_ == zeroAddress && state.sender == Verity.defaultState.sender
+  | .revert _ _ => false
+
+example : loadPositionExecutableKeepsTupleShape = true := by native_decide
+
+def loadApprovalExecutableKeepsTupleShape : Bool :=
+  match MacroStructDestructuring.loadApproval Verity.defaultState.sender Verity.defaultState.sender Verity.defaultState with
+  | .success (allowance, nonce) state =>
+      allowance == 0 && nonce == 0 && state.sender == Verity.defaultState.sender
+  | .revert _ _ => false
+
+example : loadApprovalExecutableKeepsTupleShape = true := by native_decide
+
+end MacroStructDestructuringSmoke
+
 private def expectTrue (label : String) (ok : Bool) : IO Unit := do
   if !ok then
     throw (IO.userError s!"✗ {label}")
@@ -387,7 +451,7 @@ private def stringAbiSpec : CompilationModel := {
       params := [{ name := "message", ty := ParamType.string, kind := EventParamKind.unindexed }]
     }
   ]
-  errors := [
+  «errors» := [
     { name := "BadMessage"
       params := [ParamType.string]
     }

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -91,7 +91,7 @@ private def stringAbiSmokeSpec : CompilationModel := {
       params := [{ name := "message", ty := ParamType.string, kind := EventParamKind.unindexed }]
     }
   ]
-  errors := [
+  «errors» := [
     { name := "BadMessage"
       params := [ParamType.string]
     }

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -68,6 +68,10 @@ def structMember {κ α : Type} [Inhabited α] (_field : String) (_key : κ) (_m
     Contract α := pure default
 def structMember2 {κ₁ κ₂ α : Type} [Inhabited α]
     (_field : String) (_key1 : κ₁) (_key2 : κ₂) (_member : String) : Contract α := pure default
+def structMembers {κ α : Type} [Inhabited α]
+    (_field : String) (_key : κ) (_members : List String) : α := default
+def structMembers2 {κ₁ κ₂ α : Type} [Inhabited α]
+    (_field : String) (_key1 : κ₁) (_key2 : κ₂) (_members : List String) : α := default
 def setStructMember {κ α : Type} (_field : String) (_key : κ) (_member : String) (_value : α) :
     Contract Unit := pure ()
 def setStructMember2 {κ₁ κ₂ α : Type}

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -612,32 +612,86 @@ private def tupleValueExprs
     (params : Array ParamDecl)
     (locals : Array String)
     (rhs : Term) : CommandElabM (Array Term) := do
+  let structValueExprs? : CommandElabM (Option (Array Term)) := do
+    match stripParens rhs with
+    | `(term| structMembers $field:term $key:term $members:term) => do
+        let fieldName := ← expectStringOrIdent field
+        let memberNames := ← expectStringList members
+        let exprs ← memberNames.mapM fun memberName => do
+          let _ ← lookupStructMemberDecl fields fieldName memberName false
+          `(Compiler.CompilationModel.Expr.structMember
+              $(strTerm fieldName)
+              $(← translatePureExpr fields params locals key)
+              $(strTerm memberName))
+        pure (some exprs)
+    | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
+        let fieldName := ← expectStringOrIdent field
+        let memberNames := ← expectStringList members
+        let exprs ← memberNames.mapM fun memberName => do
+          let _ ← lookupStructMemberDecl fields fieldName memberName true
+          `(Compiler.CompilationModel.Expr.structMember2
+              $(strTerm fieldName)
+              $(← translatePureExpr fields params locals key1)
+              $(← translatePureExpr fields params locals key2)
+              $(strTerm memberName))
+        pure (some exprs)
+    | _ => pure none
   match tupleElemsFromTerm? rhs with
   | some elems =>
       elems.mapM (translatePureExpr fields params locals)
   | none =>
-      match stripParens rhs with
-      | `(term| $id:ident) =>
-          match (← tupleParamElemExprs? params (toString id.getId)) with
-          | some exprs => pure exprs
-          | none => throwErrorAt rhs "tuple destructuring currently requires a tuple literal or tuple-typed parameter"
-      | _ =>
-          throwErrorAt rhs "tuple destructuring currently requires a tuple literal or tuple-typed parameter"
+      match (← structValueExprs?) with
+      | some exprs => pure exprs
+      | none =>
+          match stripParens rhs with
+          | `(term| $id:ident) =>
+              match (← tupleParamElemExprs? params (toString id.getId)) with
+              | some exprs => pure exprs
+              | none => throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, or structMembers/structMembers2 source"
+          | _ =>
+              throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, or structMembers/structMembers2 source"
 
 private def tupleReturnValueExprs?
     (fields : Array StorageFieldDecl)
     (params : Array ParamDecl)
     (locals : Array String)
     (rhs : Term) : CommandElabM (Option (Array Term)) := do
+  let structValueExprs? : CommandElabM (Option (Array Term)) := do
+    match stripParens rhs with
+    | `(term| structMembers $field:term $key:term $members:term) => do
+        let fieldName := ← expectStringOrIdent field
+        let memberNames := ← expectStringList members
+        let exprs ← memberNames.mapM fun memberName => do
+          let _ ← lookupStructMemberDecl fields fieldName memberName false
+          `(Compiler.CompilationModel.Expr.structMember
+              $(strTerm fieldName)
+              $(← translatePureExpr fields params locals key)
+              $(strTerm memberName))
+        pure (some exprs)
+    | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
+        let fieldName := ← expectStringOrIdent field
+        let memberNames := ← expectStringList members
+        let exprs ← memberNames.mapM fun memberName => do
+          let _ ← lookupStructMemberDecl fields fieldName memberName true
+          `(Compiler.CompilationModel.Expr.structMember2
+              $(strTerm fieldName)
+              $(← translatePureExpr fields params locals key1)
+              $(← translatePureExpr fields params locals key2)
+              $(strTerm memberName))
+        pure (some exprs)
+    | _ => pure none
   match tupleElemsFromTerm? rhs with
   | some elems =>
       pure (some (← elems.mapM (translatePureExpr fields params locals)))
   | none =>
-      match stripParens rhs with
-      | `(term| $id:ident) =>
-          tupleParamElemExprs? params (toString id.getId)
-      | _ =>
-          pure none
+      match (← structValueExprs?) with
+      | some exprs => pure (some exprs)
+      | none =>
+          match stripParens rhs with
+          | `(term| $id:ident) =>
+              tupleParamElemExprs? params (toString id.getId)
+          | _ =>
+              pure none
 
 private def expectExprList
     (fields : Array StorageFieldDecl)

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -309,10 +309,12 @@ Location: `Contracts/Common.lean`
 ```lean
 let (first, second) := pair
 let (lhs, rhs) := (seed, add seed 1)
+let (supply, borrow, delegate_) := structMembers positions user [supplyShares, borrowShares, delegate]
 return (first, second)
+return structMembers2 approvals owner spender [allowance, nonce]
 ```
 
-Today this elaborates cleanly for tuple literals and tuple-typed parameters. `return (..)` lowers to `Stmt.returnValues [...]`, and tuple-parameter destructuring maps onto the ABI-flattened component names (`pair_0`, `pair_1`, ...), so the generated model stays explicit for debugging and proofs.
+Today this elaborates cleanly for tuple literals, tuple-typed parameters, and storage-backed mapping-struct reads via `structMembers` / `structMembers2`. `return (..)` lowers to `Stmt.returnValues [...]`, tuple-parameter destructuring maps onto the ABI-flattened component names (`pair_0`, `pair_1`, ...), and struct-backed destructuring lowers to explicit `Expr.structMember` / `Expr.structMember2` reads, so the generated model stays explicit for debugging and proofs.
 
 ## Custom Errors
 


### PR DESCRIPTION
## Summary
- extend tuple destructuring/tuple return lowering so `verity_contract` can read mapping-backed struct members through `structMembers` and `structMembers2`
- add macro/runtime smoke coverage for the new struct-backed destructuring path
- fix the pre-existing parser collision between Verity's `errors` keyword and `CompilationModel` structure literals by escaping `«errors»` in affected tests

## Testing
- lake build Verity.Macro.Translate
- lake build Compiler.ABITest
- lake build Compiler.CompilationModelFeatureTest
- lake build Compiler.CompileDriverTest
- make check

Refs #1415

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends `verity_contract` macro lowering for tuple binds/returns to expand `structMembers`/`structMembers2` into multiple storage reads, which can affect generated compilation models/Yul for contracts using this syntax. Changes are localized and covered by new smoke tests and doc updates.
> 
> **Overview**
> Adds macro support for destructuring/returning tuples sourced from mapping-backed structs: `structMembers`/`structMembers2` now lower into explicit `Expr.structMember`/`Expr.structMember2` reads when used in tuple `let (...) := ...` or `return ...` forms.
> 
> Introduces lightweight runtime stubs for `structMembers` and `structMembers2`, plus new macro/model/executable smoke tests validating the lowering and tuple shape preservation for both single- and double-key mapping structs.
> 
> Fixes a parser keyword collision in tests by escaping the `CompilationModel` field as `«errors»`, and updates the EDSL docs to describe the new struct-backed tuple sugar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19e6ee2b2e70b034bb1e9ec253766793c9fc142e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->