### PR TITLE
proofs: remove has-selector dead-variable axiom

### DIFF
--- a/AXIOMS.md
+++ b/AXIOMS.md
@@ -36,34 +36,9 @@ Selector hashing is modeled as an external cryptographic primitive rather than r
 
 **Risk**: Low.
 
-### 2. `execYulStmtsFuel_setVar_hasSelector_irrelevant`
+### 2. `execYulStmtsFuel_fuel_adequate`
 
-**Location**: `Compiler/Proofs/YulGeneration/Preservation.lean:757`
-
-**Statement**:
-```lean
-private axiom execYulStmtsFuel_setVar_hasSelector_irrelevant
-```
-
-**Purpose**:
-Variable irrelevance: the dispatch variable `__has_selector` is never read by
-function body statements, so adding it to the variable environment does not
-change execution. This is a purely Yul-level property: it says
-`execYulStmtsFuel fuel (state.setVar "__has_selector" 1) body = execYulStmtsFuel fuel state body`.
-
-**Why this is currently an axiom**:
-Proving this mechanically requires showing that no subexpression in `body`
-evaluates `YulExpr.ident "__has_selector"`. The compiler never emits references
-to `__has_selector` inside function bodies (only in the dispatch prelude), but
-the proof infrastructure for "variable X is dead in statement list S" is not yet
-built.
-
-**Risk**: Low. Purely Yul-level, does not mention IR types. The property is
-a standard dead-variable elimination fact.
-
-### 3. `execYulStmtsFuel_fuel_adequate`
-
-**Location**: `Compiler/Proofs/YulGeneration/Preservation.lean:766`
+**Location**: `Compiler/Proofs/YulGeneration/Preservation.lean:812`
 
 **Statement**:
 ```lean
@@ -97,7 +72,7 @@ In particular, the non-payable `msgValue = 0` dispatch path is handled construct
 inside the guard-stepping lemmas (`dispatchGuardsSafe_msgValue_zero_mod_of_nonpayable`
 plus `exec_callvalueGuard_noop`), so it is not covered by any separate bridge axiom.
 
-### 4. `supported_function_body_correct_from_exact_state`
+### 3. `supported_function_body_correct_from_exact_state`
 
 **Location**: `Compiler/Proofs/IRGeneration/Function.lean:827`
 
@@ -257,9 +232,15 @@ Specifically:
   `execIRFunctionFuel_adequate`) that the core path already uses. This avoids
   the unsound `length + 1` fuel budget that is insufficient for nested `block`s.
 
-These removals reduced prior axiom debt. The Layer 3 switch-case bridge still has
-a small explicit preservation-side axiom boundary for dispatch-step normalization
-and case-body bridging; those active axioms are tracked above.
+These removals reduced prior axiom debt. The Layer 3 switch-case bridge no longer
+uses a dedicated kernel axiom for `__has_selector` dead-variable irrelevance.
+Instead, `Compiler/Proofs/YulGeneration/Preservation.lean` exposes:
+
+- syntactic predicates `yulExprNoRef` / `yulStmtNoRef` / `yulStmtsNoRef`
+- an explicit theorem hypothesis `HasSelectorDeadBridge`
+
+That keeps the remaining trust boundary visible in theorem signatures without
+adding a new Lean axiom.
 
 ## Non-Axiom: Arithmetic Semantics
 
@@ -267,7 +248,7 @@ Wrapping modular arithmetic at 2^256 is **proven**, not assumed. All 15 pure bui
 
 ## Trust Summary
 
-- Active axioms: 4
+- Active axioms: 3
 - Production blockers from axioms: 0
 - Enforcement: `scripts/check_axioms.py` ensures this file tracks exact source location.
 - Compilation-path totalization work in `Compiler/CompilationModel.lean` does not

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -204,6 +204,10 @@ theorem layer3_contract_preserves_semantics
           selector := tx.functionSelector })
     (hdispatchGuardSafe : ∀ fn, fn ∈ contract.functions →
       DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ contract.functions →
+      yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ contract.functions →
+      HasSelectorDeadBridge fn.body)
     (hWF : ContractWF contract)
     (hNoFallback : contract.fallbackEntrypoint = none)
     (hNoReceive : contract.receiveEntrypoint = none) :
@@ -211,7 +215,7 @@ theorem layer3_contract_preserves_semantics
       (interpretIR contract tx initialState)
       (interpretYulFromIR contract tx initialState) := by
   apply yulCodegen_preserves_semantics contract tx initialState
-    hselector hNoWrap hWF hNoFallback hNoReceive hdispatchGuardSafe
+    hselector hNoWrap hWF hNoFallback hNoReceive hdispatchGuardSafe hNoHasSelector hHasSelectorDead
   · intro fn hmem
     exact (yulBody_from_state_eq_yulBody fn tx
       { initialState with
@@ -240,6 +244,10 @@ theorem layer3_contract_preserves_semantics_general
     (hNoReceive : contract.receiveEntrypoint = none)
     (hdispatchGuardSafe : ∀ fn, fn ∈ contract.functions →
       DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ contract.functions →
+      yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ contract.functions →
+      HasSelectorDeadBridge fn.body)
     (hbody : ∀ fn, fn ∈ contract.functions →
       Compiler.Proofs.YulGeneration.resultsMatch
         (execIRFunction fn tx.args
@@ -268,7 +276,7 @@ theorem layer3_contract_preserves_semantics_general
       (interpretIR contract tx initialState)
       (interpretYulFromIR contract tx initialState) :=
   yulCodegen_preserves_semantics contract tx initialState
-    hselector hNoWrap hWF hNoFallback hNoReceive hdispatchGuardSafe hbody
+    hselector hNoWrap hWF hNoFallback hNoReceive hdispatchGuardSafe hNoHasSelector hHasSelectorDead hbody
 
 /-! ## Layers 2+3 Composition -/
 
@@ -297,6 +305,10 @@ theorem layers2_3_ir_matches_yul
           selector := tx.functionSelector })
     (hdispatchGuardSafe : ∀ fn, fn ∈ irContract.functions →
       DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ irContract.functions →
+      yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ irContract.functions →
+      HasSelectorDeadBridge fn.body)
     (hWF : ContractWF irContract)
     (hNoFallback : irContract.fallbackEntrypoint = none)
     (hNoReceive : irContract.receiveEntrypoint = none) :
@@ -304,7 +316,7 @@ theorem layers2_3_ir_matches_yul
       (interpretIR irContract tx initialState)
       (interpretYulFromIR irContract tx initialState) :=
   layer3_contract_preserves_semantics irContract tx initialState
-    hselector hNoWrap hvars hmemory hreturn hparamErase hdispatchGuardSafe hWF hNoFallback hNoReceive
+    hselector hNoWrap hvars hmemory hreturn hparamErase hdispatchGuardSafe hNoHasSelector hHasSelectorDead hWF hNoFallback hNoReceive
 
 /-! ## Concrete Instantiation: SimpleStorage -/
 
@@ -318,6 +330,10 @@ theorem simpleStorage_endToEnd
     (hreturn : initialState.returnValue = none)
     (hdispatchGuardSafe : ∀ fn, fn ∈ simpleStorageIRContract.functions →
       DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      HasSelectorDeadBridge fn.body)
     (hparamErase : ∀ fn, fn ∈ simpleStorageIRContract.functions →
       paramLoadErasure fn tx
         { initialState with
@@ -334,7 +350,7 @@ theorem simpleStorage_endToEnd
       (interpretIR simpleStorageIRContract tx initialState)
       (interpretYulFromIR simpleStorageIRContract tx initialState) :=
   layer3_contract_preserves_semantics simpleStorageIRContract tx initialState
-    hselector hNoWrap hvars hmemory hreturn hparamErase hdispatchGuardSafe
+    hselector hNoWrap hvars hmemory hreturn hparamErase hdispatchGuardSafe hNoHasSelector hHasSelectorDead
     (by intro s hs; simp [simpleStorageIRContract] at hs) rfl rfl
 
 /-! ## Universal Pure Arithmetic Bridge

--- a/Compiler/Proofs/YulGeneration/Preservation.lean
+++ b/Compiler/Proofs/YulGeneration/Preservation.lean
@@ -72,6 +72,59 @@ See `TRUST_ASSUMPTIONS.md` for the full trust-boundary description.
           fn.body) := by
   simp [interpretYulBody]
 
+mutual
+def yulExprNoRef (name : String) : YulExpr → Prop
+  | .lit _ => True
+  | .hex _ => True
+  | .str _ => True
+  | .ident ident => ident ≠ name
+  | .call _ args => yulExprsNoRef name args
+
+def yulExprsNoRef (name : String) : List YulExpr → Prop
+  | [] => True
+  | expr :: exprs => yulExprNoRef name expr ∧ yulExprsNoRef name exprs
+end
+
+mutual
+def yulStmtNoRef (name : String) : YulStmt → Prop
+  | .comment _ => True
+  | .let_ _ value => yulExprNoRef name value
+  | .letMany _ value => yulExprNoRef name value
+  | .assign _ value => yulExprNoRef name value
+  | .expr expr => yulExprNoRef name expr
+  | .leave => True
+  | .if_ cond body => yulExprNoRef name cond ∧ yulStmtsNoRef name body
+  | .for_ init cond post body =>
+      yulStmtsNoRef name init ∧ yulExprNoRef name cond ∧
+        yulStmtsNoRef name post ∧ yulStmtsNoRef name body
+  | .switch expr cases defaultCase =>
+      yulExprNoRef name expr ∧ yulSwitchCasesNoRef name cases ∧
+        yulOptionStmtsNoRef name defaultCase
+  | .block stmts => yulStmtsNoRef name stmts
+  | .funcDef _ _ _ _ => True
+
+def yulStmtsNoRef (name : String) : List YulStmt → Prop
+  | [] => True
+  | stmt :: stmts => yulStmtNoRef name stmt ∧ yulStmtsNoRef name stmts
+
+def yulSwitchCasesNoRef (name : String) : List (Nat × List YulStmt) → Prop
+  | [] => True
+  | (_, body) :: rest => yulStmtsNoRef name body ∧ yulSwitchCasesNoRef name rest
+
+def yulOptionStmtsNoRef (name : String) : Option (List YulStmt) → Prop
+  | none => True
+  | some body => yulStmtsNoRef name body
+end
+
+/-- Explicit theorem hypothesis used in place of the old kernel axiom. -/
+def HasSelectorDeadBridge (body : List YulStmt) : Prop :=
+  ∀ state fuel,
+    yulStmtsNoRef "__has_selector" body →
+    yulResultOfExecWithRollback state
+      (execYulStmtsFuel fuel (state.setVar "__has_selector" 1) body) =
+    yulResultOfExecWithRollback state
+      (execYulStmtsFuel fuel state body)
+
 /-- Helper: initial Yul state aligned with the IR transaction/state. -/
 private def initialYulState (tx : YulTransaction) (state : IRState) : YulState :=
   YulState.initial tx state.storage state.events
@@ -746,18 +799,11 @@ After the guard prefix has been proved to pass (by `exec_switchCaseBody_continue
 the remaining gap is connecting fuel-bounded execution of `fn.body` in a state
 where `__has_selector = 1` to the total `interpretYulRuntime fn.body ...`.
 
