### PR TITLE
docs: clarify interpreter matrix legacy labels

### DIFF
--- a/docs/INTERPRETER_FEATURE_MATRIX.md
+++ b/docs/INTERPRETER_FEATURE_MATRIX.md
@@ -15,7 +15,12 @@ Machine-readable version: [`artifacts/interpreter_feature_matrix.json`](../artif
 | **YulSemantics** | `Compiler/Proofs/YulGeneration/Semantics.lean` | `execYulFuel` | Layer-3 Yul execution semantics |
 | **EVMYulLean bridge** | `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean` | `evalBuiltinCallViaEvmYulLean` | Pure builtin evaluation via EVMYulLean UInt256 |
 
-The `SpecInterpreter` has been removed. EDSL semantics are now defined directly in `Verity/Core.lean` via the `Contract` monad and composed with IR/Yul layers through `SemanticBridge` proofs.
+The old `SpecInterpreter` module has been removed. Source semantics now live in
+`Verity/Core.lean`, with the supported whole-contract Layer-2 source-side model
+assembled in `Compiler/Proofs/IRGeneration/SourceSemantics.lean`. This matrix
+keeps the legacy `Spec (basic)` / `Spec (fuel)` column names, and the
+machine-readable artifact keeps `SpecInterpreter_*` keys, for compatibility
+with the existing sync scripts and boundary checks.
 
 ---
 
@@ -159,5 +164,5 @@ Proof-boundary features split across two buckets. Partially modeled features cur
 
 ---
 
-**Last Updated**: 2026-03-08
+**Last Updated**: 2026-03-11
 **Machine-readable artifact**: `artifacts/interpreter_feature_matrix.json`


### PR DESCRIPTION
## Summary
- clarify that the old `SpecInterpreter` module is gone and the source semantics now live in `Verity/Core.lean`
- point the interpreter matrix at `Compiler/Proofs/IRGeneration/SourceSemantics.lean` for the supported whole-contract Layer 2 source-side model
- explain that the `Spec (basic)` / `Spec (fuel)` labels and `SpecInterpreter_*` artifact keys are intentionally retained as compatibility labels for existing sync scripts

## Why
The repo's main proof-status docs were already updated for the current Layer 2 boundary, but `docs/INTERPRETER_FEATURE_MATRIX.md` still described source semantics as composing through `SemanticBridge` proofs. That was stale and narrower than the current theorem surface.

This does not claim to solve the generic Layer 2 proof issue. It is a documentation follow-up that keeps the interpreter matrix aligned with the current boundary tracked in #1510.

## Validation
- `python3 scripts/check_interpreter_feature_summary_sync.py`
- `python3 scripts/check_interpreter_feature_boundary_catalog_sync.py`

Refs #1510

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update that clarifies naming/compatibility intent; no runtime or proof code changes.
> 
> **Overview**
> Updates `docs/INTERPRETER_FEATURE_MATRIX.md` to reflect that the `SpecInterpreter` module is gone and that source semantics now live in `Verity/Core.lean`, with the supported whole-contract Layer-2 source model assembled in `Compiler/Proofs/IRGeneration/SourceSemantics.lean`.
> 
> Clarifies that the matrix’s `Spec (basic)` / `Spec (fuel)` columns and the JSON artifact’s `SpecInterpreter_*` keys are retained as **legacy compatibility labels** for existing sync scripts/boundary checks, and bumps the document’s **Last Updated** date.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 474758eac63eea9e9694255c628fb8bbd98db80d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->