### PR TITLE
ci: pin verify step contracts

### DIFF
--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -5,7 +5,7 @@ This document is the long-form reference for script responsibilities.
 ## Verify workflow sync
 
 - `check_verify_sync.py`: unified table-driven validator for workflow invariants.
-- `verify_sync_spec.json`: expected job order, command lists, path filters, foundry settings, and artifact producers.
+- `verify_sync_spec.json`: expected job order, top-level job contracts, critical step contracts, command lists, path filters, foundry settings, and artifact producers.
 - `check_docs_workflow_sync.py`: keep the docs workflow self-triggering and aligned across push/pull_request path filters.
 
 ## Issue #1060 automation

--- a/scripts/check_verify_sync.py
+++ b/scripts/check_verify_sync.py
@@ -179,6 +179,85 @@ def _extract_top_level_job_value(job_body: str, key: str) -> str | None:
     return None
 
 
+def _extract_top_level_step_value(step_block: str, key: str) -> str | None:
+    lines = step_block.splitlines()
+    if not lines:
+        return None
+
+    first = re.match(rf"^\s*-\s*{re.escape(key)}:\s*(?P<value>.*?)\s*$", lines[0])
+    if first:
+        raw = strip_yaml_inline_comment(first.group("value"))
+        return unquote_yaml_scalar(raw) if raw else ""
+
+    step_indent = len(lines[0]) - len(lines[0].lstrip(" "))
+    min_child_indent: int | None = None
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if child_indent <= step_indent:
+            continue
+        if min_child_indent is None or child_indent < min_child_indent:
+            min_child_indent = child_indent
+    if min_child_indent is None:
+        return None
+
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if child_indent != min_child_indent:
+            continue
+        m = re.match(rf"^\s*{re.escape(key)}:\s*(?P<value>.*?)\s*$", line)
+        if not m:
+            continue
+        raw = strip_yaml_inline_comment(m.group("value"))
+        return unquote_yaml_scalar(raw) if raw else ""
+    return None
+
+
+def _extract_top_level_step_block_lines(step_block: str, key: str) -> list[str]:
+    lines = step_block.splitlines()
+    if not lines:
+        return []
+
+    step_indent = len(lines[0]) - len(lines[0].lstrip(" "))
+    min_child_indent: int | None = None
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if child_indent <= step_indent:
+            continue
+        if min_child_indent is None or child_indent < min_child_indent:
+            min_child_indent = child_indent
+    if min_child_indent is None:
+        return []
+
+    for idx, line in enumerate(lines[1:], start=1):
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if child_indent != min_child_indent:
+            continue
+        m = re.match(rf"^\s*{re.escape(key)}:\s*(?P<value>.*?)\s*$", line)
+        if not m or strip_yaml_inline_comment(m.group("value")):
+            continue
+
+        block_lines: list[str] = []
+        for nested in lines[idx + 1 :]:
+            if not nested.strip():
+                block_lines.append("")
+                continue
+            nested_indent = len(nested) - len(nested.lstrip(" "))
+            if nested_indent <= child_indent:
+                break
+            block_lines.append(nested)
+        return block_lines
+
+    return []
+
+
 def _extract_literal_top_level_mapping(body: str, key: str) -> dict[str, str]:
     block_lines = _extract_top_level_job_block_lines(body, key)
     if not block_lines:
@@ -213,6 +292,45 @@ def _extract_literal_top_level_mapping(body: str, key: str) -> dict[str, str]:
         if previous is not None and previous != value:
             raise ValueError(
                 f"Conflicting {key}.{entry_key} values in {VERIFY_YML}: {previous!r} vs {value!r}"
+            )
+        values[entry_key] = value
+    return values
+
+
+def _extract_literal_step_mapping(step_block: str, key: str) -> dict[str, str]:
+    block_lines = _extract_top_level_step_block_lines(step_block, key)
+    if not block_lines:
+        return {}
+
+    min_child_indent: int | None = None
+    for line in block_lines:
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if min_child_indent is None or child_indent < min_child_indent:
+            min_child_indent = child_indent
+    if min_child_indent is None:
+        return {}
+
+    values: dict[str, str] = {}
+    for line in block_lines:
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if child_indent != min_child_indent:
+            continue
+        m = re.match(r"^\s*(?P<entry_key>[A-Za-z0-9_-]+):\s*(?P<value>.+?)\s*$", line)
+        if not m:
+            raise ValueError(f"Unsupported literal mapping entry in step {key} block in {VERIFY_YML}")
+        entry_key = m.group("entry_key")
+        raw_value = strip_yaml_inline_comment(m.group("value"))
+        if not raw_value:
+            raise ValueError(f"Empty step {key}.{entry_key} value in {VERIFY_YML}")
+        value = unquote_yaml_scalar(raw_value)
+        previous = values.get(entry_key)
+        if previous is not None and previous != value:
+            raise ValueError(
+                f"Conflicting step {key}.{entry_key} values in {VERIFY_YML}: {previous!r} vs {value!r}"
             )
         values[entry_key] = value
     return values
