### PR TITLE
docs: clarify current string support boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ FOUNDRY_PROFILE=difftest forge test
 
 Current theorem totals, test counts, coverage, and proof status live in [docs/VERIFICATION_STATUS.md](docs/VERIFICATION_STATUS.md).
 
+Current dynamic-type status: ABI-level `String` support is available for macro parsing, calldata flow, `returnBytes`, event payloads, and custom-error payloads, but Solidity-style string storage/layout, dynamic linked externals, and word-style string operators still remain intentionally unsupported while issue [#1159](https://github.com/Th0rgal/verity/issues/1159) stays open for the remaining work.
+
 ---
 
 ## External calls

--- a/docs-site/content/guides/solidity-to-verity.mdx
+++ b/docs-site/content/guides/solidity-to-verity.mdx
@@ -78,8 +78,8 @@ Model guard manually with a dedicated storage slot (`entered : Bool` encoded as 
 
 ### String-heavy logic
 
-String support is not complete (see issue `#1159`).
-Prefer numeric/address/bytes-based logic for now.
+ABI-level `String` support exists today for macro parsing, calldata flow, `returnBytes`, event payloads, and custom-error payloads (see issue `#1159`).
+String storage/layout, dynamic linked externals, and word-style operators over `String` remain unsupported, so prefer numeric/address/bytes-based logic unless you only need ABI transport.
 
 ## 3. Worked Walkthrough: Minimal ERC20 Transfer Path
 

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -122,6 +122,7 @@ Conservation proofs use `List.countOcc` to account for duplicate addresses. For 
 - **No gas modeling**: EDSL models storage and control flow only; verification assumes infinite gas.
 - **Events**: The CompilationModel DSL supports event emission (`Stmt.emit`), but the EDSL core does not yet model events in proofs.
 - **Nested mappings**: The CompilationModel DSL supports double mappings (`mapping2`/`setMapping2`), but EDSL-level proofs for nested mapping semantics are still limited.
+- **Strings are ABI-only today**: `String` flows through macro parsing, calldata, `returnBytes`, event payloads, and custom errors, but Solidity-style string storage/layout, dynamic linked externals, and word-style string operators still fail fast instead of pretending to be supported (see issue `#1159`).
 
 ## Compiler Development
 


### PR DESCRIPTION
## Summary
- replace the vague docs-site guidance around `String` with the actual ABI-only support boundary
- add a matching README note so the repo front page reflects what already works
- call out the still-open unsupported pieces that keep `#1159` legitimately open

## Testing
- docs-only diff inspection

Partially addresses #1159.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only update that clarifies the current `String` support boundary; no code or behavior changes.
> 
> **Overview**
> Adds explicit documentation of the current dynamic-type boundary: `String` is supported for ABI transport paths (macro parsing, calldata flow, `returnBytes`, event payloads, and custom-error payloads), but **not** for Solidity-style storage/layout, dynamic linked externals, or word-style `String` operators.
> 
> Updates the repo `README` plus the Solidity translation guide and research limitations section to align on this ABI-only stance and reference the remaining work in issue `#1159`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b182119b6ad574a62d8677a6fb77d60b79bf91d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->