### PR TITLE
trust: add assumption report artifact

### DIFF
--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -779,6 +779,30 @@ private def localObligationJson (entry : LocalObligation) : String :=
     ("obligation", jsonString entry.obligation)
   ]
 
+private structure AssumptionReportEntry where
+  category : String
+  siteKind : String
+  siteName : String
+  name : String
+  status : ProofStatus
+  detail : String := ""
+  assumption : String := ""
+  moduleName : String := ""
+  axioms : List String := []
+
+private def assumptionReportEntryJson (entry : AssumptionReportEntry) : String :=
+  jsonObject [
+    ("category", jsonString entry.category),
+    ("siteKind", jsonString entry.siteKind),
+    ("siteName", jsonString entry.siteName),
+    ("name", jsonString entry.name),
+    ("status", proofStatusString entry.status),
+    ("detail", jsonString entry.detail),
+    ("assumption", jsonString entry.assumption),
+    ("module", jsonString entry.moduleName),
+    ("axioms", jsonArray (entry.axioms.map jsonString))
+  ]
+
 private def proofStatusBucketJson
     (primitives externals modules localObligations : List String) : String :=
   jsonObject [
@@ -944,6 +968,56 @@ private def usageSitesJson (spec : CompilationModel) : String :=
       ])
     ]
   jsonArray ((collectUsageSiteSummaries spec).map siteJson)
+
+private def assumptionReportEntriesForSite (site : UsageSiteSummary) : List AssumptionReportEntry :=
+  let primitiveEntries :=
+    site.primitives.map (fun primitive =>
+      { category := "axiomatizedPrimitive"
+        siteKind := site.kind
+        siteName := site.name
+        name := primitive
+        status := .assumed
+        assumption := primitiveAssumptionName primitive })
+  let externalEntries :=
+    site.externals.map (fun ext =>
+      { category := "linkedExternal"
+        siteKind := site.kind
+        siteName := site.name
+        name := ext.name
+        status := ext.proofStatus
+        axioms := ext.axiomNames })
+  let moduleEntries :=
+    site.modules.map (fun mod =>
+      { category := "ecmModule"
+        siteKind := site.kind
+        siteName := site.name
+        name := mod.name
+        status := mod.proofStatus
+        axioms := mod.axioms })
+  let axiomEntries :=
+    site.modules.flatMap (fun mod =>
+      mod.axioms.map (fun assumptionName =>
+        { category := "ecmAxiom"
+          siteKind := site.kind
+          siteName := site.name
+          name := assumptionName
+          status := mod.proofStatus
+          moduleName := mod.name }))
+  let localObligationEntries :=
+    site.localObligations.map (fun obligation =>
+      { category := "localObligation"
+        siteKind := site.kind
+        siteName := site.name
+        name := obligation.name
+        status := obligation.proofStatus
+        detail := obligation.obligation })
+  primitiveEntries ++ externalEntries ++ moduleEntries ++ axiomEntries ++ localObligationEntries
+
+private def assumptionReportEntries (spec : CompilationModel) : List AssumptionReportEntry :=
+  (collectUsageSiteSummaries spec).flatMap assumptionReportEntriesForSite
+
+private def undischargedAssumptionReportEntries (spec : CompilationModel) : List AssumptionReportEntry :=
+  (assumptionReportEntries spec).filter (fun entry => entry.status != .proved)
 
 private def namesByProofStatus
     (status : ProofStatus)
@@ -1276,6 +1350,19 @@ where
         ("ecmAxioms", jsonArray ((collectEcmAxioms spec).map ecmJson)),
         ("ecmModules", jsonArray ((collectUsedEcmModules spec).map ecmModuleJson))
       ])
+    ]
+
+/-- Render a flat machine-readable assumption inventory for audit workflows. -/
+def emitAssumptionReportJson (specs : List CompilationModel) : String :=
+  jsonObject [
+    ("contracts", jsonArray (specs.map contractJson))
+  ]
+where
+  contractJson (spec : CompilationModel) : String :=
+    jsonObject [
+      ("contract", jsonString spec.name),
+      ("entries", jsonArray ((assumptionReportEntries spec).map assumptionReportEntryJson)),
+      ("undischarged", jsonArray ((undischargedAssumptionReportEntries spec).map assumptionReportEntryJson))
     ]
 
 end Compiler.CompilationModel

--- a/Compiler/CompileDriver.lean
+++ b/Compiler/CompileDriver.lean
@@ -55,6 +55,10 @@ private def writeTrustReport (path : String) (specs : List CompilationModel) : I
   ensureParentDirExists path
   IO.FS.writeFile path (emitTrustReportJson specs ++ "\n")
 
