### PR TITLE
ci: pin verify workflow trigger set

### DIFF
--- a/scripts/REFERENCE.md
+++ b/scripts/REFERENCE.md
@@ -5,7 +5,7 @@ This document is the long-form reference for script responsibilities.
 ## Verify workflow sync
 
 - `check_verify_sync.py`: unified table-driven validator for workflow invariants.
-- `verify_sync_spec.json`: expected trigger paths/branches, job order, top-level workflow/job/strategy contracts, critical step contracts, command lists, foundry settings, and artifact producers.
+- `verify_sync_spec.json`: expected trigger keys/paths/branches, job order, top-level workflow/job/strategy contracts, critical step contracts, command lists, foundry settings, and artifact producers.
 - `check_docs_workflow_sync.py`: keep the docs workflow self-triggering and aligned across push/pull_request path filters.
 
 ## Issue #1060 automation

--- a/scripts/check_verify_sync.py
+++ b/scripts/check_verify_sync.py
@@ -122,6 +122,25 @@ def _extract_push_branches(text: str) -> list[str]:
     )
 
 
+def _extract_trigger_keys(text: str) -> list[str]:
+    on_match = re.search(r"^on:\n(?P<body>(?:^  .*\n)*)", text, re.MULTILINE)
+    if not on_match:
+        raise ValueError(f"Could not locate on in {VERIFY_YML}")
+
+    trigger_keys: list[str] = []
+    for line in on_match.group("body").splitlines():
+        if not line.strip():
+            continue
+        if len(line) - len(line.lstrip(" ")) != 2:
+            continue
+        match = re.match(r"^\s{2}(?P<key>[A-Za-z0-9_-]+):(?:\s|$)", line)
+        if match:
+            trigger_keys.append(match.group("key"))
+    if not trigger_keys:
+        raise ValueError(f"No workflow triggers found under on in {VERIFY_YML}")
+    return trigger_keys
+
+
 def _extract_pr_paths(text: str) -> list[str]:
     return _extract_list_block(
         text,
@@ -693,10 +712,12 @@ def _load_spec() -> dict:
 
 def check_paths(snapshot: Snapshot, spec: dict) -> CheckResult:
     errors: list[str] = []
+    trigger_keys = _extract_trigger_keys(snapshot.workflow_text)
     push_paths = _extract_push_paths(snapshot.workflow_text)
     pr_paths = _extract_pr_paths(snapshot.workflow_text)
     changes_paths = _extract_changes_filter_paths(snapshot.workflow_text, "code")
     compiler_changes_paths = _extract_changes_filter_paths(snapshot.workflow_text, "compiler")
+    expected_trigger_keys = spec.get("expected_trigger_keys", [])
     expected_push_branches = spec.get("expected_push_branches", [])
     require_workflow_dispatch = spec.get("require_workflow_dispatch", False)
 
@@ -715,6 +736,16 @@ def check_paths(snapshot: Snapshot, spec: dict) -> CheckResult:
         dup = _duplicates(values)
         if dup:
             errors.append(f"{label} has duplicates: {', '.join(dup)}")
+
+    if expected_trigger_keys:
+        errors.extend(
+            _compare_lists(
+                "workflow triggers",
+                trigger_keys,
+                "spec workflow triggers",
+                expected_trigger_keys,
+            )
+        )
 
     if expected_push_branches:
         errors.extend(

--- a/scripts/test_check_verify_sync.py
+++ b/scripts/test_check_verify_sync.py
@@ -49,6 +49,7 @@ class VerifySyncTests(unittest.TestCase):
         *,
         check_only_paths: list[str],
         compiler_paths: list[str],
+        expected_trigger_keys: list[str] | None = None,
         expected_push_branches: list[str] | None = None,
         require_workflow_dispatch: bool = False,
     ) -> tuple[int, str, str]:
@@ -62,6 +63,7 @@ class VerifySyncTests(unittest.TestCase):
                     {
                         "check_only_paths": check_only_paths,
                         "compiler_paths": compiler_paths,
+                        "expected_trigger_keys": expected_trigger_keys or [],
                         "expected_push_branches": expected_push_branches or [],
                         "require_workflow_dispatch": require_workflow_dispatch,
                     }
@@ -375,13 +377,57 @@ class VerifySyncTests(unittest.TestCase):
             workflow,
             check_only_paths=[],
             compiler_paths=["src/**"],
+            expected_trigger_keys=["push", "pull_request", "workflow_dispatch"],
             expected_push_branches=["main"],
             require_workflow_dispatch=True,
         )
         self.assertEqual(rc, 1)
         self.assertIn("[FAIL] paths", err)