-This gap is decomposed into two independent sub-properties, each captured by
-its own axiom:
+This gap is decomposed into:
+- an explicit dead-variable bridge hypothesis for bodies that syntactically do
+  not read `__has_selector`
+- the remaining fuel-adequacy axiom
 -/
-
-/-- **Variable irrelevance**: the `__has_selector` dispatch variable is never
-read by function body statements, so adding it to the variable environment
-does not change execution.  This is a purely Yul-level property that does not
-mention IR types. -/
-private axiom execYulStmtsFuel_setVar_hasSelector_irrelevant
-    (body : List YulStmt) (state : YulState) (fuel : Nat) :
-    execYulStmtsFuel fuel (state.setVar "__has_selector" 1) body =
-    execYulStmtsFuel fuel state body
 
 /-- **Fuel adequacy**: when the fuel budget is at least `sizeOf body + 1`
 (the amount used by `execYulStmts`), fuel-bounded execution gives the same
@@ -771,12 +817,14 @@ private axiom execYulStmtsFuel_fuel_adequate
 /-- Composition of variable irrelevance and fuel adequacy. -/
 private theorem SwitchCaseBodyBridge_body
     (body : List YulStmt) (state : YulState) (fuel : Nat)
+    (hDead : HasSelectorDeadBridge body)
+    (hNoRef : yulStmtsNoRef "__has_selector" body)
     (h : fuel ≥ sizeOf body + 1) :
     yulResultOfExecWithRollback state
       (execYulStmtsFuel fuel (state.setVar "__has_selector" 1) body) =
     yulResultOfExecWithRollback state
       (execYulStmts state body) := by
