### PR TITLE
macro: add int256 surface support

### DIFF
--- a/Compiler/ABI.lean
+++ b/Compiler/ABI.lean
@@ -12,6 +12,7 @@ private def joinJsonFields (fields : List String) : String :=
 
 private def abiTypeString : ParamType → String
   | .uint256 => "uint256"
+  | .int256 => "int256"
   | .uint8 => "uint8"
   | .address => "address"
   | .bool => "bool"

--- a/Compiler/CompilationModel/AbiEncoding.lean
+++ b/Compiler/CompilationModel/AbiEncoding.lean
@@ -13,7 +13,7 @@ open Compiler.Yul
 def encodeStaticCustomErrorArg (errorName : String) (ty : ParamType) (argExpr : YulExpr) :
     Except String YulExpr :=
   match ty with
-  | ParamType.uint256 | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.bytes32 =>
       pure argExpr
   | ParamType.uint8 =>
       pure (YulExpr.call "and" [argExpr, YulExpr.lit 255])
@@ -37,7 +37,7 @@ partial def compileUnindexedAbiEncode
     (srcBase dstBase : YulExpr) (stem : String) :
     Except String (List YulStmt × YulExpr) := do
   match ty with
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       let loaded := dynamicWordLoad dynamicSource srcBase
       pure ([
         YulStmt.expr (YulExpr.call "mstore" [dstBase, normalizeEventWord ty loaded])
@@ -279,7 +279,7 @@ def revertWithCustomError (dynamicSource : DynamicDataSource)
   let argsWithHeadOffsets := attachOffsets argsWithSources 4
   let argStores ← argsWithHeadOffsets.zipIdx.mapM fun ((ty, srcExpr, argExpr, headOffset), idx) => do
     match ty with
-    | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+    | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
         let encoded ← encodeStaticCustomErrorArg errorDef.name ty argExpr
         pure [YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit headOffset, encoded])]
     | ParamType.tuple _ | ParamType.fixedArray _ _ =>

--- a/Compiler/CompilationModel/AbiHelpers.lean
+++ b/Compiler/CompilationModel/AbiHelpers.lean
@@ -45,6 +45,7 @@ def revertWithMessage (message : String) : List YulStmt :=
 mutual
   def paramTypeToSolidityString : ParamType → String
     | ParamType.uint256 => "uint256"
+    | ParamType.int256 => "int256"
     | ParamType.uint8 => "uint8"
     | ParamType.address => "address"
     | ParamType.bool => "bool"

--- a/Compiler/CompilationModel/AbiTypeLayout.lean
+++ b/Compiler/CompilationModel/AbiTypeLayout.lean
@@ -7,6 +7,7 @@ namespace Compiler.CompilationModel
 mutual
   def isDynamicParamType : ParamType → Bool
     | ParamType.uint256 => false
+    | ParamType.int256 => false
     | ParamType.uint8 => false
     | ParamType.address => false
     | ParamType.bool => false
@@ -30,6 +31,7 @@ end
 mutual
   def paramHeadSize : ParamType → Nat
     | ParamType.uint256 => 32
+    | ParamType.int256 => 32
     | ParamType.uint8 => 32
     | ParamType.address => 32
     | ParamType.bool => 32

--- a/Compiler/CompilationModel/EventAbiHelpers.lean
+++ b/Compiler/CompilationModel/EventAbiHelpers.lean
@@ -23,7 +23,7 @@ def normalizeEventWord (ty : ParamType) (expr : YulExpr) : YulExpr :=
 partial def staticCompositeLeaves (baseName : String) (ty : ParamType) :
     List (ParamType × YulExpr) :=
   match ty with
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       [(ty, YulExpr.ident baseName)]
   | ParamType.fixedArray elemTy n =>
       (List.range n).flatMap fun i =>
@@ -40,7 +40,7 @@ partial def staticCompositeLeaves (baseName : String) (ty : ParamType) :
 partial def staticCompositeLeafTypeOffsets
     (baseOffset : Nat) (ty : ParamType) : List (Nat × ParamType) :=
   match ty with
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       [(baseOffset, ty)]
   | ParamType.fixedArray elemTy n =>
       (List.range n).flatMap fun i =>
