### PR TITLE
ci: pin verify strategy contracts

### DIFF
--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -5,7 +5,7 @@ This document is the long-form reference for script responsibilities.
 ## Verify workflow sync
 
 - `check_verify_sync.py`: unified table-driven validator for workflow invariants.
-- `verify_sync_spec.json`: expected job order, top-level workflow/job contracts, critical step contracts, command lists, path filters, foundry settings, and artifact producers.
+- `verify_sync_spec.json`: expected job order, top-level workflow/job/strategy contracts, critical step contracts, command lists, path filters, foundry settings, and artifact producers.
 - `check_docs_workflow_sync.py`: keep the docs workflow self-triggering and aligned across push/pull_request path filters.
 
 ## Issue #1060 automation

--- a/scripts/check_verify_sync.py
+++ b/scripts/check_verify_sync.py
@@ -400,6 +400,38 @@ def _extract_job_needs(job_body: str) -> list[str]:
     return [raw]
 
 
+def _extract_job_strategy_fail_fast(job_body: str) -> str | None:
+    block_lines = _extract_top_level_job_block_lines(job_body, "strategy")
+    if not block_lines:
+        return None
+
+    min_child_indent: int | None = None
+    for line in block_lines:
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if min_child_indent is None or child_indent < min_child_indent:
+            min_child_indent = child_indent
+    if min_child_indent is None:
+        return None
+
+    for line in block_lines:
+        if not line.strip():
+            continue
+        child_indent = len(line) - len(line.lstrip(" "))
+        if child_indent != min_child_indent:
+            continue
+        m = re.match(r"^\s*fail-fast:\s*(?P<value>.+?)\s*$", line)
+        if not m:
+            continue
+        raw_value = strip_yaml_inline_comment(m.group("value"))
+        if not raw_value:
+            raise ValueError(f"Empty strategy.fail-fast value in {VERIFY_YML}")
+        return unquote_yaml_scalar(raw_value)
+
+    return None
+
+
 def _compare_mappings(
     name_a: str, a: dict[str, str], name_b: str, b: dict[str, str]
 ) -> list[str]:
@@ -689,6 +721,7 @@ def check_job_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
     expected_conditions: dict[str, str] = spec.get("expected_job_if_conditions", {})
     expected_runs_on: dict[str, str] = spec.get("expected_job_runs_on", {})
     expected_timeouts: dict[str, int] = spec.get("expected_job_timeouts", {})
