### PR TITLE
macro: expose receive and fallback entrypoints

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -288,6 +288,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.CustomErrorSmoke.spec
   , Contracts.Smoke.StatelessSmoke.spec
   , Contracts.Smoke.MutabilitySmoke.spec
+  , Contracts.Smoke.SpecialEntrypointSmoke.spec
   , Contracts.Smoke.InitializerSmoke.spec
   , Contracts.Smoke.ConstantSmoke.spec
   , Contracts.Smoke.ImmutableSmoke.spec
@@ -341,6 +342,7 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("CustomErrorSmoke", ["echo(uint256)"])
   , ("StatelessSmoke", ["echoWord(uint256)", "whoAmI()"])
   , ("MutabilitySmoke", ["deposit()", "currentOwner()"])
+  , ("SpecialEntrypointSmoke", ["getReceiveCount()", "getFallbackCount()"])
   , ("InitializerSmoke", ["initOwner(address)", "upgradeToV2()"])
   , ("ConstantSmoke", ["feeOn(uint256)", "treasuryAddr()"])
   , ("ImmutableSmoke", ["supplyCap()", "treasuryAddr()", "shadowed(uint256)"])
@@ -391,6 +393,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("CustomErrorSmoke", ["0x6279e43c"])
   , ("StatelessSmoke", ["0x26534f53", "0xda91254c"])
   , ("MutabilitySmoke", ["0xd0e30db0", "0xb387ef92"])
+  , ("SpecialEntrypointSmoke", ["0x931999fb", "0x74b204a4"])
   , ("InitializerSmoke", ["0x0d009297", "0xcc01053e"])
   , ("ConstantSmoke", ["0x9c421eb5", "0x30d9a62a"])
   , ("ImmutableSmoke", ["0x8f770ad0", "0x30d9a62a", "0x655b96ec"])
@@ -446,6 +449,23 @@ private def checkMutabilitySmoke : IO Unit := do
   expectTrue "MutabilitySmoke: deposit body reads msgValue"
     (contains (reprStr deposit.body) "Expr.msgValue")
 
+private def checkSpecialEntrypointSmoke : IO Unit := do
+  let functions := Contracts.Smoke.SpecialEntrypointSmoke.spec.functions
+  let receiveFn? := functions.find? (·.name == "receive")
+  let fallback? := functions.find? (·.name == "fallback")
+  let receiveFn := receiveFn?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  let fallbackFn := fallback?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  expectTrue "SpecialEntrypointSmoke: receive entrypoint is materialized in the spec"
+    (receiveFn.name == "receive")
+  expectTrue "SpecialEntrypointSmoke: receive entrypoint is implicitly payable"
+    receiveFn.isPayable
+  expectTrue "SpecialEntrypointSmoke: receive entrypoint remains selector-free"
+    receiveFn.params.isEmpty
+  expectTrue "SpecialEntrypointSmoke: fallback entrypoint is materialized in the spec"
+    (fallbackFn.name == "fallback")
+  expectTrue "SpecialEntrypointSmoke: fallback entrypoint remains selector-free"
+    fallbackFn.params.isEmpty
+
 private def checkSpec (spec : CompilationModel) : IO Unit := do
   let extFns := externalFunctions spec
   let fnNames := extFns.map (·.name)
@@ -499,6 +519,13 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
         (irFnNames == fnNames)
       expectTrue s!"{spec.name}: IR selectors preserve canonical selector order"
         (irSelectors == selectors)