@@ -65,7 +65,7 @@ partial def compileIndexedInPlaceEncoding
     (srcBase dstBase : YulExpr) (stem : String) :
     Except String (List YulStmt × YulExpr) := do
   match ty with
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       let loaded := dynamicWordLoad dynamicSource srcBase
       pure ([
         YulStmt.expr (YulExpr.call "mstore" [dstBase, normalizeEventWord ty loaded])

--- a/Compiler/CompilationModel/ParamLoading.lean
+++ b/Compiler/CompilationModel/ParamLoading.lean
@@ -12,7 +12,7 @@ open Compiler
 open Compiler.Yul
 
 private def isScalarParamType : ParamType → Bool
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 => true
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 => true
   | _ => false
 
 private def genDynamicParamLoads
@@ -76,6 +76,8 @@ def genScalarLoad
   match ty with
   | ParamType.uint256 =>
       [YulStmt.let_ name load]
+  | ParamType.int256 =>
+      [YulStmt.let_ name load]
   | ParamType.uint8 =>
       [YulStmt.let_ name (YulExpr.call "and" [load, YulExpr.lit 255])]
   | ParamType.bytes32 =>
@@ -106,7 +108,7 @@ private partial def genStaticTypeLoads
     (loadWord : YulExpr → YulExpr) (name : String) (ty : ParamType) (offset : Nat) :
     List YulStmt :=
   match ty with
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       genScalarLoad loadWord name ty offset
   | ParamType.fixedArray elemTy n =>
       (List.range n).flatMap fun i =>
@@ -130,7 +132,7 @@ def genParamLoadBodyFrom
   | [] => []
   | param :: rest =>
       let stmts := match param.ty with
-        | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+        | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
           genScalarLoad loadWord param.name param.ty headOffset
         | ParamType.tuple elemTypes =>
           if isDynamicParamType param.ty then
@@ -184,7 +186,7 @@ private def constructorArgAliases (params : List Param) : List YulStmt :=
           YulExpr.ident s!"{param.name}_offset"
         else
           match param.ty with
-          | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+          | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
               YulExpr.ident param.name
           | _ =>
               YulExpr.call "mload" [YulExpr.lit headOffset]

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -11,7 +11,7 @@ def findParamType (params : List Param) (name : String) : Option ParamType :=
 
 partial def staticParamBindingNames (name : String) (ty : ParamType) : List String :=
   match ty with
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 =>
       [name]
   | ParamType.fixedArray elemTy n =>
       (List.range n).flatMap (fun i => staticParamBindingNames s!"{name}_{i}" elemTy)
@@ -28,17 +28,18 @@ def dynamicParamBindingNames (name : String) : List String :=
   [s!"{name}_offset", s!"{name}_length", s!"{name}_data_offset"]
 
 mutual
-def isDynamicParamTypeForScope : ParamType → Bool
-  | ParamType.uint256 => false
-  | ParamType.uint8 => false
-  | ParamType.address => false
-  | ParamType.bool => false
-  | ParamType.bytes32 => false
-  | ParamType.string => true
-  | ParamType.array _ => true
-  | ParamType.bytes => true
-  | ParamType.fixedArray elemTy _ => isDynamicParamTypeForScope elemTy
-  | ParamType.tuple elemTys => paramTypeListAnyDynamicForScope elemTys
+  def isDynamicParamTypeForScope : ParamType → Bool
+    | ParamType.uint256 => false
+    | ParamType.int256 => false
+    | ParamType.uint8 => false
+    | ParamType.address => false
+    | ParamType.bool => false
+    | ParamType.bytes32 => false
+    | ParamType.string => true
+    | ParamType.array _ => true
+    | ParamType.bytes => true
+    | ParamType.fixedArray elemTy _ => isDynamicParamTypeForScope elemTy
+    | ParamType.tuple elemTys => paramTypeListAnyDynamicForScope elemTys
 termination_by ty => sizeOf ty
 decreasing_by all_goals simp_wf; all_goals omega
 
@@ -50,7 +51,7 @@ decreasing_by all_goals simp_wf; all_goals omega
 end
 
 def isScalarParamTypeForScope : ParamType → Bool
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 => true
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 => true
   | _ => false
 
 def paramBindingNames (param : Param) : List String :=

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -138,6 +138,7 @@ Extended parameter types supporting arrays, bytes, and bytes32.
 
 inductive ParamType
   | uint256
+  | int256
   | uint8
   | address
   | bool                                   -- Solidity bool (ABI-encoded as 32-byte 0/1)
@@ -157,6 +158,7 @@ structure Param where
 -- Convert to IR types
 def ParamType.toIRType : ParamType → IRType
   | uint256 => IRType.uint256
+  | int256 => IRType.uint256
   | uint8 => IRType.uint256
   | address => IRType.address
   | bool => IRType.uint256

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -445,7 +445,7 @@ def validateExternalCallTargetsInConstructor
 
 mutual
 def supportedCustomErrorParamType : ParamType → Bool
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 | ParamType.bytes | ParamType.string => true
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 | ParamType.bytes | ParamType.string => true
   | ParamType.array elemTy => supportedCustomErrorParamType elemTy
   | ParamType.fixedArray elemTy _ => supportedCustomErrorParamType elemTy
   | ParamType.tuple elemTys => supportedCustomErrorParamTypes elemTys

--- a/Compiler/CompilationModel/ValidationEvents.lean
+++ b/Compiler/CompilationModel/ValidationEvents.lean
@@ -10,7 +10,7 @@ import Compiler.CompilationModel.ScopeValidation
 namespace Compiler.CompilationModel
 
 def customErrorRequiresDirectParamRef : ParamType → Bool
-  | ParamType.uint256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 => false
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address | ParamType.bool | ParamType.bytes32 => false
   | _ => true
 
 def validateDirectParamCustomErrorArg

--- a/Compiler/TypedIRCompiler.lean
+++ b/Compiler/TypedIRCompiler.lean
@@ -47,6 +47,7 @@ private def emit (stmt : TStmt) : CompileM Unit :=
 
 private def paramTypeToTy : ParamType → Except String Ty
   | .uint256 => Except.ok Ty.uint256
+  | .int256 => Except.ok Ty.uint256
   | .uint8 => Except.ok Ty.uint256
   | .address => Except.ok Ty.address
   | .bool => Except.ok Ty.bool

--- a/Contracts/Common.lean
+++ b/Contracts/Common.lean
@@ -71,6 +71,16 @@ def bitAnd (a b : Uint256) : Uint256 := Verity.Core.Uint256.and a b
 def bitOr (a b : Uint256) : Uint256 := Verity.Core.Uint256.or a b
 def bitXor (a b : Uint256) : Uint256 := Verity.Core.Uint256.xor a b
 
+structure Int256 where
+  word : Uint256
+  deriving Repr, BEq, DecidableEq, Inhabited
+
+def toInt256 (value : Uint256) : Int256 := ⟨value⟩
+def toUint256 (value : Int256) : Uint256 := value.word
+
+instance : Coe Int256 Uint256 := ⟨Int256.word⟩
+instance : OfNat Int256 n := ⟨toInt256 (n : Uint256)⟩
+
 class CustomErrorArg (α : Type) where
   encode : α → String
 
@@ -122,6 +132,9 @@ private def signedToWord (value : Int) : Uint256 :=
 
 private def signedAbsNat (value : Int) : Nat :=
   Int.natAbs value
+
+instance : CustomErrorArg Int256 where
+  encode value := toString (wordToSigned value.word)
 
 private def pow2 (n : Nat) : Nat := 2 ^ n
 
@@ -178,6 +191,14 @@ def signextend (byteIndex value : Uint256) : Uint256 :=
       ((lowBits + (Verity.Core.Uint256.modulus - lowMask - 1)) : Uint256)
     else
       (lowBits : Uint256)
+
+instance : Add Int256 := ⟨fun a b => toInt256 (a.word + b.word)⟩
+instance : Sub Int256 := ⟨fun a b => toInt256 (a.word - b.word)⟩
+instance : Mul Int256 := ⟨fun a b => toInt256 (a.word * b.word)⟩
+instance : Div Int256 := ⟨fun a b => toInt256 (sdiv a.word b.word)⟩
+instance : Mod Int256 := ⟨fun a b => toInt256 (smod a.word b.word)⟩
+instance : LT Int256 := ⟨fun a b => wordToSigned a.word < wordToSigned b.word⟩
+instance : LE Int256 := ⟨fun a b => wordToSigned a.word ≤ wordToSigned b.word⟩
 
 abbrev mulDivDown := Verity.Stdlib.Math.mulDivDown
 abbrev mulDivUp := Verity.Stdlib.Math.mulDivUp
@@ -245,12 +266,16 @@ class ExternalResult (α : Type) where
   fromWord : Uint256 → α
 instance : ExternalArg Uint256 where
   toWord value := value
+instance : ExternalArg Int256 where
+  toWord value := value.word
 instance : ExternalArg Address where
   toWord value := value.toNat
 instance : ExternalArg Bool where
   toWord value := if value then 1 else 0
 instance : ExternalResult Uint256 where
   fromWord value := value
+instance : ExternalResult Int256 where
+  fromWord value := toInt256 value
 instance : ExternalResult Address where
   fromWord value := wordToAddress value
 instance : ExternalResult Bool where

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -345,7 +345,9 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("StorageWordsSmoke", ["extSloadsLike(bytes32[])"])
   , ("CustomErrorSmoke", ["echo(uint256)"])
   , ("SignedBuiltinSmoke", ["signedDiv(uint256,uint256)", "signedMod(uint256,uint256)", "signedLt(uint256,uint256)",
-      "signedGt(uint256,uint256)", "arithmeticShift(uint256,uint256)", "signExtended()", "shiftedMask()"])
+      "signedGt(uint256,uint256)", "arithmeticShift(uint256,uint256)", "signExtended()", "shiftedMask()",
+      "signedDivSurface(int256,int256)", "signedModSurface(int256,int256)", "castToInt(uint256)",
+      "castToUint(int256)", "minusOne()"])
   , ("StatelessSmoke", ["echoWord(uint256)", "whoAmI()"])
   , ("MutabilitySmoke", ["deposit()", "currentOwner()"])
   , ("SpecialEntrypointSmoke", ["getReceiveCount()", "getFallbackCount()"])
