### PR TITLE
ci: pin verify trigger contracts

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,11 @@
+## Summary
+
+- pin the verify workflow trigger contract in `check_verify_sync.py`
+- require pushes to stay limited to `main` and require `workflow_dispatch` to remain enabled
+- add regression coverage for trigger drift, including the live inline `branches: [main]` form
+
+## Testing
+
+- `python3 -m unittest scripts.test_check_verify_sync -v`
+- `python3 scripts/check_verify_sync.py`
+- `make check`

--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -5,7 +5,7 @@ This document is the long-form reference for script responsibilities.
 ## Verify workflow sync
 
 - `check_verify_sync.py`: unified table-driven validator for workflow invariants.
-- `verify_sync_spec.json`: expected job order, top-level workflow/job/strategy contracts, critical step contracts, command lists, path filters, foundry settings, and artifact producers.
+- `verify_sync_spec.json`: expected trigger paths/branches, job order, top-level workflow/job/strategy contracts, critical step contracts, command lists, foundry settings, and artifact producers.
 - `check_docs_workflow_sync.py`: keep the docs workflow self-triggering and aligned across push/pull_request path filters.
 
 ## Issue #1060 automation

--- a/scripts/check_verify_sync.py
+++ b/scripts/check_verify_sync.py
@@ -101,6 +101,27 @@ def _extract_push_paths(text: str) -> list[str]:
     )
 
 
+def _extract_push_branches(text: str) -> list[str]:
+    push_match = re.search(r"^  push:\n(?P<body>(?:^    .*\n)*)", text, re.MULTILINE)
+    if not push_match:
+        raise ValueError(f"Could not locate on.push in {VERIFY_YML}")
+
+    push_body = push_match.group("body")
+    inline_match = re.search(r"^    branches:\s*(?P<value>\[.*\])\s*$", push_body, re.MULTILINE)
+    if inline_match:
+        raw = strip_yaml_inline_comment(inline_match.group("value"))
+        inner = raw[1:-1].strip()
+        if not inner:
+            raise ValueError(f"on.push.branches is empty in {VERIFY_YML}")
+        return [unquote_yaml_scalar(part.strip()) for part in inner.split(",")]
+
+    return _extract_list_block(
+        text,
+        r"^  push:\n(?:^    .*\n)*?^    branches:\n(?P<block>(?:^      - .*\n)+)",
+        "on.push.branches",
+    )
+
+
 def _extract_pr_paths(text: str) -> list[str]:
     return _extract_list_block(
         text,
@@ -676,18 +697,39 @@ def check_paths(snapshot: Snapshot, spec: dict) -> CheckResult:
     pr_paths = _extract_pr_paths(snapshot.workflow_text)
     changes_paths = _extract_changes_filter_paths(snapshot.workflow_text, "code")
     compiler_changes_paths = _extract_changes_filter_paths(snapshot.workflow_text, "compiler")
+    expected_push_branches = spec.get("expected_push_branches", [])
+    require_workflow_dispatch = spec.get("require_workflow_dispatch", False)
 
-    for label, values in [
+    list_blocks = [
         ("on.push.paths", push_paths),
         ("on.pull_request.paths", pr_paths),
         ("changes.filter.code", changes_paths),
         ("changes.filter.compiler", compiler_changes_paths),
-    ]:
+    ]
+    push_branches: list[str] = []
+    if expected_push_branches:
+        push_branches = _extract_push_branches(snapshot.workflow_text)
+        list_blocks.insert(0, ("on.push.branches", push_branches))
+
+    for label, values in list_blocks:
         dup = _duplicates(values)
         if dup:
             errors.append(f"{label} has duplicates: {', '.join(dup)}")
 
+    if expected_push_branches:
+        errors.extend(
+            _compare_lists(
+                "on.push.branches",
+                push_branches,
+                "spec push branches",
+                expected_push_branches,
+            )
+        )
+
     errors.extend(_compare_lists("on.push.paths", push_paths, "on.pull_request.paths", pr_paths))
+
+    if require_workflow_dispatch and "\n  workflow_dispatch:\n" not in f"\n{snapshot.workflow_text}":
+        errors.append("workflow_dispatch trigger is missing from verify.yml")
 
     check_only = spec["check_only_paths"]
     missing_check_only = sorted(set(check_only) - set(push_paths))

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -49,6 +49,8 @@ class VerifySyncTests(unittest.TestCase):
         *,
         check_only_paths: list[str],
         compiler_paths: list[str],
+        expected_push_branches: list[str] | None = None,
+        require_workflow_dispatch: bool = False,
     ) -> tuple[int, str, str]:
         with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as td:
             root = Path(td)
