### PR TITLE
ci: verify all workflow edits

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,8 +6,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/docs.yml'
-      - '.github/workflows/issue-intake-guard.yml'
+      - '.github/workflows/**'
       - '.github/workflows/verify.yml'
       - 'artifacts/**'
       - 'Verity/**'
@@ -34,8 +33,7 @@ on:
     paths:
       - '.github/actions/**'
       - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/docs.yml'
-      - '.github/workflows/issue-intake-guard.yml'
+      - '.github/workflows/**'
       - '.github/workflows/verify.yml'
       - 'artifacts/**'
       - 'Verity/**'

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -271,6 +271,44 @@ class VerifySyncTests(unittest.TestCase):
             err,
         )
 
+    def test_paths_check_passes_with_workflow_wildcard_and_explicit_verify_filters(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            on:
+              push:
+                paths:
+                  - '.github/workflows/**'
+                  - '.github/workflows/verify.yml'
+                  - 'scripts/**'
+              pull_request:
+                paths:
+                  - '.github/workflows/**'
+                  - '.github/workflows/verify.yml'
+                  - 'scripts/**'
+            jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: dorny/paths-filter@v3
+                    with:
+                      filters: |
+                        code:
+                          - '.github/workflows/verify.yml'
+                          - 'scripts/**'
+                        compiler:
+                          - '.github/workflows/verify.yml'
+                          - 'scripts/**'
+            """
+        )
+        rc, out, err = self._run_paths_check(
+            workflow,
+            check_only_paths=[".github/workflows/**"],
+            compiler_paths=[".github/workflows/verify.yml", "scripts/**"],
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertIn("[PASS] paths", out)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -1,7 +1,6 @@
 {
   "check_only_paths": [
-    ".github/workflows/docs.yml",
-    ".github/workflows/issue-intake-guard.yml",
+    ".github/workflows/**",
     ".github/ISSUE_TEMPLATE/**",
     "artifacts/**",
     "docs/**",


### PR DESCRIPTION
## Summary
- trigger `Verify proofs` for any `.github/workflows/**` edit instead of maintaining per-file workflow path entries
- keep `.github/workflows/verify.yml` explicit in the heavy-job filters so only verify-workflow edits fan out into build jobs
- add a regression test covering the wildcard-trigger plus explicit-verify-filter contract

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI trigger/path-filter contracts for the `Verify proofs` workflow, which could cause the heavy jobs to run more often or not run when expected if path patterns are wrong. No production code is affected.
> 
> **Overview**
> **`Verify proofs` now triggers on any `.github/workflows/**` edit** (and on `artifacts/**` changes), replacing the previous per-workflow allowlist in the `on.push`/`on.pull_request` path filters.
> 
> Updates the verify-sync spec to match the new wildcard workflow trigger, and extends `scripts/test_check_verify_sync.py` with regression tests that (1) require `artifacts/**` to be included in triggers and (2) ensure wildcard workflow triggers still work while keeping `dorny/paths-filter` heavy-job filters explicit to `verify.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d2504a2b5adbcaefed20529bc030e58d0d4bfd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->