+        self.assertIn("workflow triggers does not match spec workflow triggers.", err)
         self.assertIn("on.push.branches does not match spec push branches.", err)
         self.assertIn("workflow_dispatch trigger is missing from verify.yml", err)
+
+    def test_paths_check_fails_when_extra_trigger_is_added(self) -> None:
+        workflow = textwrap.dedent(
+            """
+            name: verify
+            on:
+              push:
+                branches: [main]
+                paths:
+                  - 'src/**'
+              pull_request:
+                paths:
+                  - 'src/**'
+              workflow_dispatch:
+              schedule:
+                - cron: '0 0 * * *'
+            jobs:
+              changes:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                  - id: filter
+                    uses: dorny/paths-filter@v3
+                    with:
+                      filters: |
+                        code:
+                          - 'src/**'
+                        compiler:
+                          - 'src/**'
+            """
+        )
+        rc, _, err = self._run_paths_check(
+            workflow,
+            check_only_paths=[],
+            compiler_paths=["src/**"],
+            expected_trigger_keys=["push", "pull_request", "workflow_dispatch"],
+            expected_push_branches=["main"],
+            require_workflow_dispatch=True,
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("workflow triggers does not match spec workflow triggers.", err)
+        self.assertIn("idx 3: workflow triggers='schedule', spec workflow triggers='<missing>'", err)
 
     def test_paths_check_passes_when_trigger_contracts_match_spec(self) -> None:
         workflow = textwrap.dedent(
@@ -415,6 +461,7 @@ class VerifySyncTests(unittest.TestCase):
             workflow,
             check_only_paths=[],
             compiler_paths=["src/**"],
+            expected_trigger_keys=["push", "pull_request", "workflow_dispatch"],
             expected_push_branches=["main"],
             require_workflow_dispatch=True,
         )

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -31,6 +31,11 @@
   "expected_push_branches": [
     "main"
   ],
+  "expected_trigger_keys": [
+    "push",
+    "pull_request",
+    "workflow_dispatch"
+  ],
   "require_workflow_dispatch": true,
   "expected_jobs": [
     "changes",


### PR DESCRIPTION
## Summary

- pin the exact `verify.yml` trigger set in `scripts/check_verify_sync.py`
- fail closed if `verify.yml` gains an unexpected trigger such as `schedule`
- add regression coverage and document the stricter trigger contract

## Why

The sync checker already pinned trigger paths, push branches, and `workflow_dispatch`, but it still allowed silent trigger-surface drift. Adding a new top-level trigger would change when CI runs without tripping `make check`.

## Validation

- `python3 -m unittest scripts.test_check_verify_sync -v`
- `python3 scripts/check_verify_sync.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI guard scripts/specs and tests, but may cause CI to fail if `verify.yml` adds/reorders triggers (intentionally enforcing the new contract).
> 
> **Overview**
> **Pins the `verify.yml` trigger surface.** `check_verify_sync.py` now extracts the top-level keys under `on:` and compares them against a new spec field, failing if triggers are missing, reordered, or newly added (e.g., `schedule`).
> 
> Updates `verify_sync_spec.json` to define `expected_trigger_keys`, adds regression tests for trigger drift, and adjusts `scripts/REFERENCE.md` to document the stricter trigger contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18cc8029629960b0dd4c257a781c665359025757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->