### PR TITLE
compiler: allow effect-only linked externals

### DIFF
--- a/Compiler/CompilationModel/Compile.lean
+++ b/Compiler/CompilationModel/Compile.lean
@@ -183,7 +183,10 @@ def compileStmt (fields : List Field) (events : List EventDef := [])
       pure [YulStmt.letMany names (YulExpr.call (internalFunctionYulName functionName) argExprs)]
   | Stmt.externalCallBind resultVars externalName args => do
       let argExprs ← compileExprList fields dynamicSource args
-      pure [YulStmt.letMany resultVars (YulExpr.call externalName argExprs)]
+      if resultVars.isEmpty then
+        pure [YulStmt.expr (YulExpr.call externalName argExprs)]
+      else
+        pure [YulStmt.letMany resultVars (YulExpr.call externalName argExprs)]
   -- NOTE: safeTransfer, safeTransferFrom, externalCallWithReturn, callback, ecrecover
   -- have been removed. Use Stmt.ecm with the appropriate module from Compiler/Modules/.
   | Stmt.ecm mod args => do

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -397,8 +397,6 @@ def validateExternalCallTargetsInStmt
           if args.length != ext.params.length then
             throw s!"Compilation error: {context} calls external function '{externalName}' with {args.length} args, expected {ext.params.length}."
           let returns ← externalFunctionReturns ext
-          if resultVars.isEmpty then
-            throw s!"Compilation error: {context} uses Stmt.externalCallBind with no result variables."
           if returns.length != resultVars.length then
             throw s!"Compilation error: {context} binds {resultVars.length} values from external function '{externalName}', but it returns {returns.length}."
           let rec checkDuplicateVars (seen : List String) : List String → Except String Unit

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -1445,6 +1445,54 @@ private def reservedExternalBindSpec : CompilationModel := {
   ]
 }
 
+private def effectOnlyExternalBindSpec : CompilationModel := {
+  name := "EffectOnlyExternalBind"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "poke"
+      params := [{ name := "next", ty := ParamType.uint256 }]
+      returnType := none
+      body := [
+        Stmt.externalCallBind [] "notify" [Expr.param "next"],
+        Stmt.stop
+      ]
+    }
+  ]
+  externals := [
+    { name := "notify"
+      params := [ParamType.uint256]
+      returnType := none
+      returns := []
+      axiomNames := ["notify_effect_only"]
+    }
+  ]
+}
+
+private def effectOnlyExternalBindMismatchSpec : CompilationModel := {
+  name := "EffectOnlyExternalBindMismatch"
+  fields := []
+  «constructor» := none
+  functions := [
+    { name := "store"
+      params := [{ name := "next", ty := ParamType.uint256 }]
+      returnType := none
+      body := [
+        Stmt.externalCallBind [] "echo" [Expr.param "next"],
+        Stmt.stop
+      ]
+    }
+  ]
+  externals := [
+    { name := "echo"
+      params := [ParamType.uint256]
+      returnType := some ParamType.uint256
+      returns := [ParamType.uint256]
+      axiomNames := ["echo_matches_identity"]
+    }
+  ]
+}
+
 private def rawLogTraceSmokeSpec : CompilationModel := {
   name := "RawLogTraceSmoke"
   fields := []
@@ -2097,6 +2145,16 @@ set_option maxRecDepth 4096 in
     "reserved compiler prefix is rejected in external call binders"
     reservedExternalBindSpec
     "local binder '__external_ret' uses reserved compiler prefix '__'"
+  let effectOnlyExternalBindYul ← expectCompileToYul
+    "effect-only external call bind compiles"
+    effectOnlyExternalBindSpec
+  expectTrue "effect-only external call bind lowers to a bare Yul call"
+    (contains effectOnlyExternalBindYul "notify(next)" &&
+      !(contains effectOnlyExternalBindYul "let  := notify(next)"))
+  expectCompileErrorContains
+    "effect-only external call bind still rejects non-void externals"
+    effectOnlyExternalBindMismatchSpec
+    "binds 0 values from external function 'echo', but it returns 1."
   expectCompileErrorContains
     "reserved compiler prefix is rejected in ECM result binders"
     reservedEcmResultVarSpec


### PR DESCRIPTION
## Summary
- allow `Stmt.externalCallBind [] name args` when the linked external declaration returns zero values
- compile that effect-only form as a bare Yul call expression instead of an invalid empty `let`
- add regression coverage for both the accepted void case and the still-rejected non-void mismatch

Closes #1495.

## Testing
- `lake build Compiler.CompilationModelFeatureTest`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler codegen and validation for `Stmt.externalCallBind`, which can change generated Yul for external calls and could affect downstream contracts if behavior diverges from expected return arity handling.
> 
> **Overview**
> Allows `Stmt.externalCallBind [] name args` when the linked external declaration returns **zero** values.
> 
> The compiler now lowers this effect-only form to a **bare Yul call statement** instead of emitting an invalid empty `let`, and validation no longer rejects empty binders as long as the external’s declared return arity matches.
> 
> Adds feature-test coverage that (a) void externals compile and render as `name(args)` without `let`, and (b) empty binders are still rejected when the external declares non-void returns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e59771f373754eae7efd92f6afea6165cf1755be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->