+private def writeAssumptionReport (path : String) (specs : List CompilationModel) : IO Unit := do
+  ensureParentDirExists path
+  IO.FS.writeFile path (emitAssumptionReportJson specs ++ "\n")
+
 private def writeLayoutReport (path : String) (specs : List CompilationModel) : IO Unit := do
   ensureParentDirExists path
   IO.FS.writeFile path (emitLayoutReportJson specs ++ "\n")
@@ -157,6 +161,7 @@ def compileSpecsWithOptions
     (options : YulEmitOptions)
     (patchReportPath : Option String)
     (trustReportPath : Option String)
+    (assumptionReportPath : Option String)
     (abiOutDir : Option String)
     (denyUncheckedDependencies : Bool := false)
     (denyAssumedDependencies : Bool := false)
@@ -208,6 +213,12 @@ def compileSpecsWithOptions
       writeTrustReport path specs
       if verbose then
         IO.println s!"✓ Wrote trust report: {path}"
+  | none => pure ()
+  match assumptionReportPath with
+  | some path =>
+      writeAssumptionReport path specs
+      if verbose then
+        IO.println s!"✓ Wrote assumption report: {path}"
   | none => pure ()
   match layoutReportPath with
   | some path =>
@@ -440,6 +451,7 @@ unsafe def compileModulesWithOptions
     (options : YulEmitOptions := {})
     (patchReportPath : Option String := none)
     (trustReportPath : Option String := none)
+    (assumptionReportPath : Option String := none)
     (abiOutDir : Option String := none)
     (denyUncheckedDependencies : Bool := false)
     (denyAssumedDependencies : Bool := false)
@@ -456,6 +468,6 @@ unsafe def compileModulesWithOptions
     | .ok specs => pure specs
     | .error err => throw (IO.userError err)
   compileSpecsWithOptions
-    specs outDir verbose libraryPaths options patchReportPath trustReportPath abiOutDir
+    specs outDir verbose libraryPaths options patchReportPath trustReportPath assumptionReportPath abiOutDir
     denyUncheckedDependencies denyAssumedDependencies denyAxiomatizedPrimitives denyLocalObligations denyLinearMemoryMechanics
     denyEventEmission denyLowLevelMechanics denyRuntimeIntrospection denyProxyUpgradeability layoutReportPath

--- a/Compiler/CompileDriverTest.lean
+++ b/Compiler/CompileDriverTest.lean
@@ -969,7 +969,7 @@ unsafe def runTests : IO Unit := do
 
   expectFailureContains
     "compileSpecsWithOptions reports missing linked library"
-    (compileSpecsWithOptions [abiSmokeSpec, linkedLibrarySpec] outDir false [missingLib] {} none none (some abiDir))
+    (compileSpecsWithOptions [abiSmokeSpec, linkedLibrarySpec] outDir false [missingLib] {} none none none (some abiDir))
     missingLib
 
   let hasEarlySuccessfulAbi ← fileExists earlySuccessfulAbi
@@ -977,7 +977,7 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError s!"✗ expected ABI artifact for early successful contract, missing: {earlySuccessfulAbi}")
   IO.println "✓ ABI artifacts still emitted for contracts compiled before failure"
 
-  compileSpecsWithOptions [stringAbiSmokeSpec] stringOutDir false [] {} none none (some stringAbiDir)
+  compileSpecsWithOptions [stringAbiSmokeSpec] stringOutDir false [] {} none none none (some stringAbiDir)
   expectFileContains
     "compileSpecsWithOptions emits string ABI artifacts"
     s!"{stringAbiDir}/StringAbiSmoke.abi.json"
@@ -1004,7 +1004,7 @@ unsafe def runTests : IO Unit := do
     , "\"inputs\": [{\"name\": \"\", \"type\": \"string\"}, {\"name\": \"\", \"type\": \"string\"}]"
     ]
 
-  compileSpecsWithOptions [abiHeadCompileDriverSpec] abiHeadOutDir false [] {} none none (some abiHeadAbiDir)
+  compileSpecsWithOptions [abiHeadCompileDriverSpec] abiHeadOutDir false [] {} none none none (some abiHeadAbiDir)
   let abiHeadYulExists ← fileExists s!"{abiHeadOutDir}/AbiHeadCompileDriverSmoke.yul"
   if !abiHeadYulExists then
     throw (IO.userError "✗ compileSpecsWithOptions emits Yul for ABI-head parameter smoke contract")
@@ -1021,14 +1021,14 @@ unsafe def runTests : IO Unit := do
     , "\"outputs\": [{\"name\": \"\", \"type\": \"uint256\"}]"
     ]
 
