### PR TITLE
ci: pin verify workflow env

### DIFF
--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -5,7 +5,7 @@ This document is the long-form reference for script responsibilities.
 ## Verify workflow sync
 
 - `check_verify_sync.py`: unified table-driven validator for workflow invariants.
-- `verify_sync_spec.json`: expected job order, top-level job contracts, critical step contracts, command lists, path filters, foundry settings, and artifact producers.
+- `verify_sync_spec.json`: expected job order, top-level workflow/job contracts, critical step contracts, command lists, path filters, foundry settings, and artifact producers.
 - `check_docs_workflow_sync.py`: keep the docs workflow self-triggering and aligned across push/pull_request path filters.
 
 ## Issue #1060 automation

--- a/scripts/check_verify_sync.py
+++ b/scripts/check_verify_sync.py
@@ -699,6 +699,7 @@ def check_job_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
     expected_workflow_concurrency: dict[str, str] = spec.get(
         "expected_workflow_concurrency", {}
     )
+    expected_workflow_env: dict[str, str] = spec.get("expected_workflow_env", {})
 
     actual_workflow_permissions = _extract_literal_top_level_mapping(
         snapshot.workflow_text, "permissions"
@@ -721,6 +722,16 @@ def check_job_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
             actual_workflow_concurrency,
             "spec workflow concurrency",
             expected_workflow_concurrency,
+        )
+    )
+
+    actual_workflow_env = _extract_literal_top_level_mapping(snapshot.workflow_text, "env")
+    errors.extend(
+        _compare_mappings(
+            "workflow env",
+            actual_workflow_env,
+            "spec workflow env",
+            expected_workflow_env,
         )
     )
 

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -94,6 +94,7 @@ class VerifySyncTests(unittest.TestCase):
         expected_job_permissions: dict[str, dict[str, str]] | None = None,
         expected_workflow_permissions: dict[str, str] | None = None,
         expected_workflow_concurrency: dict[str, str] | None = None,
+        expected_workflow_env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as td:
             root = Path(td)
@@ -111,6 +112,7 @@ class VerifySyncTests(unittest.TestCase):
                         "expected_job_permissions": expected_job_permissions or {},
                         "expected_workflow_permissions": expected_workflow_permissions or {},
                         "expected_workflow_concurrency": expected_workflow_concurrency or {},
+                        "expected_workflow_env": expected_workflow_env or {},
                     }
                 ),
                 encoding="utf-8",
@@ -462,6 +464,8 @@ class VerifySyncTests(unittest.TestCase):
             concurrency:
               group: ${{ github.ref }}
               cancel-in-progress: false
+            env:
+              SOLC_VERSION: "0.8.32"
             jobs:
               changes:
                 runs-on: ubuntu-22.04
@@ -503,10 +507,12 @@ class VerifySyncTests(unittest.TestCase):
                 "group": "${{ github.workflow }}-${{ github.ref }}",
                 "cancel-in-progress": "true",
             },
+            expected_workflow_env={"SOLC_VERSION": "0.8.33"},
         )
         self.assertEqual(rc, 1)
         self.assertIn("workflow permissions does not match spec workflow permissions.", err)
         self.assertIn("workflow concurrency does not match spec workflow concurrency.", err)
+        self.assertIn("workflow env does not match spec workflow env.", err)
         self.assertIn(
             "changes runs-on does not match spec: workflow='ubuntu-22.04', spec='ubuntu-latest'",
             err,
@@ -527,6 +533,9 @@ class VerifySyncTests(unittest.TestCase):
             concurrency:
               group: ${{ github.workflow }}-${{ github.ref }}
               cancel-in-progress: true
+            env:
+              SOLC_VERSION: "0.8.33"
+              SOLC_URL: "https://example.invalid/solc"
             jobs:
               changes:
                 runs-on: ubuntu-latest
@@ -568,6 +577,10 @@ class VerifySyncTests(unittest.TestCase):
             expected_workflow_concurrency={
                 "group": "${{ github.workflow }}-${{ github.ref }}",
                 "cancel-in-progress": "true",
+            },
+            expected_workflow_env={
+                "SOLC_VERSION": "0.8.33",
+                "SOLC_URL": "https://example.invalid/solc",
             },
         )
         self.assertEqual(rc, 0, err)

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -132,6 +132,11 @@
     "group": "${{ github.workflow }}-${{ github.ref }}",
     "cancel-in-progress": "true"
   },
+  "expected_workflow_env": {
+    "SOLC_VERSION": "0.8.33",
+    "SOLC_URL": "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21",
+    "SOLC_SHA256": "1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468"
+  },
   "expected_step_contracts": {
     "changes": [
       {


### PR DESCRIPTION
## Summary
- pin the top-level `verify.yml` `env` block in `check_verify_sync.py`
- record the expected `SOLC_VERSION`, `SOLC_URL`, and `SOLC_SHA256` values in `verify_sync_spec.json`
- add regression coverage for workflow-env drift and matching workflow-env contracts

## Testing
- `python3 -m unittest scripts.test_check_verify_sync -v`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CI invariants by failing the verify-workflow sync check when top-level `env` values drift, which could cause unexpected CI failures if the YAML parsing/spec is out of sync.
> 
> **Overview**
> Adds **top-level workflow `env` contract enforcement** to `check_verify_sync.py` by extracting and comparing the `verify.yml` `env` mapping against a new `expected_workflow_env` section in `verify_sync_spec.json` (pinning `SOLC_VERSION`, `SOLC_URL`, and `SOLC_SHA256`).
> 
> Updates unit tests to include the new spec field and adds regression coverage for both *env drift* failure messages and the passing case when the workflow `env` matches the spec, plus a small wording tweak in `scripts/REFERENCE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d12a95693ee134ba9ef27d4d23f4192bfe16d92c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->