### PR TITLE
macro: support helper tuple destructuring with :=

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -114,6 +114,11 @@ verity_contract MacroTupleDestructuring where
     setStorage firstSlot first
     setStorage secondSlot second
 
+  function storeHelperPairEq (seed : Uint256) : Unit := do
+    let (first, second) := helperPair seed
+    setStorage firstSlot first
+    setStorage secondSlot second
+
 def storePairModelDestructuresTupleParam : Bool :=
   match MacroTupleDestructuring.storePair_modelBody with
   | [Stmt.letVar "first" (Expr.param "pair_0"),
@@ -167,6 +172,17 @@ def storeHelperPairModelUsesInternalCallAssign : Bool :=
 
 example : storeHelperPairModelUsesInternalCallAssign = true := by native_decide
 
+def storeHelperPairEqModelUsesInternalCallAssign : Bool :=
+  match MacroTupleDestructuring.storeHelperPairEq_modelBody with
+  | [Stmt.internalCallAssign ["first", "second"] "helperPair" [Expr.param "seed"],
+      Stmt.setStorage "firstSlot" (Expr.localVar "first"),
+      Stmt.setStorage "secondSlot" (Expr.localVar "second"),
+      Stmt.stop] =>
+      true
+  | _ => false
+
+example : storeHelperPairEqModelUsesInternalCallAssign = true := by native_decide
+
 def echoPairExecutableKeepsTupleShape : Bool :=
   match MacroTupleDestructuring.echoPair (11, 17) Verity.defaultState with
   | .success (first, second) state =>
@@ -182,6 +198,14 @@ def storeHelperPairExecutableStoresHelperResults : Bool :=
   | .revert _ _ => false
 
 example : storeHelperPairExecutableStoresHelperResults = true := by native_decide
+
+def storeHelperPairEqExecutableStoresHelperResults : Bool :=
+  match MacroTupleDestructuring.storeHelperPairEq 11 Verity.defaultState with
+  | .success () state =>
+      state.storage 0 == 11 && state.storage 1 == 12
+  | .revert _ _ => false
+
+example : storeHelperPairEqExecutableStoresHelperResults = true := by native_decide
 
 end MacroTupleDestructuringSmoke
 

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -18,6 +18,21 @@ macro_rules
       `(doElem| require false $(Lean.quote (toString errorName.getId)))
   | `(doElem| requireError $cond:term $errorName:ident($_args,*)) =>
       `(doElem| if $cond then pure () else require false $(Lean.quote (toString errorName.getId)))
+  | `(doElem| let $pat:term := $rhs:term) => do
+      if pat.raw.getKind != `Lean.Parser.Term.tuple then
+        Lean.Macro.throwUnsupported
+      match rhs.raw with
+      | .node _ `Lean.Parser.Term.app args =>
+          match args.getD 0 Lean.Syntax.missing with
+          | .ident _ raw _ _ =>
+              if raw.toString == "structMembers" || raw.toString == "structMembers2" then
+                Lean.Macro.throwUnsupported
+              else
+                `(doElem| let $pat:term ← $rhs:term)
+          | _ =>
+              Lean.Macro.throwUnsupported
+      | _ =>
+          Lean.Macro.throwUnsupported
 
 
 def bitAnd (a b : Uint256) : Uint256 := Verity.Core.Uint256.and a b

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -607,51 +607,7 @@ partial def translatePureExpr
           $(strTerm memberName))
   | _ => throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
 
-private def tupleValueExprs
-    (fields : Array StorageFieldDecl)
-    (params : Array ParamDecl)
-    (locals : Array String)
-    (rhs : Term) : CommandElabM (Array Term) := do
-  let structValueExprs? : CommandElabM (Option (Array Term)) := do
-    match stripParens rhs with
-    | `(term| structMembers $field:term $key:term $members:term) => do
-        let fieldName := ← expectStringOrIdent field
-        let memberNames := ← expectStringList members
-        let exprs ← memberNames.mapM fun memberName => do
-          let _ ← lookupStructMemberDecl fields fieldName memberName false
-          `(Compiler.CompilationModel.Expr.structMember
-              $(strTerm fieldName)
-              $(← translatePureExpr fields params locals key)
-              $(strTerm memberName))
-        pure (some exprs)
-    | `(term| structMembers2 $field:term $key1:term $key2:term $members:term) => do
-        let fieldName := ← expectStringOrIdent field
-        let memberNames := ← expectStringList members
-        let exprs ← memberNames.mapM fun memberName => do
-          let _ ← lookupStructMemberDecl fields fieldName memberName true
-          `(Compiler.CompilationModel.Expr.structMember2
-              $(strTerm fieldName)
-              $(← translatePureExpr fields params locals key1)
-              $(← translatePureExpr fields params locals key2)
-              $(strTerm memberName))
-        pure (some exprs)
-    | _ => pure none
-  match tupleElemsFromTerm? rhs with
-  | some elems =>
-      elems.mapM (translatePureExpr fields params locals)
-  | none =>
-      match (← structValueExprs?) with
-      | some exprs => pure exprs
-      | none =>
-          match stripParens rhs with
-          | `(term| $id:ident) =>
-              match (← tupleParamElemExprs? params (toString id.getId)) with
-              | some exprs => pure exprs
-              | none => throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, or structMembers/structMembers2 source"
-          | _ =>
-              throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, or structMembers/structMembers2 source"
-
-private def tupleReturnValueExprs?
+private def tupleLiteralOrStructValueExprs?
     (fields : Array StorageFieldDecl)
     (params : Array ParamDecl)
     (locals : Array String)
@@ -684,14 +640,66 @@ private def tupleReturnValueExprs?
   | some elems =>
       pure (some (← elems.mapM (translatePureExpr fields params locals)))
   | none =>
-      match (← structValueExprs?) with
-      | some exprs => pure (some exprs)
-      | none =>
-          match stripParens rhs with
-          | `(term| $id:ident) =>
-              tupleParamElemExprs? params (toString id.getId)
-          | _ =>
-              pure none
+      structValueExprs?
+
+private def tupleValueExprs
+    (fields : Array StorageFieldDecl)
+    (params : Array ParamDecl)
+    (locals : Array String)
+    (rhs : Term) : CommandElabM (Array Term) := do
+  match (← tupleLiteralOrStructValueExprs? fields params locals rhs) with
+  | some exprs => pure exprs
+  | none =>
+      match stripParens rhs with
+      | `(term| $id:ident) =>
+          match (← tupleParamElemExprs? params (toString id.getId)) with
+          | some exprs => pure exprs
+          | none => throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, or structMembers/structMembers2 source"
+      | _ =>
+          throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, or structMembers/structMembers2 source"
+
+private def tupleReturnValueExprs?
+    (fields : Array StorageFieldDecl)
+    (params : Array ParamDecl)
+    (locals : Array String)
+    (rhs : Term) : CommandElabM (Option (Array Term)) := do
+  match (← tupleLiteralOrStructValueExprs? fields params locals rhs) with
+  | some exprs => pure (some exprs)
+  | none =>
+      match stripParens rhs with
+      | `(term| $id:ident) =>
+          tupleParamElemExprs? params (toString id.getId)
+      | _ =>
+          pure none
+
+private def tupleInternalCallAssignStmt?
+    (fields : Array StorageFieldDecl)
+    (params : Array ParamDecl)
+    (locals : Array String)
+    (rhs : Term)
+    (names : Array String) : CommandElabM (Option Term) := do
+  let rhs := stripParens rhs
+  match rhs.raw with
+  | .node _ `Lean.Parser.Term.app args =>
+      match args.getD 0 Syntax.missing with
+      | .ident _ raw _ _ =>
+          let argExprs ← (args.getD 1 Syntax.missing).getArgs.mapM
+            (translatePureExpr fields params locals ∘ fun syn => ⟨syn⟩)
+          let resultNameTerms := names.map strTerm
+          pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
+            [ $[$resultNameTerms],* ]
+            $(strTerm raw.toString)
+            [ $[$argExprs],* ])))
+      | _ =>
+          pure none
+  | .ident _ raw _ _ =>
+      let resultNameTerms := names.map strTerm
+      pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
+        [ $[$resultNameTerms],* ]
+        $(strTerm raw.toString)
+        [])))
+  | _ =>
+      pure none
 
 private def expectExprList
     (fields : Array StorageFieldDecl)