-  compileModulesWithOptions outDir canonicalModules false [] {} none none (some abiDir)
+  compileModulesWithOptions outDir canonicalModules false [] {} none none none (some abiDir)
   expectModuleArtifacts "explicit module list emits Yul/ABI for all requested contracts" canonicalModules outDir abiDir
 
   let manifestModules ←
     match ← Compiler.ModuleInput.resolveRawModules (some "packages/verity-examples/contracts.manifest") [] with
     | .ok modules => pure modules
     | .error err => throw (IO.userError err)
-  compileModulesWithOptions manifestOutDir manifestModules false [] {} none none (some manifestAbiDir)
+  compileModulesWithOptions manifestOutDir manifestModules false [] {} none none none (some manifestAbiDir)
   expectModuleArtifacts "manifest module list emits Yul/ABI for all requested contracts" manifestModules manifestOutDir manifestAbiDir
 
   for moduleName in canonicalModules do
@@ -1043,7 +1043,7 @@ unsafe def runTests : IO Unit := do
       s!"{manifestAbiDir}/{contractName}.abi.json"
 
   let selectedModules := ["Contracts.SimpleStorage.SimpleStorage", "Contracts.Counter.Counter"]
-  compileModulesWithOptions selectedOutDir selectedModules false [] {} none none (some selectedAbiDir)
+  compileModulesWithOptions selectedOutDir selectedModules false [] {} none none none (some selectedAbiDir)
   expectOnlySelectedArtifacts
     "selected module compilation emits only requested artifacts"
     selectedModules
@@ -1051,7 +1051,7 @@ unsafe def runTests : IO Unit := do
     selectedOutDir
     selectedAbiDir
 
-  compileModulesWithOptions reversedOutDir selectedModules.reverse false [] {} none none (some reversedAbiDir)
+  compileModulesWithOptions reversedOutDir selectedModules.reverse false [] {} none none none (some reversedAbiDir)
   expectOnlySelectedArtifacts
     "selected module compilation is order-invariant for artifact set"
     selectedModules
@@ -1072,7 +1072,7 @@ unsafe def runTests : IO Unit := do
 
   expectFailureContains
     "duplicate selected modules fail closed"
-    (compileModulesWithOptions outDir ["Contracts.Counter.Counter", "Contracts.Counter.Counter"] false [] {} none none (some abiDir))
+    (compileModulesWithOptions outDir ["Contracts.Counter.Counter", "Contracts.Counter.Counter"] false [] {} none none none (some abiDir))
     "Duplicate module input: Contracts.Counter.Counter"
 
   let trustReport := emitTrustReportJson [trustSurfaceSpec]
@@ -1223,6 +1223,23 @@ unsafe def runTests : IO Unit := do
   if !contains localObligationUsageSiteReport "- LocalObligationTrustSurface [function:unsafeEdge]: assumed local obligations: manual_delegatecall_refinement" then
     throw (IO.userError "✗ local-obligation diagnostics localize usage sites")
   IO.println "✓ trust report surfaces local unsafe/refinement obligations"
+
+  let assumptionReport := emitAssumptionReportJson [trustSurfaceSpec, localObligationTrustSurfaceSpec]
+  if !contains assumptionReport "\"contract\":\"TrustSurfaceSmoke\"" then
+    throw (IO.userError "✗ assumption report emits contract name")
+  if !contains assumptionReport "\"category\":\"axiomatizedPrimitive\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"keccak256\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"keccak256_memory_slice_matches_evm\"" then
+    throw (IO.userError "✗ assumption report emits primitive assumption entries")
+  if !contains assumptionReport "\"category\":\"linkedExternal\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"PoseidonT3_hash\",\"status\":\"assumed\"" then
+    throw (IO.userError "✗ assumption report emits linked external entries")
+  if !contains assumptionReport "\"category\":\"ecmModule\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"testCall\",\"status\":\"assumed\"" then
+    throw (IO.userError "✗ assumption report emits ECM module entries")
+  if !contains assumptionReport "\"category\":\"ecmAxiom\",\"siteKind\":\"function\",\"siteName\":\"exercise\",\"name\":\"test_call_interface\",\"status\":\"assumed\",\"detail\":\"\",\"assumption\":\"\",\"module\":\"testCall\"" then
+    throw (IO.userError "✗ assumption report emits ECM axiom entries")
+  if !contains assumptionReport "\"category\":\"localObligation\",\"siteKind\":\"function\",\"siteName\":\"unsafeEdge\",\"name\":\"manual_delegatecall_refinement\",\"status\":\"assumed\",\"detail\":\"Caller must separately prove the handwritten assembly path refines the intended state transition.\"" then
+    throw (IO.userError "✗ assumption report emits localized local-obligation entries")
+  if !contains assumptionReport "\"undischarged\":[{\"category\":\"localObligation\",\"siteKind\":\"function\",\"siteName\":\"unsafeEdge\",\"name\":\"manual_delegatecall_refinement\",\"status\":\"assumed\"" then
+    throw (IO.userError "✗ assumption report tracks undischarged entries separately")
+  IO.println "✓ assumption report flattens assumption-backed boundaries by usage site"
 
   let uncheckedTrustReport := emitTrustReportJson [uncheckedTrustSurfaceSpec]
   if !contains uncheckedTrustReport "\"hasUncheckedDependencies\":true" then
