### PR TITLE
tests: fix generated tuple property args

### DIFF
--- a/artifacts/macro_property_tests/PropertyTupleSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyTupleSmoke.t.sol
@@ -20,7 +20,7 @@ contract PropertyTupleSmokeTest is YulTestBase {
     // Property 1: setFromPair has no unexpected revert
     function testAuto_SetFromPair_NoUnexpectedRevert() public {
         vm.prank(alice);
-        (bool ok,) = target.call(abi.encodeWithSignature("setFromPair((uint256,uint256))", abi.encode(uint256(1), uint256(1))));
+        (bool ok,) = target.call(abi.encodeWithSignature("setFromPair((uint256,uint256))", abi.decode(abi.encode(uint256(1), uint256(1)), (uint256, uint256))));
         require(ok, "setFromPair reverted unexpectedly");
     }
     // Property 2: TODO decode and assert `getPair` result
@@ -35,7 +35,7 @@ contract PropertyTupleSmokeTest is YulTestBase {
     // Property 3: processConfig has no unexpected revert
     function testAuto_ProcessConfig_NoUnexpectedRevert() public {
         vm.prank(alice);
-        (bool ok,) = target.call(abi.encodeWithSignature("processConfig((address,address,uint256))", abi.encode(alice, alice, uint256(1))));
+        (bool ok,) = target.call(abi.encodeWithSignature("processConfig((address,address,uint256))", abi.decode(abi.encode(alice, alice, uint256(1)), (address, address, uint256))));
         require(ok, "processConfig reverted unexpectedly");
     }
 }

--- a/artifacts/macro_property_tests/PropertyUint8Smoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyUint8Smoke.t.sol
@@ -20,7 +20,7 @@ contract PropertyUint8SmokeTest is YulTestBase {
     // Property 1: acceptSig has no unexpected revert
     function testAuto_AcceptSig_NoUnexpectedRevert() public {
         vm.prank(alice);
-        (bool ok,) = target.call(abi.encodeWithSignature("acceptSig((uint8,bytes32,bytes32))", abi.encode(uint8(27), bytes32(uint256(0xBEEF)), bytes32(uint256(0xBEEF)))));
+        (bool ok,) = target.call(abi.encodeWithSignature("acceptSig((uint8,bytes32,bytes32))", abi.decode(abi.encode(uint8(27), bytes32(uint256(0xBEEF)), bytes32(uint256(0xBEEF))), (uint8, bytes32, bytes32))));
         require(ok, "acceptSig reverted unexpectedly");
     }
     // Property 2: sigV returns the declared constant result

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -296,6 +296,16 @@ def _sol_type(lean_ty: str) -> str:
     raise ValueError(f"unsupported Lean type for Solidity signature mapping: {ty!r}")
 
 
+def _sol_tuple_value_type(lean_ty: str) -> str:
+    ty = _normalize_type(lean_ty)
+    if ty.startswith("Tuple [") and ty.endswith("]"):
+        inner = ty[len("Tuple [") : -1]
+        elems = _parse_tuple_elements(inner)
+        sol_elems = ", ".join(_sol_type(e) for e in elems)
+        return f"({sol_elems})"
+    raise ValueError(f"unsupported Lean tuple type for Solidity tuple value mapping: {ty!r}")
+
+
 def _example_value(lean_ty: str) -> str:
     ty = _normalize_type(lean_ty)
     if ty == "Uint256":
@@ -326,7 +336,8 @@ def _example_value(lean_ty: str) -> str:
         inner = ty[len("Tuple [") : -1]
         elems = _parse_tuple_elements(inner)
         elem_vals = ", ".join(_example_value(e) for e in elems)
-        return f"abi.encode({elem_vals})"
+        tuple_ty = _sol_tuple_value_type(ty)
+        return f"abi.decode(abi.encode({elem_vals}), {tuple_ty})"
     raise ValueError(f"unsupported Lean type for generated example value: {ty!r}")
 
 

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -278,7 +278,16 @@ class RenderTests(unittest.TestCase):
         )
         rendered = gen.render_contract_test(contract)
         self.assertIn('"submit((address,address,uint256))"', rendered)
-        self.assertIn("abi.encode(alice, alice, uint256(1))", rendered)
+        self.assertIn(
+            "abi.decode(abi.encode(alice, alice, uint256(1)), (address, address, uint256))",
+            rendered,
+        )
+
+    def test_example_value_tuple_uses_tuple_typed_expression(self) -> None:
+        self.assertEqual(
+            gen._example_value("Tuple [Uint8, Bytes32, Bytes32]"),
+            "abi.decode(abi.encode(uint8(27), bytes32(uint256(0xBEEF)), bytes32(uint256(0xBEEF))), (uint8, bytes32, bytes32))",
+        )
 
     def test_render_tuple_return_shape_assertion(self) -> None:
         contract = gen.ContractDecl(


### PR DESCRIPTION
## Summary
- fix generated macro property tests so tuple-typed example arguments are passed as typed tuple values instead of pre-encoded `bytes`
- add unit coverage for the tuple example renderer and update the tuple rendering expectation
- regenerate the affected tuple-based property artifacts

## Why
The property-test generator was emitting calls like:

```solidity
abi.encodeWithSignature("setFromPair((uint256,uint256))", abi.encode(uint256(1), uint256(1)))
```

That second argument is `bytes`, not a tuple value, so the generated stub was not actually exercising the tuple ABI shape it claimed to cover. This silently weakened the checked-in property baseline for tuple entrypoints.

The fix now emits typed tuple expressions via `abi.decode(abi.encode(...), (<tuple types>))`, which Solidity accepts as a tuple value for `abi.encodeWithSignature(...)` without needing generated structs.

## Validation
- `python3 -m unittest scripts.test_generate_macro_property_tests`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the property-test generator and regenerated test artifacts, improving tuple argument encoding without touching production contract logic.
> 
> **Overview**
> Fixes generated macro property tests so tuple parameters are passed as *typed tuple values* (via `abi.decode(abi.encode(...), (<tuple types>))`) instead of pre-encoded `bytes`, ensuring `abi.encodeWithSignature(...)` exercises the intended tuple ABI shape.
> 
> Adds/updates unit coverage around tuple example rendering and regenerates affected tuple-based property artifacts to match the new call pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7416f72df9fffc34f58c575fcb32f4bcdaf86648. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->