-  rw [execYulStmtsFuel_setVar_hasSelector_irrelevant]
+  rw [hDead state fuel hNoRef]
   rw [execYulStmtsFuel_fuel_adequate body state fuel h]
 
 /-! ### switchCaseBody bridge theorem
@@ -784,10 +832,13 @@ private theorem SwitchCaseBodyBridge_body
 `SwitchCaseBodyBridge` is now a proved theorem rather than an axiom.
 It composes two pieces:
 1. `exec_switchCaseBody_continue_of_long` — proved guard-prefix stepping
-2. `SwitchCaseBodyBridge_body` — composed from variable irrelevance + fuel adequacy axioms
+2. `SwitchCaseBodyBridge_body` — composed from an explicit dead-variable bridge
+   hypothesis and the fuel adequacy axiom
 -/
 private theorem SwitchCaseBodyBridge
     (fn : IRFunction) (tx : IRTransaction) (irState : IRState) (fuel : Nat)
+    (hDead : HasSelectorDeadBridge fn.body)
+    (hNoRef : yulStmtsNoRef "__has_selector" fn.body)
     (hFuelAdequate : fuel ≥ sizeOf fn.body + 5) :
     DispatchGuardsSafe fn tx →
     4 + tx.args.length * 32 < evmModulus →
@@ -857,7 +908,7 @@ private theorem SwitchCaseBodyBridge
   -- fuel' ≥ (fuel - 2) - 2 = fuel - 4 (by hge).
   -- Since fuel ≥ sizeOf fn.body + 5, we have fuel - 4 ≥ sizeOf fn.body + 1.
   have hfuelAdequate' : fuel' ≥ sizeOf fn.body + 1 := by omega
