### PR TITLE
ci: pin verify execution contracts

### DIFF
--- a/scripts/check_verify_sync.py
+++ b/scripts/check_verify_sync.py
@@ -179,6 +179,45 @@ def _extract_top_level_job_value(job_body: str, key: str) -> str | None:
     return None
 
 
+def _extract_literal_top_level_mapping(body: str, key: str) -> dict[str, str]:
+    block_lines = _extract_top_level_job_block_lines(body, key)
+    if not block_lines:
+        return {}
+
+    min_child_indent: int | None = None
+    for line in block_lines:
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if min_child_indent is None or child_indent < min_child_indent:
+            min_child_indent = child_indent
+    if min_child_indent is None:
+        return {}
+
+    values: dict[str, str] = {}
+    for line in block_lines:
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if child_indent != min_child_indent:
+            continue
+        m = re.match(r"^\s*(?P<entry_key>[A-Za-z0-9_-]+):\s*(?P<value>.+?)\s*$", line)
+        if not m:
+            raise ValueError(f"Unsupported literal mapping entry in {key} block in {VERIFY_YML}")
+        entry_key = m.group("entry_key")
+        raw_value = strip_yaml_inline_comment(m.group("value"))
+        if not raw_value:
+            raise ValueError(f"Empty {key}.{entry_key} value in {VERIFY_YML}")
+        value = unquote_yaml_scalar(raw_value)
+        previous = values.get(entry_key)
+        if previous is not None and previous != value:
+            raise ValueError(
+                f"Conflicting {key}.{entry_key} values in {VERIFY_YML}: {previous!r} vs {value!r}"
+            )
+        values[entry_key] = value
+    return values
+
+
 def _extract_top_level_job_block_lines(job_body: str, key: str) -> list[str]:
     lines = job_body.splitlines()
     min_child_indent: int | None = None
@@ -241,6 +280,20 @@ def _extract_job_needs(job_body: str) -> list[str]:
             entries.append(value)
         return entries
     return [raw]
+
+
+def _compare_mappings(
+    name_a: str, a: dict[str, str], name_b: str, b: dict[str, str]
+) -> list[str]:
+    if a == b:
+        return []
+    errors = [f"{name_a} does not match {name_b}."]
+    for key in sorted(set(a) | set(b)):
+        va = a.get(key, "<missing>")
+        vb = b.get(key, "<missing>")
+        if va != vb:
+            errors.append(f"  {key}: {name_a}={va!r}, {name_b}={vb!r}")
+    return errors
 
 
 def _extract_verify_shard_indices(foundry_body: str) -> list[int]:
@@ -516,6 +569,45 @@ def check_job_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
     errors: list[str] = []
     expected_needs: dict[str, list[str]] = spec.get("expected_job_needs", {})
     expected_conditions: dict[str, str] = spec.get("expected_job_if_conditions", {})
+    expected_runs_on: dict[str, str] = spec.get("expected_job_runs_on", {})
+    expected_timeouts: dict[str, int] = spec.get("expected_job_timeouts", {})
+    expected_outputs: dict[str, dict[str, str]] = spec.get("expected_job_outputs", {})
+    expected_job_permissions: dict[str, dict[str, str]] = spec.get(
+        "expected_job_permissions", {}
+    )
+    expected_workflow_permissions: dict[str, str] = spec.get(
+        "expected_workflow_permissions", {}
+    )
+    expected_workflow_concurrency: dict[str, str] = spec.get(
+        "expected_workflow_concurrency", {}
+    )
+
+    actual_workflow_permissions = _extract_literal_top_level_mapping(
+        snapshot.workflow_text, "permissions"
+    )
+    errors.extend(
+        _compare_mappings(
+            "workflow permissions",
+            actual_workflow_permissions,
+            "spec workflow permissions",
+            expected_workflow_permissions,
+        )
+    )
+
+    actual_workflow_concurrency = _extract_literal_top_level_mapping(
+        snapshot.workflow_text, "concurrency"
+    )
+    errors.extend(
+        _compare_mappings(
+            "workflow concurrency",
+            actual_workflow_concurrency,
+            "spec workflow concurrency",
+            expected_workflow_concurrency,
+        )
+    )
+
+    actual_output_jobs: dict[str, dict[str, str]] = {}
+    actual_permission_jobs: dict[str, dict[str, str]] = {}
 
     for job in snapshot.jobs:
         job_body = snapshot.job_body(job)
