### PR TITLE
ci: pin verify bootstrap steps

### DIFF
--- a/scripts/check_verify_sync.py
+++ b/scripts/check_verify_sync.py
@@ -811,6 +811,8 @@ def check_job_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
 
 def _describe_step_locator(step_spec: dict) -> str:
     parts: list[str] = []
+    if "id" in step_spec:
+        parts.append(f"id={step_spec['id']!r}")
     if "name" in step_spec:
         parts.append(f"name={step_spec['name']!r}")
     if "uses" in step_spec:
@@ -821,8 +823,11 @@ def _describe_step_locator(step_spec: dict) -> str:
 def _find_matching_step(job_body: str, step_spec: dict) -> str | None:
     matches: list[str] = []
     for step_block in _iter_step_blocks(job_body):
+        actual_id = _extract_top_level_step_value(step_block, "id")
         actual_name = _extract_top_level_step_value(step_block, "name")
         actual_uses = _extract_top_level_step_value(step_block, "uses")
+        if "id" in step_spec and actual_id != step_spec["id"]:
+            continue
         if "name" in step_spec and actual_name != step_spec["name"]:
             continue
         if "uses" in step_spec and actual_uses != step_spec["uses"]:
@@ -850,7 +855,7 @@ def check_step_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
                 errors.append(f"{job} is missing expected step {locator}")
                 continue
 
-            for key in ("name", "uses", "if"):
+            for key in ("id", "name", "uses", "if", "run"):
                 if key not in step_spec:
                     continue
                 actual_value = _extract_top_level_step_value(step_block, key)

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -597,6 +597,18 @@ class VerifySyncTests(unittest.TestCase):
             """
             name: verify
             jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                  - id: changed-filter
+                    uses: dorny/paths-filter@v3
+              checks:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                  - name: Run all checks
+                    run: make verify
               build:
                 runs-on: ubuntu-latest
                 steps:
@@ -625,6 +637,24 @@ class VerifySyncTests(unittest.TestCase):
         rc, _, err = self._run_step_contracts_check(
             workflow,
             expected_step_contracts={
+                "changes": [
+                    {
+                        "uses": "actions/checkout@v4",
+                    },
+                    {
+                        "id": "filter",
+                        "uses": "dorny/paths-filter@v3",
+                    },
+                ],
+                "checks": [
+                    {
+                        "uses": "actions/checkout@v4",
+                    },
+                    {
+                        "name": "Run all checks",
+                        "run": "make check",
+                    },
+                ],
                 "build": [
                     {
                         "uses": "actions/checkout@v4",
@@ -654,6 +684,14 @@ class VerifySyncTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("[FAIL] step-contracts", err)
         self.assertIn(
+            "changes is missing expected step id='filter', uses='dorny/paths-filter@v3'",
+            err,
+        )
+        self.assertIn(
+            "checks step name='Run all checks' has run='make verify', expected 'make check'",
+            err,
+        )
+        self.assertIn(
             "build step name='Setup Lean', uses='./.github/actions/setup-lean' has with.cache-key-prefix='stale', expected 'lake'",
             err,
         )
@@ -671,6 +709,18 @@ class VerifySyncTests(unittest.TestCase):
             """
             name: verify
             jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                  - id: filter
+                    uses: dorny/paths-filter@v3
+              checks:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                  - name: Run all checks
+                    run: make check
               build:
                 runs-on: ubuntu-latest
                 steps:
@@ -699,6 +749,24 @@ class VerifySyncTests(unittest.TestCase):
         rc, out, err = self._run_step_contracts_check(
             workflow,
             expected_step_contracts={
+                "changes": [
+                    {
+                        "uses": "actions/checkout@v4",
+                    },
+                    {
+                        "id": "filter",
+                        "uses": "dorny/paths-filter@v3",
+                    },
+                ],
+                "checks": [
+                    {
+                        "uses": "actions/checkout@v4",
+                    },
+                    {
+                        "name": "Run all checks",
+                        "run": "make check",
+                    },
+                ],
                 "build": [
                     {
                         "uses": "actions/checkout@v4",

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -133,6 +133,24 @@
     "cancel-in-progress": "true"
   },
   "expected_step_contracts": {
+    "changes": [
+      {
+        "uses": "actions/checkout@v4"
+      },
+      {
+        "id": "filter",
+        "uses": "dorny/paths-filter@v3"
+      }
+    ],
+    "checks": [
+      {
+        "uses": "actions/checkout@v4"
+      },
+      {
+        "name": "Run all checks",
+        "run": "make check"
+      }
+    ],
     "build": [
       {
         "uses": "actions/checkout@v4",


### PR DESCRIPTION
## Summary
- teach `check_verify_sync.py` step contracts to validate step `id` and `run` fields
- pin the `changes` workflow bootstrap step (`id: filter` on `dorny/paths-filter`) and the `checks` execution step (`Run all checks` -> `make check`)
- add regression coverage for both drift cases

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/workflow drift validation and accompanying tests/spec updates, with no production code or security-sensitive behavior affected.
> 
> **Overview**
> **Verify workflow drift checks are stricter.** The `step-contracts` validator now locates steps by `id` (in addition to `name`/`uses`) and also validates `run` (and `id`) fields when present in the spec.
> 
> **Spec + tests updated to pin critical steps.** `verify_sync_spec.json` now asserts the `changes` job’s `dorny/paths-filter@v3` step has `id: filter` and the `checks` job runs `make check`, with new unit tests covering both drift and success cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea4db4e5eea5a73555059e13dd858f83367af36a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->