-  have hbody := SwitchCaseBodyBridge_body fn.body s₀ fuel' hfuelAdequate'
+  have hbody := SwitchCaseBodyBridge_body fn.body s₀ fuel' hDead hNoRef hfuelAdequate'
   -- hmatch gives us resultsMatch via interpretYulRuntime
   -- interpretYulRuntime fn.body yulTx ... = yulResultOfExecWithRollback s₀ (execYulStmts s₀ fn.body)
   rw [hbody]
@@ -882,6 +933,10 @@ theorem yulCodegen_preserves_semantics
     (hNoFallback : contract.fallbackEntrypoint = none)
     (hNoReceive : contract.receiveEntrypoint = none)
     (hdispatchGuardSafe : ∀ fn, fn ∈ contract.functions → DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ contract.functions →
+      yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ contract.functions →
+      HasSelectorDeadBridge fn.body)
     (hbody : ∀ fn, fn ∈ contract.functions →
       resultsMatch
         (execIRFunction fn tx.args
@@ -1048,7 +1103,8 @@ theorem yulCodegen_preserves_semantics
               blobBaseFee := tx.blobBaseFee
               calldata := tx.args
               selector := tx.functionSelector }
-            (m + 2) hFuelBody (hdispatchGuardSafe fn hmem) hNoWrap hlen hmatch)
+            (m + 2) (hHasSelectorDead fn hmem) (hNoHasSelector fn hmem)
+            hFuelBody (hdispatchGuardSafe fn hmem) hNoWrap hlen hmatch)
       · simpa [hlen] using
           (SwitchCaseBodyBridge_short fn tx
             { initialState with

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -4,7 +4,7 @@
     "example_contracts": 14
   },
   "proofs": {
-    "axioms": 4,
+    "axioms": 3,
     "sorry": 0
   },
   "schema_version": 1,


### PR DESCRIPTION
Closes #1562

## Summary
- remove the kernel axiom `execYulStmtsFuel_setVar_hasSelector_irrelevant`
- replace it with an explicit `HasSelectorDeadBridge` theorem input guarded by `yulStmtsNoRef "__has_selector"`
- sync the axiom registry and public proof-status docs from 4 axioms down to 3

## Why this shape
The old axiom was too strong as a kernel assumption for a property that is really a Yul-level dead-variable bridge. This change makes that bridge explicit in the theorem surface instead of trusting it globally, while keeping the remaining Layer 3 fuel-adequacy axiom isolated.

## Validation
- `python3 scripts/check_axioms.py`
- `lake build Compiler.Proofs.YulGeneration.Preservation Compiler.Proofs.EndToEnd` is still running in a fresh worktree because this worktree had to bootstrap the full Lean dependency graph first

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Layer 3 preservation theorem signatures; callers must now supply new hypotheses, and any mismatch in the no-reference/bridge assumptions could invalidate downstream proof composition.
> 
> **Overview**
> Removes the kernel axiom that `__has_selector` is execution-irrelevant, and replaces it with explicit, per-function hypotheses: a syntactic no-reference predicate (`yulExprNoRef`/`yulStmtNoRef`/`yulStmtsNoRef`) plus a `HasSelectorDeadBridge` assumption threaded through the Layer 3 `SwitchCaseBodyBridge`/`yulCodegen_preserves_semantics` and end-to-end theorems.
> 
> Updates the axiom registry/docs (`AXIOMS.md`) and proof status artifact to reflect **4 → 3 active axioms**, keeping only the Yul fuel-adequacy axiom as the remaining Layer 3 kernel assumption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfa79644ffb7b051f67023152e4efb18feb83fb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->