### PR TITLE
ci: keep docs workflow self-triggering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/docs.yml'
       - 'docs-site/**'
   pull_request:
     paths:
+      - '.github/workflows/docs.yml'
       - 'docs-site/**'
   workflow_dispatch:
 

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ check: ## Run local CI-equivalent checks job (no Lean build, no solc)
 	python3 scripts/check_solc_pin.py
 	python3 scripts/check_property_manifest_sync.py
 	python3 scripts/check_issue_templates.py
+	python3 scripts/check_docs_workflow_sync.py
 	python3 scripts/check_macro_health.py
 	python3 scripts/check_storage_layout.py
 	python3 scripts/check_lean_hygiene.py

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,4 +22,5 @@ make test-foundry
 
 - Verify workflow sync contract: `scripts/verify_sync_spec.json`
 - Unified verify workflow validator: `scripts/check_verify_sync.py`
+- Docs workflow trigger contract: `scripts/check_docs_workflow_sync.py`
 - Verification metrics: `artifacts/verification_status.json`

--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -6,6 +6,7 @@ This document is the long-form reference for script responsibilities.
 
 - `check_verify_sync.py`: unified table-driven validator for workflow invariants.
 - `verify_sync_spec.json`: expected job order, command lists, path filters, foundry settings, and artifact producers.
+- `check_docs_workflow_sync.py`: keep the docs workflow self-triggering and aligned across push/pull_request path filters.
 
 ## Issue #1060 automation
 

