### PR TITLE
ci: pin critical build guard commands

### DIFF
--- a/scripts/check_verify_sync.py
+++ b/scripts/check_verify_sync.py
@@ -381,6 +381,11 @@ def _extract_non_script_python_commands(run_commands: list[str]) -> list[str]:
     return result
 
 
+def _missing_required_run_substrings(run_commands: list[str], required_substrings: list[str]) -> list[str]:
+    joined = "\n".join(run_commands)
+    return [needle for needle in required_substrings if needle not in joined]
+
+
 def check_python_commands(snapshot: Snapshot, spec: dict) -> CheckResult:
     errors: list[str] = []
     expected_checks = spec["expected_checks_commands"]
@@ -424,6 +429,24 @@ def check_python_commands(snapshot: Snapshot, spec: dict) -> CheckResult:
             spec["expected_build_compiler_commands"],
         )
     )
+    missing_build_run = _missing_required_run_substrings(
+        snapshot.run_commands("build"),
+        spec.get("required_build_run_commands", []),
+    )
+    if missing_build_run:
+        errors.append(
+            "build job is missing required run commands: " + ", ".join(missing_build_run)
+        )
+
+    missing_build_compiler_run = _missing_required_run_substrings(
+        snapshot.run_commands("build-compiler"),
+        spec.get("required_build_compiler_run_commands", []),
+    )
+    if missing_build_compiler_run:
+        errors.append(
+            "build-compiler job is missing required run commands: "
+            + ", ".join(missing_build_compiler_run)
+        )
     return CheckResult("python-commands", errors)
 
 

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -128,6 +128,52 @@ class VerifySyncTests(unittest.TestCase):
                 check.MAKEFILE = old_makefile
                 sys.argv = old_argv
 
