### PR TITLE
docs: guard interpreter feature summary sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/check_verify_sync.py
 	python3 scripts/check_bridge_coverage_sync.py
 	python3 scripts/check_builtin_bridge_matrix_sync.py
+	python3 scripts/check_interpreter_feature_summary_sync.py
 	python3 scripts/check_low_level_call_boundary_sync.py
 	python3 scripts/check_linear_memory_boundary_sync.py
 	python3 scripts/check_struct_mapping_surface_sync.py

--- a/docs/INTERPRETER_FEATURE_MATRIX.md
+++ b/docs/INTERPRETER_FEATURE_MATRIX.md
@@ -141,8 +141,8 @@ Legend: **ok** = native evaluation, **del** = delegated to Verity path (bridge r
 
 | Category | Proved | Assumed | Partial | Not Modeled |
 |---|---|---|---|---|
-| Expression features | 25 | 1 (`externalCall`) | 3 (`chainid`, `mload`, `returndataOptionalBoolAt`) | 5 |
-| Statement features | 24 | 0 | 1 (`mstore`) | 7 |
+| Expression features | 24 | 1 (`externalCall`) | 5 (`blockNumber`, `contractAddress`, `chainid`, `mload`, `returndataOptionalBoolAt`) | 4 (`keccak256`, `call`, `staticcall`, `delegatecall`) |
+| Statement features | 25 | 0 | 1 (`mstore`) | 6 (`calldatacopy`, `returndataCopy`, `revertReturndata`, `rawLog`, `externalCallBind`, `ecm`) |
 | Builtins (agreement) | 15 | 0 | 0 | 7 (delegated) |
 
 **Not-modeled features** are handled correctly by the compiler but are outside the current proof scope. They include low-level calls, returndata handling, linear memory, contract introspection, and external call modules. These features are validated by differential testing (70,000+ test vectors against actual EVM execution).

--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -28,6 +28,7 @@ Primary guards:
 - `check_property_coverage.py`
 - `check_property_manifest_sync.py`
 - `check_builtin_bridge_matrix_sync.py`: keep the builtin bridge matrix artifact and docs in sync, including delegated env builtins.
+- `check_interpreter_feature_summary_sync.py`: keep the interpreter feature summary table aligned with the machine-readable feature matrix artifact.
 - `check_low_level_call_boundary_sync.py`: keep docs aligned with the current low-level call proof boundary.
 - `check_linear_memory_boundary_sync.py`: keep docs aligned with the current linear-memory proof boundary.
 - `check_struct_mapping_surface_sync.py`: keep struct-mapping storage docs aligned with the current compiler surface.

--- a/scripts/check_interpreter_feature_summary_sync.py
+++ b/scripts/check_interpreter_feature_summary_sync.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Keep interpreter feature summary docs aligned with the machine-readable matrix."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FEATURE_MATRIX = ROOT / "artifacts" / "interpreter_feature_matrix.json"
+TARGET_DOC = ROOT / "docs" / "INTERPRETER_FEATURE_MATRIX.md"
+DISPLAY_NAME_OVERRIDES = {
+    "externalCall_expr": "externalCall",
+}
+PROOF_STATUS_ORDER = ("proved", "assumed", "partial", "not_modeled")
+
+
+def normalize_ws(text: str) -> str:
+    return " ".join(text.split())
+
+
+def load_feature_matrix(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def display_name(feature: str) -> str:
+    return DISPLAY_NAME_OVERRIDES.get(feature, feature)
+
+
+def summarize(entries: list[dict]) -> list[str]:
+    by_status = {status: [] for status in PROOF_STATUS_ORDER}
+    for entry in entries:
+        status = entry.get("proof_status")
+        feature = entry.get("feature")
+        if status not in by_status:
+            raise ValueError(f"unexpected proof status `{status}` for `{feature}`")
+        if not isinstance(feature, str):
+            raise ValueError("feature matrix entry is missing string feature name")
+        by_status[status].append(display_name(feature))
+
+    summary: list[str] = []
+    for status in PROOF_STATUS_ORDER:
+        names = by_status[status]
+        count = len(names)
+        if count == 0:
+            summary.append("0")
+            continue
+        if status == "not_modeled" or count <= 5:
+            rendered_names = ", ".join(f"`{name}`" for name in names)
+            summary.append(f"{count} ({rendered_names})")
+        else:
+            summary.append(str(count))
+    return summary
+
+
+def expected_summary_rows(matrix: dict) -> list[str]:
+    expr_features = matrix.get("expr_features")
+    stmt_features = matrix.get("stmt_features")
+    builtin_features = matrix.get("builtin_features")
+    if not isinstance(expr_features, list):
+        raise ValueError("interpreter feature matrix is missing expr_features")
+    if not isinstance(stmt_features, list):
+        raise ValueError("interpreter feature matrix is missing stmt_features")
+    if not isinstance(builtin_features, list):
+        raise ValueError("interpreter feature matrix is missing builtin_features")
+
+    builtins_proved = sum(1 for entry in builtin_features if entry.get("agreement_proved") is True)
+    builtins_remaining = sum(1 for entry in builtin_features if entry.get("agreement_proved") is False)
+    if builtins_proved + builtins_remaining != len(builtin_features):
+        raise ValueError("builtin_features contains non-boolean agreement_proved values")
+
+    expr_cells = summarize(expr_features)
+    stmt_cells = summarize(stmt_features)
+    builtin_row = f"| Builtins (agreement) | {builtins_proved} | 0 | 0 | {builtins_remaining} (delegated) |"
+    return [
+        f"| Expression features | {' | '.join(expr_cells)} |",
+        f"| Statement features | {' | '.join(stmt_cells)} |",
+        builtin_row,
+    ]
+
+
+def main() -> int:
+    if not FEATURE_MATRIX.exists():
+        print(f"Missing: {FEATURE_MATRIX.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+    if not TARGET_DOC.exists():
+        print(f"Missing: {TARGET_DOC.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+
+    try:
+        matrix = load_feature_matrix(FEATURE_MATRIX)
+        expected_rows = expected_summary_rows(matrix)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"{FEATURE_MATRIX.relative_to(ROOT)}: {exc}", file=sys.stderr)
+        return 1
+
+    normalized_doc = normalize_ws(TARGET_DOC.read_text(encoding="utf-8"))
+    errors: list[str] = []
+    for row in expected_rows:
+        if normalize_ws(row) not in normalized_doc:
+            errors.append(
+                f"{TARGET_DOC.relative_to(ROOT)} is out of sync with interpreter feature summary: missing `{row}`"
+            )
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("interpreter feature summary sync passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_interpreter_feature_summary_sync.py
+++ b/scripts/test_check_interpreter_feature_summary_sync.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_interpreter_feature_summary_sync as check
+
+
+class InterpreterFeatureSummarySyncTests(unittest.TestCase):
+    def _write_fixture_tree(self, root: Path, *, matrix: dict, doc_text: str) -> None:
+        feature_matrix = root / "artifacts" / "interpreter_feature_matrix.json"
+        feature_matrix.parent.mkdir(parents=True, exist_ok=True)
+        feature_matrix.write_text(json.dumps(matrix), encoding="utf-8")
+
+        target_doc = root / "docs" / "INTERPRETER_FEATURE_MATRIX.md"
+        target_doc.parent.mkdir(parents=True, exist_ok=True)
+        target_doc.write_text(doc_text, encoding="utf-8")
+
+    def _run_check(self, *, matrix: dict, doc_text: str) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._write_fixture_tree(root, matrix=matrix, doc_text=doc_text)
+
+            old_root = check.ROOT
+            old_feature_matrix = check.FEATURE_MATRIX
+            old_target_doc = check.TARGET_DOC
+            check.ROOT = root
+            check.FEATURE_MATRIX = root / "artifacts" / "interpreter_feature_matrix.json"
+            check.TARGET_DOC = root / "docs" / "INTERPRETER_FEATURE_MATRIX.md"
+            try:
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    rc = check.main()
+                return rc, stdout.getvalue() + stderr.getvalue()
+            finally:
+                check.ROOT = old_root
+                check.FEATURE_MATRIX = old_feature_matrix
+                check.TARGET_DOC = old_target_doc
+
+    @staticmethod
+    def _matrix_fixture() -> dict:
+        return {
+            "expr_features": [
+                {"feature": "provedExpr", "proof_status": "proved"},
+                {"feature": "externalCall_expr", "proof_status": "assumed"},
+                {"feature": "chainid", "proof_status": "partial"},
+                {"feature": "mload", "proof_status": "partial"},
+                {"feature": "call", "proof_status": "not_modeled"},
+                {"feature": "delegatecall", "proof_status": "not_modeled"},
+            ],
+            "stmt_features": [
+                {"feature": "provedStmt", "proof_status": "proved"},
+                {"feature": "mstore", "proof_status": "partial"},
+                {"feature": "calldatacopy", "proof_status": "not_modeled"},
+            ],
+            "builtin_features": [
+                {"feature": "add", "agreement_proved": True},
+                {"feature": "caller", "agreement_proved": False},
+            ],
+        }
+
+    def test_missing_summary_row_fails_closed(self) -> None:
+        rc, output = self._run_check(
+            matrix=self._matrix_fixture(),
+            doc_text="| Expression features | 2 | 0 | 0 | 0 |\n",
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("docs/INTERPRETER_FEATURE_MATRIX.md is out of sync", output)
+
+    def test_invalid_builtin_agreement_value_fails(self) -> None:
+        matrix = self._matrix_fixture()
+        matrix["builtin_features"][0]["agreement_proved"] = "yes"
+        rc, output = self._run_check(matrix=matrix, doc_text="")
+        self.assertEqual(rc, 1)
+        self.assertIn("non-boolean agreement_proved", output)
+
+    def test_repository_doc_is_currently_in_sync(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = check.main()
+        output = stdout.getvalue() + stderr.getvalue()
+        self.assertEqual(rc, 0, output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a CI sync guard for the `docs/INTERPRETER_FEATURE_MATRIX.md` proof-status summary rows so the human-readable counts and feature lists cannot drift from `artifacts/interpreter_feature_matrix.json`
- fix the current summary drift in the doc, including the expression and statement proved/partial/not-modeled totals and the affected feature names
- cover the new guard with focused unit tests and wire it into `make check`

## Testing
- `python3 scripts/test_check_interpreter_feature_summary_sync.py`
- `python3 scripts/check_interpreter_feature_summary_sync.py`
- `make check`

Refs #1411

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new CI-style check that can fail `make check` if `docs/INTERPRETER_FEATURE_MATRIX.md` drifts from `artifacts/interpreter_feature_matrix.json`, but it doesn’t change compiler/proof logic. Risk is limited to potential CI/doc-sync churn when the artifact changes.
> 
> **Overview**
> Prevents drift between the machine-readable `artifacts/interpreter_feature_matrix.json` and the **Proof Status Summary** rows in `docs/INTERPRETER_FEATURE_MATRIX.md` by adding `scripts/check_interpreter_feature_summary_sync.py` and wiring it into `make check`.
> 
> Updates the doc’s summary counts/lists for expression and statement features to match the artifact, and adds focused unit tests (`scripts/test_check_interpreter_feature_summary_sync.py`) plus a reference entry in `scripts/REFERENCE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 629b683144ef524e7cc3df66dbe8fc039ff4ecc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->