### PR TITLE
test: add proxy upgradeability macro smoke

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -8,6 +8,7 @@ import Compiler.Modules.Precompiles
 import Compiler.Yul.PrettyPrint
 import Contracts.Common
 import Contracts.LocalObligationMacroSmoke.LocalObligationMacroSmoke
+import Contracts.ProxyUpgradeabilityMacroSmoke
 
 namespace Compiler.CompilationModelFeatureTest
 
@@ -57,6 +58,69 @@ def dischargedEdgeExecutableStillRuns : Bool :=
 example : dischargedEdgeExecutableStillRuns = true := by native_decide
 
 end MacroLocalObligationSmoke
+
+namespace MacroProxyUpgradeabilitySmoke
+
+open Contracts
+
+def initProxyCarriesInitializerObligation : Bool :=
+  match ProxyUpgradeabilityMacroSmoke.initProxy_model with
+  | { localObligations := [{ name := "implementation_slot_discipline"
+                             obligation := "Proxy storage-slot discipline must be validated against the intended implementation layout."
+                             proofStatus := .assumed }]
+      body := [Stmt.require (Expr.eq (Expr.storage "initializedVersion") (Expr.literal 0)) "initializer already run",
+               Stmt.setStorage "initializedVersion" (Expr.literal 1),
+               Stmt.setStorageAddr "admin" (Expr.param "seedAdmin"),
+               Stmt.setStorageAddr "implementation" (Expr.param "seedImplementation"),
+               Stmt.stop], .. } => true
+  | _ => false
+
+example : initProxyCarriesInitializerObligation = true := by native_decide
+
+def upgradeToCarriesUpgradeObligations : Bool :=
+  match ProxyUpgradeabilityMacroSmoke.upgradeTo_model with
+  | { localObligations := [{ name := "upgrade_authorization"
+                             obligation := "Caller must separately prove that only the intended admin can authorize upgrades."
+                             proofStatus := .assumed },
+                           { name := "storage_layout_compatibility"
+                             obligation := "Storage-layout compatibility across versions remains a manual proof obligation."
+                             proofStatus := .unchecked }]
+      body := [Stmt.require (Expr.lt (Expr.storage "initializedVersion") (Expr.literal 2)) "reinitializer(2) already run",
+               Stmt.setStorage "initializedVersion" (Expr.literal 2),
+               Stmt.setStorageAddr "implementation" (Expr.param "newImplementation"),
+               Stmt.stop], .. } => true
+  | _ => false
+
+example : upgradeToCarriesUpgradeObligations = true := by native_decide
+
+def forwardCarriesProxyBoundary : Bool :=
+  match ProxyUpgradeabilityMacroSmoke.forward_model with
+  | { localObligations := [{ name := "delegatecall_refinement"
+                             obligation := "Delegatecall fallback behavior must be shown to refine the selected proxy semantics."
+                             proofStatus := .assumed }]
+      body := body, .. } =>
+      body.length == 3
+  | _ => false
+
+example : forwardCarriesProxyBoundary = true := by native_decide
+
+def forwardExecutableReadsImplementation : Bool :=
+  let seededState :=
+    (ProxyUpgradeabilityMacroSmoke.initProxy (Verity.wordToAddress 11) (Verity.wordToAddress 19)).run Verity.defaultState
+  match seededState with
+  | .success _ state =>
+      match ProxyUpgradeabilityMacroSmoke.forward 100 0 32 64 32 state with
+      | .success ok nextState =>
+          ok == delegatecall 100 19 0 32 64 32 &&
+            nextState.storage ProxyUpgradeabilityMacroSmoke.initializedVersion.slot == 1 &&
+            nextState.storageAddr ProxyUpgradeabilityMacroSmoke.admin.slot == Verity.wordToAddress 11 &&
+            nextState.storageAddr ProxyUpgradeabilityMacroSmoke.implementation.slot == Verity.wordToAddress 19
+      | .revert _ _ => false
+  | .revert _ _ => false
+
+example : forwardExecutableReadsImplementation = true := by native_decide
+
+end MacroProxyUpgradeabilitySmoke
 
 namespace MacroEcrecoverSmoke
 

--- a/Compiler/MainTest.lean
+++ b/Compiler/MainTest.lean
@@ -1,6 +1,7 @@
 import Contracts
 import Contracts.LocalObligationMacroSmoke.LocalObligationMacroSmoke
 import Contracts.LocalObligationTrustSurface
