### PR TITLE
ci: verify docs workflow changes

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/ISSUE_TEMPLATE/**'
+      - '.github/workflows/docs.yml'
       - '.github/workflows/issue-intake-guard.yml'
       - '.github/workflows/verify.yml'
       - 'Verity/**'
@@ -32,6 +33,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/ISSUE_TEMPLATE/**'
+      - '.github/workflows/docs.yml'
       - '.github/workflows/issue-intake-guard.yml'
       - '.github/workflows/verify.yml'
       - 'Verity/**'

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -194,6 +194,44 @@ class VerifySyncTests(unittest.TestCase):
             err,
         )
 
+    def test_paths_check_fails_when_docs_workflow_is_missing_from_triggers(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            on:
+              push:
+                paths:
+                  - '.github/workflows/verify.yml'
+                  - 'docs-site/**'
+              pull_request:
+                paths:
+                  - '.github/workflows/verify.yml'
+                  - 'docs-site/**'
+            jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: dorny/paths-filter@v3
+                    with:
+                      filters: |
+                        code:
+                          - '.github/workflows/verify.yml'
+                          - 'docs-site/**'
+                        compiler:
+                          - '.github/workflows/verify.yml'
+            """
+        )
+        rc, _, err = self._run_paths_check(
+            workflow,
+            check_only_paths=[".github/workflows/docs.yml", "docs-site/**"],
+            compiler_paths=[".github/workflows/verify.yml"],
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "check_only_paths includes entries missing from on.push.paths: .github/workflows/docs.yml",
+            err,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -1,5 +1,6 @@
 {
   "check_only_paths": [
+    ".github/workflows/docs.yml",
     ".github/workflows/issue-intake-guard.yml",
     ".github/ISSUE_TEMPLATE/**",
     "docs/**",


### PR DESCRIPTION
## Summary
- trigger `Verify proofs` when `.github/workflows/docs.yml` changes
- extend the verify sync contract so docs-workflow-only PRs still run `make check`
- add a regression test covering the missing docs workflow trigger path

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that broadens `Verify proofs` triggers; main impact is potentially running `make check` more often when `.github/workflows/docs.yml` changes.
> 
> **Overview**
> Updates the `Verify proofs` GitHub Actions workflow to also trigger when `.github/workflows/docs.yml` changes, ensuring docs-workflow-only PRs still run the `checks` (`make check`) job.
> 
> Extends the verify-sync contract (`verify_sync_spec.json`) to treat the docs workflow as `check_only_paths`, and adds a regression test to fail if that path is omitted from the workflow triggers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccc708dd8089b902f6923ec92e5b7653e7b444d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->