@@ -398,7 +400,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("StorageWordsSmoke", ["0x764fa434"])
   , ("CustomErrorSmoke", ["0x6279e43c"])
   , ("SignedBuiltinSmoke", ["0x5aafa47b", "0x1c781eb5", "0x2ff7ce03", "0x5f28fa76", "0x49795601",
-      "0xcc634d7f", "0x7c4ab1e5"])
+      "0xcc634d7f", "0x7c4ab1e5", "0x44b95b1e", "0x17ea5a3e", "0xf6814165", "0xae1a9a3e", "0x6622d274"])
   , ("StatelessSmoke", ["0x26534f53", "0xda91254c"])
   , ("MutabilitySmoke", ["0xd0e30db0", "0xb387ef92"])
   , ("SpecialEntrypointSmoke", ["0x931999fb", "0x74b204a4"])
@@ -466,6 +468,11 @@ private def checkSignedBuiltinSmoke : IO Unit := do
   let arithmeticShift? := functions.find? (·.name == "arithmeticShift")
   let signExtended? := functions.find? (·.name == "signExtended")
   let shiftedMask? := functions.find? (·.name == "shiftedMask")
+  let signedDivSurface? := functions.find? (·.name == "signedDivSurface")
+  let signedModSurface? := functions.find? (·.name == "signedModSurface")
+  let castToInt? := functions.find? (·.name == "castToInt")
+  let castToUint? := functions.find? (·.name == "castToUint")
+  let minusOne? := functions.find? (·.name == "minusOne")
   let signedDiv := signedDiv?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
   let signedMod := signedMod?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
   let signedLt := signedLt?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
@@ -473,6 +480,11 @@ private def checkSignedBuiltinSmoke : IO Unit := do
   let arithmeticShift := arithmeticShift?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
   let signExtended := signExtended?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
   let shiftedMask := shiftedMask?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  let signedDivSurface := signedDivSurface?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  let signedModSurface := signedModSurface?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  let castToInt := castToInt?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  let castToUint := castToUint?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  let minusOne := minusOne?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
   expectTrue "SignedBuiltinSmoke: signedDiv body uses Expr.sdiv"
     (bodyUsesSignedBuiltin signedDiv.body "Expr.sdiv")
   expectTrue "SignedBuiltinSmoke: signedMod body uses Expr.smod"
@@ -487,6 +499,16 @@ private def checkSignedBuiltinSmoke : IO Unit := do
     (bodyUsesSignedBuiltin signExtended.body "Expr.signextend")
   expectTrue "SignedBuiltinSmoke: shiftedMask body inlines Expr.sar"
     (bodyUsesSignedBuiltin shiftedMask.body "Expr.sar")
+  expectTrue "SignedBuiltinSmoke: signedDivSurface lowers Int256 div to Expr.sdiv"
+    (bodyUsesSignedBuiltin signedDivSurface.body "Expr.sdiv")
+  expectTrue "SignedBuiltinSmoke: signedModSurface lowers Int256 mod to Expr.smod"
+    (bodyUsesSignedBuiltin signedModSurface.body "Expr.smod")
+  expectTrue "SignedBuiltinSmoke: castToInt stays word-level in the model"
+    (!bodyUsesSignedBuiltin castToInt.body "Expr.sdiv")
+  expectTrue "SignedBuiltinSmoke: castToUint stays word-level in the model"
+    (!bodyUsesSignedBuiltin castToUint.body "Expr.sdiv")
+  expectTrue "SignedBuiltinSmoke: minusOne preserves Int256 constants as raw words"
+    (!minusOne.body.isEmpty)
 
 private def checkSpecialEntrypointSmoke : IO Unit := do
   let functions := Contracts.Smoke.SpecialEntrypointSmoke.spec.functions

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -90,6 +90,7 @@ verity_contract SignedBuiltinSmoke where
   constants
     extendedByte : Uint256 := (signextend 0 255)
     arithmeticShifted : Uint256 := (sar 255 (sub 0 1))