+    expected_fail_fast: dict[str, bool] = spec.get("expected_job_strategy_fail_fast", {})
     expected_outputs: dict[str, dict[str, str]] = spec.get("expected_job_outputs", {})
     expected_job_permissions: dict[str, dict[str, str]] = spec.get(
         "expected_job_permissions", {}
@@ -772,6 +805,16 @@ def check_job_contracts(snapshot: Snapshot, spec: dict) -> CheckResult:
             errors.append(
                 f"{job} timeout-minutes does not match spec: workflow={actual_timeout!r}, spec={expected_timeout_value!r}"
             )
+
+        expected_fail_fast_value = expected_fail_fast.get(job)
+        if expected_fail_fast_value is not None:
+            actual_fail_fast = _extract_job_strategy_fail_fast(job_body)
+            expected_fail_fast_scalar = "true" if expected_fail_fast_value else "false"
+            if actual_fail_fast != expected_fail_fast_scalar:
+                errors.append(
+                    f"{job} strategy.fail-fast does not match spec: "
+                    f"workflow={actual_fail_fast!r}, spec={expected_fail_fast_scalar!r}"
+                )
 
         outputs = _extract_literal_top_level_mapping(job_body, "outputs")
         if outputs:

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -90,6 +90,7 @@ class VerifySyncTests(unittest.TestCase):
         expected_job_if_conditions: dict[str, str | None],
         expected_job_runs_on: dict[str, str] | None = None,
         expected_job_timeouts: dict[str, int] | None = None,
+        expected_job_strategy_fail_fast: dict[str, bool] | None = None,
         expected_job_outputs: dict[str, dict[str, str]] | None = None,
         expected_job_permissions: dict[str, dict[str, str]] | None = None,
         expected_workflow_permissions: dict[str, str] | None = None,
@@ -108,6 +109,7 @@ class VerifySyncTests(unittest.TestCase):
                         "expected_job_if_conditions": expected_job_if_conditions,
                         "expected_job_runs_on": expected_job_runs_on or {},
                         "expected_job_timeouts": expected_job_timeouts or {},
+                        "expected_job_strategy_fail_fast": expected_job_strategy_fail_fast or {},
                         "expected_job_outputs": expected_job_outputs or {},
                         "expected_job_permissions": expected_job_permissions or {},
                         "expected_workflow_permissions": expected_workflow_permissions or {},
@@ -524,6 +526,35 @@ class VerifySyncTests(unittest.TestCase):
         self.assertIn("changes outputs does not match spec changes outputs.", err)
         self.assertIn("failure-hints permissions does not match spec failure-hints permissions.", err)
 
+    def test_job_contracts_check_fails_when_strategy_fail_fast_drifts(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              foundry:
+                runs-on: ubuntu-latest
+                timeout-minutes: 15
+                strategy:
+                  fail-fast: true
+                  matrix:
+                    shard_index: [0, 1]
+                steps: []
+            """
+        )
+        rc, _, err = self._run_job_contracts_check(
+            workflow,
+            expected_job_needs={"foundry": []},
+            expected_job_if_conditions={"foundry": None},
+            expected_job_runs_on={"foundry": "ubuntu-latest"},
+            expected_job_timeouts={"foundry": 15},
+            expected_job_strategy_fail_fast={"foundry": False},
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            "foundry strategy.fail-fast does not match spec: workflow='true', spec='false'",
+            err,
+        )
+
     def test_job_contracts_check_passes_when_workflow_platform_contracts_match_spec(self) -> None:
         workflow = textwrap.dedent(
             """
@@ -581,6 +612,46 @@ class VerifySyncTests(unittest.TestCase):
             expected_workflow_env={
                 "SOLC_VERSION": "0.8.33",
                 "SOLC_URL": "https://example.invalid/solc",
+            },
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertIn("[PASS] job-contracts", out)
+
+    def test_job_contracts_check_passes_when_strategy_fail_fast_matches_spec(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            jobs:
+              foundry:
+                runs-on: ubuntu-latest
+                timeout-minutes: 15
+                strategy:
+                  fail-fast: false
+                  matrix:
+                    shard_index: [0, 1]
+                steps: []
+              foundry-multi-seed:
+                runs-on: ubuntu-latest
+                timeout-minutes: 25
+                strategy:
+                  fail-fast: false
+                  matrix:
+                    seed: [42, 123]
+                steps: []
+            """
+        )
+        rc, out, err = self._run_job_contracts_check(
+            workflow,
+            expected_job_needs={"foundry": [], "foundry-multi-seed": []},
+            expected_job_if_conditions={"foundry": None, "foundry-multi-seed": None},
+            expected_job_runs_on={
+                "foundry": "ubuntu-latest",
+                "foundry-multi-seed": "ubuntu-latest",
+            },
+            expected_job_timeouts={"foundry": 15, "foundry-multi-seed": 25},
+            expected_job_strategy_fail_fast={
+                "foundry": False,
+                "foundry-multi-seed": False,
             },
         )
         self.assertEqual(rc, 0, err)

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -113,6 +113,10 @@
     "foundry-patched": 15,
     "foundry-multi-seed": 25
   },
+  "expected_job_strategy_fail_fast": {
+    "foundry": false,
+    "foundry-multi-seed": false
+  },
   "expected_job_outputs": {
     "changes": {
       "code": "${{ steps.filter.outputs.code }}",


### PR DESCRIPTION
## Summary
- pin the `verify.yml` matrix-job `strategy.fail-fast` contract in `check_verify_sync.py`
- declare the expected `fail-fast: false` shape for `foundry` and `foundry-multi-seed`
- add regression tests and update the script reference

## Testing
- python3 -m unittest scripts.test_check_verify_sync -v
- python3 scripts/check_verify_sync.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CI workflow validation by adding a new `strategy.fail-fast` invariant, which could start failing builds if the parser/spec doesn’t match real `verify.yml` formatting. Scope is small and covered by new unit tests.
> 
> **Overview**
> **Pins matrix job `strategy.fail-fast` behavior in `verify.yml`** by extending `check_verify_sync.py` to extract and compare `strategy.fail-fast` values against the sync spec.
> 
> Updates `verify_sync_spec.json` to declare `fail-fast: false` for `foundry` and `foundry-multi-seed`, adds regression tests for drift/pass cases, and refreshes `scripts/REFERENCE.md` to note strategy contracts are validated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97a9519a1745ef02fe70f5d5078e47a060c0546e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->