### PR TITLE
ci: trigger verify on issue intake workflow edits

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/ISSUE_TEMPLATE/**'
+      - '.github/workflows/issue-intake-guard.yml'
       - '.github/workflows/verify.yml'
       - 'Verity/**'
       - 'Verity.lean'
@@ -31,6 +32,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/ISSUE_TEMPLATE/**'
+      - '.github/workflows/issue-intake-guard.yml'
       - '.github/workflows/verify.yml'
       - 'Verity/**'
       - 'Verity.lean'

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -155,6 +155,45 @@ class VerifySyncTests(unittest.TestCase):
             err,
         )
 
+    def test_paths_check_fails_when_issue_intake_workflow_is_missing_from_filters(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            on:
+              push:
+                paths:
+                  - '.github/workflows/verify.yml'
+                  - 'scripts/**'
+              pull_request:
+                paths:
+                  - '.github/workflows/verify.yml'
+                  - 'scripts/**'
+            jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: dorny/paths-filter@v3
+                    with:
+                      filters: |
+                        code:
+                          - '.github/workflows/verify.yml'
+                          - 'scripts/**'
+                        compiler:
+                          - '.github/workflows/verify.yml'
+                          - 'scripts/**'
+            """
+        )
+        rc, _, err = self._run_paths_check(
+            workflow,
+            check_only_paths=[".github/workflows/issue-intake-guard.yml"],
+            compiler_paths=[".github/workflows/verify.yml", "scripts/**"],
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "check_only_paths includes entries missing from on.push.paths: .github/workflows/issue-intake-guard.yml",
+            err,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -1,5 +1,6 @@
 {
   "check_only_paths": [
+    ".github/workflows/issue-intake-guard.yml",
     ".github/ISSUE_TEMPLATE/**",
     "docs/**",
     "docs-site/**",


### PR DESCRIPTION
## Summary
- trigger `Verify proofs` on `.github/workflows/issue-intake-guard.yml` edits
- keep `changes` filters treating that workflow as `check_only` so heavy Lean/compiler jobs stay skipped
- add a regression test covering the missing-trigger case

## Why
`make check` already exercises the issue-intake validation scripts, but edits to the issue-intake workflow itself currently do not trigger any PR CI. That leaves a blind spot where the workflow can drift without the repo's existing checks running.

## Validation
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that expands `Verify proofs` triggers; main risk is unintended CI runs/skips if path filters are misconfigured.
> 
> **Overview**
> `Verify proofs` now triggers on edits to `.github/workflows/issue-intake-guard.yml` for both `push` and `pull_request`, closing a gap where that workflow could change without any PR CI.
> 
> The verify-sync contract is updated to treat this workflow as *check-only* via `verify_sync_spec.json`, and a new unit test ensures the sync checker fails if the path isn’t included in the workflow trigger paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5003a6d18bcfb40761e81e3584f9b0ba69e35ca1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->