@@ -1425,13 +1442,23 @@ unsafe def runTests : IO Unit := do
     throw (IO.userError "✗ erc4626 deposit trust report emits assumed ECM proof-status bucket")
   IO.println "✓ erc4626 deposit trust report emits standard vault module assumption"
 
-  compileSpecsWithOptions [abiSmokeSpec] outDir false [] {} none (some trustReportPath) none
+  compileSpecsWithOptions [abiSmokeSpec] outDir false [] {} none (some trustReportPath) none none
   let writtenTrustReport ← fileExists trustReportPath
   if !writtenTrustReport then
     throw (IO.userError "✗ compileSpecsWithOptions writes trust report file")
   IO.println "✓ compileSpecsWithOptions writes trust report file"
 
-  compileSpecsWithOptions [layoutReportSpec] outDir false [] {} none none none false false false false false false false false false (some layoutReportPath)
+  let assumptionReportPath := s!"{trustReportDir}/assumption-report.json"
+  compileSpecsWithOptions [localObligationTrustSurfaceSpec] outDir false [] {} none none (some assumptionReportPath) none
+  let writtenAssumptionReport ← fileExists assumptionReportPath
+  if !writtenAssumptionReport then
+    throw (IO.userError "✗ compileSpecsWithOptions writes assumption report file")
+  expectFileContains
+    "compileSpecsWithOptions assumption report includes local obligation entries"
+    assumptionReportPath
+    ["\"contract\":\"LocalObligationTrustSurface\"", "\"category\":\"localObligation\"", "\"name\":\"manual_delegatecall_refinement\""]
+
+  compileSpecsWithOptions [layoutReportSpec] outDir false [] {} none none none none false false false false false false false false false (some layoutReportPath)
   let writtenLayoutReport ← fileExists layoutReportPath
   if !writtenLayoutReport then
     throw (IO.userError "✗ compileSpecsWithOptions writes layout report file")
@@ -1444,7 +1471,7 @@ unsafe def runTests : IO Unit := do
   expectFailureContains
     "compileSpecsWithOptions rejects low-level call/returndata mechanics when deny flag enabled"
     (compileSpecsWithOptions
-      [lowLevelOnlyTrustSurfaceSpec] outDir false [] {} none (some deniedTrustReportPath) none false false false false false false true false false)
+      [lowLevelOnlyTrustSurfaceSpec] outDir false [] {} none (some deniedTrustReportPath) none none false false false false false false true false false)
     "Low-level mechanics remain:\n- LowLevelOnlyTrustSurface [function:exerciseLowLevel]: call, staticcall, delegatecall, returndataCopy, returndataSize"
   let deniedLowLevelTrustReportWritten ← fileExists deniedTrustReportPath
   if !deniedLowLevelTrustReportWritten then
@@ -1453,7 +1480,7 @@ unsafe def runTests : IO Unit := do
 
   let denyLowLevelMemoryOutDir := s!"/tmp/compile-driver-deny-low-level-memory-ok-{nonce}"
   compileSpecsWithOptions
-    [memoryOnlyTrustSurfaceSpec] denyLowLevelMemoryOutDir false [] {} none none none false false false false false false true false false
+    [memoryOnlyTrustSurfaceSpec] denyLowLevelMemoryOutDir false [] {} none none none none false false false false false false true false false
   let denyLowLevelMemoryArtifactWritten ← fileExists s!"{denyLowLevelMemoryOutDir}/MemoryOnlyTrustSurface.yul"
   if !denyLowLevelMemoryArtifactWritten then
     throw (IO.userError "✗ compileSpecsWithOptions allows memory-only mechanics under deny-low-level gate")
@@ -1461,7 +1488,7 @@ unsafe def runTests : IO Unit := do
 
   let denyProxyUpgradeabilityOutDir := s!"/tmp/compile-driver-deny-proxy-upgradeability-ok-{nonce}"
   compileSpecsWithOptions
-    [abiSmokeSpec] denyProxyUpgradeabilityOutDir false [] {} none none none false false false false false false false false true
+    [abiSmokeSpec] denyProxyUpgradeabilityOutDir false [] {} none none none none false false false false false false false false true
   let denyProxyUpgradeabilityArtifactWritten ← fileExists s!"{denyProxyUpgradeabilityOutDir}/AbiSmoke.yul"
   if !denyProxyUpgradeabilityArtifactWritten then
     throw (IO.userError "✗ compileSpecsWithOptions allows contracts without proxy mechanics under deny-proxy gate")