--- a/scripts/check_docs_workflow_sync.py
+++ b/scripts/check_docs_workflow_sync.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Validate docs workflow trigger paths."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from property_utils import ROOT
+
+DOCS_WORKFLOW = ROOT / ".github" / "workflows" / "docs.yml"
+EXPECTED_PATHS = [
+    ".github/workflows/docs.yml",
+    "docs-site/**",
+]
+
+
+def _normalize_path(raw: str) -> str:
+    value = raw.strip()
+    if value.startswith("- "):
+        value = value[2:].strip()
+    if (value.startswith("'") and value.endswith("'")) or (
+        value.startswith('"') and value.endswith('"')
+    ):
+        value = value[1:-1]
+    return value
+
+
+def _extract_list_block(text: str, pattern: str, label: str, workflow_path: Path) -> list[str]:
+    match = re.search(pattern, text, re.MULTILINE)
+    if not match:
+        raise ValueError(f"Could not locate {label} in {workflow_path}")
+    block = match.group("block")
+    entries = [_normalize_path(line) for line in block.splitlines() if line.strip()]
+    if not entries:
+        raise ValueError(f"{label} is empty in {workflow_path}")
+    return entries
+
+
+def _extract_push_paths(text: str, workflow_path: Path) -> list[str]:
+    return _extract_list_block(
+        text,
+        r"^  push:\n(?:^    .*\n)*?^    paths:\n(?P<block>(?:^      - .*\n)+)",
+        "on.push.paths",
+        workflow_path,
+    )
+
+
+def _extract_pr_paths(text: str, workflow_path: Path) -> list[str]:
+    return _extract_list_block(
+        text,
+        r"^  pull_request:\n(?:^    .*\n)*?^    paths:\n(?P<block>(?:^      - .*\n)+)",
+        "on.pull_request.paths",
+        workflow_path,
+    )
+
+
+def _compare_lists(name_a: str, a: list[str], name_b: str, b: list[str]) -> list[str]:
+    if a == b:
+        return []
+    errors = [f"{name_a} does not match {name_b}."]
+    max_len = max(len(a), len(b))
+    for i in range(max_len):
+        va = a[i] if i < len(a) else "<missing>"
+        vb = b[i] if i < len(b) else "<missing>"
+        if va != vb:
+            errors.append(f"  idx {i}: {name_a}={va!r}, {name_b}={vb!r}")
+    return errors
+
+
+def check_docs_workflow_sync(workflow_path: Path = DOCS_WORKFLOW) -> int:
+    text = workflow_path.read_text(encoding="utf-8")
+    push_paths = _extract_push_paths(text, workflow_path)
+    pr_paths = _extract_pr_paths(text, workflow_path)
+
+    errors: list[str] = []
+    errors.extend(_compare_lists("on.push.paths", push_paths, "expected paths", EXPECTED_PATHS))
+    errors.extend(_compare_lists("on.pull_request.paths", pr_paths, "expected paths", EXPECTED_PATHS))
+    errors.extend(_compare_lists("on.push.paths", push_paths, "on.pull_request.paths", pr_paths))
+
+    if errors:
+        print("docs workflow sync failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  {error}", file=sys.stderr)
+        return 1
+
+    print(f"docs workflow paths OK ({workflow_path})")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workflow",
+        default=str(DOCS_WORKFLOW.relative_to(ROOT)),
+        help="Path to docs workflow relative to repo root (default: .github/workflows/docs.yml).",
+    )
+    args = parser.parse_args()
+    return check_docs_workflow_sync(ROOT / args.workflow)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_docs_workflow_sync.py
+++ b/scripts/test_check_docs_workflow_sync.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import textwrap
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_docs_workflow_sync as check
+
+
+class CheckDocsWorkflowSyncTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent)
+        self.root = Path(self.tempdir.name)
+        self.workflow = self.root / ".github" / "workflows" / "docs.yml"
+        self.workflow.parent.mkdir(parents=True, exist_ok=True)
+
+        self.old_root = check.ROOT
+        self.old_workflow = check.DOCS_WORKFLOW
+        check.ROOT = self.root
+        check.DOCS_WORKFLOW = self.workflow
+
+    def tearDown(self) -> None:
+        check.ROOT = self.old_root
+        check.DOCS_WORKFLOW = self.old_workflow
+        self.tempdir.cleanup()
+
+    def _write_workflow(self, text: str) -> None:
+        self.workflow.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+
+    def test_check_passes_for_expected_paths(self) -> None:
+        self._write_workflow(
+            """
+            name: Docs
+            on:
+              push:
+                branches: [main]
+                paths:
+                  - '.github/workflows/docs.yml'
+                  - 'docs-site/**'
+              pull_request:
+                paths:
+                  - '.github/workflows/docs.yml'
+                  - 'docs-site/**'
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: npm run build
+            """
+        )
+
+        self.assertEqual(check.check_docs_workflow_sync(self.workflow), 0)
+
+    def test_check_fails_when_workflow_file_is_missing_from_push_paths(self) -> None:
+        self._write_workflow(
+            """
+            name: Docs
+            on:
+              push:
+                branches: [main]
+                paths:
+                  - 'docs-site/**'
+              pull_request:
+                paths:
+                  - '.github/workflows/docs.yml'
+                  - 'docs-site/**'
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: npm run build
+            """
+        )
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            rc = check.check_docs_workflow_sync(self.workflow)
+
+        self.assertEqual(rc, 1)
+        self.assertIn("on.push.paths does not match expected paths.", stderr.getvalue())
+
+    def test_main_fails_when_push_and_pull_request_paths_diverge(self) -> None:
+        self._write_workflow(
+            """
+            name: Docs
+            on:
+              push:
+                branches: [main]
+                paths:
+                  - '.github/workflows/docs.yml'
+                  - 'docs-site/**'
+              pull_request:
+                paths:
+                  - 'docs-site/**'
+                  - '.github/workflows/docs.yml'
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - run: npm run build
+            """
+        )
+
+        old_argv = sys.argv
+        sys.argv = ["check_docs_workflow_sync.py"]
+        try:
+            stderr = io.StringIO()
+            stdout = io.StringIO()
+            with redirect_stderr(stderr), redirect_stdout(stdout):
+                rc = check.main()
+        finally:
+            sys.argv = old_argv
+
+        self.assertEqual(rc, 1)
+        self.assertIn("on.push.paths does not match on.pull_request.paths.", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `.github/workflows/docs.yml` to the docs workflow path filters so docs CI runs when its own workflow changes
- add `scripts/check_docs_workflow_sync.py` plus unit coverage to keep push/pull_request path filters aligned and self-triggering
- run the new guard from `make check` and document it in the scripts references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it alters when the `Docs` GitHub Actions workflow runs and adds a guard script, so the main risk is unexpected extra/insufficient docs CI triggers if the path parsing assumptions drift.
> 
> **Overview**
> Ensures the `Docs` GitHub Actions workflow is **self-triggering** by adding `.github/workflows/docs.yml` to the `on.push.paths` and `on.pull_request.paths` filters.
> 
> Adds `scripts/check_docs_workflow_sync.py` (with unit tests) and wires it into `make check` to enforce that docs workflow path filters match an expected list and stay identical between `push` and `pull_request`, and documents the new contract in the scripts references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13fd013c3cef84023a2a1d76200fd497c86c11f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->