+    negativeOne : Int256 := (toInt256 (sub 0 1))
 
   function signedDiv (lhs : Uint256, rhs : Uint256) : Uint256 := do
     return (sdiv lhs rhs)
@@ -111,6 +112,21 @@ verity_contract SignedBuiltinSmoke where
 
   function shiftedMask () : Uint256 := do
     return arithmeticShifted
+
+  function signedDivSurface (lhs : Int256, rhs : Int256) : Int256 := do
+    return (lhs / rhs)
+
+  function signedModSurface (lhs : Int256, rhs : Int256) : Int256 := do
+    return (lhs % rhs)
+
+  function castToInt (value : Uint256) : Int256 := do
+    return (toInt256 value)
+
+  function castToUint (value : Int256) : Uint256 := do
+    return (toUint256 value)
+
+  function minusOne () : Int256 := do
+    return negativeOne
 
 verity_contract StatelessSmoke where
   storage
@@ -261,7 +277,7 @@ verity_contract ConstantRuntimeBuiltinRejected where
     return seededAt
 
 /--
-error: contract immutables currently support only Uint256, Uint8, Address, Bytes32, and Bool; 'metadata' uses unsupported type
+ error: contract immutables currently support only Uint256, Int256, Uint8, Address, Bytes32, and Bool; 'metadata' uses unsupported type
 -/
 #guard_msgs in
 verity_contract ImmutableTypeRejected where
@@ -658,7 +674,7 @@ verity_contract ERC20HelperShadowWriteRejected where
     safeTransfer token to amount
 
 /--
-error: linked external 'describe' uses unsupported parameter type; executable externalCall currently supports only Uint256, Uint8, Address, Bytes32, and Bool
+ error: linked external 'describe' uses unsupported parameter type; executable externalCall currently supports only Uint256, Int256, Uint8, Address, Bytes32, and Bool
 -/
 #guard_msgs in
 verity_contract ExternalCallUnsupportedType where

--- a/Contracts/StringSmoke.lean
+++ b/Contracts/StringSmoke.lean
@@ -58,7 +58,7 @@ verity_contract StringStorageUnsupported where
     pure ()
 
 /--
-error: equality is currently supported only for Bool and word-like values (Uint256, Uint8, Address, Bytes32); got Verity.Macro.ValueType.string and Verity.Macro.ValueType.string
+ error: equality is currently supported only for Bool and word-like values (Uint256, Int256, Uint8, Address, Bytes32); got Verity.Macro.ValueType.string and Verity.Macro.ValueType.string
 -/
 #guard_msgs in
 verity_contract StringEqUnsupported where
@@ -83,7 +83,7 @@ verity_contract StringLogicalUnsupported where
       return 0
 
 /--
-error: equality is currently supported only for Bool and word-like values (Uint256, Uint8, Address, Bytes32); got Verity.Macro.ValueType.string and Verity.Macro.ValueType.string
+ error: equality is currently supported only for Bool and word-like values (Uint256, Int256, Uint8, Address, Bytes32); got Verity.Macro.ValueType.string and Verity.Macro.ValueType.string
 -/
 #guard_msgs in
 verity_contract StringImmutableEqUnsupported where

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -18,6 +18,7 @@ abbrev DoSeq := TSyntax `Lean.Parser.Term.doSeq
 
 inductive ValueType where
   | uint256
+  | int256
   | uint8
   | address
   | bytes32
@@ -121,6 +122,7 @@ private def natFromSyntax (stx : Syntax) : CommandElabM Nat :=
 private partial def valueTypeFromSyntax (ty : Term) : CommandElabM ValueType := do
   match ty with
   | `(term| Uint256) => pure .uint256
+  | `(term| Int256) => pure .int256
   | `(term| Uint8) => pure .uint8
   | `(term| Address) => pure .address
   | `(term| Bytes32) => pure .bytes32
@@ -139,7 +141,7 @@ private partial def valueTypeFromSyntax (ty : Term) : CommandElabM ValueType := 
         throwErrorAt ty "tuple types must have at least 2 elements"
       pure (.tuple elems.toList)
   | `(term| Unit) => pure .unit
-  | _ => throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Uint8, Address, Bytes32, Bool, String, Bytes, Array <type>, Tuple [...], or Unit"
+  | _ => throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Int256, Uint8, Address, Bytes32, Bool, String, Bytes, Array <type>, Tuple [...], or Unit"
 
 private def storageTypeFromSyntax (ty : Term) : CommandElabM StorageType := do
   let keyTypeFromSyntax (stx : Term) : CommandElabM MappingKeyType := do
@@ -200,6 +202,7 @@ private def modelStructMemberTerm (member : StructMemberDecl) : CommandElabM Ter
 private def modelFieldTypeTerm (ty : StorageType) : CommandElabM Term :=
   match ty with
   | .scalar .uint256 => `(Compiler.CompilationModel.FieldType.uint256)
+  | .scalar .int256 => throwError "storage fields cannot be Int256; use Uint256 encoding"
   | .scalar .uint8 => throwError "storage fields cannot be Uint8; use Uint256 encoding"
   | .scalar .address => `(Compiler.CompilationModel.FieldType.address)
   | .scalar .bytes32 => throwError "storage fields cannot be Bytes32; use Uint256 encoding"
@@ -233,6 +236,7 @@ private def modelFieldTypeTerm (ty : StorageType) : CommandElabM Term :=
 private partial def modelParamTypeTerm (ty : ValueType) : CommandElabM Term :=
   match ty with
   | .uint256 => `(Compiler.CompilationModel.ParamType.uint256)