+import Contracts.ProxyUpgradeabilityMacroSmoke
 import Contracts.RawLogTrustSurface
 import Compiler.Main
 import Compiler.Linker
@@ -171,6 +172,32 @@ unsafe def runTests : IO Unit := do
     "strict proxy-upgradeability gate rejects delegatecall mechanics"
     ["--module", "Contracts.Counter.Counter", "--deny-proxy-upgradeability", "--output", s!"/tmp/verity-main-test-{nonce}-proxy-fail-out"]
     "Counter [function:previewLowLevel]: delegatecall"
+  let proxyMacroTrustReportPath := s!"/tmp/verity-main-test-{nonce}-proxy-macro-trust-report.json"
+  let proxyMacroOutDir := s!"/tmp/verity-main-test-{nonce}-proxy-macro-out"
+  IO.FS.createDirAll proxyMacroOutDir
+  main
+    [ "--module", "Contracts.ProxyUpgradeabilityMacroSmoke"
+    , "--trust-report", proxyMacroTrustReportPath
+    , "--output", proxyMacroOutDir
+    ]
+  let proxyMacroTrustReport ← IO.FS.readFile proxyMacroTrustReportPath
+  expectTrue "macro proxy trust report includes delegatecall proxy boundary"
+    (contains proxyMacroTrustReport "\"notModeledProxyUpgradeability\":[\"delegatecall\"]")
+  expectTrue "macro proxy trust report includes initializer proxy obligation"
+    (contains proxyMacroTrustReport "\"name\":\"implementation_slot_discipline\",\"status\":\"assumed\"")
+  expectTrue "macro proxy trust report includes upgrade obligations"
+    ((contains proxyMacroTrustReport "\"name\":\"upgrade_authorization\",\"status\":\"assumed\"") &&
+      (contains proxyMacroTrustReport "\"name\":\"storage_layout_compatibility\",\"status\":\"unchecked\""))
+  expectTrue "macro proxy trust report localizes delegatecall usage"
+    (contains proxyMacroTrustReport "\"kind\":\"function\",\"name\":\"forward\"")
+  expectErrorContains
+    "strict proxy-upgradeability gate rejects macro proxy delegatecall"
+    ["--module", "Contracts.ProxyUpgradeabilityMacroSmoke", "--deny-proxy-upgradeability", "--output", s!"/tmp/verity-main-test-{nonce}-proxy-macro-fail-out"]
+    "ProxyUpgradeabilityMacroSmoke [function:forward]: delegatecall"
+  expectErrorContains
+    "strict local-obligation gate rejects macro proxy obligations"
+    ["--module", "Contracts.ProxyUpgradeabilityMacroSmoke", "--deny-local-obligations", "--output", s!"/tmp/verity-main-test-{nonce}-proxy-macro-local-fail-out"]
+    "ProxyUpgradeabilityMacroSmoke [function:initProxy]: assumed local obligations: implementation_slot_discipline"
   let nonSelectedArtifactFlags ←
     (canonicalModules.filter (· != "Contracts.Counter.Counter")).mapM
       (fun moduleName => fileExists (contractArtifactPath singleOutDir moduleName))

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -5,6 +5,7 @@ import Compiler.Selector
 import Compiler.Hex
 import Contracts
 import Contracts.Smoke
+import Contracts.ProxyUpgradeabilityMacroSmoke
 import Contracts.StringErrorSmoke
 import Contracts.StringSmoke
 
@@ -269,6 +270,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Owned.spec
   , Contracts.Ledger.spec
   , Contracts.LocalObligationMacroSmoke.spec
+  , Contracts.ProxyUpgradeabilityMacroSmoke.spec
   , Contracts.Vault.spec
   , Contracts.SafeCounter.spec
   , Contracts.OwnedCounter.spec
