### PR TITLE
docs: guard axiomatized primitive boundary notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/check_interpreter_feature_summary_sync.py
 	python3 scripts/check_low_level_call_boundary_sync.py
 	python3 scripts/check_linear_memory_boundary_sync.py
+	python3 scripts/check_axiomatized_primitive_boundary_sync.py
 	python3 scripts/check_struct_mapping_surface_sync.py
 	python3 scripts/check_solc_pin.py
 	python3 scripts/check_property_manifest_sync.py

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -302,6 +302,8 @@ Use typed intrinsics (`Expr.mload`, `Expr.keccak256`, `Expr.contractAddress`, `E
 
 Memory-oriented intrinsics (`mload`, `mstore`, `calldatacopy`, `returndataCopy`, `returndataOptionalBoolAt`) compile, but the current proof interpreters still model them only partially. For audit-oriented or proof-strict builds, surface that boundary with `--trust-report` / `--deny-linear-memory-mechanics`; the remaining gap is tracked under issue `#1411`.
 
+The `keccak256` intrinsic also compiles, but it remains axiomatized in the current proof stack rather than fully modeled end to end. For audit-oriented or proof-strict builds, archive `--trust-report` and add `--deny-axiomatized-primitives` if the selected contracts must stay inside the proved subset (see issue `#1411`).
+
 For Morpho-style `mapping(K => Struct)` / `mapping(K1 => mapping(K2 => Struct))` layouts, declare `FieldType.mappingStruct` / `FieldType.mappingStruct2` and access named members through `Expr.structMember` / `Expr.structMember2`. The `verity_contract` surface now exposes matching storage forms:
 
 ```lean

--- a/docs-site/content/edsl-api-reference.mdx
+++ b/docs-site/content/edsl-api-reference.mdx
@@ -598,6 +598,8 @@ let digest := keccak256 offset size
 
 This elaborates to `Compiler.CompilationModel.Expr.keccak256` and lowers to the Yul `keccak256(offset, size)` builtin. The machine-readable trust report records the explicit primitive assumption `keccak256_memory_slice_matches_evm`.
 
+`Expr.keccak256` also remains an explicit proof boundary today: the compiler supports it directly, but the current proof stack still treats it as an axiomatized primitive instead of a fully modeled operation. When it appears, archive `--trust-report` and use `--deny-axiomatized-primitives` for proof-strict runs (see issue `#1411`).
+
 ### `ecrecover` precompile
 
 `verity_contract` can bind the standard `ecrecover` precompile directly:

--- a/docs-site/content/guides/solidity-to-verity.mdx
+++ b/docs-site/content/guides/solidity-to-verity.mdx
@@ -68,6 +68,8 @@ Those low-level call mechanics compile, but they are still outside the current p
 
 Manual ABI or memory plumbing (`mload` / `mstore` / copy-based payload handling) compiles, but it is still outside the fully proved interpreter semantics today. Treat that path as an explicit trust boundary, prefer higher-level helpers when available, and use `--deny-linear-memory-mechanics` if the translated contract must stay inside the proved subset (see issue `#1411`).
 
+Raw `keccak256` hashing also compiles through the typed intrinsic surface, but it still relies on an explicit axiom in the current proof stack. Treat it as a separate trust boundary, archive `--trust-report`, and use `--deny-axiomatized-primitives` when the translated contract must stay inside the proved subset (see issue `#1411`).
+
 ### Reentrancy guard primitive
 
 Not first-class yet (see issue `#1160`).

--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -32,6 +32,7 @@ Primary guards:
 - `check_interpreter_feature_summary_sync.py`: keep the interpreter feature summary table aligned with the machine-readable feature matrix artifact.
 - `check_low_level_call_boundary_sync.py`: keep docs aligned with the current low-level call proof boundary.
 - `check_linear_memory_boundary_sync.py`: keep docs aligned with the current linear-memory proof boundary.
+- `check_axiomatized_primitive_boundary_sync.py`: keep docs aligned with the current axiomatized-primitive proof boundary.
 - `check_struct_mapping_surface_sync.py`: keep struct-mapping storage docs aligned with the current compiler surface.
 - `check_storage_layout.py`
 - `check_lean_hygiene.py`

--- a/scripts/check_axiomatized_primitive_boundary_sync.py
+++ b/scripts/check_axiomatized_primitive_boundary_sync.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Keep axiomatized-primitive boundary docs aligned with the interpreter feature matrix."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FEATURE_MATRIX = ROOT / "artifacts" / "interpreter_feature_matrix.json"
+TARGET_FILES = {
+    "EDSL_API": ROOT / "docs-site" / "content" / "edsl-api-reference.mdx",
+    "COMPILER_DOC": ROOT / "docs-site" / "content" / "compiler.mdx",
+    "SOLIDITY_GUIDE": ROOT / "docs-site" / "content" / "guides" / "solidity-to-verity.mdx",
+}
+AXIOMATIZED_EXPR_FEATURES = {"keccak256"}
+
+
+def normalize_ws(text: str) -> str:
+    return " ".join(text.split())
+
+
+def load_feature_matrix(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def axiomatized_primitives_need_boundary_note(matrix: dict) -> bool:
+    expr_features = {
+        entry["feature"]: entry
+        for entry in matrix.get("expr_features", [])
+        if entry.get("feature") in AXIOMATIZED_EXPR_FEATURES
+    }
+    if expr_features.keys() != AXIOMATIZED_EXPR_FEATURES:
+        raise ValueError("interpreter feature matrix is missing one or more axiomatized primitive entries")
+
+    for entry in expr_features.values():
+        if entry.get("proof_status") != "proved":
+            return True
+        if entry.get("SpecInterpreter_basic") != "supported":
+            return True
+        if entry.get("SpecInterpreter_fuel") != "supported":
+            return True
+    return False
+
+
+def expected_snippets(needs_boundary_note: bool) -> dict[str, list[str]]:
+    if not needs_boundary_note:
+        return {label: [] for label in TARGET_FILES}
+
+    return {
+        "EDSL_API": [
+            "`Expr.keccak256` also remains an explicit proof boundary today: the compiler supports it directly, but the current proof stack still treats it as an axiomatized primitive instead of a fully modeled operation.",
+            "archive `--trust-report` and use `--deny-axiomatized-primitives` for proof-strict runs (see issue `#1411`).",
+        ],
+        "COMPILER_DOC": [
+            "The `keccak256` intrinsic also compiles, but it remains axiomatized in the current proof stack rather than fully modeled end to end.",
+            "archive `--trust-report` and add `--deny-axiomatized-primitives` if the selected contracts must stay inside the proved subset (see issue `#1411`).",
+        ],
+        "SOLIDITY_GUIDE": [
+            "Raw `keccak256` hashing also compiles through the typed intrinsic surface, but it still relies on an explicit axiom in the current proof stack.",
+            "archive `--trust-report`, and use `--deny-axiomatized-primitives` when the translated contract must stay inside the proved subset (see issue `#1411`).",
+        ],
+    }
+
+
+def main() -> int:
+    if not FEATURE_MATRIX.exists():
+        print(f"Missing: {FEATURE_MATRIX.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+
+    try:
+        matrix = load_feature_matrix(FEATURE_MATRIX)
+        needs_boundary_note = axiomatized_primitives_need_boundary_note(matrix)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"{FEATURE_MATRIX.relative_to(ROOT)}: {exc}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    expected = expected_snippets(needs_boundary_note)
+    for label, path in TARGET_FILES.items():
+        if not path.exists():
+            errors.append(f"Missing: {path.relative_to(ROOT)}")
+            continue
+        normalized = normalize_ws(path.read_text(encoding="utf-8"))
+        for snippet in expected[label]:
+            if normalize_ws(snippet) not in normalized:
+                errors.append(
+                    f"{path.relative_to(ROOT)} is out of sync with axiomatized-primitive proof boundary: missing `{snippet}`"
+                )
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    status = "required" if needs_boundary_note else "not required"
+    print(f"axiomatized-primitive boundary sync passed: boundary note {status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_axiomatized_primitive_boundary_sync.py
+++ b/scripts/test_check_axiomatized_primitive_boundary_sync.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import textwrap
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_axiomatized_primitive_boundary_sync as check
+
+
+class AxiomatizedPrimitiveBoundarySyncTests(unittest.TestCase):
+    def _write_fixture_tree(
+        self,
+        root: Path,
+        *,
+        proof_status: str,
+        basic_status: str,
+        fuel_status: str,
+        edsl_doc: str,
+        compiler_doc: str,
+        solidity_guide: str,
+    ) -> None:
+        matrix = {
+            "expr_features": [
+                {
+                    "feature": "keccak256",
+                    "proof_status": proof_status,
+                    "SpecInterpreter_basic": basic_status,
+                    "SpecInterpreter_fuel": fuel_status,
+                }
+            ],
+            "stmt_features": [],
+        }
+        feature_matrix = root / "artifacts" / "interpreter_feature_matrix.json"
+        feature_matrix.parent.mkdir(parents=True, exist_ok=True)
+        feature_matrix.write_text(json.dumps(matrix), encoding="utf-8")
+
+        edsl_path = root / "docs-site" / "content" / "edsl-api-reference.mdx"
+        edsl_path.parent.mkdir(parents=True, exist_ok=True)
+        edsl_path.write_text(edsl_doc, encoding="utf-8")
+
+        compiler_path = root / "docs-site" / "content" / "compiler.mdx"
+        compiler_path.parent.mkdir(parents=True, exist_ok=True)
+        compiler_path.write_text(compiler_doc, encoding="utf-8")
+
+        guide_path = root / "docs-site" / "content" / "guides" / "solidity-to-verity.mdx"
+        guide_path.parent.mkdir(parents=True, exist_ok=True)
+        guide_path.write_text(solidity_guide, encoding="utf-8")
+
+    def _run_check(
+        self,
+        *,
+        proof_status: str,
+        basic_status: str,
+        fuel_status: str,
+        edsl_doc: str,
+        compiler_doc: str,
+        solidity_guide: str,
+    ) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._write_fixture_tree(
+                root,
+                proof_status=proof_status,
+                basic_status=basic_status,
+                fuel_status=fuel_status,
+                edsl_doc=edsl_doc,
+                compiler_doc=compiler_doc,
+                solidity_guide=solidity_guide,
+            )
+
+            old_root = check.ROOT
+            old_matrix = check.FEATURE_MATRIX
+            old_targets = check.TARGET_FILES
+            check.ROOT = root
+            check.FEATURE_MATRIX = root / "artifacts" / "interpreter_feature_matrix.json"
+            check.TARGET_FILES = {
+                "EDSL_API": root / "docs-site" / "content" / "edsl-api-reference.mdx",
+                "COMPILER_DOC": root / "docs-site" / "content" / "compiler.mdx",
+                "SOLIDITY_GUIDE": root / "docs-site" / "content" / "guides" / "solidity-to-verity.mdx",
+            }
+            try:
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    rc = check.main()
+                return rc, stdout.getvalue() + stderr.getvalue()
+            finally:
+                check.ROOT = old_root
+                check.FEATURE_MATRIX = old_matrix
+                check.TARGET_FILES = old_targets
+
+    def test_boundary_note_required_when_axiomatized_primitive_not_fully_modeled(self) -> None:
+        note = textwrap.dedent(
+            """
+            `Expr.keccak256` also remains an explicit proof boundary today: the compiler supports it directly, but the current proof stack still treats it as an axiomatized primitive instead of a fully modeled operation.
+            archive `--trust-report` and use `--deny-axiomatized-primitives` for proof-strict runs (see issue `#1411`).
+            The `keccak256` intrinsic also compiles, but it remains axiomatized in the current proof stack rather than fully modeled end to end.
+            archive `--trust-report` and add `--deny-axiomatized-primitives` if the selected contracts must stay inside the proved subset (see issue `#1411`).
+            Raw `keccak256` hashing also compiles through the typed intrinsic surface, but it still relies on an explicit axiom in the current proof stack.
+            archive `--trust-report`, and use `--deny-axiomatized-primitives` when the translated contract must stay inside the proved subset (see issue `#1411`).
+            """
+        )
+        rc, output = self._run_check(
+            proof_status="not_modeled",
+            basic_status="unsupported",
+            fuel_status="unsupported",
+            edsl_doc=note,
+            compiler_doc=note,
+            solidity_guide=note,
+        )
+        self.assertEqual(rc, 0, output)
+        self.assertIn("boundary note required", output)
+
+    def test_missing_boundary_note_fails_when_axiomatized_primitive_not_fully_modeled(self) -> None:
+        rc, output = self._run_check(
+            proof_status="not_modeled",
+            basic_status="unsupported",
+            fuel_status="unsupported",
+            edsl_doc="keccak doc\n",
+            compiler_doc="compiler doc\n",
+            solidity_guide="guide doc\n",
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("edsl-api-reference.mdx is out of sync", output)
+
+    def test_boundary_note_not_required_once_axiomatized_primitive_is_fully_modeled(self) -> None:
+        rc, output = self._run_check(
+            proof_status="proved",
+            basic_status="supported",
+            fuel_status="supported",
+            edsl_doc="keccak doc\n",
+            compiler_doc="compiler doc\n",
+            solidity_guide="guide doc\n",
+        )
+        self.assertEqual(rc, 0, output)
+        self.assertIn("boundary note not required", output)
+
+    def test_repository_docs_are_currently_in_sync(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = check.main()
+        output = stdout.getvalue() + stderr.getvalue()
+        self.assertEqual(rc, 0, output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the missing docs-site note that `keccak256` remains an axiomatized proof boundary and document `--deny-axiomatized-primitives`
- add a CI sync guard plus unit tests so those docs stay aligned with `artifacts/interpreter_feature_matrix.json`
- wire the new guard into `make check` and the scripts reference

## Testing
- `python3 scripts/test_check_axiomatized_primitive_boundary_sync.py`
- `python3 scripts/check_axiomatized_primitive_boundary_sync.py`
- `make check`

Refs #1411

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation updates plus a new CI/doc-sync guard; main impact is potentially failing `make check` if the interpreter feature matrix or docs change without updating the required snippets.
> 
> **Overview**
> Adds explicit documentation that `Expr.keccak256` is an *axiomatized proof boundary* and recommends archiving `--trust-report` and using `--deny-axiomatized-primitives` for proof-strict runs.
> 
> Introduces `scripts/check_axiomatized_primitive_boundary_sync.py` (with unit tests) to enforce that these boundary notes are present whenever `artifacts/interpreter_feature_matrix.json` indicates `keccak256` is not fully proved/supported, and wires the new check into `make check` and `scripts/REFERENCE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2fb79e8e888559182b5ff1374b7662b07d26891. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->