### PR TITLE
docs: clarify Layer 1 vs contract spec proofs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,7 +283,7 @@ See [AXIOMS.md](AXIOMS.md) for current axioms and detailed guidelines.
 
 ## Key Files
 
-- `Verity/` - EDSL, specs, Layer 1 proofs
+- `Verity/` - EDSL, user-facing specs, and contract-specific specification proofs
 - `Compiler/` - IR, Yul, codegen
 - `Compiler/Proofs/` - Layer 2 & 3 proofs
 - `docs/ROADMAP.md` - Progress tracking

--- a/Compiler/Proofs/README.md
+++ b/Compiler/Proofs/README.md
@@ -7,9 +7,10 @@ See `TRUST_ASSUMPTIONS.md` for the full trust boundary.
 
 ## Verification Layers
 
-- **Layer 1: EDSL ≡ CompilationModel**. Contract-specific proofs live in
-  `Contracts/<Name>/Proofs/`, with generic typed-IR compilation correctness in
-  `Compiler/TypedIRCompilerCorrectness.lean`.
+- **Layer 1: EDSL ≡ CompilationModel**. This is the frontend semantic bridge.
+  Contract-specific specification proofs live separately in
+  `Contracts/<Name>/Proofs/`, while generic typed-IR compilation correctness
+  lives in `Compiler/TypedIRCompilerCorrectness.lean`.
 - **Layer 2: CompilationModel -> IR**. The current proof surface is split:
   a generic supported-statement-fragment theorem lives in
   `Compiler/TypedIRCompilerCorrectness.lean` and

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The compiler turns contracts into Yul (Solidity's low-level IR) through three la
 EDSL contract (Lean)
   ↓  Layer 1: EDSL ≡ CompilationModel     [PROVEN]
 CompilationModel (declarative IR spec)
-  ↓  Layer 2: CompilationModel → IR        [PROVEN]
+  ↓  Layer 2: CompilationModel → IR        [PARTIAL GENERIC, CONTRACT BRIDGES ACTIVE]
 Intermediate Representation
   ↓  Layer 3: IR → Yul                     [PROVEN, 1 axiom]
 Yul
@@ -92,10 +92,10 @@ EVM Bytecode
 | Layer | What it proves | Key file |
 |-------|---------------|----------|
 | 1 | EDSL execution = CompilationModel interpretation | [TypedIRCompilerCorrectness.lean](Compiler/TypedIRCompilerCorrectness.lean) |
-| 2 | CompilationModel → IR preserves behavior | [IRInterpreter.lean](Compiler/Proofs/IRGeneration/IRInterpreter.lean) |
+| 2 | CompilationModel → IR preserves behavior for the currently proved contract bridge surface | [IRInterpreter.lean](Compiler/Proofs/IRGeneration/IRInterpreter.lean) |
 | 3 | IR → Yul codegen preserves behavior | [Preservation.lean](Compiler/Proofs/YulGeneration/Preservation.lean) |
 
-Layers 2 and 3 (`CompilationModel → IR → Yul`) are verified with 1 axiom (the selector axiom). See [AXIOMS.md](AXIOMS.md).
+Layer 1 is the frontend EDSL-to-`CompilationModel` bridge. The per-contract files in `Contracts/<Name>/Proofs/` prove human-readable contract specifications; they are not what “Layer 1” means in the compiler stack. Layers 2 and 3 (`CompilationModel → IR → Yul`) are verified with the current documented axioms and bridge boundaries; see [docs/VERIFICATION_STATUS.md](docs/VERIFICATION_STATUS.md) and [AXIOMS.md](AXIOMS.md).
 
 ### 5. Test the compiled output (belt and suspenders)
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -20,7 +20,7 @@ All three layers are proven in Lean, with 1 documented axiom (the selector axiom
 
 ## What's Verified
 
-- **Layer 1**: EDSL behavior matches its CompilationModel. For supported contracts, a generic typed-IR compilation-correctness theorem eliminates per-contract manual proofs.
+- **Layer 1**: EDSL behavior matches its `CompilationModel`. This names the frontend semantic bridge only; it does not refer to the contract-specific specification theorems in `Contracts/<Name>/Proofs/`. For supported contracts, macro-generated bridge theorems and the typed-IR correctness path discharge this boundary.
 - **Layer 2**: CompilationModel → IR preserves behavior.
 - **Layer 3**: IR → Yul preserves behavior, with 1 documented axiom (keccak256 selector).
 - **Cross-layer**: `Compiler/Proofs/SemanticBridge.lean` has zero `sorry`; `Compiler/Proofs/EndToEnd.lean` composes Layers 2+3.

--- a/docs-site/content/add-contract.mdx
+++ b/docs-site/content/add-contract.mdx
@@ -44,7 +44,7 @@ This creates 7 scaffold files (EDSL, Spec, Invariants, Proofs re-export shim, Ba
    - Implement contract logic in `Verity/Examples/<Name>.lean`
    - Reuse helper lemmas for storage updates and mapping reads
 
-3. **Layer 1 Proofs**
+3. **Contract Specification Proofs**
    - Prove correctness in `Verity/Proofs/<Name>/Basic.lean` and `Correctness.lean`
    - Each theorem states observable behavior (return values + storage deltas)
 
@@ -74,7 +74,7 @@ Verity/Specs/<Name>/
 
 Verity/Examples/<Name>.lean     # EDSL implementation
 Verity/Proofs/<Name>/
-  ├── Basic.lean       # Basic correctness proofs (Layer 1)
+  ├── Basic.lean       # Basic contract-spec correctness proofs
   └── Correctness.lean # Advanced correctness proofs
 Compiler/TypedIRCompilerCorrectness.lean  # Generic compilation correctness (shared)
 test/Differential<Name>.t.sol          # Differential tests

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -29,11 +29,13 @@ Important: Verity has two different "spec" concepts.
 ## Trust Model
 
 ### What's Verified (Zero Trust Required)
-- **Layer 1 per contract**: EDSL behavior is proven equivalent to its `CompilationModel`.
+- **Layer 1 frontend bridge**: EDSL behavior is proven equivalent to its `CompilationModel`.
 - **Layer 2 framework proof**: `CompilationModel -> IR` preserves semantics.
 - **Layer 3 framework proof**: `IR -> Yul` preserves semantics.
 - **Machine-checked proofs**: see [VERIFICATION_STATUS.md](https://github.com/Th0rgal/verity/blob/main/docs/VERIFICATION_STATUS.md) for the current proof-status snapshot and [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md) for documented axioms.
 - **Interpreter semantics**: Spec, IR, and Yul semantics defined and linked in Lean
+
+The per-contract files in `Contracts/<Name>/Proofs/` are separate contract-specification proofs. They show that a given contract satisfies its human-readable spec; they are not the definition of Layer 1 in the compiler stack.
 
 ### What's Tested (High Confidence)
 - **Compilation correctness**: Foundry unit and differential tests cover compiled contracts

--- a/docs-site/content/guides/first-contract.mdx
+++ b/docs-site/content/guides/first-contract.mdx
@@ -250,7 +250,7 @@ If successful, the `#eval` block evaluates and prints `some 100`.
 
 This is where formal verification happens. We prove that our implementation matches our specification.
 
-### 4.1 Write Layer 1 Proofs
+### 4.1 Write Contract Specification Proofs
 
 Open `Verity/Proofs/TipJar/Basic.lean`:
 

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -80,7 +80,7 @@ The Lean compiler verifies every proof. If a proof is wrong, compilation fails.
 
 - **User-facing specs**: `Verity/Specs/<Name>/Spec.lean` (+ `Invariants.lean`)
 - **Implementations (EDSL)**: `Verity/Examples/<Name>.lean`
-- **Layer 1 proofs (EDSL correctness)**: `Verity/Proofs/<Name>/Basic.lean` + `Correctness.lean`
+- **Contract-specific specification proofs**: `Verity/Proofs/<Name>/Basic.lean` + `Correctness.lean`
 - **Compilation correctness**: `Compiler/TypedIRCompilerCorrectness.lean` (generic theorem) + `Compiler/Proofs/SemanticBridge.lean`
 - **Reusable proof infrastructure**: `Verity/Proofs/Stdlib/` (spec interpreter + automation)
 - **Compiler specs (for codegen)**: `Compiler/Specs.lean` (separate from user specs)
@@ -98,6 +98,8 @@ Use `python3 scripts/generate_contract.py <Name>` to scaffold all boilerplate fi
 6. Add tests in `test/` (unit + property + differential if applicable).
 
 See [Add a Contract](/add-contract) for the full guide.
+
+In this repo, “Layer 1” refers specifically to the EDSL-to-`CompilationModel` semantic bridge in the compiler pipeline. The files under `Verity/Proofs/<Name>/` are contract-level specification proofs.
 
 ## Example Contracts
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -19,7 +19,7 @@ The project evolved in two phases:
 
 This is the single source of truth for progress, roadmap, and milestone updates.
 
-- **Layer 1 (Spec Correctness)**: Complete for all 8 verified contracts (7 compiler-spec contracts + ReentrancyExample).
+- **Contract-specific specification proofs**: Complete for all 8 verified contracts (7 compiler-spec contracts + ReentrancyExample).
 - **Layer 2 (CompilationModel → IR)**: Complete for all 7 contracts (per‑function preservation theorems compiled in Lean).
 - **Layer 3 (IR → Yul)**: Complete — all 8 statement equivalence proofs + universal dispatcher proven (PR #42).
 
@@ -102,8 +102,8 @@ Each contract has:
 - `Verity/Examples/X.lean` — Implementation (EDSL)
 - `Verity/Specs/X/Spec.lean` — Pre/postconditions for each operation
 - `Verity/Specs/X/Invariants.lean` — State properties that should hold
-- `Verity/Proofs/X/Basic.lean` — Layer 1: Spec conformance, basic properties
-- `Verity/Proofs/X/Correctness.lean` — Layer 1: Revert proofs, composition, end-to-end
+- `Verity/Proofs/X/Basic.lean` — Contract-specific spec conformance and basic properties
+- `Verity/Proofs/X/Correctness.lean` — Contract-specific revert proofs, composition, and end-to-end properties
 - `Compiler/TypedIRCompilerCorrectness.lean` — Compilation correctness (generic theorem, 36 supported fragments)
 
 Some contracts have additional proof files:

--- a/docs-site/content/verification.mdx
+++ b/docs-site/content/verification.mdx
@@ -29,7 +29,7 @@ This section is a dated historical snapshot. Use [docs/VERIFICATION_STATUS.md](h
 
 ## Compiler Proofs (IR + Yul)
 
-- **Semantic bridge**: `Compiler/Proofs/SemanticBridge.lean` (EDSL ≡ CompilationModel for all supported contracts)
+- **Semantic bridge**: `Compiler/Proofs/SemanticBridge.lean` (active contract-level bridge surface used to connect EDSL/CompilationModel executions to compiled IR/Yul executions)
 - **End-to-end proofs**: `Compiler/Proofs/EndToEnd.lean` (full pipeline correctness)
 - **Typed IR correctness**: `Compiler/TypedIRCompilerCorrectness.lean` (generic compilation-correctness theorem with 36 supported statement fragments, including ABI-head tuple/bytes/fixed-array/dynamic-array/string params as word-typed inputs)
 - **IR generation**: `Compiler/Proofs/IRGeneration/` (infrastructure + concrete IR proofs in `Expr.lean`)
@@ -45,11 +45,11 @@ Verity/
 ├── Specs/{Contract}/
 │   ├── Spec.lean                 # What each operation should do
 │   └── Invariants.lean           # Properties that should always hold
-│   └── Proofs.lean               # User-facing proofs (spec → impl)
+│   └── Proofs.lean               # User-facing spec statements and re-exports
 ├── Proofs/Stdlib/                # Reusable proof infrastructure
 └── Proofs/{Contract}/            # Deeper contract proof suites
-    ├── Basic.lean                # Core properties and lemmas
-    ├── Correctness.lean          # Composition and revert behavior
+    ├── Basic.lean                # Contract-specific spec conformance and lemmas
+    ├── Correctness.lean          # Contract-specific composition and revert behavior
     ├── Conservation.lean         # Sum conservation laws (Ledger)
     ├── Supply.lean               # Supply conservation (SimpleToken)
     └── Isolation.lean            # Storage isolation (SimpleToken)

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -26,7 +26,8 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 ## Architecture
 
 ```
-Layer 1: EDSL Proofs      — Lean theorems about contract behavior
+Layer 1: EDSL -> CompilationModel bridge
+Contract proofs: human-readable spec theorems for each contract
 Layer 2: Compiler Proofs  — CompilationModel -> IR preservation
 Layer 3: IR -> Yul        — Statement/expression equivalence proofs
 Trust:   Yul -> Bytecode  — Via solc (validated by differential testing)

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -18,7 +18,7 @@ EVM Bytecode
 
 ## Layer 1: EDSL ≡ CompilationModel — COMPLETE
 
-**What it proves**: The EDSL `Contract` monad execution is equivalent to `CompilationModel` interpretation for all supported contracts. Per-contract proofs under `Contracts/<Name>/Proofs/` then show these contracts satisfy their human-readable specifications.
+**What it proves**: The EDSL `Contract` monad execution is equivalent to `CompilationModel` interpretation for all supported contracts. This is the frontend semantic bridge. Separate per-contract proofs under `Contracts/<Name>/Proofs/` show that each contract satisfies its human-readable specifications; those specification theorems are downstream contract proofs, not the definition of Layer 1 itself.
 
 ### Verified Contracts
 
@@ -38,11 +38,11 @@ EVM Bytecode
 | CryptoHash | 0 | No specs | `Contracts/CryptoHash/Contract.lean` |
 | **Total** | **277** | **✅ 100%** | — |
 
-> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (277 total properties).
+> **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (277 total properties).
 
-Layer 1 uses macro-generated bridge theorems backed by a generic typed-IR compilation-correctness theorem ([`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean)). Tuple/bytes/fixed-array/dynamic-array/string parameters now stay inside that proof path when they are carried as ABI head words/offsets. Advanced constructs beyond that typed-IR head-word surface (linked libraries, ECMs, fully custom ABI behavior) are still expressed directly in `CompilationModel` and trusted at that boundary.
+Layer 1 uses macro-generated EDSL-to-`CompilationModel` bridge theorems backed by a generic typed-IR compilation-correctness theorem ([`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean)). Tuple/bytes/fixed-array/dynamic-array/string parameters now stay inside that proof path when they are carried as ABI head words/offsets. Advanced constructs beyond that typed-IR head-word surface (linked libraries, ECMs, fully custom ABI behavior) are still expressed directly in `CompilationModel` and trusted at that boundary.
 
-Internal helper calls are supported operationally in `CompilationModel` and the fuel-based interpreter path, but helper-level compositional proof reuse across callers is not yet a first-class verified interface. Current Layer 1 bridges remain contract-specific; the reusable internal-helper proof boundary is tracked in [#1335](https://github.com/Th0rgal/verity/issues/1335).
+Internal helper calls are supported operationally in `CompilationModel` and the fuel-based interpreter path, but helper-level compositional proof reuse across callers is not yet a first-class verified interface. Current EDSL-to-`CompilationModel` bridge instantiations remain contract-specific; the reusable internal-helper proof boundary is tracked in [#1335](https://github.com/Th0rgal/verity/issues/1335).
 
 ### Lowering Bridge
 

--- a/scripts/test_check_verification_status_doc.py
+++ b/scripts/test_check_verification_status_doc.py
@@ -91,7 +91,7 @@ class VerificationStatusDocTests(unittest.TestCase):
             | CryptoHash | 0 | No specs | `Contracts/CryptoHash/Contract.lean` |
             | **Total** | **7** | **✅ 100%** | — |
 
-            > **Note**: Stdlib (0 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (7 total properties).
+            > **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (7 total properties).
 
             | Contract | Coverage | Exclusions |
             |----------|----------|------------|
@@ -146,7 +146,7 @@ class VerificationStatusDocTests(unittest.TestCase):
             | CryptoHash | 0 | No specs | `Contracts/CryptoHash/Contract.lean` |
             | **Total** | **7** | **✅ 100%** | — |
 
-            > **Note**: Stdlib (0 internal proof-automation properties) is excluded from the Layer 1 contracts table above but included in overall coverage statistics (7 total properties).
+            > **Note**: Stdlib (0 internal proof-automation properties) is excluded from the contract-spec theorem table above but included in overall coverage statistics (7 total properties).
 
             | Contract | Coverage | Exclusions |
             |----------|----------|------------|


### PR DESCRIPTION
## Summary
- reserve "Layer 1" for the EDSL-to-CompilationModel bridge throughout the repo docs
- relabel  as contract-specific specification proofs instead of Layer 1
- update the verification-status doc guard test to match the wording change

## Why
Several docs and comments mixed compiler-layer terminology with per-contract specification proofs. This PR makes the distinction explicit so Layer 1 is not used as a catch-all label for contract proofs.

## Validation
- 
- 
no tests ran in 0.00s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording updates plus a small test fixture string change; no runtime or proof logic is modified.
> 
> **Overview**
> Clarifies repo/docs-site terminology to consistently reserve **“Layer 1”** for the frontend EDSL-to-`CompilationModel` semantic bridge, and relabels per-contract theorems as *contract-specification proofs* across `README.md`, `TRUST_ASSUMPTIONS.md`, `docs/VERIFICATION_STATUS.md`, `CONTRIBUTING.md`, and multiple docs-site pages.
> 
> Updates the Layer 2 wording to reflect the current state (*partial generic theorem with contract-specific bridges still active*) and adjusts `scripts/test_check_verification_status_doc.py` fixtures to match the updated note text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc0c00fe527d21e2dcfb95cb40c944f2e5f94615. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->