@@ -536,6 +628,65 @@ def check_job_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
             errors.append(
                 f"{job} if does not match spec: workflow={actual_condition!r}, spec={expected_condition!r}"
             )
+
+        actual_runs_on = _extract_top_level_job_value(job_body, "runs-on")
+        expected_job_runs_on = expected_runs_on.get(job)
+        if actual_runs_on != expected_job_runs_on:
+            errors.append(
+                f"{job} runs-on does not match spec: workflow={actual_runs_on!r}, spec={expected_job_runs_on!r}"
+            )
+
+        actual_timeout = _extract_top_level_job_value(job_body, "timeout-minutes")
+        expected_job_timeout = expected_timeouts.get(job)
+        expected_timeout_value = None if expected_job_timeout is None else str(expected_job_timeout)
+        if actual_timeout != expected_timeout_value:
+            errors.append(
+                f"{job} timeout-minutes does not match spec: workflow={actual_timeout!r}, spec={expected_timeout_value!r}"
+            )
+
+        outputs = _extract_literal_top_level_mapping(job_body, "outputs")
+        if outputs:
+            actual_output_jobs[job] = outputs
+
+        permissions = _extract_literal_top_level_mapping(job_body, "permissions")
+        if permissions:
+            actual_permission_jobs[job] = permissions
+
+    errors.extend(
+        _compare_lists(
+            "jobs with outputs",
+            [job for job in snapshot.jobs if job in actual_output_jobs],
+            "spec jobs with outputs",
+            list(expected_outputs),
+        )
+    )
+    for job, expected_mapping in expected_outputs.items():
+        errors.extend(
+            _compare_mappings(
+                f"{job} outputs",
+                actual_output_jobs.get(job, {}),
+                f"spec {job} outputs",
+                expected_mapping,
+            )
+        )
+
+    errors.extend(
+        _compare_lists(
+            "jobs with permissions",
+            [job for job in snapshot.jobs if job in actual_permission_jobs],
+            "spec jobs with permissions",
+            list(expected_job_permissions),
+        )
+    )
+    for job, expected_mapping in expected_job_permissions.items():
+        errors.extend(
+            _compare_mappings(
+                f"{job} permissions",
+                actual_permission_jobs.get(job, {}),
+                f"spec {job} permissions",
+                expected_mapping,
+            )
+        )
 
     return CheckResult("job-contracts", errors)
 

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -88,6 +88,12 @@ class VerifySyncTests(unittest.TestCase):
         *,
         expected_job_needs: dict[str, list[str]],
         expected_job_if_conditions: dict[str, str | None],
+        expected_job_runs_on: dict[str, str] | None = None,
+        expected_job_timeouts: dict[str, int] | None = None,
+        expected_job_outputs: dict[str, dict[str, str]] | None = None,
+        expected_job_permissions: dict[str, dict[str, str]] | None = None,
+        expected_workflow_permissions: dict[str, str] | None = None,
+        expected_workflow_concurrency: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as td:
             root = Path(td)
@@ -99,6 +105,12 @@ class VerifySyncTests(unittest.TestCase):
                     {
                         "expected_job_needs": expected_job_needs,
                         "expected_job_if_conditions": expected_job_if_conditions,
+                        "expected_job_runs_on": expected_job_runs_on or {},
+                        "expected_job_timeouts": expected_job_timeouts or {},
+                        "expected_job_outputs": expected_job_outputs or {},
+                        "expected_job_permissions": expected_job_permissions or {},
+                        "expected_workflow_permissions": expected_workflow_permissions or {},
+                        "expected_workflow_concurrency": expected_workflow_concurrency or {},
                     }
                 ),
                 encoding="utf-8",