@@ -306,6 +308,7 @@ private def functionSignature (fn : FunctionSpec) : String :=
 private def expectedExternalSignatures : List (String × List String) :=
   [ ("SimpleStorage", ["store(uint256)", "retrieve()"])
   , ("LocalObligationMacroSmoke", ["unsafeEdge()", "dischargedEdge(uint256)"])
+  , ("ProxyUpgradeabilityMacroSmoke", ["initProxy(address,address)", "upgradeTo(address)", "forward(uint256,uint256,uint256,uint256,uint256)"])
   , ("Counter", ["increment()", "decrement()", "getCount()", "previewAddTwice(uint256)",
       "previewOps(uint256,uint256,uint256)", "previewEnvOps(uint256,uint256)",
       "previewLowLevel(uint256,uint256)"])

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -2,6 +2,7 @@ import Compiler.Selector
 import Compiler.Hex
 import Compiler.Proofs.YulGeneration.Equivalence
 import Contracts
+import Contracts.ProxyUpgradeabilityMacroSmoke
 import Contracts.Smoke
 
 namespace Compiler.MacroTranslateRoundTripFuzz
@@ -29,6 +30,7 @@ private def writeSlots (spec : CompilationModel) : List Nat :=
 private def macroSpecs : List CompilationModel :=
   [ Contracts.SimpleStorage.spec
   , Contracts.LocalObligationMacroSmoke.spec
+  , Contracts.ProxyUpgradeabilityMacroSmoke.spec
   , Contracts.Counter.spec
   , Contracts.Owned.spec
   , Contracts.Ledger.spec

--- a/Contracts/ProxyUpgradeabilityMacroSmoke.lean
+++ b/Contracts/ProxyUpgradeabilityMacroSmoke.lean
@@ -1,0 +1,30 @@
+import Contracts.Common
+
+namespace Contracts
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract ProxyUpgradeabilityMacroSmoke where
+  storage
+    initializedVersion : Uint256 := slot 0
+    admin : Address := slot 1
+    implementation : Address := slot 2
+
+  function initProxy (seedAdmin : Address, seedImplementation : Address) initializer(initializedVersion)
+      local_obligations [implementation_slot_discipline := assumed "Proxy storage-slot discipline must be validated against the intended implementation layout."] : Unit := do
+    setStorageAddr admin seedAdmin
+    setStorageAddr implementation seedImplementation
+
+  function upgradeTo (newImplementation : Address) reinitializer(initializedVersion, 2)
+      local_obligations [upgrade_authorization := assumed "Caller must separately prove that only the intended admin can authorize upgrades.", storage_layout_compatibility := unchecked "Storage-layout compatibility across versions remains a manual proof obligation."] : Unit := do
+    setStorageAddr implementation newImplementation
+
+  function forward (gas : Uint256, inOffset : Uint256, inSize : Uint256, outOffset : Uint256, outSize : Uint256)
+      local_obligations [delegatecall_refinement := assumed "Delegatecall fallback behavior must be shown to refine the selected proxy semantics."] : Uint256 := do
+    let target ← getStorageAddr implementation
+    let ok := delegatecall gas (addressToWord target) inOffset inSize outOffset outSize
+    return ok
+
+end Contracts

--- a/artifacts/macro_property_tests/PropertyProxyUpgradeabilityMacroSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyProxyUpgradeabilityMacroSmoke.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyProxyUpgradeabilityMacroSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/ProxyUpgradeabilityMacroSmoke.lean
+ */
+contract PropertyProxyUpgradeabilityMacroSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("ProxyUpgradeabilityMacroSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+}


### PR DESCRIPTION
## Summary
- add a `ProxyUpgradeabilityMacroSmoke` contract that combines initializer/reinitializer guards, explicit local obligations, and a `delegatecall` fallback on the native macro path
- cover the new proxy-shaped surface in `CompilationModelFeatureTest` and `MainTest`, including trust-report and strict-gate diagnostics
- register the contract with macro invariant, round-trip fuzz, and generated property-stub coverage so macro health checks stay green

## Testing
- `lake build Contracts.ProxyUpgradeabilityMacroSmoke`
- `lake build Compiler.CompilationModelFeatureTest`
- `lake build Compiler.MainTest`
- `make check`

Refs #1420.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new macro smoke contract and expands test coverage/trust-report assertions without changing compiler core logic. Main risk is test brittleness due to pinned trust-report substrings and signature snapshots.
> 
> **Overview**
> Introduces `Contracts.ProxyUpgradeabilityMacroSmoke`, a new macro contract that exercises **upgradeable-proxy mechanics** via `initializer`/`reinitializer` guards, explicit `local_obligations`, and a `delegatecall`-based `forward` function.
> 
> Extends feature and integration tests to assert the generated compilation model (guards + obligations), executable behavior, and trust-surface JSON output, and verifies that `--deny-proxy-upgradeability` and `--deny-local-obligations` reject this proxy-shaped surface.
> 
> Registers the new spec in macro translation invariant checks and IR↔Yul round-trip fuzz harnesses, and adds an auto-generated Solidity property-test stub for the new contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b7c3fc7472b15439992bb3b2b14b596bcb697a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->