@@ -1470,7 +1497,7 @@ unsafe def runTests : IO Unit := do
   expectFailureContains
     "compileSpecsWithOptions rejects undischarged local obligations when deny flag enabled"
     (compileSpecsWithOptions
-      [localObligationTrustSurfaceSpec] outDir false [] {} none (some deniedTrustReportPath) none false false false true false false false false false)
+      [localObligationTrustSurfaceSpec] outDir false [] {} none (some deniedTrustReportPath) none none false false false true false false false false false)
     "Undischarged local obligations remain:\n- LocalObligationTrustSurface [function:unsafeEdge]: assumed local obligations: manual_delegatecall_refinement"
   let deniedLocalObligationTrustReportWritten ← fileExists deniedTrustReportPath
   if !deniedLocalObligationTrustReportWritten then
@@ -1480,7 +1507,7 @@ unsafe def runTests : IO Unit := do
   expectFailureContains
     "compileSpecsWithOptions rejects unchecked dependencies when deny flag enabled"
     (compileSpecsWithOptions
-      [constructorOnlyEcmTrustSurfaceSpec] outDir false [] {} none (some deniedTrustReportPath) none true false false false false false false false false)
+      [constructorOnlyEcmTrustSurfaceSpec] outDir false [] {} none (some deniedTrustReportPath) none none true false false false false false false false false)
     "Unchecked foreign dependencies remain:\n- ConstructorOnlyEcmTrustSurface [constructor:constructor]: unchecked ECM modules: ctorHook"
   let deniedTrustReportWritten ← fileExists deniedTrustReportPath
   if !deniedTrustReportWritten then
@@ -1491,7 +1518,7 @@ unsafe def runTests : IO Unit := do
   expectFailureContains
     "compileSpecsWithOptions rejects assumed dependencies when proof-strict deny flag enabled"
     (compileSpecsWithOptions
-      [oracleTrustSurfaceSpec] outDir false [] {} none (some deniedAssumedTrustReportPath) none false true false false false false false false false)
+      [oracleTrustSurfaceSpec] outDir false [] {} none (some deniedAssumedTrustReportPath) none none false true false false false false false false false)
     "Assumed or unchecked foreign dependencies remain:\n- OracleTrustSurface [function:peek]: assumed ECM modules: oracleReadUint256"
   let deniedAssumedTrustReportWritten ← fileExists deniedAssumedTrustReportPath
   if !deniedAssumedTrustReportWritten then
@@ -1502,7 +1529,7 @@ unsafe def runTests : IO Unit := do
   expectFailureContains
     "compileSpecsWithOptions rejects axiomatized primitives when deny flag enabled"
     (compileSpecsWithOptions
-      [primitiveOnlyTrustSurfaceSpec] outDir false [] {} none (some deniedPrimitiveTrustReportPath) none false false true false false false false false false)
+      [primitiveOnlyTrustSurfaceSpec] outDir false [] {} none (some deniedPrimitiveTrustReportPath) none none false false true false false false false false false)
     "Axiomatized primitives remain:\n- PrimitiveOnlyTrustSurface [function:exercisePrimitive]: keccak256"
   let deniedPrimitiveTrustReportWritten ← fileExists deniedPrimitiveTrustReportPath
   if !deniedPrimitiveTrustReportWritten then
@@ -1513,7 +1540,7 @@ unsafe def runTests : IO Unit := do
   expectFailureContains
     "compileSpecsWithOptions rejects partially modeled linear memory when deny flag enabled"
     (compileSpecsWithOptions
-      [memoryTrustSurfaceSpec] outDir false [] {} none (some deniedLinearMemoryTrustReportPath) none false false false false true false false false false)
+      [memoryTrustSurfaceSpec] outDir false [] {} none (some deniedLinearMemoryTrustReportPath) none none false false false false true false false false false)
     "Partially modeled linear-memory mechanics remain:\n- MemoryTrustSurface [function:exerciseMemory]: mstore, calldatacopy, returndataCopy, mload"
   let deniedLinearMemoryTrustReportWritten ← fileExists deniedLinearMemoryTrustReportPath
   if !deniedLinearMemoryTrustReportWritten then