+  | .int256 => `(Compiler.CompilationModel.ParamType.int256)
   | .uint8 => `(Compiler.CompilationModel.ParamType.uint8)
   | .address => `(Compiler.CompilationModel.ParamType.address)
   | .bytes32 => `(Compiler.CompilationModel.ParamType.bytes32)
@@ -250,6 +254,7 @@ private def modelReturnTypeTerm (ty : ValueType) : CommandElabM Term :=
   match ty with
   | .unit => `(none)
   | .uint256 => `(some Compiler.CompilationModel.FieldType.uint256)
+  | .int256 => `(none)
   | .uint8 => `(none)
   | .address => `(some Compiler.CompilationModel.FieldType.address)
   | .bytes32 => `(none)
@@ -263,6 +268,7 @@ private partial def modelReturnsTerm (ty : ValueType) : CommandElabM Term :=
   match ty with
   | .unit => `([])
   | .uint256 => `([Compiler.CompilationModel.ParamType.uint256])
+  | .int256 => `([Compiler.CompilationModel.ParamType.int256])
   | .uint8 => `([Compiler.CompilationModel.ParamType.uint8])
   | .address => `([Compiler.CompilationModel.ParamType.address])
   | .bytes32 => `([Compiler.CompilationModel.ParamType.bytes32])
@@ -287,6 +293,7 @@ private partial def mkTupleContractType (elemTys : List ValueType) : CommandElab
 private partial def contractValueTypeTerm (ty : ValueType) : CommandElabM Term :=
   match ty with
   | .uint256 => `(Uint256)
+  | .int256 => `(Int256)
   | .uint8 => `(Uint256)
   | .address => `(Address)
   | .bytes32 => `(Uint256)
@@ -535,7 +542,7 @@ def immutableStorageFieldDecl
     ident := immutableSlotIdent imm
     name := immutableHiddenName imm
     ty := match imm.ty with
-      | .uint256 | .uint8 | .bytes32 | .bool => .scalar .uint256
+      | .uint256 | .int256 | .uint8 | .bytes32 | .bool => .scalar .uint256
       | .address => .scalar .address
       | _ => .scalar imm.ty
     slotNum := immutableSlotIndex fields idx
@@ -543,10 +550,10 @@ def immutableStorageFieldDecl
 
 private def validateImmutableType (imm : ImmutableDecl) : CommandElabM Unit :=
   match imm.ty with
-  | .uint256 | .uint8 | .address | .bytes32 | .bool => pure ()
+  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => pure ()
   | _ =>
       throwErrorAt imm.ident
-        s!"contract immutables currently support only Uint256, Uint8, Address, Bytes32, and Bool; '{imm.name}' uses unsupported type"
+        s!"contract immutables currently support only Uint256, Int256, Uint8, Address, Bytes32, and Bool; '{imm.name}' uses unsupported type"
 
 private def validateImmutableBodyType
     (imm : ImmutableDecl)
@@ -560,7 +567,7 @@ private def validateImmutableBodyType
     discard <| Lean.Elab.Term.elabTerm wrappedBody none
 
 private def externalExecutableWordType? : ValueType → Bool
-  | .uint256 | .uint8 | .address | .bytes32 | .bool => true
+  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => true
   | _ => false
 
 private def validateExternalExecutableType
@@ -570,7 +577,7 @@ private def validateExternalExecutableType
     (role : String) : CommandElabM Unit := do
   if !externalExecutableWordType? ty then
     throwErrorAt extIdent
-      s!"linked external '{extName}' uses unsupported {role} type; executable externalCall currently supports only Uint256, Uint8, Address, Bytes32, and Bool"
+      s!"linked external '{extName}' uses unsupported {role} type; executable externalCall currently supports only Uint256, Int256, Uint8, Address, Bytes32, and Bool"
 
 private partial def stripParens (stx : Term) : Term :=
   match stx with
@@ -704,6 +711,8 @@ private def mkImmutableBoundBody
         match imm.ty with
         | .uint256 | .uint8 | .bytes32 =>
             pure #[← `(doElem| let $(imm.ident) ← getStorage $(slotField.ident))]
+        | .int256 =>
+            pure #[← `(doElem| let $(imm.ident) := toInt256 (← getStorage $(slotField.ident)))]
         | .bool =>
             let rawName := mkIdent (Name.mkSimple s!"__verity_immutable_raw_{imm.name}")
             pure #[
