### PR TITLE
ci: trigger verify on any workflow edits

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,8 +6,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/docs.yml'
-      - '.github/workflows/issue-intake-guard.yml'
+      - '.github/workflows/**'
       - '.github/workflows/verify.yml'
       - 'artifacts/**'
       - 'Verity/**'
@@ -34,8 +33,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/docs.yml'
-      - '.github/workflows/issue-intake-guard.yml'
+      - '.github/workflows/**'
       - '.github/workflows/verify.yml'
       - 'artifacts/**'
       - 'Verity/**'

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -155,7 +155,7 @@ class VerifySyncTests(unittest.TestCase):
             err,
         )
 
-    def test_paths_check_fails_when_issue_intake_workflow_is_missing_from_filters(self) -> None:
+    def test_paths_check_fails_when_workflow_glob_is_missing_from_triggers(self) -> None:
         workflow = textwrap.dedent(
             """
             name: verify
@@ -185,50 +185,12 @@ class VerifySyncTests(unittest.TestCase):
         )
         rc, _, err = self._run_paths_check(
             workflow,
-            check_only_paths=[".github/workflows/issue-intake-guard.yml"],
+            check_only_paths=[".github/workflows/**"],
             compiler_paths=[".github/workflows/verify.yml", "scripts/**"],
         )
         self.assertEqual(rc, 1)
         self.assertIn(
-            "check_only_paths includes entries missing from on.push.paths: .github/workflows/issue-intake-guard.yml",
-            err,
-        )
-
-    def test_paths_check_fails_when_docs_workflow_is_missing_from_triggers(self) -> None:
-        workflow = textwrap.dedent(
-            """
-            name: verify
-            on:
-              push:
-                paths:
-                  - '.github/workflows/verify.yml'
-                  - 'docs-site/**'
-              pull_request:
-                paths:
-                  - '.github/workflows/verify.yml'
-                  - 'docs-site/**'
-            jobs:
-              changes:
-                runs-on: ubuntu-latest
-                steps:
-                  - uses: dorny/paths-filter@v3
-                    with:
-                      filters: |
-                        code:
-                          - '.github/workflows/verify.yml'
-                          - 'docs-site/**'
-                        compiler:
-                          - '.github/workflows/verify.yml'
-            """
-        )
-        rc, _, err = self._run_paths_check(
-            workflow,
-            check_only_paths=[".github/workflows/docs.yml", "docs-site/**"],
-            compiler_paths=[".github/workflows/verify.yml"],
-        )
-        self.assertEqual(rc, 1)
-        self.assertIn(
-            "check_only_paths includes entries missing from on.push.paths: .github/workflows/docs.yml",
+            "check_only_paths includes entries missing from on.push.paths: .github/workflows/**",
             err,
         )
 

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -1,7 +1,6 @@
 {
   "check_only_paths": [
-    ".github/workflows/docs.yml",
-    ".github/workflows/issue-intake-guard.yml",
+    ".github/workflows/**",
     ".github/ISSUE_TEMPLATE/**",
     "artifacts/**",
     "docs/**",


### PR DESCRIPTION
## Summary
- trigger `Verify proofs` on any `.github/workflows/**` change instead of enumerating workflow files one by one
- keep `.github/workflows/verify.yml` in the build-trigger set so verify-workflow edits still exercise the heavy jobs
- simplify the sync spec and regression test to guard the generic workflow glob

## Why
We have already fixed multiple PR-CI blind spots caused by newly added workflow files not being added to `verify.yml` path filters. This change removes that maintenance trap and makes future workflow additions automatically covered by required verify CI.

## Validation
- `python3 scripts/check_verify_sync.py`
- `python3 -m unittest scripts.test_check_verify_sync -v`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI path filters and their sync-spec/tests; main risk is unintended extra or missed CI runs due to broader `.github/workflows/**` matching.
> 
> **Overview**
> Ensures `Verify proofs` runs when *any* GitHub workflow file changes by replacing individually listed workflow paths with a single `.github/workflows/**` glob in `verify.yml` push/PR triggers.
> 
> Updates the verify-workflow sync contract (`verify_sync_spec.json`) and its regression test to validate the new glob-based trigger requirement, removing the now-redundant per-workflow missing-trigger test cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b95ea9aaf87d4810b666205076460223ab36cb13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->