### PR TITLE
math: prove mulDiv monotonicity lemmas

### DIFF
--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -552,8 +552,12 @@ import Compiler.Proofs.YulGeneration.Equivalence
 -- #print axioms Verity.Proofs.Stdlib.Math.lt_modulus_of_le_max  -- private
 #print axioms Verity.Proofs.Stdlib.Math.mulDivDown_nat_eq
 #print axioms Verity.Proofs.Stdlib.Math.mulDivDown_mul_le
+#print axioms Verity.Proofs.Stdlib.Math.mulDivDown_monotone_left
+#print axioms Verity.Proofs.Stdlib.Math.mulDivDown_monotone_right
 #print axioms Verity.Proofs.Stdlib.Math.mulDivUp_nat_eq
 #print axioms Verity.Proofs.Stdlib.Math.mulDivDown_le_mulDivUp
+#print axioms Verity.Proofs.Stdlib.Math.mulDivUp_monotone_left
+#print axioms Verity.Proofs.Stdlib.Math.mulDivUp_monotone_right
 #print axioms Verity.Proofs.Stdlib.Math.wMulDown_nat_eq
 #print axioms Verity.Proofs.Stdlib.Math.wDivUp_nat_eq
 #print axioms Verity.Proofs.Stdlib.Math.safeAdd_some
@@ -727,4 +731,4 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy
--- Total: 617 theorems/lemmas (565 public, 52 private)
+-- Total: 621 theorems/lemmas (569 public, 52 private)