@@ -833,9 +842,30 @@ private def lookupVarExpr (params : Array ParamDecl) (locals : Array String) (na
 
 private abbrev TypedLocal := String × ValueType
 
-private def isWordLikeValueType : ValueType → Bool
-  | .uint256 | .uint8 | .address | .bytes32 => true
+private def isSignedWordValueType : ValueType → Bool
+  | .int256 => true
   | _ => false
+
+private def isWordLikeValueType : ValueType → Bool
+  | .uint256 | .int256 | .uint8 | .address | .bytes32 => true
+  | _ => false
+
+private def classifyWordArithmeticResultType
+    (stx : Syntax)
+    (context : String)
+    (lhsTy rhsTy : ValueType) : CommandElabM ValueType := do
+  unless isWordLikeValueType lhsTy do
+    throwErrorAt stx s!"{context} requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got {reprStr lhsTy}"
+  unless isWordLikeValueType rhsTy do
+    throwErrorAt stx s!"{context} requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got {reprStr rhsTy}"
+  if isSignedWordValueType lhsTy || isSignedWordValueType rhsTy then
+    if lhsTy == .int256 && rhsTy == .int256 then
+      pure .int256
+    else
+      throwErrorAt stx
+        s!"{context} requires explicit casts when mixing Int256 with non-Int256 words; got {reprStr lhsTy} and {reprStr rhsTy}"
+  else
+    pure .uint256
 
 private def lookupTypedLocalType? (locals : Array TypedLocal) (name : String) : Option ValueType :=
   locals.findSome? fun localTy =>
@@ -861,7 +891,7 @@ private def renderValueType (ty : ValueType) : String :=
 
 private def requireWordLikeType (stx : Syntax) (context : String) (ty : ValueType) : CommandElabM Unit := do
   unless isWordLikeValueType ty do
-    throwErrorAt stx s!"{context} requires a word-like value (Uint256, Uint8, Address, or Bytes32), got {renderValueType ty}"
+    throwErrorAt stx s!"{context} requires a word-like value (Uint256, Int256, Uint8, Address, or Bytes32), got {renderValueType ty}"
 
 private def requireBoolType (stx : Syntax) (context : String) (ty : ValueType) : CommandElabM Unit := do
   unless ty == .bool do
@@ -872,7 +902,7 @@ private def requireEqComparableTypes (stx : Syntax) (lhsTy rhsTy : ValueType) : 
   let bothBool := lhsTy == .bool && rhsTy == .bool
   unless bothWordLike || bothBool do
     throwErrorAt stx
-      s!"equality is currently supported only for Bool and word-like values (Uint256, Uint8, Address, Bytes32); got {renderValueType lhsTy} and {renderValueType rhsTy}"
+      s!"equality is currently supported only for Bool and word-like values (Uint256, Int256, Uint8, Address, Bytes32); got {renderValueType lhsTy} and {renderValueType rhsTy}"
 
 private def requireSameOrWordLikeTypes (stx : Syntax) (context : String) (lhsTy rhsTy : ValueType) : CommandElabM Unit := do
   unless lhsTy == rhsTy || (isWordLikeValueType lhsTy && isWordLikeValueType rhsTy) do
@@ -925,6 +955,12 @@ private partial def inferPureExprType
       unless ty == .address do
         throwErrorAt a s!"addressToWord requires Address, got {renderValueType ty}"
       pure .uint256
+  | `(term| toInt256 $a:term) => do
+      requireWordLikeType a "toInt256" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
+      pure .int256
+  | `(term| toUint256 $a:term) => do
+      requireWordLikeType a "toUint256" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
+      pure .uint256
   | `(term| boolToWord $a:term) =>
       requireBoolType a "boolToWord" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       pure .uint256
@@ -940,21 +976,28 @@ private partial def inferPureExprType
   | `(term| $n:num) =>
       pure .uint256
   | `(term| add $a $b) | `(term| sub $a $b) | `(term| mul $a $b)
-    | `(term| div $a $b) | `(term| sdiv $a $b) | `(term| mod $a $b) | `(term| smod $a $b) | `(term| bitAnd $a $b)
+    | `(term| bitAnd $a $b)
     | `(term| bitOr $a $b) | `(term| bitXor $a $b) | `(term| and $a $b)
     | `(term| or $a $b) | `(term| xor $a $b) | `(term| min $a $b)
     | `(term| max $a $b) | `(term| wMulDown $a $b) | `(term| wDivUp $a $b) => do
-      requireWordLikeType a "word arithmetic" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
-      requireWordLikeType b "word arithmetic" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants)
-      pure .uint256
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants
+      classifyWordArithmeticResultType stx "word arithmetic" lhsTy rhsTy
+  | `(term| div $a $b) | `(term| $a / $b) | `(term| mod $a $b) | `(term| $a % $b)
+    | `(term| sdiv $a $b) | `(term| smod $a $b) => do
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants
+      classifyWordArithmeticResultType stx "division/modulo" lhsTy rhsTy
   | `(term| bitNot $a) | `(term| not $a) => do
-      requireWordLikeType a "bitwise not" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
-      pure .uint256
+      let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
+      requireWordLikeType a "bitwise not" ty
+      pure (if ty == .int256 then .int256 else .uint256)
   | `(term| shl $shift $value) | `(term| shr $shift $value) | `(term| sar $shift $value)
     | `(term| signextend $shift $value) => do
       requireWordLikeType shift "shift" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals shift visitingConstants)
-      requireWordLikeType value "shift" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals value visitingConstants)
-      pure .uint256
+      let valueTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals value visitingConstants
+      requireWordLikeType value "shift" valueTy
+      pure (if valueTy == .int256 then .int256 else .uint256)
   | `(term| slt $a $b) | `(term| sgt $a $b) => do
       requireWordLikeType a "signed ordering comparison" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
       requireWordLikeType b "signed ordering comparison" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants)
@@ -965,8 +1008,9 @@ private partial def inferPureExprType
       requireEqComparableTypes stx lhsTy rhsTy
       pure .bool
   | `(term| $a >= $b) | `(term| $a > $b) | `(term| $a < $b) | `(term| $a <= $b) => do
-      requireWordLikeType a "ordering comparison" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
-      requireWordLikeType b "ordering comparison" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants)
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls externalDecls params locals b visitingConstants
+      discard <| classifyWordArithmeticResultType stx "ordering comparison" lhsTy rhsTy
       pure .bool
   | `(term| $a && $b) | `(term| $a || $b) => do
       requireBoolType a "logical operator" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals a visitingConstants)
