### PR TITLE
proof: clarify current non-payable switch-case guard stepping

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -38,7 +38,7 @@ Selector hashing is modeled as an external cryptographic primitive rather than r
 
 ### 2. `execYulStmtsFuel_setVar_hasSelector_irrelevant`
 
-**Location**: `Compiler/Proofs/YulGeneration/Preservation.lean:748`
+**Location**: `Compiler/Proofs/YulGeneration/Preservation.lean:757`
 
 **Statement**:
 ```lean
@@ -63,7 +63,7 @@ a standard dead-variable elimination fact.
 
 ### 3. `execYulStmtsFuel_fuel_adequate`
 
-**Location**: `Compiler/Proofs/YulGeneration/Preservation.lean:757`
+**Location**: `Compiler/Proofs/YulGeneration/Preservation.lean:766`
 
 **Statement**:
 ```lean
@@ -93,6 +93,9 @@ standard fuel-monotonicity / fuel-saturation fact for bounded recursion.
 *Note*: The former monolithic `SwitchCaseBodyBridge` axiom has been eliminated.
 `SwitchCaseBodyBridge` is now a proved theorem built by composing the short-calldata
 guard theorems with these two smaller Yul-level axioms through `SwitchCaseBodyBridge_body`.
+In particular, the non-payable `msgValue = 0` dispatch path is handled constructively
+inside the guard-stepping lemmas (`dispatchGuardsSafe_msgValue_zero_mod_of_nonpayable`
+plus `exec_callvalueGuard_noop`), so it is not covered by any separate bridge axiom.
 
 ### 4. `supported_function_body_correct_from_exact_state`
 

--- a/Compiler/Proofs/YulGeneration/Preservation.lean
+++ b/Compiler/Proofs/YulGeneration/Preservation.lean
@@ -478,6 +478,17 @@ private theorem evalSelectorExpr_setVar_has_selector (state : YulState) (v : Nat
   simpa using (evalYulExpr_selectorExpr_eq (state.setVar "__has_selector" v) (by
     simpa [YulState.setVar] using hselector))
 
+/-- In the non-payable branch, `DispatchGuardsSafe` forces `msgValue = 0 mod 2^256`. -/
+private theorem dispatchGuardsSafe_msgValue_zero_mod_of_nonpayable
+    (fn : IRFunction) (tx : IRTransaction)
+    (hguards : DispatchGuardsSafe fn tx)
+    (hNonPayable : fn.payable = false) :
+    tx.msgValue % evmModulus = 0 := by
+  rcases hguards with ⟨hValueSafe, _⟩
+  rcases hValueSafe with hPayable | hZero
+  · cases (by simpa [hNonPayable] using hPayable : False)
+  · exact hZero
+
 private theorem exec_switchCaseBody_revert_of_short
     (fn : IRFunction) (tx : IRTransaction) (irState : IRState) (fuel : Nat)
     (hguards : DispatchGuardsSafe fn tx)
@@ -557,10 +568,9 @@ private theorem exec_switchCaseBody_revert_of_short
       | succ fuel =>
           have hMsgValue :
               state.msgValue % evmModulus = 0 := by
-            have hZero : tx.msgValue % evmModulus = 0 := by
-              rcases hValueSafe with hTrue | hZero
-              · cases (by simpa [hPayable] using hTrue : False)
-              · exact hZero
+            have hZero : tx.msgValue % evmModulus = 0 :=
+              dispatchGuardsSafe_msgValue_zero_mod_of_nonpayable fn tx
+                ⟨hValueSafe, hParamNoWrap⟩ hPayable
             simpa [state, YulState.initial, YulState.setVar] using hZero
           have hValueGuard :
               execYulStmtFuel (fuel + 1) state Compiler.callvalueGuard = .continue state := by
@@ -712,10 +722,9 @@ private theorem exec_switchCaseBody_continue_of_long
       rw [execYulStmtsFuel_cons_continue (fuel := k + 2) (next := state) (hstmt := hComment)]
       have hMsgValue :
           state.msgValue % evmModulus = 0 := by
-        have hZero : tx.msgValue % evmModulus = 0 := by
-          rcases hValueSafe with hTrue | hZero
-          · cases (by simpa [hPayable] using hTrue : False)
-          · exact hZero
+        have hZero : tx.msgValue % evmModulus = 0 :=
+          dispatchGuardsSafe_msgValue_zero_mod_of_nonpayable fn tx
+            ⟨hValueSafe, hParamNoWrap⟩ hPayable
         simpa [state, YulState.initial, YulState.setVar] using hZero
       have hValueGuard :
           execYulStmtFuel (k + 1 + 1) state Compiler.callvalueGuard = .continue state := by

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -709,7 +709,6 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.IRGeneration.Function.supported_function_body_correct_from_exact_state_core
 #print axioms Compiler.Proofs.IRGeneration.Function.supported_function_body_correct_from_exact_state_core_extraFuel
 #print axioms Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_correct_of_body
-#print axioms Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_correct_of_body_supported
 #print axioms Compiler.Proofs.IRGeneration.Function.compileFunctionSpec_correct_of_body_supported_extraFuel
 #print axioms Compiler.Proofs.IRGeneration.Function.supported_function_correct
 
@@ -1153,4 +1152,4 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv
--- Total: 1025 theorems/lemmas (851 public, 174 private)
+-- Total: 1024 theorems/lemmas (850 public, 174 private)


### PR DESCRIPTION
## Summary

- restack this branch on current `main`, since the original `SwitchCaseBodyBridge` narrowing work was superseded by later merged proof changes
- extract `dispatchGuardsSafe_msgValue_zero_mod_of_nonpayable` in `Preservation.lean`
- reuse that helper in both the short-calldata revert path and the long-calldata success path so the non-payable `msgValue = 0` reduction is explicit in the current proof
- update `AXIOMS.md` to state clearly that this path is handled constructively, not by a dedicated bridge axiom

## Why this PR still helps

The old review concern on this PR was that the branch claimed the non-payable `msgValue = 0` path was mechanically reduced, but the proof shape at that time did not make that reduction explicit.

Current `main` already has the stronger post-#1559 proof architecture, so this PR is now a small follow-up cleanup in that architecture: it factors the `DispatchGuardsSafe -> msgValue = 0` consequence into a named helper and uses it exactly where the old review concern lived.

## Testing

- `python3 scripts/check_axioms.py`
- `lake build Compiler.Proofs.YulGeneration.Preservation` (local bootstrap in progress)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only refactors Lean proof code and axiom documentation, without changing compiler/runtime behavior. Main risk is proof breakage if the new helper lemma is misapplied, but it is a straightforward extraction from existing case analysis.
> 
> **Overview**
> Makes the non-payable dispatch path’s `msgValue % evmModulus = 0` consequence explicit by extracting `dispatchGuardsSafe_msgValue_zero_mod_of_nonpayable` and reusing it in both the short-calldata revert proof and the long-calldata success proof in `Preservation.lean`.
> 
> Updates `AXIOMS.md` to clarify that the non-payable `msgValue = 0` reduction is handled constructively inside guard-stepping lemmas (not via a separate bridge axiom), adjusts recorded axiom line numbers accordingly, and removes one stale `#print axioms` entry in `PrintAxioms.lean` (updating the totals).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd81e69406152f92569126b40ddbcf2ab42bb9f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->