### PR TITLE
docs: guard interpreter proof-boundary catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/check_verify_sync.py
 	python3 scripts/check_bridge_coverage_sync.py
 	python3 scripts/check_builtin_bridge_matrix_sync.py
+	python3 scripts/check_interpreter_feature_boundary_catalog_sync.py
 	python3 scripts/check_interpreter_feature_summary_sync.py
 	python3 scripts/check_low_level_call_boundary_sync.py
 	python3 scripts/check_linear_memory_boundary_sync.py

--- a/docs/INTERPRETER_FEATURE_MATRIX.md
+++ b/docs/INTERPRETER_FEATURE_MATRIX.md
@@ -145,7 +145,7 @@ Legend: **ok** = native evaluation, **del** = delegated to Verity path (bridge r
 | Statement features | 25 | 0 | 1 (`mstore`) | 6 (`calldatacopy`, `returndataCopy`, `revertReturndata`, `rawLog`, `externalCallBind`, `ecm`) |
 | Builtins (agreement) | 15 | 0 | 0 | 7 (delegated) |
 
-**Not-modeled features** are handled correctly by the compiler but are outside the current proof scope. They include low-level calls, returndata handling, linear memory, contract introspection, and external call modules. These features are validated by differential testing (70,000+ test vectors against actual EVM execution).
+Proof-boundary features split across two buckets. Partially modeled features currently include runtime introspection (`blockNumber`, `contractAddress`, `chainid`) and single-word linear-memory forms (`mload`, `mstore`, `returndataOptionalBoolAt`). Fully not-modeled features currently include `keccak256`, low-level call / returndata plumbing (`call`, `staticcall`, `delegatecall`, `calldatacopy`, `returndataCopy`, `revertReturndata`), event emission (`rawLog`), and external call modules (`externalCallBind`, `ecm`). These features are still compiler-supported and are validated by differential testing (70,000+ test vectors against actual EVM execution).
 
 ---
 

--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -28,6 +28,7 @@ Primary guards:
 - `check_property_coverage.py`
 - `check_property_manifest_sync.py`
 - `check_builtin_bridge_matrix_sync.py`: keep the builtin bridge matrix artifact and docs in sync, including delegated env builtins.
+- `check_interpreter_feature_boundary_catalog_sync.py`: keep the interpreter proof-boundary category note aligned with the machine-readable feature matrix.
 - `check_interpreter_feature_summary_sync.py`: keep the interpreter feature summary table aligned with the machine-readable feature matrix artifact.
 - `check_low_level_call_boundary_sync.py`: keep docs aligned with the current low-level call proof boundary.
 - `check_linear_memory_boundary_sync.py`: keep docs aligned with the current linear-memory proof boundary.

--- a/scripts/check_interpreter_feature_boundary_catalog_sync.py
+++ b/scripts/check_interpreter_feature_boundary_catalog_sync.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Keep the interpreter proof-boundary category note aligned with the feature matrix."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FEATURE_MATRIX = ROOT / "artifacts" / "interpreter_feature_matrix.json"
+TARGET_DOC = ROOT / "docs" / "INTERPRETER_FEATURE_MATRIX.md"
+
+RUNTIME_INTROSPECTION = ("blockNumber", "contractAddress", "chainid")
+PARTIAL_LINEAR_MEMORY = ("mload", "mstore", "returndataOptionalBoolAt")
+NOT_MODELED_LOW_LEVEL = (
+    "keccak256",
+    "call",
+    "staticcall",
+    "delegatecall",
+    "calldatacopy",
+    "returndataCopy",
+    "revertReturndata",
+    "rawLog",
+    "externalCallBind",
+    "ecm",
+)
+
+
+def normalize_ws(text: str) -> str:
+    return " ".join(text.split())
+
+
+def load_feature_matrix(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def feature_status_map(matrix: dict) -> dict[str, str]:
+    status_map: dict[str, str] = {}
+    for section in ("expr_features", "stmt_features"):
+        entries = matrix.get(section)
+        if not isinstance(entries, list):
+            raise ValueError(f"interpreter feature matrix is missing {section}")
+        for entry in entries:
+            feature = entry.get("feature")
+            status = entry.get("proof_status")
+            if not isinstance(feature, str):
+                raise ValueError(f"{section} entry is missing string feature name")
+            if not isinstance(status, str):
+                raise ValueError(f"{section} entry `{feature}` is missing proof_status")
+            status_map[feature] = status
+    return status_map
+
+
+def ensure_statuses(status_map: dict[str, str], features: tuple[str, ...], expected: str, label: str) -> None:
+    missing = [feature for feature in features if feature not in status_map]
+    if missing:
+        raise ValueError(f"interpreter feature matrix is missing {label} entries: {', '.join(missing)}")
+    mismatched = [feature for feature in features if status_map[feature] != expected]
+    if mismatched:
+        rendered = ", ".join(f"{feature}={status_map[feature]}" for feature in mismatched)
+        raise ValueError(f"{label} drifted from expected `{expected}` status: {rendered}")
+
+
+def expected_snippets(matrix: dict) -> tuple[str, str]:
+    status_map = feature_status_map(matrix)
+    ensure_statuses(status_map, RUNTIME_INTROSPECTION, "partial", "runtime introspection")
+    ensure_statuses(status_map, PARTIAL_LINEAR_MEMORY, "partial", "single-word linear memory")
+    ensure_statuses(status_map, NOT_MODELED_LOW_LEVEL, "not_modeled", "not-modeled proof-boundary")
+
+    partial_snippet = (
+        "Partially modeled features currently include runtime introspection "
+        "(`blockNumber`, `contractAddress`, `chainid`) and single-word linear-memory forms "
+        "(`mload`, `mstore`, `returndataOptionalBoolAt`)."
+    )
+    not_modeled_snippet = (
+        "Fully not-modeled features currently include `keccak256`, low-level call / returndata "
+        "plumbing (`call`, `staticcall`, `delegatecall`, `calldatacopy`, `returndataCopy`, "
+        "`revertReturndata`), event emission (`rawLog`), and external call modules "
+        "(`externalCallBind`, `ecm`)."
+    )
+    return partial_snippet, not_modeled_snippet
+
+
+def main() -> int:
+    if not FEATURE_MATRIX.exists():
+        print(f"Missing: {FEATURE_MATRIX.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+    if not TARGET_DOC.exists():
+        print(f"Missing: {TARGET_DOC.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+
+    try:
+        matrix = load_feature_matrix(FEATURE_MATRIX)
+        snippets = expected_snippets(matrix)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"{FEATURE_MATRIX.relative_to(ROOT)}: {exc}", file=sys.stderr)
+        return 1
+
+    normalized_doc = normalize_ws(TARGET_DOC.read_text(encoding="utf-8"))
+    errors: list[str] = []
+    for snippet in snippets:
+        if normalize_ws(snippet) not in normalized_doc:
+            errors.append(
+                f"{TARGET_DOC.relative_to(ROOT)} is out of sync with interpreter proof-boundary categories: "
+                f"missing `{snippet}`"
+            )
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("interpreter feature boundary catalog sync passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_interpreter_feature_boundary_catalog_sync.py
+++ b/scripts/test_check_interpreter_feature_boundary_catalog_sync.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_interpreter_feature_boundary_catalog_sync as check
+
+
+class InterpreterFeatureBoundaryCatalogSyncTests(unittest.TestCase):
+    def _write_fixture_tree(self, root: Path, *, matrix: dict, doc_text: str) -> None:
+        feature_matrix = root / "artifacts" / "interpreter_feature_matrix.json"
+        feature_matrix.parent.mkdir(parents=True, exist_ok=True)
+        feature_matrix.write_text(json.dumps(matrix), encoding="utf-8")
+
+        target_doc = root / "docs" / "INTERPRETER_FEATURE_MATRIX.md"
+        target_doc.parent.mkdir(parents=True, exist_ok=True)
+        target_doc.write_text(doc_text, encoding="utf-8")
+
+    def _run_check(self, *, matrix: dict, doc_text: str) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._write_fixture_tree(root, matrix=matrix, doc_text=doc_text)
+
+            old_root = check.ROOT
+            old_feature_matrix = check.FEATURE_MATRIX
+            old_target_doc = check.TARGET_DOC
+            check.ROOT = root
+            check.FEATURE_MATRIX = root / "artifacts" / "interpreter_feature_matrix.json"
+            check.TARGET_DOC = root / "docs" / "INTERPRETER_FEATURE_MATRIX.md"
+            try:
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    rc = check.main()
+                return rc, stdout.getvalue() + stderr.getvalue()
+            finally:
+                check.ROOT = old_root
+                check.FEATURE_MATRIX = old_feature_matrix
+                check.TARGET_DOC = old_target_doc
+
+    @staticmethod
+    def _matrix_fixture() -> dict:
+        return {
+            "expr_features": [
+                {"feature": "blockNumber", "proof_status": "partial"},
+                {"feature": "contractAddress", "proof_status": "partial"},
+                {"feature": "chainid", "proof_status": "partial"},
+                {"feature": "mload", "proof_status": "partial"},
+                {"feature": "returndataOptionalBoolAt", "proof_status": "partial"},
+                {"feature": "keccak256", "proof_status": "not_modeled"},
+                {"feature": "call", "proof_status": "not_modeled"},
+                {"feature": "staticcall", "proof_status": "not_modeled"},
+                {"feature": "delegatecall", "proof_status": "not_modeled"},
+            ],
+            "stmt_features": [
+                {"feature": "mstore", "proof_status": "partial"},
+                {"feature": "calldatacopy", "proof_status": "not_modeled"},
+                {"feature": "returndataCopy", "proof_status": "not_modeled"},
+                {"feature": "revertReturndata", "proof_status": "not_modeled"},
+                {"feature": "rawLog", "proof_status": "not_modeled"},
+                {"feature": "externalCallBind", "proof_status": "not_modeled"},
+                {"feature": "ecm", "proof_status": "not_modeled"},
+            ],
+        }
+
+    def test_missing_boundary_note_fails_closed(self) -> None:
+        rc, output = self._run_check(matrix=self._matrix_fixture(), doc_text="boundary note missing\n")
+        self.assertEqual(rc, 1)
+        self.assertIn("docs/INTERPRETER_FEATURE_MATRIX.md is out of sync", output)
+
+    def test_status_drift_fails_closed(self) -> None:
+        matrix = self._matrix_fixture()
+        matrix["expr_features"][0]["proof_status"] = "not_modeled"
+        rc, output = self._run_check(matrix=matrix, doc_text="")
+        self.assertEqual(rc, 1)
+        self.assertIn("runtime introspection drifted", output)
+
+    def test_repository_doc_is_currently_in_sync(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = check.main()
+        output = stdout.getvalue() + stderr.getvalue()
+        self.assertEqual(rc, 0, output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the interpreter feature matrix proof-boundary note so it no longer conflates partially modeled runtime-introspection / linear-memory forms with fully not-modeled low-level features
- add a dedicated CI sync guard for that category-level note and cover it with focused unit tests
- wire the new guard into `make check` and document it in `scripts/REFERENCE.md`

## Testing
- `python3 scripts/test_check_interpreter_feature_boundary_catalog_sync.py`
- `python3 scripts/check_interpreter_feature_boundary_catalog_sync.py`
- `make check`

Refs #1411

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation wording plus a new CI sync check and unit tests; the main risk is CI failing if the feature-matrix or doc text drifts from the expected boundary categorization.
> 
> **Overview**
> Clarifies the interpreter proof-boundary note in `docs/INTERPRETER_FEATURE_MATRIX.md` by explicitly separating *partially modeled* runtime-introspection/single-word linear-memory features from *fully not-modeled* low-level call/returndata/event/external-call-module features.
> 
> Adds a new sync guard (`scripts/check_interpreter_feature_boundary_catalog_sync.py`) with focused unit tests to ensure the doc’s category-level boundary note stays aligned with `artifacts/interpreter_feature_matrix.json`, and wires this check into `make check` (also documented in `scripts/REFERENCE.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fa8cd0bfe530c191a57bc16794306c0888f256f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->