### PR TITLE
compiler: guard dynamic-element array helpers

### DIFF
--- a/Compiler/CompilationModel/AbiTypeLayout.lean
+++ b/Compiler/CompilationModel/AbiTypeLayout.lean
@@ -53,4 +53,14 @@ def eventIsDynamicType := isDynamicParamType
 
 def eventHeadWordSize := paramHeadSize
 
+/-- Whether a parameter type is ABI-encoded as exactly one 32-byte word without
+needing offset-based dynamic handling. -/
+def isSingleWordStaticParamType (ty : ParamType) : Bool :=
+  !isDynamicParamType ty && paramHeadSize ty == 32
+
+/-- Dynamic array parameters whose elements can be copied/read word-for-word. -/
+def isWordArrayParam : ParamType → Bool
+  | ParamType.array elemTy => isSingleWordStaticParamType elemTy
+  | _ => false
+
 end Compiler.CompilationModel

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -1,4 +1,5 @@
 import Compiler.CompilationModel.Types
+import Compiler.CompilationModel.AbiTypeLayout
 import Compiler.CompilationModel.IssueRefs
 import Compiler.CompilationModel.LogicalPurity
 import Compiler.CompilationModel.EcmAxiomCollection
@@ -109,7 +110,11 @@ def validateScopedExprIdentifiers
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayLength"
   | Expr.arrayElement name index => do
       match findParamType params name with
-      | some (ParamType.array _) => pure ()
+      | some ty@(ParamType.array elemTy) =>
+          if isSingleWordStaticParamType elemTy then
+            pure ()
+          else
+            throw s!"Compilation error: {context} Expr.arrayElement '{name}' requires an array with single-word static elements, got {repr ty}"
       | some ty =>
           throw s!"Compilation error: {context} Expr.arrayElement '{name}' requires array parameter, got {repr ty}"
       | none =>

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -36,10 +36,11 @@ def validateStmtParamReferences (fnName : String) (params : List Param) :
     Stmt → Except String Unit
   | Stmt.returnArray name =>
       match findParamType params name with
-      | some (ParamType.array _) =>
-          pure ()
       | some ty =>
-          throw s!"Compilation error: function '{fnName}' returnArray '{name}' requires array parameter, got {repr ty}"
+          if isWordArrayParam ty then
+            pure ()
+          else
+            throw s!"Compilation error: function '{fnName}' returnArray '{name}' requires an array parameter with single-word static elements, got {repr ty}"
       | none =>
           throw s!"Compilation error: function '{fnName}' returnArray references unknown parameter '{name}'"
   | Stmt.returnBytes name =>
@@ -99,13 +100,20 @@ def validateReturnShapesInStmt (fnName : String) (params : List Param)
         throw s!"Compilation error: function '{fnName}' returnValues count mismatch: expected {expectedReturns.length}, got {values.length}"
       else
         pure ()
-  | Stmt.returnArray _ =>
+  | Stmt.returnArray name =>
       if isInternal then
         throw s!"Compilation error: internal function '{fnName}' cannot use Stmt.returnArray; only static returns via Stmt.return/Stmt.returnValues are supported ({issue625Ref})."
-      else if expectedReturns == [ParamType.array ParamType.uint256] then
-        pure ()
       else
-        throw s!"Compilation error: function '{fnName}' uses Stmt.returnArray but declared returns are {repr expectedReturns}"
+        match findParamType params name with
+        | some ty =>
+            if !isWordArrayParam ty then
+              throw s!"Compilation error: function '{fnName}' uses Stmt.returnArray with parameter '{name}' of type {repr ty}; only arrays with single-word static elements are currently supported"
+            else if expectedReturns == [ty] then
+              pure ()
+            else
+              throw s!"Compilation error: function '{fnName}' uses Stmt.returnArray to return parameter '{name}' of type {repr ty}, but declared returns are {repr expectedReturns}"
+        | none =>
+            throw s!"Compilation error: function '{fnName}' returnArray references unknown parameter '{name}'"
   | Stmt.returnBytes name =>
       if isInternal then
         throw s!"Compilation error: internal function '{fnName}' cannot use Stmt.returnBytes; only static returns via Stmt.return/Stmt.returnValues are supported ({issue625Ref})."

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -294,6 +294,9 @@ verity_contract MacroDynamicArray where
   function echoAmounts (amounts : Array Uint256) : Array Uint256 := do
     returnArray amounts
 
