### PR TITLE
docs: align Layer 2 status headlines

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -311,5 +311,5 @@ See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for contribution guidelines and [`VE
 
 ---
 
-**Last Updated**: 2026-03-07
-**Status**: Layers 1-3 complete. Trust reduction 1/3 done. Sum properties complete (7/7 proven). CompilationModel now supports real-world contracts (loops, branching, events, multi-mappings, internal call mechanics, verified externs).
+**Last Updated**: 2026-03-10
+**Status**: Layer 1 is complete for the current contract set; Layer 2 remains partial-generic with an open whole-contract theorem gap tracked in [#1510](https://github.com/Th0rgal/verity/issues/1510); Layer 3 is complete. Trust reduction 1/3 done. Sum properties complete (7/7 proven). CompilationModel now supports real-world contracts (loops, branching, events, multi-mappings, internal call mechanics, verified externs).

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -8,7 +8,7 @@ Verity implements a **three-layer verification stack** proving smart contracts c
 EDSL contracts (Lean)
     ↓ Layer 1: EDSL ≡ CompilationModel [PROVEN FOR CURRENT CONTRACTS; GENERIC CORE, CONTRACT BRIDGES]
 CompilationModel (declarative compiler-facing model)
-    ↓ Layer 2: CompilationModel → IR [GENERIC THEOREM SURFACE, 2 AXIOMS, CONTRACT BRIDGES ACTIVE]
+    ↓ Layer 2: CompilationModel → IR [PARTIAL GENERIC, 2 AXIOMS, CONTRACT BRIDGES ACTIVE]
 Intermediate Representation (IR)
     ↓ Layer 3: IR → Yul [GENERIC SURFACE, 1 AXIOM]
 Yul (EVM Assembly)


### PR DESCRIPTION
## Summary
- downgrade the `docs/VERIFICATION_STATUS.md` architecture banner from "generic theorem surface" to `PARTIAL GENERIC` for Layer 2 so the headline matches the section below it
- replace the stale `docs/ROADMAP.md` footer status line that still said "Layers 1-3 complete"
- link the Layer 2 whole-contract gap in the roadmap footer directly to issue #1510

## Why
The deeper docs on `main` already distinguish the current partial-generic Layer 2 theorem surface from a fully closed whole-contract compiler theorem. Two headline summaries were still overstating the status:
- the verification-status architecture banner
- the roadmap footer

This keeps the top-level status text aligned with the repo's actual proof boundary.

Refs #1510

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only edits that adjust status wording and add an issue link; no code or behavior changes.
> 
> **Overview**
> Updates documentation status banners to avoid overstating Layer 2 completeness.
> 
> `docs/VERIFICATION_STATUS.md` changes the architecture headline for Layer 2 from “generic theorem surface” to **“PARTIAL GENERIC”**.
> 
> `docs/ROADMAP.md` refreshes the footer status/date, replacing “Layers 1–3 complete” with wording that Layer 1/3 are complete for the current contract set while Layer 2 still has an open whole-contract theorem gap, now linked to `#1510`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff1469d3e223419f2a4e53bf026b2c1e252cf003. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->