@@ -312,6 +324,8 @@ class VerifySyncTests(unittest.TestCase):
                 "changes": None,
                 "build": "needs.changes.outputs.code == 'true'",
             },
+            expected_job_runs_on={"changes": "ubuntu-latest", "build": "ubuntu-latest"},
+            expected_job_timeouts={"changes": 5, "build": 45},
         )
         self.assertEqual(rc, 1)
         self.assertIn("[FAIL] job-contracts", err)
@@ -353,6 +367,11 @@ class VerifySyncTests(unittest.TestCase):
                 "build": "needs.changes.outputs.code == 'true'",
                 "foundry": "always() && github.event_name == 'pull_request'",
             },
+            expected_job_runs_on={
+                "changes": "ubuntu-latest",
+                "build": "ubuntu-latest",
+                "foundry": "ubuntu-latest",
+            },
         )
         self.assertEqual(rc, 0, err)
         self.assertIn("[PASS] job-contracts", out)
@@ -391,6 +410,131 @@ class VerifySyncTests(unittest.TestCase):
                 "changes": None,
                 "build": "needs.changes.outputs.code == 'true'",
                 "foundry": "always() && github.event_name == 'pull_request'",
+            },
+            expected_job_runs_on={
+                "changes": "ubuntu-latest",
+                "build": "ubuntu-latest",
+                "foundry": "ubuntu-latest",
+            },
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertIn("[PASS] job-contracts", out)
+
+    def test_job_contracts_check_fails_when_runner_timeout_outputs_and_permissions_drift(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            permissions:
+              contents: write
+            concurrency:
+              group: ${{ github.ref }}
+              cancel-in-progress: false
+            jobs:
+              changes:
+                runs-on: ubuntu-22.04
+                timeout-minutes: 7
+                outputs:
+                  code: ${{ steps.filter.outputs.code }}
+                  compiler: ${{ steps.filter.outputs.code }}
+                steps: []
+              failure-hints:
+                runs-on: ubuntu-latest
+                permissions:
+                  contents: read
+                steps: []
+            """
+        )
+        rc, _, err = self._run_job_contracts_check(
+            workflow,
+            expected_job_needs={"changes": [], "failure-hints": []},
+            expected_job_if_conditions={"changes": None, "failure-hints": None},
+            expected_job_runs_on={
+                "changes": "ubuntu-latest",
+                "failure-hints": "ubuntu-latest",
+            },
+            expected_job_timeouts={"changes": 5},
+            expected_job_outputs={
+                "changes": {
+                    "code": "${{ steps.filter.outputs.code }}",
+                    "compiler": "${{ steps.filter.outputs.compiler }}",
+                }
+            },
+            expected_job_permissions={
+                "failure-hints": {
+                    "contents": "read",
+                    "pull-requests": "write",
+                }
+            },
+            expected_workflow_permissions={"contents": "read"},
+            expected_workflow_concurrency={
+                "group": "${{ github.workflow }}-${{ github.ref }}",
+                "cancel-in-progress": "true",
+            },
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("workflow permissions does not match spec workflow permissions.", err)
+        self.assertIn("workflow concurrency does not match spec workflow concurrency.", err)
+        self.assertIn(
+            "changes runs-on does not match spec: workflow='ubuntu-22.04', spec='ubuntu-latest'",
+            err,
+        )
+        self.assertIn(
+            "changes timeout-minutes does not match spec: workflow='7', spec='5'",
+            err,
+        )
+        self.assertIn("changes outputs does not match spec changes outputs.", err)
+        self.assertIn("failure-hints permissions does not match spec failure-hints permissions.", err)
+
+    def test_job_contracts_check_passes_when_workflow_platform_contracts_match_spec(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            permissions:
+              contents: read
+            concurrency:
+              group: ${{ github.workflow }}-${{ github.ref }}
+              cancel-in-progress: true
+            jobs:
+              changes:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                outputs:
+                  code: ${{ steps.filter.outputs.code }}
+                  compiler: ${{ steps.filter.outputs.compiler }}
+                steps: []
+              failure-hints:
+                runs-on: ubuntu-latest
+                permissions:
+                  contents: read
+                  pull-requests: write
+                steps: []
+            """
+        )
+        rc, out, err = self._run_job_contracts_check(
+            workflow,
+            expected_job_needs={"changes": [], "failure-hints": []},
+            expected_job_if_conditions={"changes": None, "failure-hints": None},
+            expected_job_runs_on={
+                "changes": "ubuntu-latest",
+                "failure-hints": "ubuntu-latest",
+            },
+            expected_job_timeouts={"changes": 5},
+            expected_job_outputs={
+                "changes": {
+                    "code": "${{ steps.filter.outputs.code }}",
+                    "compiler": "${{ steps.filter.outputs.compiler }}",
+                }
+            },
+            expected_job_permissions={
+                "failure-hints": {
+                    "contents": "read",
+                    "pull-requests": "write",
+                }
+            },
+            expected_workflow_permissions={"contents": "read"},
+            expected_workflow_concurrency={
+                "group": "${{ github.workflow }}-${{ github.ref }}",
+                "cancel-in-progress": "true",
             },
         )
         self.assertEqual(rc, 0, err)

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -90,6 +90,48 @@
     "foundry-multi-seed": "needs.changes.outputs.compiler == 'true' && github.event_name != 'pull_request'",
     "failure-hints": "always() && github.event_name == 'pull_request' && contains(join(needs.*.result, ','), 'failure')"
   },