@@ -691,6 +809,73 @@ def check_job_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
     return CheckResult("job-contracts", errors)
 
 
+def _describe_step_locator(step_spec: dict) -> str:
+    parts: list[str] = []
+    if "name" in step_spec:
+        parts.append(f"name={step_spec['name']!r}")
+    if "uses" in step_spec:
+        parts.append(f"uses={step_spec['uses']!r}")
+    return ", ".join(parts) if parts else "<unidentified step>"
+
+
+def _find_matching_step(job_body: str, step_spec: dict) -> str | None:
+    matches: list[str] = []
+    for step_block in _iter_step_blocks(job_body):
+        actual_name = _extract_top_level_step_value(step_block, "name")
+        actual_uses = _extract_top_level_step_value(step_block, "uses")
+        if "name" in step_spec and actual_name != step_spec["name"]:
+            continue
+        if "uses" in step_spec and actual_uses != step_spec["uses"]:
+            continue
+        matches.append(step_block)
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise ValueError(
+            f"Multiple workflow steps matched locator {_describe_step_locator(step_spec)} in {VERIFY_YML}"
+        )
+    return matches[0]
+
+
+def check_step_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
+    errors: list[str] = []
+    expected_step_contracts: dict[str, list[dict]] = spec.get("expected_step_contracts", {})
+
+    for job, step_specs in expected_step_contracts.items():
+        job_body = snapshot.job_body(job)
+        for step_spec in step_specs:
+            step_block = _find_matching_step(job_body, step_spec)
+            locator = _describe_step_locator(step_spec)
+            if step_block is None:
+                errors.append(f"{job} is missing expected step {locator}")
+                continue
+
+            for key in ("name", "uses", "if"):
+                if key not in step_spec:
+                    continue
+                actual_value = _extract_top_level_step_value(step_block, key)
+                expected_value = step_spec[key]
+                if actual_value != expected_value:
+                    errors.append(
+                        f"{job} step {locator} has {key}={actual_value!r}, expected {expected_value!r}"
+                    )
+
+            for mapping_key in ("with", "env"):
+                expected_mapping = step_spec.get(mapping_key)
+                if not expected_mapping:
+                    continue
+                actual_mapping = _extract_literal_step_mapping(step_block, mapping_key)
+                for entry_key, expected_value in expected_mapping.items():
+                    actual_value = actual_mapping.get(entry_key)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"{job} step {locator} has {mapping_key}.{entry_key}={actual_value!r}, "
+                            f"expected {expected_value!r}"
+                        )
+
+    return CheckResult("step-contracts", errors)
+
+
 def _extract_non_script_python_commands(run_commands: list[str]) -> list[str]:
     """Extract python3 commands that are NOT 'python3 scripts/...' from run commands."""
     result: list[str] = []
@@ -1058,6 +1243,7 @@ def _checks() -> dict[str, callable]:
         "paths": check_paths,
         "jobs": check_jobs,
         "job-contracts": check_job_contracts,
+        "step-contracts": check_step_contracts,
         "python-commands": check_python_commands,
         "multiseed": check_multiseed,
         "foundry": check_foundry,

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -133,6 +133,39 @@ class VerifySyncTests(unittest.TestCase):
                 check.SPEC_PATH = old_spec
                 sys.argv = old_argv
 