--- a/Verity/Proofs/Stdlib/Math.lean
+++ b/Verity/Proofs/Stdlib/Math.lean
@@ -59,6 +59,34 @@ theorem mulDivDown_mul_le (a b c : Uint256) (hMul : (a : Nat) * (b : Nat) ≤ MA
     simp [hZero]
     exact Nat.div_mul_le_self _ _
 
+/-- `mulDivDown` is monotone in its left numerator operand when the product stays exact. -/
+theorem mulDivDown_monotone_left (a₁ a₂ b c : Uint256)
+    (hA : (a₁ : Nat) ≤ (a₂ : Nat))
+    (hMul : (a₂ : Nat) * (b : Nat) ≤ MAX_UINT256) :
+    (mulDivDown a₁ b c : Nat) ≤ (mulDivDown a₂ b c : Nat) := by
+  have hMul₁ : (a₁ : Nat) * (b : Nat) ≤ MAX_UINT256 := by
+    exact Nat.le_trans (Nat.mul_le_mul_right _ hA) hMul
+  by_cases hZero : (c : Nat) = 0
+  · rw [mulDivDown_nat_eq a₁ b c hMul₁, mulDivDown_nat_eq a₂ b c hMul]
+    simp [hZero]
+  · rw [mulDivDown_nat_eq a₁ b c hMul₁, mulDivDown_nat_eq a₂ b c hMul]
+    simp [hZero]
+    exact Nat.div_le_div_right (Nat.mul_le_mul_right _ hA)
+
+/-- `mulDivDown` is monotone in its right numerator operand when the product stays exact. -/
+theorem mulDivDown_monotone_right (a b₁ b₂ c : Uint256)
+    (hB : (b₁ : Nat) ≤ (b₂ : Nat))
+    (hMul : (a : Nat) * (b₂ : Nat) ≤ MAX_UINT256) :
+    (mulDivDown a b₁ c : Nat) ≤ (mulDivDown a b₂ c : Nat) := by
+  have hMul₁ : (a : Nat) * (b₁ : Nat) ≤ MAX_UINT256 := by
+    exact Nat.le_trans (Nat.mul_le_mul_left _ hB) hMul
+  by_cases hZero : (c : Nat) = 0
+  · rw [mulDivDown_nat_eq a b₁ c hMul₁, mulDivDown_nat_eq a b₂ c hMul]
+    simp [hZero]
+  · rw [mulDivDown_nat_eq a b₁ c hMul₁, mulDivDown_nat_eq a b₂ c hMul]
+    simp [hZero]
+    exact Nat.div_le_div_right (Nat.mul_le_mul_left _ hB)
+
 /-- `mulDivUp` agrees with exact ceil-division when the widened numerator does not wrap. -/
 theorem mulDivUp_nat_eq (a b c : Uint256)
     (hC : c ≠ 0)
@@ -114,6 +142,28 @@ theorem mulDivDown_le_mulDivUp (a b c : Uint256)
   simp [hCVal]
   apply Nat.div_le_div_right
   exact Nat.le_add_right _ _
+
+/-- `mulDivUp` is monotone in its left numerator operand when the widened numerator stays exact. -/
+theorem mulDivUp_monotone_left (a₁ a₂ b c : Uint256)
+    (hA : (a₁ : Nat) ≤ (a₂ : Nat))
+    (hC : c ≠ 0)
+    (hNum : (a₂ : Nat) * (b : Nat) + ((c : Nat) - 1) ≤ MAX_UINT256) :
+    (mulDivUp a₁ b c : Nat) ≤ (mulDivUp a₂ b c : Nat) := by
+  have hNum₁ : (a₁ : Nat) * (b : Nat) + ((c : Nat) - 1) ≤ MAX_UINT256 := by
+    exact Nat.le_trans (Nat.add_le_add_right (Nat.mul_le_mul_right _ hA) _) hNum
+  rw [mulDivUp_nat_eq a₁ b c hC hNum₁, mulDivUp_nat_eq a₂ b c hC hNum]
+  exact Nat.div_le_div_right (Nat.add_le_add_right (Nat.mul_le_mul_right _ hA) _)
+
+/-- `mulDivUp` is monotone in its right numerator operand when the widened numerator stays exact. -/
+theorem mulDivUp_monotone_right (a b₁ b₂ c : Uint256)
+    (hB : (b₁ : Nat) ≤ (b₂ : Nat))
+    (hC : c ≠ 0)
+    (hNum : (a : Nat) * (b₂ : Nat) + ((c : Nat) - 1) ≤ MAX_UINT256) :
+    (mulDivUp a b₁ c : Nat) ≤ (mulDivUp a b₂ c : Nat) := by
+  have hNum₁ : (a : Nat) * (b₁ : Nat) + ((c : Nat) - 1) ≤ MAX_UINT256 := by
+    exact Nat.le_trans (Nat.add_le_add_right (Nat.mul_le_mul_left _ hB) _) hNum
+  rw [mulDivUp_nat_eq a b₁ c hC hNum₁, mulDivUp_nat_eq a b₂ c hC hNum]
+  exact Nat.div_le_div_right (Nat.add_le_add_right (Nat.mul_le_mul_left _ hB) _)
 
 /-- `wMulDown` is `mulDivDown` specialized to the canonical wad scale. -/
 theorem wMulDown_nat_eq (a b : Uint256)

--- a/docs/ARITHMETIC_PROFILE.md
+++ b/docs/ARITHMETIC_PROFILE.md
@@ -58,7 +58,7 @@ Checked operations are **EDSL-level constructs**. They are not compiler-enforced
 
 **Correctness proofs**: `Verity/Proofs/Stdlib/Math.lean` proves that checked operations return the correct result within bounds and `none` otherwise (e.g., `safeAdd_some`, `safeAdd_none`).
 
-`Stdlib.Math` also exposes fixed-point helpers `mulDivDown`, `mulDivUp`, `wMulDown`, and `wDivUp`. Their proof surface is intentionally preconditioned rather than total: the new lemmas in `Verity/Proofs/Stdlib/Math.lean` prove exact floor/ceil behavior only when the relevant widened numerator stays within `MAX_UINT256`, which is the shape future AMM/share-accounting proofs need.
+`Stdlib.Math` also exposes fixed-point helpers `mulDivDown`, `mulDivUp`, `wMulDown`, and `wDivUp`. Their proof surface is intentionally preconditioned rather than total: the lemmas in `Verity/Proofs/Stdlib/Math.lean` prove exact floor/ceil behavior only when the relevant widened numerator stays within `MAX_UINT256`, and now also include numerator-monotonicity facts (`mulDivDown_monotone_left/right`, `mulDivUp_monotone_left/right`) that are useful for AMM reserve/share proofs.
 
 **Example**: See `Contracts/SafeCounter/SafeCounter.lean` and `Contracts/SafeCounter/Proofs/Basic.lean` for a contract using checked arithmetic with proven overflow/underflow behavior.
 


### PR DESCRIPTION
## Summary
- add monotonicity lemmas for `mulDivDown` and `mulDivUp` in `Verity.Proofs.Stdlib.Math`
- refresh `PrintAxioms.lean` so the new theorem surface stays in sync
- document the new fixed-point proof surface in the arithmetic profile

## Why
The open AMM issue still needs more arithmetic infrastructure before reserve/share proofs are practical. `#1515` established exact floor/ceil semantics under non-wrapping preconditions; this follow-up adds the numerator-order lemmas that those proofs typically need next.

## Testing
- `lake build Verity.Proofs.Stdlib.Math`

Partially addresses #1162.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: proof-only changes that add lemmas and update generated/documentation artifacts without modifying runtime arithmetic semantics.
> 
> **Overview**
> Extends `Verity/Proofs/Stdlib/Math.lean` with four new theorems showing numerator monotonicity for fixed-point helpers under the existing non-wrapping preconditions: `mulDivDown_monotone_left/right` and `mulDivUp_monotone_left/right`.
> 
> Refreshes `PrintAxioms.lean` to include the new theorems in the exported proof surface (total count updated), and updates `docs/ARITHMETIC_PROFILE.md` to document the added monotonicity facts alongside the existing `mulDiv*` exactness lemmas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 866fa5048d82db72ee9df99629d8a80ac58565a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->