@@ -1263,6 +1307,8 @@ private partial def validateConstantBody
   | `(term| isZeroAddress $a:term) => validateConstantBody constDecls a visiting
   | `(term| wordToAddress $a:term) => validateConstantBody constDecls a visiting
   | `(term| addressToWord $a:term) => validateConstantBody constDecls a visiting
+  | `(term| toInt256 $a:term) => validateConstantBody constDecls a visiting
+  | `(term| toUint256 $a:term) => validateConstantBody constDecls a visiting
   | `(term| boolToWord $a:term) => validateConstantBody constDecls a visiting
   | `(term| $id:ident) =>
       let name := toString id.getId
@@ -1373,6 +1419,8 @@ partial def translatePureExpr
           (Compiler.CompilationModel.Expr.literal 0))
   | `(term| wordToAddress $a:term) => translatePureExpr fields constDecls immutableDecls params locals a visitingConstants
   | `(term| addressToWord $a:term) => translatePureExpr fields constDecls immutableDecls params locals a visitingConstants
+  | `(term| toInt256 $a:term) => translatePureExpr fields constDecls immutableDecls params locals a visitingConstants
+  | `(term| toUint256 $a:term) => translatePureExpr fields constDecls immutableDecls params locals a visitingConstants
   | `(term| boolToWord $a:term) =>
       `(Compiler.CompilationModel.Expr.ite
           $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants)
@@ -1384,7 +1432,7 @@ partial def translatePureExpr
         lookupVarExpr params locals name
       else if let some imm := immutableDecls.find? (fun imm => imm.name == name) then
         match imm.ty with
-        | .uint256 | .uint8 | .bytes32 | .bool =>
+        | .uint256 | .int256 | .uint8 | .bytes32 | .bool =>
             `(Compiler.CompilationModel.Expr.storage $(strTerm (immutableHiddenName imm)))
         | .address => `(Compiler.CompilationModel.Expr.storageAddr $(strTerm (immutableHiddenName imm)))
         | _ => throwErrorAt stx s!"immutable '{name}' uses unsupported type"
@@ -1394,9 +1442,21 @@ partial def translatePureExpr
   | `(term| add $a $b) => `(Compiler.CompilationModel.Expr.add $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| sub $a $b) => `(Compiler.CompilationModel.Expr.sub $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| mul $a $b) => `(Compiler.CompilationModel.Expr.mul $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| div $a $b) => `(Compiler.CompilationModel.Expr.div $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+  | `(term| div $a $b) | `(term| $a / $b) => do
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) b visitingConstants
+      if lhsTy == .int256 && rhsTy == .int256 then
+        `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+      else
+        `(Compiler.CompilationModel.Expr.div $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| sdiv $a $b) => `(Compiler.CompilationModel.Expr.sdiv $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| mod $a $b) => `(Compiler.CompilationModel.Expr.mod $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+  | `(term| mod $a $b) | `(term| $a % $b) => do
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) b visitingConstants
+      if lhsTy == .int256 && rhsTy == .int256 then
+        `(Compiler.CompilationModel.Expr.smod $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+      else
+        `(Compiler.CompilationModel.Expr.mod $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| smod $a $b) => `(Compiler.CompilationModel.Expr.smod $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| bitAnd $a $b) => `(Compiler.CompilationModel.Expr.bitAnd $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| bitOr $a $b) => `(Compiler.CompilationModel.Expr.bitOr $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
@@ -1412,12 +1472,42 @@ partial def translatePureExpr
           (Compiler.CompilationModel.Expr.eq
             $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants)
             $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants)))
-  | `(term| $a >= $b) => `(Compiler.CompilationModel.Expr.ge $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| $a > $b) => `(Compiler.CompilationModel.Expr.gt $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+  | `(term| $a >= $b) => do
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) b visitingConstants
+      if lhsTy == .int256 && rhsTy == .int256 then
+        `(Compiler.CompilationModel.Expr.logicalNot
+            (Compiler.CompilationModel.Expr.slt
+              $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants)
+              $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants)))
+      else
+        `(Compiler.CompilationModel.Expr.ge $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+  | `(term| $a > $b) => do
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) b visitingConstants
+      if lhsTy == .int256 && rhsTy == .int256 then
+        `(Compiler.CompilationModel.Expr.sgt $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+      else
+        `(Compiler.CompilationModel.Expr.gt $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| sgt $a $b) => `(Compiler.CompilationModel.Expr.sgt $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| $a < $b) => `(Compiler.CompilationModel.Expr.lt $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+  | `(term| $a < $b) => do
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) b visitingConstants
+      if lhsTy == .int256 && rhsTy == .int256 then
+        `(Compiler.CompilationModel.Expr.slt $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+      else
+        `(Compiler.CompilationModel.Expr.lt $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| slt $a $b) => `(Compiler.CompilationModel.Expr.slt $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
-  | `(term| $a <= $b) => `(Compiler.CompilationModel.Expr.le $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
+  | `(term| $a <= $b) => do
+      let lhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) a visitingConstants
+      let rhsTy ← inferPureExprType fields constDecls immutableDecls #[] params (locals.map (fun name => (name, .uint256))) b visitingConstants
+      if lhsTy == .int256 && rhsTy == .int256 then
+        `(Compiler.CompilationModel.Expr.logicalNot
+            (Compiler.CompilationModel.Expr.sgt
+              $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants)
+              $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants)))
+      else
+        `(Compiler.CompilationModel.Expr.le $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| $a && $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| $a || $b) => `(Compiler.CompilationModel.Expr.logicalOr $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
   | `(term| logicalAnd $a $b) => `(Compiler.CompilationModel.Expr.logicalAnd $(← translatePureExpr fields constDecls immutableDecls params locals a visitingConstants) $(← translatePureExpr fields constDecls immutableDecls params locals b visitingConstants))
@@ -2660,7 +2750,7 @@ private def immutableInitStmtTerms
     let slotField := immutableStorageFieldDecl fields imm idx
     let valueExpr ← translatePureExpr fields constDecls #[] ctorParams #[] imm.body
     match imm.ty with
-    | .uint256 | .uint8 | .bytes32 | .bool =>
+    | .uint256 | .int256 | .uint8 | .bytes32 | .bool =>
         `(Compiler.CompilationModel.Stmt.setStorage $(strTerm slotField.name) $valueExpr)
     | .address =>
         `(Compiler.CompilationModel.Stmt.setStorageAddr $(strTerm slotField.name) $valueExpr)
@@ -2725,6 +2815,7 @@ private def mkStorageDefCommand (field : StorageFieldDecl) : CommandElabM Cmd :=
   let storageTy ←
     match field.ty with
     | .scalar .uint256 => `(Uint256)
+    | .scalar .int256 => throwError "storage field cannot be Int256; use Uint256 encoding"
     | .scalar .uint8 => throwError "storage field cannot be Uint8; use Uint256 encoding"
     | .scalar .address => `(Address)
     | .scalar .bytes32 => throwError "storage field cannot be Bytes32; use Uint256 encoding"

--- a/artifacts/macro_property_tests/PropertySignedBuiltinSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertySignedBuiltinSmoke.t.sol
@@ -80,4 +80,49 @@ contract PropertySignedBuiltinSmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
+    // Property 8: TODO decode and assert `signedDivSurface` result
+    function testTODO_SignedDivSurface_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("signedDivSurface(int256,int256)", int256(1), int256(1)));
+        require(ok, "signedDivSurface reverted unexpectedly");
+        assertEq(ret.length, 32, "signedDivSurface ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 9: TODO decode and assert `signedModSurface` result
+    function testTODO_SignedModSurface_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("signedModSurface(int256,int256)", int256(1), int256(1)));
+        require(ok, "signedModSurface reverted unexpectedly");
+        assertEq(ret.length, 32, "signedModSurface ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 10: TODO decode and assert `castToInt` result
+    function testTODO_CastToInt_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("castToInt(uint256)", uint256(1)));
+        require(ok, "castToInt reverted unexpectedly");
+        assertEq(ret.length, 32, "castToInt ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 11: TODO decode and assert `castToUint` result
+    function testTODO_CastToUint_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("castToUint(int256)", int256(1)));
+        require(ok, "castToUint reverted unexpectedly");
+        assertEq(ret.length, 32, "castToUint ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 12: TODO decode and assert `minusOne` result
+    function testTODO_MinusOne_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("minusOne()"));
+        require(ok, "minusOne reverted unexpectedly");
+        assertEq(ret.length, 32, "minusOne ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
 }

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -273,6 +273,8 @@ def _sol_type(lean_ty: str) -> str:
     ty = _normalize_type(lean_ty)
     if ty == "Uint256":
         return "uint256"
+    if ty == "Int256":
+        return "int256"
     if ty == "Uint8":
         return "uint8"
     if ty == "Address":
@@ -310,6 +312,8 @@ def _example_value(lean_ty: str) -> str:
     ty = _normalize_type(lean_ty)
     if ty == "Uint256":
         return "uint256(1)"
+    if ty == "Int256":
+        return "int256(1)"
     if ty == "Uint8":
         return "uint8(27)"
     if ty == "Address":
@@ -352,7 +356,7 @@ def _fn_camel(name: str) -> str:
 
 def _return_shape_assertion(lean_ty: str, fn_name: str) -> str:
     ty = _normalize_type(lean_ty)
-    if ty in {"Uint256", "Uint8", "Address", "Bool", "Bytes32"}:
+    if ty in {"Uint256", "Int256", "Uint8", "Address", "Bool", "Bytes32"}:
         return (
             f'        assertEq(ret.length, 32, "{fn_name} ABI return length mismatch (expected 32 bytes)");'
         )
@@ -376,7 +380,7 @@ def _return_shape_assertion(lean_ty: str, fn_name: str) -> str:
 
 def _storage_word_expr(lean_ty: str, value_expr: str) -> str:
     ty = _normalize_type(lean_ty)
-    if ty in {"Uint256", "Uint8"}:
+    if ty in {"Uint256", "Int256", "Uint8"}:
         return f"bytes32(uint256({value_expr}))"
     if ty == "Bool":
         return f"bytes32(uint256({value_expr} ? 1 : 0))"
@@ -389,7 +393,7 @@ def _storage_word_expr(lean_ty: str, value_expr: str) -> str:
 
 def _literal_expr(value: str, lean_ty: str) -> str | None:
     ty = _normalize_type(lean_ty)
-    if ty in {"Uint256", "Uint8"} and re.fullmatch(r"(0x[0-9A-Fa-f]+|[0-9]+)", value):
+    if ty in {"Uint256", "Int256", "Uint8"} and re.fullmatch(r"(0x[0-9A-Fa-f]+|[0-9]+)", value):
         return value
     if ty == "Bool" and value in {"true", "false"}:
         return value


### PR DESCRIPTION
Closes #1568.

## Summary
- add `Int256` as a first-class `verity_contract` value type and ABI param/return type
- add explicit `toInt256` / `toUint256` casts plus executable-model support in `Contracts.Common`
- lower signed `/` and `%` on `Int256` to `Expr.sdiv` / `Expr.smod`, and thread `int256` through ABI/codegen/property-test generation
- extend smoke + invariant coverage and refresh the generated `PropertySignedBuiltinSmoke` artifact

## Verification
- `lake build Contracts.Smoke`
- `lake build Contracts.MacroTranslateInvariantTest`
- `lake build Contracts.MacroTranslateRoundTripFuzz`
- `python3 scripts/check_macro_health.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Threads `int256` through the macro/typechecker and ABI/codegen paths (param loading, event/custom-error encoding, selector signatures), which can affect external interfaces and runtime encoding correctness. Changes are mostly additive but touch core compilation and validation logic.
> 
> **Overview**
> Adds first-class `Int256` support to the `verity_contract` surface: introduces `ParamType.int256`/`ValueType.int256`, renders `int256` in ABI JSON and Solidity signature strings, and treats it as a static 32-byte word in ABI layout, calldata decoding, event encoding, and custom-error encoding/validation.
> 
> Extends the macro translation/type inference with explicit `toInt256`/`toUint256` casts, enforces stricter rules when mixing signed/unsigned word arithmetic, and lowers `/` and `%` on `Int256` to signed EVM ops (`Expr.sdiv`/`Expr.smod`) plus signed comparisons for ordering. Updates contract-side runtime helpers (`Contracts.Common`) with an `Int256` wrapper, arithmetic/comparison instances, and external call arg/result conversions, and expands smoke/invariant/property-test generation/artifacts to cover new `int256` entrypoints and return-shape assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f8013d3b744690cfcf460062dd914614f7ff284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->