### PR TITLE
ci: pin verify artifact contracts

### DIFF
--- a/scripts/check_verify_sync.py
+++ b/scripts/check_verify_sync.py
@@ -573,30 +573,86 @@ def check_foundry(snapshot: Snapshot, spec: dict) -> CheckResult:
 
 def check_artifacts(snapshot: Snapshot, spec: dict) -> CheckResult:
     errors: list[str] = []
-    producer_jobs = spec["artifact_producer_jobs"]
+    expected_uploads: dict[str, list[str]] = spec.get("expected_uploaded_artifacts", {})
+    expected_downloads: dict[str, list[str]] = spec.get("expected_downloaded_artifacts", {})
 
-    upload_names: list[str] = []
-    for job in producer_jobs:
-        if job not in snapshot.jobs:
-            errors.append(f"producer job missing from workflow: {job}")
-            continue
-        upload_names.extend(_extract_artifact_names(snapshot.job_body(job), action="upload-artifact"))
+    actual_uploads: dict[str, list[str]] = {}
+    actual_downloads: dict[str, list[str]] = {}
 
+    for job in snapshot.jobs:
+        job_body = snapshot.job_body(job)
+        upload_names = _extract_artifact_names(job_body, action="upload-artifact")
+        download_names = _extract_artifact_names(job_body, action="download-artifact")
+
+        if upload_names:
+            actual_uploads[job] = upload_names
+        if download_names:
+            actual_downloads[job] = download_names
+
+        if len(upload_names) != len(set(upload_names)):
+            errors.append(f"duplicate upload artifact names in {job}: {upload_names}")
+        if len(download_names) != len(set(download_names)):
+            errors.append(f"duplicate download artifact names in {job}: {download_names}")
+
+    expected_upload_jobs = list(expected_uploads)
+    actual_upload_jobs = [job for job in snapshot.jobs if job in actual_uploads]
+    errors.extend(
+        _compare_lists(
+            "upload-artifact jobs",
+            actual_upload_jobs,
+            "spec upload-artifact jobs",
+            expected_upload_jobs,
+        )
+    )
+
+    expected_download_jobs = list(expected_downloads)
+    actual_download_jobs = [job for job in snapshot.jobs if job in actual_downloads]
+    errors.extend(
+        _compare_lists(
+            "download-artifact jobs",
+            actual_download_jobs,
+            "spec download-artifact jobs",
+            expected_download_jobs,
+        )
+    )
+
+    upload_names = [name for names in actual_uploads.values() for name in names]
     if not upload_names:
-        errors.append("no upload-artifact names found in producer jobs")
+        errors.append("no upload-artifact names found in workflow")
         return CheckResult("artifacts", errors)
 
     dup_upload = sorted([name for name, count in Counter(upload_names).items() if count > 1])
     if dup_upload:
-        errors.append("duplicate upload artifacts across producer jobs: " + ", ".join(dup_upload))
+        errors.append("duplicate upload artifacts across workflow: " + ", ".join(dup_upload))
+
+    for job, expected_names in expected_uploads.items():
+        if job not in actual_uploads:
+            errors.append(f"expected upload-artifact job missing from workflow: {job}")
+            continue
+        errors.extend(
+            _compare_lists(
+                f"{job} upload artifacts",
+                actual_uploads[job],
+                f"spec {job} upload artifacts",
+                expected_names,
+            )
+        )
+
+    for job, expected_names in expected_downloads.items():
+        if job not in actual_downloads:
+            errors.append(f"expected download-artifact job missing from workflow: {job}")
+            continue
+        errors.extend(
+            _compare_lists(
+                f"{job} download artifacts",
+                actual_downloads[job],
+                f"spec {job} download artifacts",
+                expected_names,
+            )
+        )
 
     uploaded = set(upload_names)
-    for job in snapshot.jobs:
-        if job in producer_jobs:
-            continue
-        names = _extract_artifact_names(snapshot.job_body(job), action="download-artifact")
-        if len(names) != len(set(names)):
-            errors.append(f"duplicate download artifact names in {job}: {names}")
+    for job, names in actual_downloads.items():
         for name in names:
             if name not in uploaded:
                 errors.append(f"{job} downloads unknown artifact: {name}")

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -128,6 +128,45 @@ class VerifySyncTests(unittest.TestCase):
                 check.MAKEFILE = old_makefile
                 sys.argv = old_argv
 