+    def _run_python_commands_check(
+        self,
+        workflow_text: str,
+        *,
+        expected_checks_commands: list[str],
+        expected_build_commands: list[str],
+        expected_build_compiler_commands: list[str],
+        required_build_run_commands: list[str] | None = None,
+        required_build_compiler_run_commands: list[str] | None = None,
+    ) -> tuple[int, str, str]:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as td:
+            root = Path(td)
+            verify = root / "verify.yml"
+            spec = root / "verify_sync_spec.json"
+            verify.write_text(textwrap.dedent(workflow_text).lstrip(), encoding="utf-8")
+            spec.write_text(
+                json.dumps(
+                    {
+                        "expected_checks_commands": expected_checks_commands,
+                        "expected_checks_other_commands": [],
+                        "expected_build_commands": expected_build_commands,
+                        "expected_build_compiler_commands": expected_build_compiler_commands,
+                        "required_build_run_commands": required_build_run_commands or [],
+                        "required_build_compiler_run_commands": required_build_compiler_run_commands or [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            old_verify = check.VERIFY_YML
+            old_spec = check.SPEC_PATH
+            check.VERIFY_YML = verify
+            check.SPEC_PATH = spec
+            old_argv = sys.argv
+            sys.argv = ["check_verify_sync.py", "--only", "python-commands"]
+            try:
+                stderr = io.StringIO()
+                stdout = io.StringIO()
+                with redirect_stderr(stderr), redirect_stdout(stdout):
+                    rc = check.main()
+                return rc, stdout.getvalue(), stderr.getvalue()
+            finally:
+                check.VERIFY_YML = old_verify
+                check.SPEC_PATH = old_spec
+                sys.argv = old_argv
+
     def test_jobs_check_passes_when_order_matches(self) -> None:
         workflow = textwrap.dedent(
             """
@@ -424,6 +470,96 @@ class VerifySyncTests(unittest.TestCase):
             "check_only_paths includes entries missing from on.push.paths: Makefile",
             err,
         )
+
+    def test_python_commands_check_fails_when_required_build_run_commands_are_missing(self) -> None:
+        workflow = """
+        name: verify
+        jobs:
+          checks:
+            runs-on: ubuntu-latest
+            steps:
+              - run: make check
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - run: python3 scripts/check_split_package_builds.py
+              - run: python3 scripts/check_lean_warning_regression.py --log lake-build.log
+              - run: lake exe compiler-main-test
+          build-compiler:
+            runs-on: ubuntu-latest
+            steps:
+              - run: python3 scripts/check_gas.py report
+        """
+        rc, _, err = self._run_python_commands_check(
+            workflow,
+            expected_checks_commands=["make check"],
+            expected_build_commands=[
+                "check_split_package_builds.py",
+                "check_lean_warning_regression.py --log lake-build.log",
+            ],
+            expected_build_compiler_commands=["check_gas.py report"],
+            required_build_run_commands=[
+                "lake exe compiler-main-test",
+                "lake build Compiler.CompilationModelFeatureTest",
+                "lake exe macro-roundtrip-fuzz",
+                "lake build PrintAxioms",
+                "lake env lean PrintAxioms.lean",
+            ],
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "build job is missing required run commands: "
+            "lake build Compiler.CompilationModelFeatureTest, "
+            "lake exe macro-roundtrip-fuzz, "
+            "lake build PrintAxioms, "
+            "lake env lean PrintAxioms.lean",
+            err,
+        )
+
+    def test_python_commands_check_passes_when_required_build_run_commands_are_present(self) -> None:
+        workflow = """
+        name: verify
+        jobs:
+          checks:
+            runs-on: ubuntu-latest
+            steps:
+              - run: make check
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - run: python3 scripts/check_split_package_builds.py
+              - run: python3 scripts/check_lean_warning_regression.py --log lake-build.log
+              - run: |
+                  lake exe compiler-main-test
+                  lake build Compiler.CompilationModelFeatureTest
+                  lake exe macro-roundtrip-fuzz
+                  lake build PrintAxioms
+                  lake env lean PrintAxioms.lean 2>&1 | tee axiom-report-raw.log
+              - run: python3 scripts/check_proof_length.py --format=markdown >> $GITHUB_STEP_SUMMARY
+          build-compiler:
+            runs-on: ubuntu-latest
+            steps:
+              - run: python3 scripts/check_gas.py report
+        """
+        rc, out, err = self._run_python_commands_check(
+            workflow,
+            expected_checks_commands=["make check"],
+            expected_build_commands=[
+                "check_split_package_builds.py",
+                "check_lean_warning_regression.py --log lake-build.log",
+                "check_proof_length.py --format=markdown >> $GITHUB_STEP_SUMMARY",
+            ],
+            expected_build_compiler_commands=["check_gas.py report"],
+            required_build_run_commands=[
+                "lake exe compiler-main-test",
+                "lake build Compiler.CompilationModelFeatureTest",
+                "lake exe macro-roundtrip-fuzz",
+                "lake build PrintAxioms",
+                "lake env lean PrintAxioms.lean",
+            ],
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertIn("[PASS] python-commands", out)
 
     def test_makefile_check_fails_when_required_unit_test_command_is_missing(self) -> None:
         rc, _, err = self._run_makefile_check(

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -88,6 +88,13 @@
     "report_property_coverage.py --format=markdown >> $GITHUB_STEP_SUMMARY",
     "check_storage_layout.py --format=markdown >> $GITHUB_STEP_SUMMARY"
   ],
+  "required_build_run_commands": [
+    "lake exe compiler-main-test",
+    "lake build Compiler.CompilationModelFeatureTest",
+    "lake exe macro-roundtrip-fuzz",
+    "lake build PrintAxioms",
+    "lake env lean PrintAxioms.lean"
+  ],
   "expected_build_compiler_commands": [
     "generate_yul_identity_diff_report.py --verity-dir compiler/yul-parity-pack --solc-dir compiler/yul-parity-reference --output compiler/parity-pack-identity-report.json",
     "check_parity_pack_metrics.py --report compiler/parity-pack-identity-report.json --max-only-in-verity 0 --max-only-in-solidity 0 --max-hash-mismatch 0 --format markdown >> \"$GITHUB_STEP_SUMMARY\"",
@@ -98,6 +105,7 @@
     "check_gas.py report",
     "check_patch_gas_delta.py --baseline-report gas-report-static.tsv --patched-report gas-report-static-patched.tsv --min-improved-contracts 0 --summary-markdown patch-gas-delta-summary.md >> \"$GITHUB_STEP_SUMMARY\""
   ],
+  "required_build_compiler_run_commands": [],
   "expected_foundry": {
     "shards": 8,
     "seed": 42


### PR DESCRIPTION
## Summary
- pin critical non-Python `build` job guard commands in `check_verify_sync.py`
- declare the required `build` commands in `verify_sync_spec.json`
- add regression tests covering missing and present build guard commands

## Testing
- `python3 -m unittest scripts.test_check_verify_sync -v`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it tightens CI invariants and can start failing verification if `verify.yml` drifts from the newly pinned required `run` commands. Functional impact is limited to workflow sync validation scripts and tests.
> 
> **Overview**
> **Tightens verify workflow sync checks** by adding validation that `build`/`build-compiler` jobs contain specified *required `run` command substrings* (not just expected `python3 scripts/...` invocations).
> 
> Updates `verify_sync_spec.json` to declare `required_build_run_commands` (and an empty `required_build_compiler_run_commands`) and adds unit tests covering both missing and present required build guard commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf493205f162712d050d71b2328fbcf47d1f9e2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->