### PR TITLE
docs: record constant and immutable macro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,31 @@ verity_contract Counter where
     setStorage count (add current 1)
 ```
 
-Under the hood, the macro generates a `Contract α` state monad (`ContractState → ContractResult α`) with operations like `getStorage`, `setStorage`, and `require` that manipulate blockchain state. You generally should not hand-write a separate `CompilationModel`; the macro-generated one is the compiler input.
+The macro surface also supports contract-level constants and constructor-bound immutables:
+
+```lean
+verity_contract FeeVault where
+  storage
+    owner : Address := slot 0
+
+  constants
+    basisPoints : Uint256 := 10000
+
+  immutables
+    treasury : Address := seedTreasury
+    withdrawFeeBps : Uint256 := 30
+
+  constructor (seedTreasury : Address) := do
+    setStorageAddr owner msgSender
+
+  function feeOn (amount : Uint256) : Uint256 := do
+    return div (mul amount withdrawFeeBps) basisPoints
+
+  function treasuryAddr () : Address := do
+    return treasury
+```
+
+Under the hood, the macro generates a `Contract α` state monad (`ContractState → ContractResult α`) with operations like `getStorage`, `setStorage`, and `require` that manipulate blockchain state. Constants are validated as compile-time expressions, and immutables are initialized once from constructor-visible expressions and exposed as read-only values in function bodies. You generally should not hand-write a separate `CompilationModel`; the macro-generated one is the compiler input.
 
 ### 2. Write a spec
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,6 +96,12 @@ Recent progress for ABI-level string support (`#1159`):
 - `ParamType.string` now compiles through the existing dynamic-bytes ABI path for macro parsing/lowering, calldata loading, ABI JSON/signature rendering, `Stmt.returnBytes`, event emission, and custom errors.
 - This support is intentionally ABI-only for now: Solidity-style string storage/layout and typed-IR string lowering remain unsupported and should continue to fail fast with explicit diagnostics.
 
+Recent progress for constants and immutables (`#1569`):
+- `verity_contract` now exposes `constants` and `immutables` sections in the macro surface, with smoke, invariant, round-trip, and generated Foundry property coverage.
+- Constants are validated as compile-time expressions, elaborated as Lean definitions, and can reference earlier constants while failing fast on runtime-dependent expressions and recursive definitions.
+- Immutables support `Uint256`, `Uint8`, `Address`, `Bytes32`, and `Bool` values bound from constructor-visible expressions, materialized as hidden storage-backed fields in the compilation model, and reintroduced as read-only bindings in function bodies.
+- Name-collision and type-mismatch diagnostics now fail fast for storage/constant/immutable/function conflicts and unsupported immutable payload types.
+
 Delivery policy for unsupported features:
 1. Compiler diagnostics must identify the exact unsupported construct.
 2. Error text must suggest the nearest currently-supported pattern.


### PR DESCRIPTION
## Summary
- document the `verity_contract` support for contract-level `constants` and constructor-bound `immutables` in the README
- record the already-landed implementation and coverage status in the roadmap
- close the stale feature request now that the docs reflect the current supported surface

## Verification
- inspected the docs diff locally
- `markdownlint` is not installed in this environment

Closes #1569.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that does not modify compiler or verification behavior; risk is limited to potential documentation inaccuracies.
> 
> **Overview**
> Documents newly supported `verity_contract` macro sections for contract-level `constants` and constructor-bound `immutables`, including a worked example and a brief explanation of compile-time validation/initialization semantics.
> 
> Updates the roadmap to record the landing of constants/immutables support (#1569) and summarizes current validation/diagnostic behavior and test coverage at a high level.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2676cef18948391eef9610751d1894bb9ccb930. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->