+      if spec.name == "SpecialEntrypointSmoke" then
+        expectTrue "SpecialEntrypointSmoke: IR keeps receive entrypoint out of selector dispatch"
+          ir.receiveEntrypoint.isSome
+        expectTrue "SpecialEntrypointSmoke: IR keeps fallback entrypoint out of selector dispatch"
+          ir.fallbackEntrypoint.isSome
+      else
+        pure ()
       let indexedFns := List.zip (List.range extFns.length) extFns
       let mappingSafeFns :=
         indexedFns.filterMap (fun (idx, fnSpec) =>
@@ -554,6 +581,7 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
     "Owned.transferOwnership keeps address storage writes explicit in macro output"
     (bodyUsesAddressStorageWrite Contracts.Owned.transferOwnership_modelBody)
   checkMutabilitySmoke
+  checkSpecialEntrypointSmoke
   for spec in macroSpecs do
     checkSpec spec
 

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -51,6 +51,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.CustomErrorSmoke.spec
   , Contracts.Smoke.StatelessSmoke.spec
   , Contracts.Smoke.MutabilitySmoke.spec
+  , Contracts.Smoke.SpecialEntrypointSmoke.spec
   , Contracts.Smoke.InitializerSmoke.spec
   , Contracts.Smoke.ConstantSmoke.spec
   , Contracts.Smoke.ImmutableSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -109,6 +109,27 @@ verity_contract MutabilitySmoke where
     let ownerAddr ← getStorageAddr owner
     return ownerAddr
 
+verity_contract SpecialEntrypointSmoke where
+  storage
+    receiveCount : Uint256 := slot 0
+    fallbackCount : Uint256 := slot 1
+
+  receive := do
+    let current ← getStorage receiveCount
+    setStorage receiveCount (add current 1)
+
+  fallback := do
+    let current ← getStorage fallbackCount
+    setStorage fallbackCount (add current 1)
+
+  function getReceiveCount () : Uint256 := do
+    let current ← getStorage receiveCount
+    return current
+
+  function getFallbackCount () : Uint256 := do
+    let current ← getStorage fallbackCount
+    return current
+
 verity_contract ConstantSmoke where
   storage
 
@@ -844,6 +865,7 @@ end SpecGenSmoke
 #check_contract StorageWordsSmoke
 #check_contract CustomErrorSmoke
 #check_contract StatelessSmoke
+#check_contract SpecialEntrypointSmoke
 #check_contract TupleSmoke
 #check_contract Uint8Smoke
 #check_contract AddressHelpersSmoke

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -16,6 +16,7 @@ declare_syntax_cat verityLocalObligations
 declare_syntax_cat verityConstructor
 declare_syntax_cat verityMutability
 declare_syntax_cat verityInitGuard
+declare_syntax_cat veritySpecialEntrypoint
 declare_syntax_cat verityFunction
 
 syntax ident " : " term " := " "slot" num : verityStorageField
@@ -41,6 +42,8 @@ syntax "revertError " ident "(" sepBy(term, ",") ")" : doElem
 syntax "requireError " term:max ppSpace ident "(" sepBy(term, ",") ")" : doElem
 syntax "constructor " "(" sepBy(verityParam, ",") ")" (ppSpace verityLocalObligations)? " := " term : verityConstructor
 syntax "constructor " "(" sepBy(verityParam, ",") ")" " payable" (ppSpace verityLocalObligations)? " := " term : verityConstructor
+syntax "receive" (ppSpace verityLocalObligations)? " := " term : veritySpecialEntrypoint
+syntax "fallback" (ppSpace verityLocalObligations)? " := " term : veritySpecialEntrypoint
 syntax "function " verityMutability* ident " (" sepBy(verityParam, ",") ")" (ppSpace verityInitGuard)? (ppSpace verityLocalObligations)? " : " term " := " term : verityFunction
 
 syntax (name := verityContractCmd)
@@ -51,7 +54,8 @@ syntax (name := verityContractCmd)
   ("immutables " verityImmutable+)?
   ("linked_externals " verityExternal+)?
   (verityConstructor)?
-  verityFunction+ : command
+  (veritySpecialEntrypoint)*
+  verityFunction* : command
 
 syntax (name := checkContractCmd)
   "#check_contract " ident : command

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -428,6 +428,40 @@ private def parseLocalObligations
       obligations.mapM parseLocalObligation
   | _ => throwErrorAt stx "invalid local obligations declaration"
 
+private def hiddenEntrypointIdent (name : String) : Ident :=
+  mkIdent (Name.mkSimple s!"__verity_{name}")
+
+private def parseSpecialEntrypoint (stx : Syntax) : CommandElabM FunctionDecl := do
+  match stx with
+  | `(veritySpecialEntrypoint| receive $[$localObligations?:verityLocalObligations]? := $body:term) => do
+      let parsedLocalObligations ←
+        match localObligations? with
+        | some obligations => parseLocalObligations obligations
+        | none => pure #[]
+      pure {
+        ident := hiddenEntrypointIdent "receive"
+        name := "receive"
+        params := #[]
+        returnTy := .unit
+        isPayable := true
+        localObligations := parsedLocalObligations
+        body := body
+      }
+  | `(veritySpecialEntrypoint| fallback $[$localObligations?:verityLocalObligations]? := $body:term) => do
+      let parsedLocalObligations ←
+        match localObligations? with
+        | some obligations => parseLocalObligations obligations
+        | none => pure #[]
+      pure {
+        ident := hiddenEntrypointIdent "fallback"
+        name := "fallback"
+        params := #[]
+        returnTy := .unit
+        localObligations := parsedLocalObligations
+        body := body
+      }
+  | _ => throwErrorAt stx "invalid special entrypoint declaration"
+
 private def parseFunction (stx : Syntax) : CommandElabM FunctionDecl := do
   match stx with
   | `(verityFunction| function $[$mods:verityMutability]* $name:ident ($[$params:verityParam],*) $[$guard?:verityInitGuard]? $[$localObligations?:verityLocalObligations]? : $retTy:term := $body:term) => do
@@ -2869,7 +2903,7 @@ def parseContractSyntax
     : CommandElabM
         (Ident × Array StorageFieldDecl × Array ErrorDecl × Array ConstantDecl × Array ImmutableDecl × Array ExternalDecl × Option ConstructorDecl × Array FunctionDecl) := do
   match stx with
-  | `(command| verity_contract $contractName:ident where storage $[$storageFields:verityStorageField]* $[errors $[$errorDecls:verityError]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$functions:verityFunction]*) =>
+  | `(command| verity_contract $contractName:ident where storage $[$storageFields:verityStorageField]* $[errors $[$errorDecls:verityError]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$functions:verityFunction]*) =>
       let parsedErrors ←
         match errorDecls with
         | some decls => decls.mapM parseError
@@ -2894,7 +2928,7 @@ def parseContractSyntax
         , parsedImmutables
         , parsedExternals
         , (← ctor.mapM parseConstructor)
-        , (← functions.mapM parseFunction)
+        , (← entrypoints.mapM parseSpecialEntrypoint) ++ (← functions.mapM parseFunction)
         )
   | _ => throwErrorAt stx "invalid verity_contract declaration"
 

--- a/artifacts/macro_property_tests/PropertySpecialEntrypointSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertySpecialEntrypointSmoke.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertySpecialEntrypointSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertySpecialEntrypointSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("SpecialEntrypointSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: getReceiveCount reads storage slot 0 and decodes the result
+    function testAuto_GetReceiveCount_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getReceiveCount()"));
+        require(ok, "getReceiveCount reverted unexpectedly");
+        assertEq(ret.length, 32, "getReceiveCount ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getReceiveCount should return storage slot 0");
+    }
+    // Property 2: getFallbackCount reads storage slot 1 and decodes the result
+    function testAuto_GetFallbackCount_ReadsConfiguredStorage() public {
+        uint256 expected = uint256(1);
+        vm.store(target, bytes32(uint256(1)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("getFallbackCount()"));
+        require(ok, "getFallbackCount reverted unexpectedly");
+        assertEq(ret.length, 32, "getFallbackCount ABI return length mismatch (expected 32 bytes)");
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, expected, "getFallbackCount should return storage slot 1");
+    }
+}


### PR DESCRIPTION
Closes #1567.

## Summary
- add first-class `receive := do ...` and `fallback := do ...` syntax to `verity_contract`
- lower special entrypoints into hidden macro-generated function models named `receive` and `fallback`
- cover the new surface in smoke, invariant, round-trip fuzz, and generated property-test artifacts

## Verification
- `lake build Contracts.Smoke`
- `lake build Contracts.MacroTranslateInvariantTest`
- `python3 scripts/check_macro_health.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core macro parsing/translation for contract declarations and special entrypoint handling, which can affect compilation/dispatch behavior across contracts; test coverage is expanded to mitigate regressions.
> 
> **Overview**
> Adds first-class `receive := ...` and `fallback := ...` declarations to `verity_contract` syntax and lowers them during macro translation into hidden, selector-free function models (with `receive` implicitly payable).
> 
> Extends the smoke suite with a new `SpecialEntrypointSmoke` fixture and threads it through macro invariant tests and round-trip fuzzing, including new assertions that IR keeps `receive`/`fallback` out of selector dispatch and updated pinned signature/selector snapshots.
> 
> Adds an auto-generated Solidity property test artifact (`PropertySpecialEntrypointSmoke.t.sol`) covering the new fixture’s storage-reading functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85111b10a64baf8e46ef2de5a0e4f6142b32b9df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->