### PR TITLE
docs: guard builtin bridge matrix sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/check_verification_status_doc.py
 	python3 scripts/check_verify_sync.py
 	python3 scripts/check_bridge_coverage_sync.py
+	python3 scripts/check_builtin_bridge_matrix_sync.py
 	python3 scripts/check_low_level_call_boundary_sync.py
 	python3 scripts/check_linear_memory_boundary_sync.py
 	python3 scripts/check_struct_mapping_surface_sync.py

--- a/artifacts/interpreter_feature_matrix.json
+++ b/artifacts/interpreter_feature_matrix.json
@@ -695,6 +695,24 @@
       "agreement_proved": false
     },
     {
+      "feature": "address",
+      "verity_path": "supported",
+      "evmyullean_bridge": "delegated",
+      "agreement_proved": false
+    },
+    {
+      "feature": "timestamp",
+      "verity_path": "supported",
+      "evmyullean_bridge": "delegated",
+      "agreement_proved": false
+    },
+    {
+      "feature": "chainid",
+      "verity_path": "supported",
+      "evmyullean_bridge": "delegated",
+      "agreement_proved": false
+    },
+    {
       "feature": "calldataload",
       "verity_path": "supported",
       "evmyullean_bridge": "delegated",
@@ -702,12 +720,6 @@
     },
     {
       "feature": "mappingSlot",
-      "verity_path": "supported",
-      "evmyullean_bridge": "delegated",
-      "agreement_proved": false
-    },
-    {
-      "feature": "chainid",
       "verity_path": "supported",
       "evmyullean_bridge": "delegated",
       "agreement_proved": false

--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -27,6 +27,7 @@ Primary guards:
 - `check_property_manifest.py`
 - `check_property_coverage.py`
 - `check_property_manifest_sync.py`
+- `check_builtin_bridge_matrix_sync.py`: keep the builtin bridge matrix artifact and docs in sync, including delegated env builtins.
 - `check_low_level_call_boundary_sync.py`: keep docs aligned with the current low-level call proof boundary.
 - `check_linear_memory_boundary_sync.py`: keep docs aligned with the current linear-memory proof boundary.
 - `check_struct_mapping_surface_sync.py`: keep struct-mapping storage docs aligned with the current compiler surface.

--- a/scripts/check_builtin_bridge_matrix_sync.py
+++ b/scripts/check_builtin_bridge_matrix_sync.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Keep builtin-bridge docs aligned with the interpreter feature matrix artifact."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FEATURE_MATRIX = ROOT / "artifacts" / "interpreter_feature_matrix.json"
+TARGET_DOC = ROOT / "docs" / "INTERPRETER_FEATURE_MATRIX.md"
+PURE_BUILTINS = [
+    "add",
+    "sub",
+    "mul",
+    "div",
+    "mod",
+    "lt",
+    "gt",
+    "eq",
+    "iszero",
+    "and",
+    "or",
+    "xor",
+    "not",
+    "shl",
+    "shr",
+]
+DELEGATED_BUILTINS = [
+    "sload",
+    "caller",
+    "address",
+    "timestamp",
+    "chainid",
+    "calldataload",
+    "mappingSlot",
+]
+EXPECTED_BUILTINS = PURE_BUILTINS + DELEGATED_BUILTINS
+
+
+def normalize_ws(text: str) -> str:
+    return " ".join(text.split())
+
+
+def load_feature_matrix(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_builtin_features(matrix: dict) -> list[dict]:
+    builtin_features = matrix.get("builtin_features")
+    if not isinstance(builtin_features, list):
+        raise ValueError("interpreter feature matrix is missing builtin_features")
+
+    found_names = [entry.get("feature") for entry in builtin_features]
+    if found_names != EXPECTED_BUILTINS:
+        raise ValueError(
+            "builtin feature list is out of sync: "
+            f"expected {EXPECTED_BUILTINS}, found {found_names}"
+        )
+
+    for entry in builtin_features:
+        feature = entry["feature"]
+        if feature in PURE_BUILTINS:
+            if entry.get("verity_path") != "supported":
+                raise ValueError(f"{feature} should have verity_path=supported")
+            if entry.get("evmyullean_bridge") != "supported":
+                raise ValueError(f"{feature} should have evmyullean_bridge=supported")
+            if entry.get("agreement_proved") is not True:
+                raise ValueError(f"{feature} should have agreement_proved=true")
+        else:
+            if entry.get("verity_path") != "supported":
+                raise ValueError(f"{feature} should have verity_path=supported")
+            if entry.get("evmyullean_bridge") != "delegated":
+                raise ValueError(f"{feature} should have evmyullean_bridge=delegated")
+            if entry.get("agreement_proved") is not False:
+                raise ValueError(f"{feature} should have agreement_proved=false")
+
+    return builtin_features
+
+
+def expected_doc_snippets(builtin_features: list[dict]) -> list[str]:
+    total = len(builtin_features)
+    proved = sum(1 for entry in builtin_features if entry["agreement_proved"])
+    remaining = total - proved
+    return [
+        f"{proved}/{total} builtins have bridge agreement coverage between Verity and EVMYulLean evaluation paths.",
+        f"{proved} are discharged by universal symbolic lemmas in `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean`, and none still require concrete-only regression coverage.",
+        f"The remaining {remaining} are state-dependent or Verity-specific helpers that remain on the Verity evaluation path.",
+        "| `address` | ok | del | -- |",
+        "| `timestamp` | ok | del | -- |",
+    ]
+
+
+def main() -> int:
+    if not FEATURE_MATRIX.exists():
+        print(f"Missing: {FEATURE_MATRIX.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+    if not TARGET_DOC.exists():
+        print(f"Missing: {TARGET_DOC.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+
+    try:
+        matrix = load_feature_matrix(FEATURE_MATRIX)
+        builtin_features = validate_builtin_features(matrix)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"{FEATURE_MATRIX.relative_to(ROOT)}: {exc}", file=sys.stderr)
+        return 1
+
+    normalized = normalize_ws(TARGET_DOC.read_text(encoding="utf-8"))
+    errors: list[str] = []
+    for snippet in expected_doc_snippets(builtin_features):
+        if normalize_ws(snippet) not in normalized:
+            errors.append(
+                f"{TARGET_DOC.relative_to(ROOT)} is out of sync with builtin bridge coverage: missing `{snippet}`"
+            )
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    proved = sum(1 for entry in builtin_features if entry["agreement_proved"])
+    print(
+        "builtin bridge matrix sync passed: "
+        f"{proved}/{len(builtin_features)} builtins covered; delegated remainder: "
+        f"{', '.join(DELEGATED_BUILTINS)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_builtin_bridge_matrix_sync.py
+++ b/scripts/test_check_builtin_bridge_matrix_sync.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_builtin_bridge_matrix_sync as check
+
+
+class BuiltinBridgeMatrixSyncTests(unittest.TestCase):
+    def _write_fixture_tree(self, root: Path, *, builtin_features: list[dict], doc_text: str) -> None:
+        feature_matrix = root / "artifacts" / "interpreter_feature_matrix.json"
+        feature_matrix.parent.mkdir(parents=True, exist_ok=True)
+        feature_matrix.write_text(json.dumps({"builtin_features": builtin_features}), encoding="utf-8")
+
+        target_doc = root / "docs" / "INTERPRETER_FEATURE_MATRIX.md"
+        target_doc.parent.mkdir(parents=True, exist_ok=True)
+        target_doc.write_text(doc_text, encoding="utf-8")
+
+    def _run_check(self, *, builtin_features: list[dict], doc_text: str) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._write_fixture_tree(root, builtin_features=builtin_features, doc_text=doc_text)
+
+            old_root = check.ROOT
+            old_feature_matrix = check.FEATURE_MATRIX
+            old_target_doc = check.TARGET_DOC
+            check.ROOT = root
+            check.FEATURE_MATRIX = root / "artifacts" / "interpreter_feature_matrix.json"
+            check.TARGET_DOC = root / "docs" / "INTERPRETER_FEATURE_MATRIX.md"
+            try:
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    rc = check.main()
+                return rc, stdout.getvalue() + stderr.getvalue()
+            finally:
+                check.ROOT = old_root
+                check.FEATURE_MATRIX = old_feature_matrix
+                check.TARGET_DOC = old_target_doc
+
+    def test_missing_delegated_builtin_fails_closed(self) -> None:
+        builtin_features = [
+            {
+                "feature": feature,
+                "verity_path": "supported",
+                "evmyullean_bridge": "supported",
+                "agreement_proved": True,
+            }
+            for feature in check.PURE_BUILTINS
+        ] + [
+            {
+                "feature": feature,
+                "verity_path": "supported",
+                "evmyullean_bridge": "delegated",
+                "agreement_proved": False,
+            }
+            for feature in ["sload", "caller", "chainid", "calldataload", "mappingSlot"]
+        ]
+        rc, output = self._run_check(
+            builtin_features=builtin_features,
+            doc_text="15/22 builtins have bridge agreement coverage between Verity and EVMYulLean evaluation paths.",
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("builtin feature list is out of sync", output)
+
+    def test_summary_drift_fails(self) -> None:
+        builtin_features = [
+            {
+                "feature": feature,
+                "verity_path": "supported",
+                "evmyullean_bridge": "supported",
+                "agreement_proved": True,
+            }
+            for feature in check.PURE_BUILTINS
+        ] + [
+            {
+                "feature": feature,
+                "verity_path": "supported",
+                "evmyullean_bridge": "delegated",
+                "agreement_proved": False,
+            }
+            for feature in check.DELEGATED_BUILTINS
+        ]
+        rc, output = self._run_check(
+            builtin_features=builtin_features,
+            doc_text=(
+                "| `address` | ok | del | -- |\n"
+                "| `timestamp` | ok | del | -- |\n"
+                "15/20 builtins have bridge agreement coverage between Verity and EVMYulLean evaluation paths.\n"
+                "15 are discharged by universal symbolic lemmas in `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean`, and none still require concrete-only regression coverage.\n"
+                "The remaining 5 are state-dependent or Verity-specific helpers that remain on the Verity evaluation path.\n"
+            ),
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("docs/INTERPRETER_FEATURE_MATRIX.md is out of sync", output)
+
+    def test_repository_files_are_currently_in_sync(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = check.main()
+        output = stdout.getvalue() + stderr.getvalue()
+        self.assertEqual(rc, 0, output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restore the missing `address` and `timestamp` delegated builtin entries in `artifacts/interpreter_feature_matrix.json`
- add a CI sync guard for the builtin bridge matrix so the machine-readable artifact and `docs/INTERPRETER_FEATURE_MATRIX.md` cannot drift on totals or delegated env builtins
- cover the new guard with focused unit tests and wire it into `make check`

## Testing
- `python3 scripts/test_check_builtin_bridge_matrix_sync.py`
- `python3 scripts/check_builtin_bridge_matrix_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/documentation consistency checks plus a small artifact list fix, with no runtime/compiler/proof logic modified.
> 
> **Overview**
> Restores the missing delegated builtins (`address`, `timestamp`) in `artifacts/interpreter_feature_matrix.json` and reorders the builtin list to match the expected matrix layout.
> 
> Adds `scripts/check_builtin_bridge_matrix_sync.py` (wired into `make check` and documented in `scripts/REFERENCE.md`) to *fail CI* if the artifact’s builtin list/statuses or the summary/table rows in `docs/INTERPRETER_FEATURE_MATRIX.md` drift, with unit tests covering both fail-closed and in-sync cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7039cd9f44c8a9146e212adc2c623b1974a4fee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->