+    def _run_step_contracts_check(
+        self,
+        workflow_text: str,
+        *,
+        expected_step_contracts: dict[str, list[dict]],
+    ) -> tuple[int, str, str]:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as td:
+            root = Path(td)
+            verify = root / "verify.yml"
+            spec = root / "verify_sync_spec.json"
+            verify.write_text(workflow_text, encoding="utf-8")
+            spec.write_text(
+                json.dumps({"expected_step_contracts": expected_step_contracts}),
+                encoding="utf-8",
+            )
+
+            old_verify = check.VERIFY_YML
+            old_spec = check.SPEC_PATH
+            check.VERIFY_YML = verify
+            check.SPEC_PATH = spec
+            old_argv = sys.argv
+            sys.argv = ["check_verify_sync.py", "--only", "step-contracts"]
+            try:
+                stderr = io.StringIO()
+                stdout = io.StringIO()
+                with redirect_stderr(stderr), redirect_stdout(stdout):
+                    rc = check.main()
+                return rc, stdout.getvalue(), stderr.getvalue()
+            finally:
+                check.VERIFY_YML = old_verify
+                check.SPEC_PATH = old_spec
+                sys.argv = old_argv
+
     def _run_makefile_check(
         self,
         makefile_text: str,
@@ -558,6 +591,142 @@ class VerifySyncTests(unittest.TestCase):
         job_body = check.extract_job_body(workflow, "build", Path("verify.yml"))
         with self.assertRaisesRegex(ValueError, "Empty needs entry"):
             check._extract_job_needs(job_body)
+
+    def test_step_contracts_check_fails_when_action_config_drifts(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                    with:
+                      submodules: false
+                  - name: Setup Lean
+                    uses: ./.github/actions/setup-lean
+                    with:
+                      cache-key-prefix: stale
+                  - name: Save Lake packages cache
+                    if: success()
+                    uses: actions/cache/save@v4
+                    with:
+                      path: build-cache
+                      key: bad-key
+              failure-hints:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Post CI failure hints
+                    uses: actions/github-script@v7
+                    env:
+                      NEEDS_JSON: stale
+            """
+        )
+        rc, _, err = self._run_step_contracts_check(
+            workflow,
+            expected_step_contracts={
+                "build": [
+                    {
+                        "uses": "actions/checkout@v4",
+                        "with": {"submodules": "recursive"},
+                    },
+                    {
+                        "name": "Setup Lean",
+                        "uses": "./.github/actions/setup-lean",
+                        "with": {"cache-key-prefix": "lake"},
+                    },
+                    {
+                        "name": "Save Lake packages cache",
+                        "uses": "actions/cache/save@v4",
+                        "if": "success() && needs.changes.outputs.code == 'true'",
+                        "with": {"path": ".lake", "key": "good-key"},
+                    },
+                ],
+                "failure-hints": [
+                    {
+                        "name": "Post CI failure hints",
+                        "uses": "actions/github-script@v7",
+                        "env": {"NEEDS_JSON": "${{ toJson(needs) }}"},
+                    }
+                ],
+            },
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("[FAIL] step-contracts", err)
+        self.assertIn(
+            "build step name='Setup Lean', uses='./.github/actions/setup-lean' has with.cache-key-prefix='stale', expected 'lake'",
+            err,
+        )
+        self.assertIn(
+            "build step name='Save Lake packages cache', uses='actions/cache/save@v4' has if='success()', expected \"success() && needs.changes.outputs.code == 'true'\"",
+            err,
+        )
+        self.assertIn(
+            "failure-hints step name='Post CI failure hints', uses='actions/github-script@v7' has env.NEEDS_JSON='stale', expected '${{ toJson(needs) }}'",
+            err,
+        )
+
+    def test_step_contracts_check_passes_when_critical_steps_match_spec(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                    with:
+                      submodules: recursive
+                  - name: Setup Lean
+                    uses: ./.github/actions/setup-lean
+                    with:
+                      cache-key-prefix: lake
+                  - name: Save Lake packages cache
+                    if: success() && needs.changes.outputs.code == 'true'
+                    uses: actions/cache/save@v4
+                    with:
+                      path: .lake
+                      key: good-key
+              failure-hints:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Post CI failure hints
+                    uses: actions/github-script@v7
+                    env:
+                      NEEDS_JSON: ${{ toJson(needs) }}
+            """
+        )
+        rc, out, err = self._run_step_contracts_check(
+            workflow,
+            expected_step_contracts={
+                "build": [
+                    {
+                        "uses": "actions/checkout@v4",
+                        "with": {"submodules": "recursive"},
+                    },
+                    {
+                        "name": "Setup Lean",
+                        "uses": "./.github/actions/setup-lean",
+                        "with": {"cache-key-prefix": "lake"},
+                    },
+                    {
+                        "name": "Save Lake packages cache",
+                        "uses": "actions/cache/save@v4",
+                        "if": "success() && needs.changes.outputs.code == 'true'",
+                        "with": {"path": ".lake", "key": "good-key"},
+                    },
+                ],
+                "failure-hints": [
+                    {
+                        "name": "Post CI failure hints",
+                        "uses": "actions/github-script@v7",
+                        "env": {"NEEDS_JSON": "${{ toJson(needs) }}"},
+                    }
+                ],
+            },
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertIn("[PASS] step-contracts", out)
 
     def test_paths_check_fails_when_check_only_path_is_missing_from_triggers(self) -> None:
         workflow = textwrap.dedent(

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -132,6 +132,126 @@
     "group": "${{ github.workflow }}-${{ github.ref }}",
     "cancel-in-progress": "true"
   },
+  "expected_step_contracts": {
+    "build": [
+      {
+        "uses": "actions/checkout@v4",
+        "with": {
+          "submodules": "recursive"
+        }
+      },
+      {
+        "name": "Setup Lean",
+        "uses": "./.github/actions/setup-lean",
+        "with": {
+          "cache-key-prefix": "lake"
+        }
+      },
+      {
+        "name": "Save Lake packages cache",
+        "uses": "actions/cache/save@v4",
+        "if": "success() && needs.changes.outputs.code == 'true'",
+        "with": {
+          "path": ".lake",
+          "key": "lake-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-${{ hashFiles('lake-manifest.json') }}"
+        }
+      }
+    ],
+    "build-compiler": [
+      {
+        "uses": "actions/checkout@v4",
+        "with": {
+          "submodules": "recursive"
+        }
+      },
+      {
+        "name": "Setup Lean",
+        "uses": "./.github/actions/setup-lean",
+        "with": {
+          "cache-key-prefix": "lake-compiler"
+        }
+      },
+      {
+        "name": "Setup solc",
+        "uses": "./.github/actions/setup-solc"
+      },
+      {
+        "name": "Save Lake compiler cache",
+        "uses": "actions/cache/save@v4",
+        "if": "success()",
+        "with": {
+          "path": ".lake",
+          "key": "lake-compiler-${{ runner.os }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lakefile.lean') }}-${{ hashFiles('lake-manifest.json') }}"
+        }
+      }
+    ],
+    "lean-profile": [
+      {
+        "uses": "actions/checkout@v4"
+      },
+      {
+        "name": "Setup Lean",
+        "uses": "./.github/actions/setup-lean"
+      }
+    ],
+    "foundry-gas-calibration": [
+      {
+        "uses": "actions/checkout@v4",
+        "with": {
+          "submodules": "recursive"
+        }
+      },
+      {
+        "name": "Setup Foundry environment",
+        "uses": "./.github/actions/setup-foundry"
+      }
+    ],
+    "foundry": [
+      {
+        "uses": "actions/checkout@v4",
+        "with": {
+          "submodules": "recursive"
+        }
+      },
+      {
+        "name": "Setup Foundry environment",
+        "uses": "./.github/actions/setup-foundry"
+      }
+    ],
+    "foundry-patched": [
+      {
+        "uses": "actions/checkout@v4",
+        "with": {
+          "submodules": "recursive"
+        }
+      },
+      {
+        "name": "Setup Foundry environment",
+        "uses": "./.github/actions/setup-foundry"
+      }
+    ],
+    "foundry-multi-seed": [
+      {
+        "uses": "actions/checkout@v4",
+        "with": {
+          "submodules": "recursive"
+        }
+      },
+      {
+        "name": "Setup Foundry environment",
+        "uses": "./.github/actions/setup-foundry"
+      }
+    ],
+    "failure-hints": [
+      {
+        "name": "Post CI failure hints",
+        "uses": "actions/github-script@v7",
+        "env": {
+          "NEEDS_JSON": "${{ toJson(needs) }}"
+        }
+      }
+    ]
+  },
   "expected_checks_commands": [
     "make check"
   ],


### PR DESCRIPTION
## Summary
- add a `step-contracts` invariant to `check_verify_sync.py` so the verify workflow fails closed when critical action steps drift
- pin the current `verify.yml` action step contracts in `verify_sync_spec.json` for checkout, setup actions, cache saves, and the failure-hints bot step
- add regression coverage for step-level action/if/with/env drift and document the expanded verify sync scope

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI invariant that can fail builds if the workflow YAML parsing or the pinned step specs don’t match, so minor `verify.yml` edits may now break CI unexpectedly.
> 
> **Overview**
> **Extends `check_verify_sync.py` with a new `step-contracts` invariant** that locates specific workflow steps (by `name`/`uses`) and asserts their `if` condition plus selected `with`/`env` keys match the spec.
> 
> **Pins critical `verify.yml` action steps in `verify_sync_spec.json`** (checkout/setup actions, cache save steps, and the failure-hints script step) and adds unit tests covering both drift failures and matching-pass cases. Documentation in `scripts/REFERENCE.md` is updated to reflect the expanded spec scope.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 720e66e0823cb3da01c80dc23b85f33f96f2358c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->