### PR TITLE
ci: pin generated report guards

### DIFF
--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -394,6 +394,11 @@ class VerifySyncTests(unittest.TestCase):
         \tpython3 scripts/check_issue_templates.py
         \tpython3 scripts/check_docs_workflow_sync.py
         \tpython3 scripts/check_solc_pin.py
+        \tpython3 scripts/check_rewrite_proof_metadata.py
+        \tpython3 scripts/generate_evmyullean_capability_report.py --check
+        \tpython3 scripts/generate_evmyullean_adapter_report.py --check
+        \tpython3 scripts/generate_print_axioms.py --check
+        \tpython3 scripts/check_issue_1060_integrity.py
         \tpython3 -m unittest discover -s scripts -p 'test_*.py' -v
         """
         rc, out, err = self._run_makefile_check(
@@ -406,10 +411,55 @@ class VerifySyncTests(unittest.TestCase):
                 "python3 scripts/check_issue_templates.py",
                 "python3 scripts/check_docs_workflow_sync.py",
                 "python3 scripts/check_solc_pin.py",
+                "python3 scripts/check_rewrite_proof_metadata.py",
+                "python3 scripts/generate_evmyullean_capability_report.py --check",
+                "python3 scripts/generate_evmyullean_adapter_report.py --check",
+                "python3 scripts/generate_print_axioms.py --check",
+                "python3 scripts/check_issue_1060_integrity.py",
             ],
         )
         self.assertEqual(rc, 0, err)
         self.assertIn("[PASS] makefile", out)
+
+    def test_makefile_check_fails_when_generated_report_commands_are_missing(self) -> None:
+        makefile = """
+        check:
+        \tpython3 scripts/generate_verification_status.py --check
+        \tpython3 scripts/check_verification_status_doc.py
+        \tpython3 scripts/check_verify_sync.py
+        \tpython3 scripts/check_issue_templates.py
+        \tpython3 scripts/check_docs_workflow_sync.py
+        \tpython3 scripts/check_solc_pin.py
+        \tpython3 -m unittest discover -s scripts -p 'test_*.py' -v
+        """
+        rc, _, err = self._run_makefile_check(
+            makefile,
+            expected_checks_commands=["make check"],
+            required_makefile_check_commands=[
+                "python3 scripts/generate_verification_status.py --check",
+                "python3 scripts/check_verification_status_doc.py",
+                "python3 scripts/check_verify_sync.py",
+                "python3 scripts/check_issue_templates.py",
+                "python3 scripts/check_docs_workflow_sync.py",
+                "python3 scripts/check_solc_pin.py",
+                "python3 scripts/check_rewrite_proof_metadata.py",
+                "python3 scripts/generate_evmyullean_capability_report.py --check",
+                "python3 scripts/generate_evmyullean_adapter_report.py --check",
+                "python3 scripts/generate_print_axioms.py --check",
+                "python3 scripts/check_issue_1060_integrity.py",
+                "python3 -m unittest discover -s scripts -p 'test_*.py' -v",
+            ],
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "Makefile check target is missing required commands: "
+            "python3 scripts/check_rewrite_proof_metadata.py, "
+            "python3 scripts/generate_evmyullean_capability_report.py --check, "
+            "python3 scripts/generate_evmyullean_adapter_report.py --check, "
+            "python3 scripts/generate_print_axioms.py --check, "
+            "python3 scripts/check_issue_1060_integrity.py",
+            err,
+        )
 
     def test_makefile_check_fails_when_required_solc_pin_command_is_missing(self) -> None:
         makefile = """

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -49,6 +49,11 @@
     "python3 scripts/check_issue_templates.py",
     "python3 scripts/check_docs_workflow_sync.py",
     "python3 scripts/check_solc_pin.py",
+    "python3 scripts/check_rewrite_proof_metadata.py",
+    "python3 scripts/generate_evmyullean_capability_report.py --check",
+    "python3 scripts/generate_evmyullean_adapter_report.py --check",
+    "python3 scripts/generate_print_axioms.py --check",
+    "python3 scripts/check_issue_1060_integrity.py",
     "python3 -m unittest discover -s scripts -p 'test_*.py' -v"
   ],
   "expected_checks_other_commands": [],


### PR DESCRIPTION
## Summary
- require `make check` to keep running the generated report and integrity guards that protect proof metadata, EVMYulLean reports, `PrintAxioms.lean`, and issue #1060 invariants
- extend the verify-sync regression tests so the contract fails closed when those commands disappear

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it tightens CI/Makefile invariants and can newly fail builds if `make check` drifts, but it only affects repo checks tooling (no runtime logic).
> 
> **Overview**
> **`make check` is now required to run additional guard scripts** by extending `verify_sync_spec.json`’s `required_makefile_check_commands` to include proof-metadata rewrite checks, EVMYulLean capability/adapter report checks, `PrintAxioms` generation checks, and an issue #1060 integrity check.
> 
> **Verify-sync regression tests were updated to fail closed**: `scripts/test_check_verify_sync.py` now expects these commands in the Makefile and adds a new test asserting the validator returns an error listing the missing guard commands when they’re absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80d04e93def584645a4affc0535e49632c1fddf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->