### PR TITLE
proofs: make typed-ir ABI-head witness explicit

### DIFF
--- a/Compiler/TypedIRCompilerCorrectness.lean
+++ b/Compiler/TypedIRCompilerCorrectness.lean
@@ -6348,6 +6348,41 @@ theorem erc721OwnersSlotFieldSlot :
 theorem erc721TokenApprovalsSlotFieldSlot :
     findFieldSlot erc721Fields "tokenApprovalsSlot" = some 5 := by rfl
 
+private def abiHeadParamWitnessFn : FunctionSpec := {
+  name := "acceptHeads"
+  params := [
+    { name := "cfg", ty := ParamType.tuple [ParamType.address, ParamType.uint256] },
+    { name := "payload", ty := ParamType.bytes },
+    { name := "fixedRecipients", ty := ParamType.fixedArray ParamType.address 2 },
+    { name := "recipients", ty := ParamType.array ParamType.address },
+    { name := "note", ty := ParamType.string }
+  ]
+  returnType := none
+  body := [Stmt.stop]
+}
+
+private def abiHeadParamWitnessSpec : CompilationModel := {
+  name := "AbiHeadParamWitness"
+  fields := []
+  «constructor» := none
+  functions := [abiHeadParamWitnessFn]
+}
+
+private def abiHeadParamWitnessExpectedTys : List Ty :=
+  [Ty.uint256, Ty.uint256, Ty.uint256, Ty.uint256, Ty.uint256]
+
+/-- ABI head-shaped params remain inside the generic typed-IR correctness surface. -/
+theorem witness_abiHeadParamShapes_compile :
+    (match compileFunctionNamed abiHeadParamWitnessSpec "acceptHeads" with
+    | .ok block =>
+        decide (block.params.map TVar.ty = abiHeadParamWitnessExpectedTys) &&
+          decide (block.locals = ([] : List TVar)) &&
+          match block.body with
+          | [TStmt.stop] => true
+          | _ => false
+    | .error _ => false) = true := by
+  native_decide
+
 -- -- getApproved(tokenId) -- --
 
 -- -- approve(approved, tokenId) -- --
@@ -6355,8 +6390,9 @@ theorem erc721TokenApprovalsSlotFieldSlot :
 /-!
 `getApproved` and `approve` depend on the live `ownersSlot = 4` /
 `tokenApprovalsSlot = 5` layout and include multi-step owner guards. They do
-not fit the older single-fragment witness surface used above, so their emitted
-typed-IR shapes are regression-tested directly in `Contracts/TypedIRTests.lean`.
+not fit the older single-fragment witness surface used above. Likewise, the
+broader ABI-head roundtrip/lowering regressions for tuple/bytes/array/string
+params live in `Contracts/TypedIRTests.lean`.
 -/
 
 -- ============================================================================

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -30,7 +30,7 @@ This section is a dated historical snapshot. Use [docs/VERIFICATION_STATUS.md](h
 
 - **Semantic bridge**: `Compiler/Proofs/SemanticBridge.lean` (EDSL ≡ CompilationModel for all supported contracts)
 - **End-to-end proofs**: `Compiler/Proofs/EndToEnd.lean` (full pipeline correctness)
-- **Typed IR correctness**: `Compiler/TypedIRCompilerCorrectness.lean` (generic compilation-correctness theorem with 36 supported statement fragments)
+- **Typed IR correctness**: `Compiler/TypedIRCompilerCorrectness.lean` (generic compilation-correctness theorem with 36 supported statement fragments, including ABI-head tuple/bytes/fixed-array/dynamic-array/string params as word-typed inputs)
 - **IR generation**: `Compiler/Proofs/IRGeneration/` (infrastructure + concrete IR proofs in `Expr.lean`)
 - **Yul semantics + preservation**: `Compiler/Proofs/YulGeneration/` (complete — PR #42)
 

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -39,7 +39,7 @@ EVM Bytecode
 
 > **Note**: Stdlib (0 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (273 total properties).
 
-Layer 1 uses macro-generated bridge theorems backed by a generic typed-IR compilation-correctness theorem ([`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean)). Advanced constructs (linked libraries, ECMs, custom ABI) are expressed directly in `CompilationModel` and trusted at that boundary.
+Layer 1 uses macro-generated bridge theorems backed by a generic typed-IR compilation-correctness theorem ([`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean)). Tuple/bytes/fixed-array/dynamic-array/string parameters now stay inside that proof path when they are carried as ABI head words/offsets. Advanced constructs beyond that typed-IR head-word surface (linked libraries, ECMs, fully custom ABI behavior) are still expressed directly in `CompilationModel` and trusted at that boundary.
 
 Internal helper calls are supported operationally in `CompilationModel` and the fuel-based interpreter path, but helper-level compositional proof reuse across callers is not yet a first-class verified interface. Current Layer 1 bridges remain contract-specific; the reusable internal-helper proof boundary is tracked in [#1335](https://github.com/Th0rgal/verity/issues/1335).
 


### PR DESCRIPTION
## Summary

- add an explicit ABI-head witness theorem to `Compiler/TypedIRCompilerCorrectness.lean` for tuple, bytes, fixed-array, dynamic-array, and string params
- update verification docs to state that these parameter shapes stay inside the typed-IR proof path when treated as ABI head words/offsets
- clarify that broader custom ABI behavior is still trusted at the `CompilationModel` boundary

## Testing

- `lake build Compiler.TypedIRCompilerCorrectness`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small, self-contained Lean witness theorem plus documentation wording updates; no runtime/compiler behavior changes, only proof coverage and docs.
> 
> **Overview**
> Adds a new Lean witness (`witness_abiHeadParamShapes_compile`) asserting that functions with ABI-head-shaped params (tuple/bytes/fixed array/dynamic array/string) compile to five `uint256`-typed inputs with no locals and a trivial `stop` body.
> 
> Updates verification documentation to explicitly state these ABI-head parameter shapes remain within the generic typed-IR correctness proof surface, while broader/custom ABI behavior is still trusted at the `CompilationModel` boundary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a084cbb8e19e640939b4036526a673864394bf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->