+  function echoRecipients (recipients : Array Address) : Array Address := do
+    returnArray recipients
+
 def countRecipientsModelUsesArrayLength : Bool :=
   match MacroDynamicArray.countRecipients_modelBody with
   | [Stmt.letVar "count" (Expr.arrayLength "recipients"),
@@ -319,6 +322,14 @@ def echoAmountsModelUsesReturnArray : Bool :=
   | _ => false
 
 example : echoAmountsModelUsesReturnArray = true := by native_decide
+
+def echoRecipientsModelUsesReturnArray : Bool :=
+  match MacroDynamicArray.echoRecipients_modelBody with
+  | [Stmt.returnArray "recipients"] =>
+      true
+  | _ => false
+
+example : echoRecipientsModelUsesReturnArray = true := by native_decide
 
 def countRecipientsExecutableUsesRuntimeHelper : Bool :=
   match MacroDynamicArray.countRecipients #[(11 : Address), (17 : Address)] Verity.defaultState with
@@ -351,6 +362,15 @@ def echoAmountsExecutableRoundTrips : Bool :=
   | .revert _ _ => false
 
 example : echoAmountsExecutableRoundTrips = true := by native_decide
+
+def echoRecipientsExecutableRoundTrips : Bool :=
+  match MacroDynamicArray.echoRecipients #[(11 : Address), (17 : Address)] Verity.defaultState with
+  | .success recipients state =>
+      recipients == #[(11 : Address), (17 : Address)] &&
+        state.sender == Verity.defaultState.sender
+  | .revert _ _ => false
+
+example : echoRecipientsExecutableRoundTrips = true := by native_decide
 
 end MacroDynamicArraySmoke
 
@@ -650,6 +670,47 @@ private def stringArrayEventSpec : CompilationModel := {
         { name := "body", ty := ParamType.array ParamType.string, kind := EventParamKind.unindexed },
         { name := "topicBody", ty := ParamType.array ParamType.string, kind := EventParamKind.indexed }
       ]
+    }
+  ]
+}
+
+private def addressArrayReturnSpec : CompilationModel := {
+  name := "AddressArrayReturn"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "echo"
+      params := [{ name := "recipients", ty := ParamType.array ParamType.address }]
+      returnType := none
+      returns := [ParamType.array ParamType.address]
+      body := [Stmt.returnArray "recipients"]
+    }
+  ]
+}
+
+private def bytesArrayReturnSpec : CompilationModel := {
+  name := "BytesArrayReturn"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "echo"
+      params := [{ name := "calls", ty := ParamType.array ParamType.bytes }]
+      returnType := none
+      returns := [ParamType.array ParamType.bytes]
+      body := [Stmt.returnArray "calls"]
+    }
+  ]
+}
+
+private def bytesArrayElementSpec : CompilationModel := {
+  name := "BytesArrayElement"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "headWord"
+      params := [{ name := "calls", ty := ParamType.array ParamType.bytes }]
+      returnType := some FieldType.uint256
+      body := [Stmt.return (Expr.arrayElement "calls" (Expr.literal 0))]
     }
   ]
 }
