### PR TITLE
macro: preserve custom error args in runtime fallback

### DIFF
--- a/Compiler/MacroCustomErrorFeatureTest.lean
+++ b/Compiler/MacroCustomErrorFeatureTest.lean
@@ -60,7 +60,8 @@ example : requirePositiveExecutablePreservesSuccess = true := by native_decide
 
 def rejectLargeExecutableUsesRuntimeFallback : Bool :=
   match MacroCustomErrorUsage.rejectLarge 101 Verity.defaultState with
-  | .revert msg state => msg == "AmountTooLarge" && state.sender == Verity.defaultState.sender
+  | .revert msg state =>
+      msg == "AmountTooLarge(101, 100)" && state.sender == Verity.defaultState.sender
   | .success _ _ => false
 
 example : rejectLargeExecutableUsesRuntimeFallback = true := by native_decide

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -22,12 +22,28 @@ macro_rules
           let _ := $_module
           let _ := $_args
           pure ())
-  | `(doElem| revert $errorName:ident($_args,*)) =>
-      `(doElem| require false $(Lean.quote (toString errorName.getId)))
-  | `(doElem| revertError $errorName:ident($_args,*)) =>
-      `(doElem| require false $(Lean.quote (toString errorName.getId)))
-  | `(doElem| requireError $cond:term $errorName:ident($_args,*)) =>
-      `(doElem| if $cond then pure () else require false $(Lean.quote (toString errorName.getId)))
+  | `(doElem| revert $errorName:ident($args,*)) => do
+      let revertFn := Lean.mkIdentFrom errorName `_root_.Contracts.revertCustomError
+      let encodeFn := Lean.mkIdentFrom errorName `_root_.Contracts.CustomErrorArg.encode
+      let encodedArgs ← args.getElems.mapM fun arg => `(term| $encodeFn:ident $arg)
+      `(doElem| $revertFn:ident
+          $(Lean.quote (toString errorName.getId))
+          [ $[$encodedArgs],* ])
+  | `(doElem| revertError $errorName:ident($args,*)) => do
+      let revertFn := Lean.mkIdentFrom errorName `_root_.Contracts.revertCustomError
+      let encodeFn := Lean.mkIdentFrom errorName `_root_.Contracts.CustomErrorArg.encode
+      let encodedArgs ← args.getElems.mapM fun arg => `(term| $encodeFn:ident $arg)
+      `(doElem| $revertFn:ident
+          $(Lean.quote (toString errorName.getId))
+          [ $[$encodedArgs],* ])
+  | `(doElem| requireError $cond:term $errorName:ident($args,*)) => do
+      let requireFn := Lean.mkIdentFrom errorName `_root_.Contracts.requireCustomError
+      let encodeFn := Lean.mkIdentFrom errorName `_root_.Contracts.CustomErrorArg.encode
+      let encodedArgs ← args.getElems.mapM fun arg => `(term| $encodeFn:ident $arg)
+      `(doElem| $requireFn:ident
+          $cond
+          $(Lean.quote (toString errorName.getId))
+          [ $[$encodedArgs],* ])
   | `(doElem| let $name:ident := arrayElement $values:term $index:term) => do
       let checked := Lean.mkIdentFrom name `_root_.Contracts.arrayElementChecked
       `(doElem| let $name ← $checked:ident $values $index)
@@ -54,6 +70,42 @@ macro_rules
 def bitAnd (a b : Uint256) : Uint256 := Verity.Core.Uint256.and a b
 def bitOr (a b : Uint256) : Uint256 := Verity.Core.Uint256.or a b
 def bitXor (a b : Uint256) : Uint256 := Verity.Core.Uint256.xor a b
