### PR TITLE
macro: expose executable rawLog event traces

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -624,6 +624,17 @@ def emitDynamicLogExecutableAppendsLowLevelTrace : Bool :=
 
 example : emitDynamicLogExecutableAppendsLowLevelTrace = true := by native_decide
 
+def rawLogExecutableRejectsTooManyTopics : Bool :=
+  match rawLog [1, 2, 3, 4, 5] 0 32 Verity.defaultState with
+  | .revert msg state =>
+      msg == "rawLog supports at most 4 topics, got 5" &&
+        match state.events with
+        | [] => true
+        | _ => false
+  | .success _ _ => false
+
+example : rawLogExecutableRejectsTooManyTopics = true := by native_decide
+
 end MacroEventTraceSmoke
 
 private def expectTrue (label : String) (ok : Bool) : IO Unit := do
@@ -1486,6 +1497,8 @@ set_option maxRecDepth 4096 in
     MacroEventTraceSmoke.emitNamedExecutableAppendsNamedEvent
   expectTrue "macro rawLog executable path appends the low-level event trace"
     MacroEventTraceSmoke.emitDynamicLogExecutableAppendsLowLevelTrace
+  expectTrue "executable rawLog rejects more than four topics like the compiler path"
+    MacroEventTraceSmoke.rawLogExecutableRejectsTooManyTopics
   let rawLogTraceYul ← expectCompileToYul
     "rawLog trace smoke spec"
     rawLogTraceSmokeSpec

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -88,10 +88,13 @@ def returnBytes {α : Type} (value : α) : Contract α := pure value
 def returnStorageWords (_slots : Array Uint256) : Contract (Array Uint256) := pure #[]
 def emit (name : String) (args : List Uint256) : Contract Unit := emitEvent name args
 def rawLog (topics : List Uint256) (dataOffset dataSize : Uint256) : Contract Unit := fun state =>
-  ContractResult.success () { state with
-    events := state.events ++
-      [{ name := s!"log{topics.length}", args := [dataOffset, dataSize], indexedArgs := topics }]
-  }
+  if topics.length > 4 then
+    ContractResult.revert s!"rawLog supports at most 4 topics, got {topics.length}" state
+  else
+    ContractResult.success () { state with
+      events := state.events ++
+        [{ name := s!"log{topics.length}", args := [dataOffset, dataSize], indexedArgs := topics }]
+    }
 def mstore (_offset _value : Uint256) : Contract Unit := pure ()
 def getMappingWord (_slot : StorageSlot (Uint256 → Uint256)) (_key _wordOffset : Uint256) :
     Contract Uint256 := pure 0

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -362,7 +362,7 @@ This sets `spec.constructor.isPayable := true`, emits constructor ABI `stateMuta
 rawLog [topic0, add topic1 1] dataOffset dataSize
 ```
 
-`rawLog topics dataOffset dataSize` lowers to `Stmt.rawLog topics dataOffset dataSize`. The executable fallback in `Contracts/Common.lean` now mirrors that surface by appending a low-level trace entry shaped like `{ name := "logN", args := [dataOffset, dataSize], indexedArgs := topics }`, so macro-authored contracts can round-trip observable log behavior instead of only compiling it.
+`rawLog topics dataOffset dataSize` lowers to `Stmt.rawLog topics dataOffset dataSize`. Both the compiler and the executable fallback currently support 0 to 4 topics only (`log0` to `log4`); larger topic lists are rejected. On the executable path, successful calls append a low-level trace entry shaped like `{ name := "logN", args := [dataOffset, dataSize], indexedArgs := topics }`, so macro-authored contracts can round-trip observable log behavior instead of only compiling it.
 
 ## Dynamic Array Surface
 


### PR DESCRIPTION
## Summary
- add executable `emit`/`rawLog` helpers in `Contracts.Common` so macro-authored contracts preserve observable event traces
- add macro regression coverage for `Stmt.emit`, dynamic-topic `Stmt.rawLog`, executable trace appends, and rendered `log2` output
- document the low-level `rawLog` surface in the EDSL reference

## Testing
- lake build Contracts.Common Compiler.CompilationModelFeatureTest
- make check

Closes #1414? No, this is a narrow slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new `Contracts.Common` executable helpers for event/log tracing plus regression tests and docs, without changing core compilation/codegen logic. Main risk is minor behavior/name-resolution impact for contracts that previously defined or relied on different `emit`/`rawLog` symbols.
> 
> **Overview**
> Adds executable `emit` and `rawLog` helpers to `Contracts.Common` so macro-authored contracts can preserve observable event/log traces when run via the interpreter; `rawLog` enforces the EVM `log0`–`log4` topic limit and appends a `logN`-shaped trace entry on success.
> 
> Extends `CompilationModelFeatureTest` with a `MacroEventTrace` smoke contract and assertions that macro lowering produces `Stmt.emit`/`Stmt.rawLog` (including dynamic topic expressions), the executable path records the expected traces and rejects >4 topics, and compiled Yul renders a `log2` for dynamic-topic `rawLog`. Updates the EDSL API reference to document the new low-level `rawLog` surface and its constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6b066c8f5c8954a490c97d74083edf758617fb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->