@@ -60,6 +62,8 @@ class VerifySyncTests(unittest.TestCase):
                     {
                         "check_only_paths": check_only_paths,
                         "compiler_paths": compiler_paths,
+                        "expected_push_branches": expected_push_branches or [],
+                        "require_workflow_dispatch": require_workflow_dispatch,
                     }
                 ),
                 encoding="utf-8",
@@ -338,6 +342,84 @@ class VerifySyncTests(unittest.TestCase):
         rc, _, err = self._run_jobs_check(workflow, ["changes", "checks"])
         self.assertEqual(rc, 1)
         self.assertIn("[FAIL] jobs", err)
+
+    def test_paths_check_fails_when_push_branch_and_workflow_dispatch_drift(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            on:
+              push:
+                branches:
+                  - release
+                paths:
+                  - 'src/**'
+              pull_request:
+                paths:
+                  - 'src/**'
+            jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                  - id: filter
+                    uses: dorny/paths-filter@v3
+                    with:
+                      filters: |
+                        code:
+                          - 'src/**'
+                        compiler:
+                          - 'src/**'
+            """
+        )
+        rc, _, err = self._run_paths_check(
+            workflow,
+            check_only_paths=[],
+            compiler_paths=["src/**"],
+            expected_push_branches=["main"],
+            require_workflow_dispatch=True,
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("[FAIL] paths", err)
+        self.assertIn("on.push.branches does not match spec push branches.", err)
+        self.assertIn("workflow_dispatch trigger is missing from verify.yml", err)
+
+    def test_paths_check_passes_when_trigger_contracts_match_spec(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            on:
+              push:
+                branches: [main]
+                paths:
+                  - 'src/**'
+              pull_request:
+                paths:
+                  - 'src/**'
+              workflow_dispatch:
+            jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                  - id: filter
+                    uses: dorny/paths-filter@v3
+                    with:
+                      filters: |
+                        code:
+                          - 'src/**'
+                        compiler:
+                          - 'src/**'
+            """
+        )
+        rc, out, err = self._run_paths_check(
+            workflow,
+            check_only_paths=[],
+            compiler_paths=["src/**"],
+            expected_push_branches=["main"],
+            require_workflow_dispatch=True,
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertIn("[PASS] paths", out)
 
     def test_job_contracts_check_fails_when_needs_and_if_drift(self) -> None:
         workflow = textwrap.dedent(

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -28,6 +28,10 @@
     "lean-toolchain",
     "foundry.toml"
   ],
+  "expected_push_branches": [
+    "main"
+  ],
+  "require_workflow_dispatch": true,
   "expected_jobs": [
     "changes",
     "checks",


### PR DESCRIPTION
## Summary

- pin the verify workflow trigger contract in `check_verify_sync.py`
- require pushes to stay limited to `main` and require `workflow_dispatch` to remain enabled
- add regression coverage for trigger drift, including the live inline `branches: [main]` form

## Testing

- `python3 -m unittest scripts.test_check_verify_sync -v`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI validation regex/parsing for workflow triggers and could cause false failures if `verify.yml` uses an unexpected YAML form.
> 
> **Overview**
> **Pins the `verify.yml` trigger contract in the verify-sync guard.** `check_verify_sync.py` now validates `on.push.branches` (including the inline `branches: [main]` form) against a spec-defined list and can require the presence of `workflow_dispatch`.
> 
> Updates `verify_sync_spec.json` to set `expected_push_branches: ["main"]` and `require_workflow_dispatch: true`, and adds unit tests that fail on branch/trigger drift. Documentation in `scripts/REFERENCE.md` is adjusted to reflect the expanded spec scope.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c911b996d5e6833a75394288569632ee17b2269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->