### PR TITLE
ci: pin make check unit tests

### DIFF
--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -356,6 +356,29 @@ class VerifySyncTests(unittest.TestCase):
         self.assertEqual(rc, 0, err)
         self.assertIn("[PASS] paths", out)
 
+    def test_makefile_check_fails_when_required_unit_test_command_is_missing(self) -> None:
+        rc, _, err = self._run_makefile_check(
+            """
+            check:
+            	python3 scripts/check_verify_sync.py
+            	python3 scripts/check_issue_templates.py
+            	python3 scripts/check_docs_workflow_sync.py
+            """,
+            expected_checks_commands=["make check"],
+            required_makefile_check_commands=[
+                "python3 scripts/check_verify_sync.py",
+                "python3 scripts/check_issue_templates.py",
+                "python3 scripts/check_docs_workflow_sync.py",
+                "python3 -m unittest discover -s scripts -p 'test_*.py' -v",
+            ],
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "Makefile check target is missing required commands: "
+            "python3 -m unittest discover -s scripts -p 'test_*.py' -v",
+            err,
+        )
+
     def test_makefile_check_passes_when_required_commands_are_present(self) -> None:
         makefile = """
         check:

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -45,7 +45,8 @@
   "required_makefile_check_commands": [
     "python3 scripts/check_verify_sync.py",
     "python3 scripts/check_issue_templates.py",
-    "python3 scripts/check_docs_workflow_sync.py"
+    "python3 scripts/check_docs_workflow_sync.py",
+    "python3 -m unittest discover -s scripts -p 'test_*.py' -v"
   ],
   "expected_checks_other_commands": [],
   "expected_build_commands": [


### PR DESCRIPTION
## Summary
- require `make check` to keep running the Python unit test suite
- extend verify sync regression coverage for a missing unittest invocation

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only tighten CI/verify sync enforcement around the Makefile `check` target and add regression tests; no production code paths are affected.
> 
> **Overview**
> Updates the verify-sync spec to **require `make check` to include running the scripts unit test suite** (`python3 -m unittest discover -s scripts -p 'test_*.py' -v`).
> 
> Extends `scripts/test_check_verify_sync.py` with a regression test that fails when the Makefile `check` target omits this unittest invocation, ensuring `check_verify_sync.py --only makefile` enforces it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2d0da392951b1558d3c81db6de7e784656614e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->