@@ -1524,7 +1551,7 @@ unsafe def runTests : IO Unit := do
   expectFailureContains
     "compileSpecsWithOptions rejects raw event emission when deny flag enabled"
     (compileSpecsWithOptions
-      [rawLogTrustSurfaceSpec] outDir false [] {} none (some deniedEventEmissionTrustReportPath) none false false false false false true false false false)
+      [rawLogTrustSurfaceSpec] outDir false [] {} none (some deniedEventEmissionTrustReportPath) none none false false false false false true false false false)
     "Not-modeled event emission remains:\n- RawLogTrustSurface [function:emitTrace]: rawLog"
   let deniedEventEmissionTrustReportWritten ← fileExists deniedEventEmissionTrustReportPath
   if !deniedEventEmissionTrustReportWritten then
@@ -1535,7 +1562,7 @@ unsafe def runTests : IO Unit := do
   expectFailureContains
     "compileSpecsWithOptions rejects partially modeled runtime introspection when deny flag enabled"
     (compileSpecsWithOptions
-      [runtimeIntrospectionTrustSurfaceSpec] outDir false [] {} none (some deniedRuntimeIntrospectionTrustReportPath) none false false false false false false false true false)
+      [runtimeIntrospectionTrustSurfaceSpec] outDir false [] {} none (some deniedRuntimeIntrospectionTrustReportPath) none none false false false false false false false true false)
     "Partially modeled runtime-introspection mechanics remain:\n- RuntimeIntrospectionTrustSurface [function:exerciseRuntime]: blockNumber, contractAddress, chainid"
   let deniedRuntimeIntrospectionTrustReportWritten ← fileExists deniedRuntimeIntrospectionTrustReportPath
   if !deniedRuntimeIntrospectionTrustReportWritten then
@@ -1546,14 +1573,14 @@ unsafe def runTests : IO Unit := do
   expectFailureContains
     "compileSpecsWithOptions rejects proxy / upgradeability mechanics when deny flag enabled"
     (compileSpecsWithOptions
-      [lowLevelOnlyTrustSurfaceSpec] outDir false [] {} none (some deniedProxyUpgradeabilityTrustReportPath) none false false false false false false false false true)
+      [lowLevelOnlyTrustSurfaceSpec] outDir false [] {} none (some deniedProxyUpgradeabilityTrustReportPath) none none false false false false false false false false true)
     "Not-modeled proxy / upgradeability mechanics remain:\n- LowLevelOnlyTrustSurface [function:exerciseLowLevel]: delegatecall"
   let deniedProxyUpgradeabilityTrustReportWritten ← fileExists deniedProxyUpgradeabilityTrustReportPath
   if !deniedProxyUpgradeabilityTrustReportWritten then
     throw (IO.userError "✗ denied proxy-upgradeability compile still writes trust report file")
   IO.println "✓ denied proxy-upgradeability compile still writes trust report file"
 
-  compileSpecsWithOptions [abiSmokeSpec] outDir false [] { patchConfig := { enabled := true } } (some patchReportPath) none none
+  compileSpecsWithOptions [abiSmokeSpec] outDir false [] { patchConfig := { enabled := true } } (some patchReportPath) none none none
   let writtenPatchReport ← fileExists patchReportPath
   if !writtenPatchReport then
     throw (IO.userError "✗ compileSpecsWithOptions writes patch report file")

--- a/Compiler/Main.lean
+++ b/Compiler/Main.lean
@@ -27,6 +27,7 @@ private structure CLIArgs where
   patchMaxIterationsExplicit : Bool := false
   patchReportPath : Option String := none
   trustReportPath : Option String := none
+  assumptionReportPath : Option String := none
   layoutReportPath : Option String := none
   denyUncheckedDependencies : Bool := false
   denyAssumedDependencies : Bool := false
@@ -91,6 +92,7 @@ private def parseArgs (args : List String) : IO CLIArgs := do
         IO.println "  --patch-max-iterations <n>  Max patch-pass fixpoint iterations (default: 2)"
         IO.println "  --patch-report <path>       Write TSV patch coverage report"
         IO.println "  --trust-report <path>       Write JSON trust-surface report"
+        IO.println "  --assumption-report <path>  Write JSON assumption inventory report"
         IO.println "  --layout-report <path>      Write JSON storage-layout report"
         IO.println "  --deny-unchecked-dependencies  Fail if any contract depends on `unchecked` foreign surfaces"
         IO.println "  --deny-assumed-dependencies    Fail if any contract depends on `assumed` or `unchecked` foreign surfaces"
@@ -188,6 +190,10 @@ private def parseArgs (args : List String) : IO CLIArgs := do
         go rest { cfg with trustReportPath := some path }
     | ["--trust-report"] =>
         throw (IO.userError "Missing value for --trust-report")
+    | "--assumption-report" :: path :: rest =>
+        go rest { cfg with assumptionReportPath := some path }
+    | ["--assumption-report"] =>
+        throw (IO.userError "Missing value for --assumption-report")
     | "--layout-report" :: path :: rest =>
         go rest { cfg with layoutReportPath := some path }
     | ["--layout-report"] =>