+
+class CustomErrorArg (α : Type) where
+  encode : α → String
+
+instance : CustomErrorArg Uint256 where
+  encode value := toString (value : Nat)
+
+instance : CustomErrorArg Nat where
+  encode value := toString value
+
+instance : CustomErrorArg Address where
+  encode value := toString value.toNat
+
+instance : CustomErrorArg Bool where
+  encode value := if value then "true" else "false"
+
+instance : CustomErrorArg String where
+  encode value := value
+
+instance : CustomErrorArg ByteArray where
+  encode value := reprStr value.toList
+
+instance [CustomErrorArg α] : CustomErrorArg (Array α) where
+  encode values := "[" ++ String.intercalate ", " (values.toList.map CustomErrorArg.encode) ++ "]"
+
+instance [CustomErrorArg α] [CustomErrorArg β] : CustomErrorArg (α × β) where
+  encode value := "(" ++ CustomErrorArg.encode value.1 ++ ", " ++ CustomErrorArg.encode value.2 ++ ")"
+
+def formatCustomError (name : String) (args : List String) : String :=
+  name ++ "(" ++ String.intercalate ", " args ++ ")"
+
+def revertCustomError (name : String) (args : List String) : Contract Unit :=
+  require false (formatCustomError name args)
+
+def requireCustomError (condition : Bool) (name : String) (args : List String) : Contract Unit :=
+  if condition then pure () else revertCustomError name args
 
 private def signedWordLimit : Nat := Verity.Core.Uint256.modulus / 2
 

--- a/Contracts/StringErrorSmoke.lean
+++ b/Contracts/StringErrorSmoke.lean
@@ -46,7 +46,7 @@ def checkMessageExecutableBranchesOnCondition : Bool :=
   match StringErrorSmoke.checkMessage true "ok" Verity.defaultState,
       StringErrorSmoke.checkMessage false "boom" Verity.defaultState with
   | .success () successState, .revert msg revertState =>
-      msg == "BadMessage" &&
+      msg == "BadMessage(boom)" &&
       successState.sender == Verity.defaultState.sender &&
       revertState.sender == Verity.defaultState.sender
   | _, _ => false
@@ -57,7 +57,7 @@ def checkTaggedMessageExecutableBranchesOnCondition : Bool :=
   match StringErrorSmoke.checkTaggedMessage 1 "ok" Verity.defaultState,
       StringErrorSmoke.checkTaggedMessage 7 "boom" Verity.defaultState with
   | .success () successState, .revert msg revertState =>
-      msg == "TaggedMessage" &&
+      msg == "TaggedMessage(7, boom)" &&
       successState.sender == Verity.defaultState.sender &&
       revertState.sender == Verity.defaultState.sender
   | _, _ => false
@@ -68,7 +68,7 @@ def checkSecondMessageExecutableBranchesOnCondition : Bool :=
   match StringErrorSmoke.checkSecondMessage true "ignored" "ok" Verity.defaultState,
       StringErrorSmoke.checkSecondMessage false "ignored" "boom" Verity.defaultState with
   | .success () successState, .revert msg revertState =>
-      msg == "SecondMessage" &&
+      msg == "SecondMessage(ignored, boom)" &&
       successState.sender == Verity.defaultState.sender &&
       revertState.sender == Verity.defaultState.sender
   | _, _ => false


### PR DESCRIPTION
Closes #1566.

This finishes the executable-side custom-error behavior that was still missing after the macro/compiler plumbing landed.

What changed:
- preserve custom error arguments in the Lean executable fallback for `revert`, `revertError`, and `requireError`
- add runtime formatting support for common custom-error argument shapes used by the macro surface
- update the focused runtime regressions to assert the formatted fallback payload, not just the bare error name

Why this matters:
- the compilation model already preserved custom errors structurally
- the executable model still collapsed every custom error to just its name, which dropped the payload and made smoke tests less representative
- this keeps the Lean fallback aligned with the issue's intended "name + args" revert-string modeling, while ABI selector/argument encoding remains a Yul/compiler concern

Verification:
- `lake build Compiler.MacroCustomErrorFeatureTest Contracts.StringErrorSmoke`
- `lake build Contracts.MacroTranslateInvariantTest Contracts.MacroTranslateRoundTripFuzz`
- `python3 scripts/check_macro_health.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core macro rewrites for error handling, which can change revert-string behavior across many contracts and potentially break existing executable-side tests or assumptions about revert messages.
> 
> **Overview**
> Updates the Lean macro expansions for `revert`, `revertError`, and `requireError` to preserve and format custom-error *arguments* in the executable/runtime fallback, rather than reverting with only the bare error name.
> 
> Adds a `CustomErrorArg` encoding/typeclass plus `formatCustomError`, `revertCustomError`, and `requireCustomError` helpers in `Contracts.Common`, and updates smoke/regression tests to assert the new formatted revert strings like `ErrorName(arg1, arg2)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 644fb551f75690fc8b183d60808d5d200317f031. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->