### PR TITLE
ci: pin docs and solc check guards

### DIFF
--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -360,15 +360,21 @@ class VerifySyncTests(unittest.TestCase):
         rc, _, err = self._run_makefile_check(
             """
             check:
+            	python3 scripts/generate_verification_status.py --check
+            	python3 scripts/check_verification_status_doc.py
             	python3 scripts/check_verify_sync.py
             	python3 scripts/check_issue_templates.py
             	python3 scripts/check_docs_workflow_sync.py
+            	python3 scripts/check_solc_pin.py
             """,
             expected_checks_commands=["make check"],
             required_makefile_check_commands=[
+                "python3 scripts/generate_verification_status.py --check",
+                "python3 scripts/check_verification_status_doc.py",
                 "python3 scripts/check_verify_sync.py",
                 "python3 scripts/check_issue_templates.py",
                 "python3 scripts/check_docs_workflow_sync.py",
+                "python3 scripts/check_solc_pin.py",
                 "python3 -m unittest discover -s scripts -p 'test_*.py' -v",
             ],
         )
@@ -382,41 +388,53 @@ class VerifySyncTests(unittest.TestCase):
     def test_makefile_check_passes_when_required_commands_are_present(self) -> None:
         makefile = """
         check:
+        \tpython3 scripts/generate_verification_status.py --check
+        \tpython3 scripts/check_verification_status_doc.py
         \tpython3 scripts/check_verify_sync.py
         \tpython3 scripts/check_issue_templates.py
         \tpython3 scripts/check_docs_workflow_sync.py
+        \tpython3 scripts/check_solc_pin.py
         \tpython3 -m unittest discover -s scripts -p 'test_*.py' -v
         """
         rc, out, err = self._run_makefile_check(
             makefile,
             expected_checks_commands=["make check"],
             required_makefile_check_commands=[
+                "python3 scripts/generate_verification_status.py --check",
+                "python3 scripts/check_verification_status_doc.py",
                 "python3 scripts/check_verify_sync.py",
                 "python3 scripts/check_issue_templates.py",
                 "python3 scripts/check_docs_workflow_sync.py",
+                "python3 scripts/check_solc_pin.py",
             ],
         )
         self.assertEqual(rc, 0, err)
         self.assertIn("[PASS] makefile", out)
 
-    def test_makefile_check_fails_when_required_command_is_missing(self) -> None:
+    def test_makefile_check_fails_when_required_solc_pin_command_is_missing(self) -> None:
         makefile = """
         check:
+        \tpython3 scripts/generate_verification_status.py --check
+        \tpython3 scripts/check_verification_status_doc.py
         \tpython3 scripts/check_verify_sync.py
         \tpython3 scripts/check_issue_templates.py
+        \tpython3 scripts/check_docs_workflow_sync.py
         """
         rc, _, err = self._run_makefile_check(
             makefile,
             expected_checks_commands=["make check"],
             required_makefile_check_commands=[
+                "python3 scripts/generate_verification_status.py --check",
+                "python3 scripts/check_verification_status_doc.py",
                 "python3 scripts/check_verify_sync.py",
                 "python3 scripts/check_issue_templates.py",
                 "python3 scripts/check_docs_workflow_sync.py",
+                "python3 scripts/check_solc_pin.py",
             ],
         )
         self.assertEqual(rc, 1)
         self.assertIn(
-            "Makefile check target is missing required commands: python3 scripts/check_docs_workflow_sync.py",
+            "Makefile check target is missing required commands: python3 scripts/check_solc_pin.py",
             err,
         )
 

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -43,9 +43,12 @@
     "make check"
   ],
   "required_makefile_check_commands": [
+    "python3 scripts/generate_verification_status.py --check",
+    "python3 scripts/check_verification_status_doc.py",
     "python3 scripts/check_verify_sync.py",
     "python3 scripts/check_issue_templates.py",
     "python3 scripts/check_docs_workflow_sync.py",
+    "python3 scripts/check_solc_pin.py",
     "python3 -m unittest discover -s scripts -p 'test_*.py' -v"
   ],
   "expected_checks_other_commands": [],


### PR DESCRIPTION
## Summary
- pin the artifact/docs/solc guard scripts in the verify sync contract
- extend verify-sync regression coverage for the added required make check commands

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to CI/verification guardrails, but it can cause `check_verify_sync`/`make check` to fail until the Makefile includes the newly required commands.
> 
> **Overview**
> **Verify-sync now enforces additional Makefile `check` guard scripts.** The `verify_sync_spec.json` contract adds `generate_verification_status.py --check`, `check_verification_status_doc.py`, and `check_solc_pin.py` as required commands under `make check`.
> 
> **Regression coverage is expanded accordingly.** `scripts/test_check_verify_sync.py` updates existing Makefile-check tests to include the new required commands and adds a focused failure case when the `check_solc_pin.py` command is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9995dfd68e1c4766281b015eb4476bd819735b34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->