@@ -269,6 +275,9 @@ unsafe def main (args : List String) : IO Unit := do
       match cfg.trustReportPath with
       | some path => IO.println s!"Trust report: {path}"
       | none => pure ()
+      match cfg.assumptionReportPath with
+      | some path => IO.println s!"Assumption report: {path}"
+      | none => pure ()
       match cfg.layoutReportPath with
       | some path => IO.println s!"Layout report: {path}"
       | none => pure ()
@@ -317,7 +326,7 @@ unsafe def main (args : List String) : IO Unit := do
     }
     compileModulesWithOptions
       cfg.outDir rawModules cfg.verbose cfg.libs options cfg.patchReportPath cfg.trustReportPath
-      cfg.abiOutDir cfg.denyUncheckedDependencies cfg.denyAssumedDependencies
+      cfg.assumptionReportPath cfg.abiOutDir cfg.denyUncheckedDependencies cfg.denyAssumedDependencies
       cfg.denyAxiomatizedPrimitives cfg.denyLocalObligations cfg.denyLinearMemoryMechanics cfg.denyEventEmission
       cfg.denyLowLevelMechanics cfg.denyRuntimeIntrospection cfg.denyProxyUpgradeability cfg.layoutReportPath
   catch e =>

--- a/Compiler/MainTest.lean
+++ b/Compiler/MainTest.lean
@@ -107,14 +107,17 @@ unsafe def runTests : IO Unit := do
     ["--module", "Contracts.LocalObligationTrustSurface", "--deny-local-obligations", "--output", s!"/tmp/verity-main-test-{nonce}-local-obligation-fail-out"]
     "LocalObligationTrustSurface [function:unsafeEdge]: assumed local obligations: manual_delegatecall_refinement"
   let macroLocalObligationTrustReportPath := s!"/tmp/verity-main-test-{nonce}-macro-local-obligation-trust-report.json"
+  let macroLocalObligationAssumptionReportPath := s!"/tmp/verity-main-test-{nonce}-macro-local-obligation-assumption-report.json"
   let macroLocalObligationOutDir := s!"/tmp/verity-main-test-{nonce}-macro-local-obligation-out"
   IO.FS.createDirAll macroLocalObligationOutDir
   main
     [ "--module", "Contracts.LocalObligationMacroSmoke.LocalObligationMacroSmoke"
     , "--trust-report", macroLocalObligationTrustReportPath
+    , "--assumption-report", macroLocalObligationAssumptionReportPath
     , "--output", macroLocalObligationOutDir
     ]
   let macroLocalObligationTrustReport ← IO.FS.readFile macroLocalObligationTrustReportPath
+  let macroLocalObligationAssumptionReport ← IO.FS.readFile macroLocalObligationAssumptionReportPath
   expectTrue "macro local-obligation trust report includes constructor obligation"
     (contains macroLocalObligationTrustReport "\"name\":\"constructor_storage_layout\",\"status\":\"unchecked\"")
   expectTrue "macro local-obligation trust report includes assumed function obligation"
@@ -123,6 +126,14 @@ unsafe def runTests : IO Unit := do
     (contains macroLocalObligationTrustReport "\"name\":\"checked_patch_pack\",\"status\":\"proved\"")
   expectTrue "macro local-obligation trust report localizes constructor usage"
     (contains macroLocalObligationTrustReport "\"kind\":\"constructor\",\"name\":\"constructor\"")
+  expectTrue "macro local-obligation assumption report flattens constructor and function obligations"
+    ((contains macroLocalObligationAssumptionReport "\"category\":\"localObligation\",\"siteKind\":\"constructor\",\"siteName\":\"constructor\",\"name\":\"constructor_storage_layout\",\"status\":\"unchecked\"") &&
+      (contains macroLocalObligationAssumptionReport "\"category\":\"localObligation\",\"siteKind\":\"function\",\"siteName\":\"unsafeEdge\",\"name\":\"manual_delegatecall_refinement\",\"status\":\"assumed\"") &&
+      (contains macroLocalObligationAssumptionReport "\"category\":\"localObligation\",\"siteKind\":\"function\",\"siteName\":\"dischargedEdge\",\"name\":\"checked_patch_pack\",\"status\":\"proved\""))
+  expectTrue "macro local-obligation assumption report keeps undischarged entries separate"
+    ((contains macroLocalObligationAssumptionReport "\"undischarged\":[") &&
+      (contains macroLocalObligationAssumptionReport "\"name\":\"constructor_storage_layout\",\"status\":\"unchecked\"") &&
+      (contains macroLocalObligationAssumptionReport "\"name\":\"manual_delegatecall_refinement\",\"status\":\"assumed\""))
   expectErrorContains
     "strict local-obligation gate rejects macro-declared undischarged obligations"
     ["--module", "Contracts.LocalObligationMacroSmoke.LocalObligationMacroSmoke", "--deny-local-obligations", "--output", s!"/tmp/verity-main-test-{nonce}-macro-local-obligation-fail-out"]