+  "expected_job_runs_on": {
+    "changes": "ubuntu-latest",
+    "checks": "ubuntu-latest",
+    "build": "ubuntu-latest",
+    "build-compiler": "ubuntu-latest",
+    "lean-profile": "ubuntu-latest",
+    "foundry-gas-calibration": "ubuntu-latest",
+    "foundry": "ubuntu-latest",
+    "foundry-patched": "ubuntu-latest",
+    "foundry-multi-seed": "ubuntu-latest",
+    "failure-hints": "ubuntu-latest"
+  },
+  "expected_job_timeouts": {
+    "changes": 5,
+    "checks": 5,
+    "build": 45,
+    "build-compiler": 90,
+    "lean-profile": 45,
+    "foundry-gas-calibration": 15,
+    "foundry": 15,
+    "foundry-patched": 15,
+    "foundry-multi-seed": 25
+  },
+  "expected_job_outputs": {
+    "changes": {
+      "code": "${{ steps.filter.outputs.code }}",
+      "compiler": "${{ steps.filter.outputs.compiler }}"
+    }
+  },
+  "expected_job_permissions": {
+    "failure-hints": {
+      "contents": "read",
+      "pull-requests": "write"
+    }
+  },
+  "expected_workflow_permissions": {
+    "contents": "read"
+  },
+  "expected_workflow_concurrency": {
+    "group": "${{ github.workflow }}-${{ github.ref }}",
+    "cancel-in-progress": "true"
+  },
   "expected_checks_commands": [
     "make check"
   ],


### PR DESCRIPTION
## Summary
- pin the remaining verify workflow execution contracts in `check_verify_sync.py`
- enforce workflow permissions/concurrency plus job runner, timeout, outputs, and permissions invariants
- add regression coverage for the new contract checks

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CI invariants by adding strict parsing/comparison of `verify.yml` workflow/job mappings (permissions/concurrency/outputs/etc.), which may cause unexpected CI failures if the workflow format changes (e.g., non-literal YAML/expression usage). Changes are limited to validation scripts/tests and do not affect runtime product behavior.
> 
> **Overview**
> **Extends `check_verify_sync.py` job-contract validation** to also enforce workflow-level `permissions` and `concurrency`, plus per-job `runs-on`, `timeout-minutes`, `outputs`, and `permissions` against `verify_sync_spec.json`.
> 
> Adds a small literal-mapping parser (`_extract_literal_top_level_mapping`) and mapping diff helper (`_compare_mappings`) to support these checks, expands unit tests to cover drift/pass scenarios, and updates `verify_sync_spec.json` with the new expected contract values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6442d94d5973610c8007af98fe20a3d201190778. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->