@@ -1097,12 +1105,40 @@ private partial def translateDoElem
       match tupleBinderNames? patDecl[0] with
       | some names =>
           ensureFreshLocalNames locals names stx
-          let valueExprs ← tupleValueExprs fields params locals ⟨patDecl[4]⟩
-          if names.size != valueExprs.size then
-            throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueExprs.size} values"
-          let stmts ← (names.zip valueExprs).mapM fun (name, valueExpr) =>
-            `(Compiler.CompilationModel.Stmt.letVar $(strTerm name) $valueExpr)
-          pure (some (stmts, locals ++ names, mutableLocals))
+          let rhs : Term := ⟨patDecl[4]⟩
+          let rhs := stripParens rhs
+          match rhs with
+          | `(term| $id:ident) =>
+              match (← tupleParamElemExprs? params (toString id.getId)) with
+              | some valueExprs =>
+                  if names.size != valueExprs.size then
+                    throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueExprs.size} values"
+                  let stmts ← (names.zip valueExprs).mapM fun (name, valueExpr) =>
+                    `(Compiler.CompilationModel.Stmt.letVar $(strTerm name) $valueExpr)
+                  pure (some (stmts, locals ++ names, mutableLocals))
+              | none =>
+                  match (← tupleInternalCallAssignStmt? fields params locals rhs names) with
+                  | some stmt => pure (some (#[(stmt)], locals ++ names, mutableLocals))
+                  | none => throwErrorAt rhs "tuple destructuring currently requires a tuple literal, tuple-typed parameter, structMembers/structMembers2 source, or internal helper call"
+          | _ =>
+              match (← tupleLiteralOrStructValueExprs? fields params locals rhs) with
+              | some valueExprs =>
+                  if names.size != valueExprs.size then
+                    throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueExprs.size} values"
+                  let stmts ← (names.zip valueExprs).mapM fun (name, valueExpr) =>
+                    `(Compiler.CompilationModel.Stmt.letVar $(strTerm name) $valueExpr)
+                  pure (some (stmts, locals ++ names, mutableLocals))
+              | none =>
+                match (← tupleInternalCallAssignStmt? fields params locals rhs names) with
+                | some stmt =>
+                    pure (some (#[(stmt)], locals ++ names, mutableLocals))
+                | none =>
+                  let valueExprs ← tupleValueExprs fields params locals rhs
+                  if names.size != valueExprs.size then
+                    throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueExprs.size} values"
+                  let stmts ← (names.zip valueExprs).mapM fun (name, valueExpr) =>
+                    `(Compiler.CompilationModel.Stmt.letVar $(strTerm name) $valueExpr)
+                  pure (some (stmts, locals ++ names, mutableLocals))
       | none => pure none
     else if stx.getKind == `Lean.Parser.Term.doLetArrow then
       let patDecl := stx[2]
@@ -1110,30 +1146,9 @@ private partial def translateDoElem
       | some names =>
           ensureFreshLocalNames locals names stx
           let rhs : Term := ⟨patDecl[2][0]⟩
-          let rhs := stripParens rhs
-          match rhs.raw with
-          | .node _ `Lean.Parser.Term.app args =>
-              match args.getD 0 Syntax.missing with
-              | .ident _ raw _ _ =>
-                  let argExprs ← (args.getD 1 Syntax.missing).getArgs.mapM
-                    (translatePureExpr fields params locals ∘ fun syn => ⟨syn⟩)
-                  let resultNameTerms := names.map strTerm
-                  let stmt ← `(Compiler.CompilationModel.Stmt.internalCallAssign
-                    [ $[$resultNameTerms],* ]
-                    $(strTerm raw.toString)
-                    [ $[$argExprs],* ])
-                  pure (some (#[(stmt)], locals ++ names, mutableLocals))
-              | _ =>
-                  throwErrorAt rhs "tuple bind sources must be internal helper calls"
-          | .ident _ raw _ _ =>
-              let resultNameTerms := names.map strTerm
-              let stmt ← `(Compiler.CompilationModel.Stmt.internalCallAssign
-                [ $[$resultNameTerms],* ]
-                $(strTerm raw.toString)
-                [])
-              pure (some (#[(stmt)], locals ++ names, mutableLocals))
-          | _ =>
-              throwErrorAt rhs "tuple bind sources must be internal helper calls"
+          match (← tupleInternalCallAssignStmt? fields params locals rhs names) with
+          | some stmt => pure (some (#[(stmt)], locals ++ names, mutableLocals))
+          | none => throwErrorAt rhs "tuple bind sources must be internal helper calls"
       | none => pure none
     else
       pure none

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -309,13 +309,14 @@ Location: `Contracts/Common.lean`
 ```lean
 let (first, second) := pair
 let (lhs, rhs) := (seed, add seed 1)
+let (assets, shares) := preview seed
 let (assets, shares) ← preview seed
 let (supply, borrow, delegate_) := structMembers positions user [supplyShares, borrowShares, delegate]
 return (first, second)
 return structMembers2 approvals owner spender [allowance, nonce]
 ```
 
-Today this elaborates cleanly for tuple literals, tuple-typed parameters, internal helper multi-returns via `let (...) ← helper ...`, and storage-backed mapping-struct reads via `structMembers` / `structMembers2`. `return (..)` lowers to `Stmt.returnValues [...]`, tuple-parameter destructuring maps onto the ABI-flattened component names (`pair_0`, `pair_1`, ...), helper-call destructuring lowers to `Stmt.internalCallAssign [...]`, and struct-backed destructuring lowers to explicit `Expr.structMember` / `Expr.structMember2` reads, so the generated model stays explicit for debugging and proofs.
+Today this elaborates cleanly for tuple literals, tuple-typed parameters, internal helper multi-returns via either `let (...) := helper ...` or `let (...) ← helper ...`, and storage-backed mapping-struct reads via `structMembers` / `structMembers2`. `return (..)` lowers to `Stmt.returnValues [...]`, tuple-parameter destructuring maps onto the ABI-flattened component names (`pair_0`, `pair_1`, ...), helper-call destructuring lowers to `Stmt.internalCallAssign [...]`, and struct-backed destructuring lowers to explicit `Expr.structMember` / `Expr.structMember2` reads, so the generated model stays explicit for debugging and proofs.
 
 ## Custom Errors
 


### PR DESCRIPTION
## Summary
- allow `verity_contract` tuple destructuring from helper multi-returns with `let (...) := helper ...`
- reuse the same `Stmt.internalCallAssign` lowering as the existing `let (...) ← helper ...` path
- add model/runtime regression coverage and document the new accepted sugar

## Testing
- `lake build Contracts.Common Verity.Macro.Translate Compiler.CompilationModelFeatureTest`
- `make check`

Refs #1415.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `verity_contract` macro translation for tuple destructuring, which can change how contract bodies are lowered to `CompilationModel` statements. Scope is limited to tuple-pattern `let` bindings and is covered by new model/runtime regression tests.
> 
> **Overview**
> Extends `verity_contract` tuple destructuring to accept helper multi-return calls written as `let (a, b) := helper ...`, lowering them to the same `Stmt.internalCallAssign` form previously used only by `let (a, b) ← helper ...`.
> 
> Refactors tuple-source detection in `Verity/Macro/Translate.lean` and adds a small `Contracts/Common.lean` macro rewrite to treat tuple-pattern `let ... :=` helper calls as monadic binds while explicitly excluding `structMembers`/`structMembers2`. Adds compilation-model and executable regression coverage plus docs updates for the new sugar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4eb30354bbf9e2a95716da90a042bf40cd867db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->