@@ -1129,6 +1190,19 @@ private def erc4626DepositSmokeSpec : CompilationModel := {
     | .ok _ => true
     | .error _ => false
   expectTrue "string[] event emission compiles for indexed and unindexed params" stringArrayEventsCompile
+  let addressArrayReturnCompiled :=
+    match Compiler.CompilationModel.compile addressArrayReturnSpec (selectorsFor addressArrayReturnSpec) with
+    | .ok _ => true
+    | .error _ => false
+  expectTrue "address[] params can round-trip through returnArray" addressArrayReturnCompiled
+  expectCompileErrorContains
+    "returnArray rejects bytes[] params until dynamic-element lowering lands"
+    bytesArrayReturnSpec
+    "only arrays with single-word static elements are currently supported"
+  expectCompileErrorContains
+    "arrayElement rejects bytes[] params until dynamic-element indexing lands"
+    bytesArrayElementSpec
+    "Expr.arrayElement 'calls' requires an array with single-word static elements"
   let envYul ← expectCompileToYul "env runtime smoke spec" envRuntimeSmokeSpec
   expectTrue "address(this) lowers to the Yul address builtin"
     (contains envYul "address()")

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -328,7 +328,7 @@ let first := arrayElement recipients 0
 returnArray amounts
 ```
 
-`arrayLength arr` lowers to `Expr.arrayLength "arr"`, `arrayElement arr idx` lowers to `Expr.arrayElement "arr" idx`, and `returnArray arr` lowers to `Stmt.returnArray "arr"`. `arrayElement` remains bounds-checked on the compiled path, and the executable fallback in `Contracts/Common.lean` now mirrors that by reverting on out-of-range indices instead of silently defaulting, so array-parameter contracts can be exercised directly in Lean while still compiling through the dynamic ABI path.
+`arrayLength arr` lowers to `Expr.arrayLength "arr"`, `arrayElement arr idx` lowers to `Expr.arrayElement "arr" idx`, and `returnArray arr` lowers to `Stmt.returnArray "arr"`. Today `arrayElement` and `returnArray` are restricted to arrays whose elements occupy exactly one ABI word (`Array Uint256`, `Array Address`, `Array Bool`, `Array Uint8`, `Array Bytes32`). Dynamic-element arrays such as `Array Bytes` and `Array String` still support `arrayLength`, but indexed element reads and direct `returnArray` lowering are rejected until the compiler grows offset-aware element lowering for those payloads. `arrayElement` remains bounds-checked on the compiled path, and the executable fallback in `Contracts/Common.lean` now mirrors that by reverting on out-of-range indices instead of silently defaulting.
 
 ## Custom Errors
 


### PR DESCRIPTION
## Summary
- guard `arrayElement` and `returnArray` so they only accept arrays whose elements fit in one ABI word
- extend safe `returnArray` support to word-sized arrays like `address[]`, not just `uint256[]`
- add regression coverage and docs for the supported surface vs. the still-unsupported `bytes[]`/`string[]` element-lowering path

## Why
`Expr.arrayElement` currently lowers through a helper that reads `data_offset + index * 32`, which is only correct for single-word static element arrays. Without a guard, `bytes[]`/`string[]` element access can be accepted even though their ABI layout is offset-based. This change fails closed on the unsafe cases and broadens the safe ones that already compile correctly.

## Testing
- `lake build Compiler.CompilationModelFeatureTest`
- `lake build Contracts.Smoke`
- `make check`

Closes #1419? No, this is a guardrail + safe-surface slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler validation rules for `Expr.arrayElement`/`Stmt.returnArray`, which may break previously-compiling contracts that used these helpers on `bytes[]`/`string[]` (now rejected) while expanding support to other word-sized arrays like `address[]`. Risk is limited to compile-time behavior and ABI lowering constraints, not runtime execution paths.
> 
> **Overview**
> **Tightens dynamic-array helper validation to fail closed on unsafe ABI layouts.** Adds ABI-layout predicates (`isSingleWordStaticParamType`, `isWordArrayParam`) and uses them to restrict `Expr.arrayElement` and `Stmt.returnArray` to arrays whose elements occupy exactly one 32-byte ABI word.
> 
> **Broadens the safe surface and adds regression coverage.** `returnArray` validation now accepts any single-word element array (e.g., `address[]`), while new feature tests assert `address[]` round-trips and that `bytes[]` is rejected for both `returnArray` and `arrayElement`; docs are updated to spell out the supported vs. unsupported array types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 901a6aff543a6b37b68e5bf7b0cc3e3c401a3325. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->