@@ -221,6 +232,7 @@ unsafe def runTests : IO Unit := do
   expectTrue "selected module mode does not emit non-selected artifacts" nonSelectedArtifactsAbsent
 
   expectErrorContains "missing --patch-report value" ["--patch-report"] "Missing value for --patch-report"
+  expectErrorContains "missing --assumption-report value" ["--assumption-report"] "Missing value for --assumption-report"
   expectErrorContains "missing --layout-report value" ["--layout-report"] "Missing value for --layout-report"
   expectErrorContains "missing --patch-max-iterations value" ["--patch-max-iterations"] "Missing value for --patch-max-iterations"
   expectErrorContains "missing --backend-profile value" ["--backend-profile"] "Missing value for --backend-profile"

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -15,6 +15,7 @@ The Verity compiler transforms `CompilationModel` models into deployable EVM byt
 
 The CLI can also emit machine-readable audit artifacts alongside Yul/ABI output:
 - `--trust-report <path>` writes proof-boundary and assumption data.
+- `--assumption-report <path>` writes a flattened assumption inventory grouped by contract and usage site.
 - `--layout-report <path>` writes resolved storage-slot metadata, including effective alias writes and reserved-slot policies for upgrade/layout reviews.
 
 Important: Verity has two different "spec" concepts.
@@ -312,7 +313,7 @@ Raw `rawLog` event emission also compiles, but the current proof interpreters st
 
 The `keccak256` intrinsic also compiles, but it remains axiomatized in the current proof stack rather than fully modeled end to end. For audit-oriented or proof-strict builds, archive `--trust-report` and add `--deny-axiomatized-primitives` if the selected contracts must stay inside the proved subset (see issue `#1411`).
 
-The trust-report surface also supports localized `localObligations` on a function or constructor. Use these when a small unsafe/assembly-shaped boundary still needs a user-supplied refinement contract without turning the whole compilation unit into an opaque trust blob. For proof-strict builds, add `--deny-local-obligations` so any undischarged local obligation fails closed.
+The trust-report surface also supports localized `localObligations` on a function or constructor. Use these when a small unsafe/assembly-shaped boundary still needs a user-supplied refinement contract without turning the whole compilation unit into an opaque trust blob. For proof-strict builds, add `--deny-local-obligations` so any undischarged local obligation fails closed. When audit tooling needs a flat machine-readable list instead of the full nested trust report, archive `--assumption-report` alongside `--trust-report`.
 
 For Morpho-style `mapping(K => Struct)` / `mapping(K1 => mapping(K2 => Struct))` layouts, declare `FieldType.mappingStruct` / `FieldType.mappingStruct2` and access named members through `Expr.structMember` / `Expr.structMember2`. The `verity_contract` surface now exposes matching storage forms:
 


### PR DESCRIPTION
## Summary
- add `emitAssumptionReportJson` and `--assumption-report <path>` for a flattened machine-readable inventory of assumption-backed boundaries
- write the assumption report alongside existing trust/layout artifacts before deny-gate failures, so audit tooling can still archive the unresolved boundary set
- cover the new artifact in compile-driver and CLI regression tests, including localized `localObligations` from the `#1424` macro smoke fixture

## Why
`#1424` is about making unsafe or refinement-shaped escape hatches explicit and auditable instead of hiding them in a broad trust blob. The nested trust report already contains this data, but downstream tooling still has to scrape multiple buckets and usage-site sections to answer the basic question: “what assumptions remain, where, and in what status?”

This PR adds a flat assumption inventory for that workflow without changing the underlying trust model.

## Validation
- `lake build Compiler.CompileDriverTest Compiler.MainTest`

Refs #1424

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is an additive, opt-in reporting artifact plus wiring/tests/docs, with no changes to compilation semantics. Main risk is minor API/CLI integration regressions due to the new `compileSpecsWithOptions`/`compileModulesWithOptions` parameter and file output path handling.
> 
> **Overview**
> Adds `emitAssumptionReportJson` to produce a **flat, machine-readable assumption inventory** per contract/usage-site (including an explicit `undischarged` subset) covering axiomatized primitives, linked externals, ECM modules/axioms, and local obligations.
> 
> Wires this report through the compiler driver and CLI via `--assumption-report <path>`, writing it alongside existing trust/layout artifacts (and before deny-gate failures), and updates regression tests/docs to validate the new output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8957009baf05fc4fdf78396f9b4e62492b2bdef1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->