+    def _run_artifacts_check(
+        self,
+        workflow_text: str,
+        *,
+        expected_uploaded_artifacts: dict[str, list[str]],
+        expected_downloaded_artifacts: dict[str, list[str]],
+    ) -> tuple[int, str, str]:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as td:
+            root = Path(td)
+            verify = root / "verify.yml"
+            spec = root / "verify_sync_spec.json"
+            verify.write_text(textwrap.dedent(workflow_text).lstrip(), encoding="utf-8")
+            spec.write_text(
+                json.dumps(
+                    {
+                        "expected_uploaded_artifacts": expected_uploaded_artifacts,
+                        "expected_downloaded_artifacts": expected_downloaded_artifacts,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            old_verify = check.VERIFY_YML
+            old_spec = check.SPEC_PATH
+            check.VERIFY_YML = verify
+            check.SPEC_PATH = spec
+            old_argv = sys.argv
+            sys.argv = ["check_verify_sync.py", "--only", "artifacts"]
+            try:
+                stderr = io.StringIO()
+                stdout = io.StringIO()
+                with redirect_stderr(stderr), redirect_stdout(stdout):
+                    rc = check.main()
+                return rc, stdout.getvalue(), stderr.getvalue()
+            finally:
+                check.VERIFY_YML = old_verify
+                check.SPEC_PATH = old_spec
+                sys.argv = old_argv
+
     def _run_python_commands_check(
         self,
         workflow_text: str,
@@ -901,6 +940,137 @@ class VerifySyncTests(unittest.TestCase):
         self.assertIn("python3 scripts/check_bridge_coverage_sync.py", err)
         self.assertIn("python3 scripts/check_storage_layout.py", err)
         self.assertIn("python3 scripts/check_proof_length.py", err)
+
+    def test_artifacts_check_fails_when_expected_upload_is_missing(self) -> None:
+        workflow = """
+        name: verify
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/upload-artifact@v4
+                with:
+                  name: axiom-dependency-report
+          build-compiler:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/upload-artifact@v4
+                with:
+                  name: generated-yul
+          foundry:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/download-artifact@v4
+                with:
+                  name: generated-yul
+        """
+        rc, _, err = self._run_artifacts_check(
+            workflow,
+            expected_uploaded_artifacts={
+                "build": ["axiom-dependency-report"],
+                "build-compiler": ["generated-yul", "static-gas-report"],
+            },
+            expected_downloaded_artifacts={
+                "foundry": ["generated-yul"],
+            },
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "build-compiler upload artifacts does not match spec build-compiler upload artifacts.",
+            err,
+        )
+        self.assertIn(
+            "idx 1: build-compiler upload artifacts='<missing>', spec build-compiler upload artifacts='static-gas-report'",
+            err,
+        )
+
+    def test_artifacts_check_fails_when_expected_download_is_missing(self) -> None:
+        workflow = """
+        name: verify
+        jobs:
+          build-compiler:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/upload-artifact@v4
+                with:
+                  name: static-gas-report
+              - uses: actions/upload-artifact@v4
+                with:
+                  name: generated-yul
+          foundry-gas-calibration:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/download-artifact@v4
+                with:
+                  name: static-gas-report
+        """
+        rc, _, err = self._run_artifacts_check(
+            workflow,
+            expected_uploaded_artifacts={
+                "build-compiler": ["static-gas-report", "generated-yul"],
+            },
+            expected_downloaded_artifacts={
+                "foundry-gas-calibration": ["static-gas-report", "generated-yul"],
+            },
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "foundry-gas-calibration download artifacts does not match spec foundry-gas-calibration download artifacts.",
+            err,
+        )
+        self.assertIn(
+            "idx 1: foundry-gas-calibration download artifacts='<missing>', spec foundry-gas-calibration download artifacts='generated-yul'",
+            err,
+        )
+
+    def test_artifacts_check_passes_when_uploads_and_downloads_match_spec(self) -> None:
+        workflow = """
+        name: verify
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/upload-artifact@v4
+                with:
+                  name: axiom-dependency-report
+          build-compiler:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/upload-artifact@v4
+                with:
+                  name: generated-yul
+              - uses: actions/upload-artifact@v4
+                with:
+                  name: static-gas-report
+          lean-profile:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/upload-artifact@v4
+                with:
+                  name: lean-perf-queue
+          foundry-gas-calibration:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/download-artifact@v4
+                with:
+                  name: static-gas-report
+              - uses: actions/download-artifact@v4
+                with:
+                  name: generated-yul
+        """
+        rc, out, err = self._run_artifacts_check(
+            workflow,
+            expected_uploaded_artifacts={
+                "build": ["axiom-dependency-report"],
+                "build-compiler": ["generated-yul", "static-gas-report"],
+                "lean-profile": ["lean-perf-queue"],
+            },
+            expected_downloaded_artifacts={
+                "foundry-gas-calibration": ["static-gas-report", "generated-yul"],
+            },
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertIn("[PASS] artifacts", out)
 
 
 if __name__ == "__main__":

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -140,8 +140,36 @@
     "artifact": "static-gas-report",
     "command": "python3 scripts/check_gas.py calibration --static-report gas-report-static.tsv"
   },
-  "artifact_producer_jobs": [
-    "build",
-    "build-compiler"
-  ]
+  "expected_uploaded_artifacts": {
+    "build": [
+      "axiom-dependency-report"
+    ],
+    "build-compiler": [
+      "generated-yul",
+      "generated-yul-patched",
+      "difftest-interpreter",
+      "static-gas-report",
+      "static-gas-report-patched",
+      "patch-coverage-report",
+      "parity-pack-identity-report"
+    ],
+    "lean-profile": [
+      "lean-perf-queue"
+    ]
+  },
+  "expected_downloaded_artifacts": {
+    "foundry-gas-calibration": [
+      "static-gas-report",
+      "generated-yul"
+    ],
+    "foundry": [
+      "generated-yul"
+    ],
+    "foundry-patched": [
+      "generated-yul-patched"
+    ],
+    "foundry-multi-seed": [
+      "generated-yul"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- make verify artifact uploads and downloads explicit in `verify_sync_spec.json`
- tighten `check_verify_sync.py` so missing or drifted artifact contracts fail locally
- add regression tests covering missing upload, missing download, and matching-spec cases

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CI validation by enforcing exact per-job artifact upload/download expectations; risk is mainly false negatives that could block CI if the spec or workflow ordering drifts.
> 
> **Overview**
> Makes the `artifacts` invariant in `scripts/check_verify_sync.py` spec-driven: the spec now declares **per-job** expected `upload-artifact` and `download-artifact` names, and the checker validates job coverage/order, per-job artifact lists, duplicate artifact names (within a job and across the workflow), and downloads of unknown artifacts.
> 
> Updates `scripts/verify_sync_spec.json` to replace `artifact_producer_jobs` with `expected_uploaded_artifacts` / `expected_downloaded_artifacts`, and adds unit tests covering missing expected uploads, missing expected downloads, and the matching-spec success case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1414914698f30a337ed9ef8a2cc9453ef9f62eb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->