### PR TITLE
docs: sync linear-memory proof boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/check_verify_sync.py
 	python3 scripts/check_bridge_coverage_sync.py
 	python3 scripts/check_low_level_call_boundary_sync.py
+	python3 scripts/check_linear_memory_boundary_sync.py
 	python3 scripts/check_struct_mapping_surface_sync.py
 	python3 scripts/check_solc_pin.py
 	python3 scripts/check_property_manifest_sync.py

--- a/artifacts/interpreter_feature_matrix.json
+++ b/artifacts/interpreter_feature_matrix.json
@@ -198,6 +198,15 @@
       "proof_status": "partial"
     },
     {
+      "feature": "returndataOptionalBoolAt",
+      "constructor": "Expr.returndataOptionalBoolAt",
+      "SpecInterpreter_basic": "fallback_zero",
+      "SpecInterpreter_fuel": "fallback_zero",
+      "IRInterpreter": "n/a",
+      "EVMYulLean_bridge": "n/a",
+      "proof_status": "partial"
+    },
+    {
       "feature": "keccak256",
       "constructor": "Expr.keccak256",
       "SpecInterpreter_basic": "fallback_zero",

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -300,6 +300,8 @@ Low-level call expressions compile to the expected Yul builtins, but their runti
 
 Use typed intrinsics (`Expr.mload`, `Expr.keccak256`, `Expr.contractAddress`, `Expr.chainid`, `Stmt.mstore`) instead of `Expr.externalCall` for these opcodes. Builtin names routed through `externalCall` remain rejected by interop validation.
 
+Memory-oriented intrinsics (`mload`, `mstore`, `calldatacopy`, `returndataCopy`, `returndataOptionalBoolAt`) compile, but the current proof interpreters still model them only partially. For audit-oriented or proof-strict builds, surface that boundary with `--trust-report` / `--deny-linear-memory-mechanics`; the remaining gap is tracked under issue `#1411`.
+
 For Morpho-style `mapping(K => Struct)` / `mapping(K1 => mapping(K2 => Struct))` layouts, declare `FieldType.mappingStruct` / `FieldType.mappingStruct2` and access named members through `Expr.structMember` / `Expr.structMember2`. The `verity_contract` surface now exposes matching storage forms:
 
 ```lean

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -652,6 +652,8 @@ Prefer ECM wrappers when they fit the use case, and see issue `#1332` plus [`doc
 
 Reference: `Compiler/CompilationModel.lean`.
 
+First-class linear-memory forms (`Expr.mload`, `Stmt.mstore`, `Stmt.calldatacopy`, `Stmt.returndataCopy`, `Expr.returndataOptionalBoolAt`) also compile today, but they are still only partially modeled by the current proof interpreters. When these forms appear, treat them as an explicit memory/ABI trust boundary, archive `--trust-report`, and use `--deny-linear-memory-mechanics` for proof-strict runs (see issue `#1411`).
+
 ## Context Accessors
 
 **Signatures**

--- a/docs-site/content/guides/solidity-to-verity.mdx
+++ b/docs-site/content/guides/solidity-to-verity.mdx
@@ -64,6 +64,10 @@ Not first-class yet (see issue `#1161`).
 Use low-level call result checks plus explicit error flow.
 Those low-level call mechanics compile, but they are still outside the current proof-interpreter semantics; treat them as an explicit trust boundary for now (see issue `#1332`).
 
+### Manual ABI / memory plumbing
+
+Manual ABI or memory plumbing (`mload` / `mstore` / copy-based payload handling) compiles, but it is still outside the fully proved interpreter semantics today. Treat that path as an explicit trust boundary, prefer higher-level helpers when available, and use `--deny-linear-memory-mechanics` if the translated contract must stay inside the proved subset (see issue `#1411`).
+
 ### Reentrancy guard primitive
 
 Not first-class yet (see issue `#1160`).

--- a/docs/INTERPRETER_FEATURE_MATRIX.md
+++ b/docs/INTERPRETER_FEATURE_MATRIX.md
@@ -42,6 +42,7 @@ The `SpecInterpreter` has been removed. EDSL semantics are now defined directly 
 | `address(this)` | `Expr.contractAddress` | **0** | **0** | ok | -- | partial |
 | `chainid` | `Expr.chainid` | **0** | **0** | ok | -- | partial |
 | `mload` | `Expr.mload` | **0** | **0** | ok | -- | partial |
+| `returndataOptionalBoolAt` | `Expr.returndataOptionalBoolAt` | **0** | **0** | -- | -- | partial |
 | `keccak256` | `Expr.keccak256` | **0** | **0** | -- | -- | n/m |
 | `call` | `Expr.call` | **0** | **0** | -- | -- | n/m |
 | `staticcall` | `Expr.staticcall` | **0** | **0** | -- | -- | n/m |
@@ -140,7 +141,7 @@ Legend: **ok** = native evaluation, **del** = delegated to Verity path (bridge r
 
 | Category | Proved | Assumed | Partial | Not Modeled |
 |---|---|---|---|---|
-| Expression features | 25 | 1 (`externalCall`) | 2 (`chainid`, `mload`) | 5 |
+| Expression features | 25 | 1 (`externalCall`) | 3 (`chainid`, `mload`, `returndataOptionalBoolAt`) | 5 |
 | Statement features | 24 | 0 | 1 (`mstore`) | 7 |
 | Builtins (agreement) | 15 | 0 | 0 | 7 (delegated) |
 
@@ -150,7 +151,7 @@ Legend: **ok** = native evaluation, **del** = delegated to Verity path (bridge r
 
 ## Known Limitations
 
-1. **Linear memory**: The IRInterpreter has single-word memory support. Full linear memory coverage requires EVMYulLean semantic integration.
+1. **Linear memory**: The IRInterpreter has single-word memory support. `mload`, `mstore`, `calldatacopy`, `returndataCopy`, and `returndataOptionalBoolAt` therefore remain only partially modeled or not modeled in the proof interpreters today. Full linear memory coverage requires EVMYulLean semantic integration.
 
 2. **Low-level calls**: `call`/`staticcall`/`delegatecall` and `externalCallBind`/`ecm` are compiler-only features validated by Foundry testing, not modeled in proof interpreters.
 

--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -28,6 +28,7 @@ Primary guards:
 - `check_property_coverage.py`
 - `check_property_manifest_sync.py`
 - `check_low_level_call_boundary_sync.py`: keep docs aligned with the current low-level call proof boundary.
+- `check_linear_memory_boundary_sync.py`: keep docs aligned with the current linear-memory proof boundary.
 - `check_struct_mapping_surface_sync.py`: keep struct-mapping storage docs aligned with the current compiler surface.
 - `check_storage_layout.py`
 - `check_lean_hygiene.py`

--- a/scripts/check_linear_memory_boundary_sync.py
+++ b/scripts/check_linear_memory_boundary_sync.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Keep linear-memory boundary docs aligned with the interpreter feature matrix."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FEATURE_MATRIX = ROOT / "artifacts" / "interpreter_feature_matrix.json"
+TARGET_FILES = {
+    "EDSL_API": ROOT / "docs-site" / "content" / "edsl-api-reference.mdx",
+    "COMPILER_DOC": ROOT / "docs-site" / "content" / "compiler.mdx",
+    "SOLIDITY_GUIDE": ROOT / "docs-site" / "content" / "guides" / "solidity-to-verity.mdx",
+}
+MEMORY_EXPR_FEATURES = {"mload", "returndataOptionalBoolAt"}
+MEMORY_STMT_FEATURES = {"mstore", "calldatacopy", "returndataCopy"}
+
+
+def normalize_ws(text: str) -> str:
+    return " ".join(text.split())
+
+
+def load_feature_matrix(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def linear_memory_needs_boundary_note(matrix: dict) -> bool:
+    expr_features = {
+        entry["feature"]: entry
+        for entry in matrix.get("expr_features", [])
+        if entry.get("feature") in MEMORY_EXPR_FEATURES
+    }
+    stmt_features = {
+        entry["feature"]: entry
+        for entry in matrix.get("stmt_features", [])
+        if entry.get("feature") in MEMORY_STMT_FEATURES
+    }
+    if expr_features.keys() != MEMORY_EXPR_FEATURES:
+        raise ValueError("interpreter feature matrix is missing one or more linear-memory expression entries")
+    if stmt_features.keys() != MEMORY_STMT_FEATURES:
+        raise ValueError("interpreter feature matrix is missing one or more linear-memory statement entries")
+
+    for entry in expr_features.values():
+        if entry.get("proof_status") != "proved":
+            return True
+        if entry.get("SpecInterpreter_basic") != "supported":
+            return True
+        if entry.get("SpecInterpreter_fuel") != "supported":
+            return True
+    for entry in stmt_features.values():
+        if entry.get("proof_status") != "proved":
+            return True
+        if entry.get("SpecInterpreter_basic") != "supported":
+            return True
+        if entry.get("SpecInterpreter_fuel") != "supported":
+            return True
+    return False
+
+
+def expected_snippets(needs_boundary_note: bool) -> dict[str, list[str]]:
+    if not needs_boundary_note:
+        return {label: [] for label in TARGET_FILES}
+
+    return {
+        "EDSL_API": [
+            "First-class linear-memory forms (`Expr.mload`, `Stmt.mstore`, `Stmt.calldatacopy`, `Stmt.returndataCopy`, `Expr.returndataOptionalBoolAt`) also compile today, but they are still only partially modeled by the current proof interpreters.",
+            "treat them as an explicit memory/ABI trust boundary, archive `--trust-report`, and use `--deny-linear-memory-mechanics` for proof-strict runs (see issue `#1411`).",
+        ],
+        "COMPILER_DOC": [
+            "Memory-oriented intrinsics (`mload`, `mstore`, `calldatacopy`, `returndataCopy`, `returndataOptionalBoolAt`) compile, but the current proof interpreters still model them only partially.",
+            "surface that boundary with `--trust-report` / `--deny-linear-memory-mechanics`; the remaining gap is tracked under issue `#1411`.",
+        ],
+        "SOLIDITY_GUIDE": [
+            "Manual ABI or memory plumbing (`mload` / `mstore` / copy-based payload handling) compiles, but it is still outside the fully proved interpreter semantics today.",
+            "use `--deny-linear-memory-mechanics` if the translated contract must stay inside the proved subset (see issue `#1411`).",
+        ],
+    }
+
+
+def main() -> int:
+    if not FEATURE_MATRIX.exists():
+        print(f"Missing: {FEATURE_MATRIX.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+
+    try:
+        matrix = load_feature_matrix(FEATURE_MATRIX)
+        needs_boundary_note = linear_memory_needs_boundary_note(matrix)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"{FEATURE_MATRIX.relative_to(ROOT)}: {exc}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    expected = expected_snippets(needs_boundary_note)
+    for label, path in TARGET_FILES.items():
+        if not path.exists():
+            errors.append(f"Missing: {path.relative_to(ROOT)}")
+            continue
+        normalized = normalize_ws(path.read_text(encoding="utf-8"))
+        for snippet in expected[label]:
+            if normalize_ws(snippet) not in normalized:
+                errors.append(
+                    f"{path.relative_to(ROOT)} is out of sync with linear-memory proof boundary: missing `{snippet}`"
+                )
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    status = "required" if needs_boundary_note else "not required"
+    print(f"linear-memory boundary sync passed: boundary note {status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_linear_memory_boundary_sync.py
+++ b/scripts/test_check_linear_memory_boundary_sync.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import textwrap
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_linear_memory_boundary_sync as check
+
+
+class LinearMemoryBoundarySyncTests(unittest.TestCase):
+    def _write_fixture_tree(
+        self,
+        root: Path,
+        *,
+        expr_proof_status: str,
+        expr_basic_status: str,
+        expr_fuel_status: str,
+        stmt_proof_status: str,
+        stmt_basic_status: str,
+        stmt_fuel_status: str,
+        edsl_doc: str,
+        compiler_doc: str,
+        solidity_guide: str,
+    ) -> None:
+        matrix = {
+            "expr_features": [
+                {
+                    "feature": feature,
+                    "proof_status": expr_proof_status,
+                    "SpecInterpreter_basic": expr_basic_status,
+                    "SpecInterpreter_fuel": expr_fuel_status,
+                }
+                for feature in ("mload", "returndataOptionalBoolAt")
+            ],
+            "stmt_features": [
+                {
+                    "feature": feature,
+                    "proof_status": stmt_proof_status,
+                    "SpecInterpreter_basic": stmt_basic_status,
+                    "SpecInterpreter_fuel": stmt_fuel_status,
+                }
+                for feature in ("mstore", "calldatacopy", "returndataCopy")
+            ],
+        }
+        feature_matrix = root / "artifacts" / "interpreter_feature_matrix.json"
+        feature_matrix.parent.mkdir(parents=True, exist_ok=True)
+        feature_matrix.write_text(json.dumps(matrix), encoding="utf-8")
+
+        edsl_path = root / "docs-site" / "content" / "edsl-api-reference.mdx"
+        edsl_path.parent.mkdir(parents=True, exist_ok=True)
+        edsl_path.write_text(edsl_doc, encoding="utf-8")
+
+        compiler_path = root / "docs-site" / "content" / "compiler.mdx"
+        compiler_path.parent.mkdir(parents=True, exist_ok=True)
+        compiler_path.write_text(compiler_doc, encoding="utf-8")
+
+        guide_path = root / "docs-site" / "content" / "guides" / "solidity-to-verity.mdx"
+        guide_path.parent.mkdir(parents=True, exist_ok=True)
+        guide_path.write_text(solidity_guide, encoding="utf-8")
+
+    def _run_check(
+        self,
+        *,
+        expr_proof_status: str,
+        expr_basic_status: str,
+        expr_fuel_status: str,
+        stmt_proof_status: str,
+        stmt_basic_status: str,
+        stmt_fuel_status: str,
+        edsl_doc: str,
+        compiler_doc: str,
+        solidity_guide: str,
+    ) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._write_fixture_tree(
+                root,
+                expr_proof_status=expr_proof_status,
+                expr_basic_status=expr_basic_status,
+                expr_fuel_status=expr_fuel_status,
+                stmt_proof_status=stmt_proof_status,
+                stmt_basic_status=stmt_basic_status,
+                stmt_fuel_status=stmt_fuel_status,
+                edsl_doc=edsl_doc,
+                compiler_doc=compiler_doc,
+                solidity_guide=solidity_guide,
+            )
+
+            old_root = check.ROOT
+            old_matrix = check.FEATURE_MATRIX
+            old_targets = check.TARGET_FILES
+            check.ROOT = root
+            check.FEATURE_MATRIX = root / "artifacts" / "interpreter_feature_matrix.json"
+            check.TARGET_FILES = {
+                "EDSL_API": root / "docs-site" / "content" / "edsl-api-reference.mdx",
+                "COMPILER_DOC": root / "docs-site" / "content" / "compiler.mdx",
+                "SOLIDITY_GUIDE": root / "docs-site" / "content" / "guides" / "solidity-to-verity.mdx",
+            }
+            try:
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    rc = check.main()
+                return rc, stdout.getvalue() + stderr.getvalue()
+            finally:
+                check.ROOT = old_root
+                check.FEATURE_MATRIX = old_matrix
+                check.TARGET_FILES = old_targets
+
+    def test_boundary_note_required_when_linear_memory_not_fully_modeled(self) -> None:
+        note = textwrap.dedent(
+            """
+            First-class linear-memory forms (`Expr.mload`, `Stmt.mstore`, `Stmt.calldatacopy`, `Stmt.returndataCopy`, `Expr.returndataOptionalBoolAt`) also compile today, but they are still only partially modeled by the current proof interpreters.
+            treat them as an explicit memory/ABI trust boundary, archive `--trust-report`, and use `--deny-linear-memory-mechanics` for proof-strict runs (see issue `#1411`).
+            Memory-oriented intrinsics (`mload`, `mstore`, `calldatacopy`, `returndataCopy`, `returndataOptionalBoolAt`) compile, but the current proof interpreters still model them only partially.
+            surface that boundary with `--trust-report` / `--deny-linear-memory-mechanics`; the remaining gap is tracked under issue `#1411`.
+            Manual ABI or memory plumbing (`mload` / `mstore` / copy-based payload handling) compiles, but it is still outside the fully proved interpreter semantics today.
+            use `--deny-linear-memory-mechanics` if the translated contract must stay inside the proved subset (see issue `#1411`).
+            """
+        )
+        rc, output = self._run_check(
+            expr_proof_status="partial",
+            expr_basic_status="fallback_zero",
+            expr_fuel_status="fallback_zero",
+            stmt_proof_status="not_modeled",
+            stmt_basic_status="unsupported",
+            stmt_fuel_status="unsupported",
+            edsl_doc=note,
+            compiler_doc=note,
+            solidity_guide=note,
+        )
+        self.assertEqual(rc, 0, output)
+        self.assertIn("boundary note required", output)
+
+    def test_missing_boundary_note_fails_when_linear_memory_not_fully_modeled(self) -> None:
+        rc, output = self._run_check(
+            expr_proof_status="partial",
+            expr_basic_status="fallback_zero",
+            expr_fuel_status="fallback_zero",
+            stmt_proof_status="not_modeled",
+            stmt_basic_status="unsupported",
+            stmt_fuel_status="unsupported",
+            edsl_doc="memory forms exist\n",
+            compiler_doc="compiler intrinsics exist\n",
+            solidity_guide="manual abi note\n",
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("edsl-api-reference.mdx is out of sync", output)
+
+    def test_boundary_note_not_required_once_linear_memory_is_fully_modeled(self) -> None:
+        rc, output = self._run_check(
+            expr_proof_status="proved",
+            expr_basic_status="supported",
+            expr_fuel_status="supported",
+            stmt_proof_status="proved",
+            stmt_basic_status="supported",
+            stmt_fuel_status="supported",
+            edsl_doc="memory forms exist\n",
+            compiler_doc="compiler intrinsics exist\n",
+            solidity_guide="manual abi note\n",
+        )
+        self.assertEqual(rc, 0, output)
+        self.assertIn("boundary note not required", output)
+
+    def test_repository_docs_are_currently_in_sync(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = check.main()
+        output = stdout.getvalue() + stderr.getvalue()
+        self.assertEqual(rc, 0, output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a linear-memory boundary sync guard for user-facing docs
- add the missing `returndataOptionalBoolAt` entry to the interpreter feature matrix
- document the current `#1411` memory/ABI proof boundary and `--deny-linear-memory-mechanics` in the docs-site pages users actually read

## Testing
- python3 scripts/test_check_linear_memory_boundary_sync.py
- python3 scripts/check_linear_memory_boundary_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation, the interpreter feature matrix artifact, and new CI-style Python guards/tests; the main impact is potentially stricter CI failures if docs drift.
> 
> **Overview**
> Documents the current *linear-memory/ABI trust boundary* (issue `#1411`) across the user-facing docs, including guidance for `--trust-report` and `--deny-linear-memory-mechanics` when `mload`/`mstore`/returndata and copy intrinsics are used.
> 
> Adds `returndataOptionalBoolAt` to the machine-readable interpreter feature matrix and updates `docs/INTERPRETER_FEATURE_MATRIX.md` to reflect its partial proof status.
> 
> Introduces a new `scripts/check_linear_memory_boundary_sync.py` (wired into `make check`) plus unit tests to enforce that these boundary notes stay in sync with the feature matrix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cae4b11ce1127d1bc59eca9a9836ade80a8e0ee4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->