### PR TITLE
test: add string array event runtime parity

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -10,6 +10,7 @@ import Contracts.Common
 import Contracts.Counter.Counter
 import Contracts.LocalObligationMacroSmoke.LocalObligationMacroSmoke
 import Contracts.ProxyUpgradeabilityMacroSmoke
+import Contracts.StringArrayEventSmoke
 
 namespace Compiler.CompilationModelFeatureTest
 
@@ -1804,30 +1805,6 @@ private def stringEventMismatchSpec : CompilationModel := {
   ]
 }
 
-private def stringArrayEventSpec : CompilationModel := {
-  name := "StringArrayEvents"
-  fields := []
-  «constructor» := none
-  functions := [
-    { name := "log"
-      params := [{ name := "messages", ty := ParamType.array ParamType.string }]
-      returnType := none
-      body := [
-        Stmt.emit "MessageBatch" [Expr.param "messages", Expr.param "messages"],
-        Stmt.stop
-      ]
-    }
-  ]
-  events := [
-    { name := "MessageBatch"
-      params := [
-        { name := "body", ty := ParamType.array ParamType.string, kind := EventParamKind.unindexed },
-        { name := "topicBody", ty := ParamType.array ParamType.string, kind := EventParamKind.indexed }
-      ]
-    }
-  ]
-}
-
 private def addressArrayReturnSpec : CompilationModel := {
   name := "AddressArrayReturn"
   fields := []
@@ -2448,7 +2425,8 @@ set_option maxRecDepth 4096 in
     stringEventMismatchSpec
     "event 'MessageLogged' param 'message' expects"
   let stringArrayEventsCompile :=
-    match Compiler.CompilationModel.compile stringArrayEventSpec (selectorsFor stringArrayEventSpec) with
+    match Compiler.CompilationModel.compile Contracts.StringArrayEventSmoke.spec
+        (selectorsFor Contracts.StringArrayEventSmoke.spec) with
     | .ok _ => true
     | .error _ => false
   expectTrue "string[] event emission compiles for indexed and unindexed params" stringArrayEventsCompile

--- a/Contracts.lean
+++ b/Contracts.lean
@@ -1,5 +1,6 @@
 import Contracts.Common
 import Contracts.StringErrorSmoke
+import Contracts.StringArrayEventSmoke
 import Contracts.StringSmoke
 import Contracts.Smoke
 import Contracts.Counter

--- a/Contracts/StringArrayEventSmoke.lean
+++ b/Contracts/StringArrayEventSmoke.lean
@@ -1,0 +1,31 @@
+import Compiler.CompilationModel
+
+namespace Contracts.StringArrayEventSmoke
+
+open Compiler.CompilationModel
+
+def spec : CompilationModel := {
+  name := "StringArrayEventSmoke"
+  fields := []
+  constructor := none
+  functions := [
+    { name := "logBatch"
+      params := [{ name := "messages", ty := ParamType.array ParamType.string }]
+      returnType := none
+      body := [
+        Stmt.emit "MessageBatch" [Expr.param "messages", Expr.param "messages"],
+        Stmt.stop
+      ]
+    }
+  ]
+  events := [
+    { name := "MessageBatch"
+      params := [
+        { name := "body", ty := ParamType.array ParamType.string, kind := EventParamKind.unindexed }
+      , { name := "topicBody", ty := ParamType.array ParamType.string, kind := EventParamKind.indexed }
+      ]
+    }
+  ]
+}
+
+end Contracts.StringArrayEventSmoke

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,9 +10,9 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 110000,
-    "foundry_functions": 511,
+    "foundry_functions": 514,
     "property_functions": 239,
-    "suites": 46
+    "suites": 47
   },
   "theorems": {
     "categories": 11,

--- a/test/StringArrayEventSmoke.t.sol
+++ b/test/StringArrayEventSmoke.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "forge-std/Test.sol";
+import "./yul/YulTestBase.sol";
+
+contract StringArrayEventSmokeReference {
+    event MessageBatch(string[] body, string[] indexed topicBody);
+
+    function logBatch(string[] calldata messages) external {
+        emit MessageBatch(messages, messages);
+    }
+}
+
+contract StringArrayEventSmokeTest is Test, YulTestBase {
+    address internal stringArrayEventSmoke;
+    StringArrayEventSmokeReference internal referenceContract;
+
+    function setUp() public {
+        stringArrayEventSmoke = deployCompiledVerityModule(
+            "Contracts.StringArrayEventSmoke",
+            "StringArrayEventSmoke",
+            "artifacts/test-string-array-event-smoke"
+        );
+        referenceContract = new StringArrayEventSmokeReference();
+    }
+
+    function _assertLogsEqual(Vm.Log[] memory lhs, Vm.Log[] memory rhs) internal pure {
+        assertEq(lhs.length, rhs.length, "log count mismatch");
+        for (uint256 i = 0; i < lhs.length; i++) {
+            assertEq(lhs[i].topics.length, rhs[i].topics.length, "topic count mismatch");
+            for (uint256 j = 0; j < lhs[i].topics.length; j++) {
+                assertEq(lhs[i].topics[j], rhs[i].topics[j], "topic mismatch");
+            }
+            assertEq(lhs[i].data, rhs[i].data, "data mismatch");
+        }
+    }
+
+    function _recordLogs(address target, bytes memory callData) internal returns (Vm.Log[] memory logs) {
+        vm.recordLogs();
+        (bool ok,) = target.call(callData);
+        assertTrue(ok, "event emitter call failed");
+        logs = vm.getRecordedLogs();
+    }
+
+    function _copyMessages(string[] memory messages) internal pure returns (string[] memory copied) {
+        copied = new string[](messages.length);
+        for (uint256 i = 0; i < messages.length; i++) {
+            copied[i] = messages[i];
+        }
+    }
+
+    function _assertLogBatchParity(string[] memory messages) internal {
+        bytes memory callData = abi.encodeWithSignature("logBatch(string[])", messages);
+        Vm.Log[] memory yulLogs = _recordLogs(stringArrayEventSmoke, callData);
+        Vm.Log[] memory refLogs = _recordLogs(
+            address(referenceContract),
+            abi.encodeWithSignature("logBatch(string[])", _copyMessages(messages))
+        );
+        _assertLogsEqual(yulLogs, refLogs);
+    }
+
+    function testLogBatchEmptyArrayParity() public {
+        string[] memory messages = new string[](0);
+        _assertLogBatchParity(messages);
+    }
+
+    function testLogBatchMixedLengthsParity() public {
+        string[] memory messages = new string[](4);
+        messages[0] = "";
+        messages[1] = "verity";
+        messages[2] = "0123456789abcdef0123456789abcdef";
+        messages[3] = "long nested dynamic payloads should preserve offsets for each string tail";
+        _assertLogBatchParity(messages);
+    }
+
+    function testLogBatchUtf8Parity() public {
+        string[] memory messages = new string[](3);
+        messages[0] = unicode"Verity grüßt";
+        messages[1] = unicode"nested 🌍 payload";
+        messages[2] = unicode"多字节 string[] event";
+        _assertLogBatchParity(messages);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `Contracts.StringArrayEventSmoke` `CompilationModel` fixture for `string[]` event emission
- add a Foundry parity suite that compares emitted topics/data from generated Yul against a Solidity reference for empty, mixed-length, and UTF-8 `string[]` payloads
- reuse the shared fixture in `CompilationModelFeatureTest` and refresh `artifacts/verification_status.json`

## Why
Issue #1159 still had a gap around nested dynamic ABI runtime coverage. `string[]` event emission was compile-covered in Lean, but not exercised end-to-end against actual EVM log encoding.

## Validation
- `lake build Contracts.StringArrayEventSmoke Compiler.CompilationModelFeatureTest`
- `python3 scripts/generate_verification_status.py`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_verification_status_doc.py`
- `FOUNDRY_PROFILE=difftest forge test --match-contract StringArrayEventSmokeTest` entered the expected `vm.ffi` path, but in this workspace `lake build verity-compiler` was still running when I opened the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/fixture-only changes that add coverage for nested dynamic ABI log encoding without altering compiler logic or production contracts.
> 
> **Overview**
> Adds an end-to-end smoke fixture and difftest suite for `string[]` event emission, validating that generated Yul logs match Solidity’s topics/data encoding for empty, mixed-length, and UTF-8 string arrays.
> 
> Refactors `CompilationModelFeatureTest` to reuse the new `Contracts.StringArrayEventSmoke.spec` (removing the inline spec), wires the new contract into `Contracts.lean`, and updates `artifacts/verification_status.json` to reflect the additional Foundry suite/functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2b66aa3cd7198edfaa66d364961679365ac998f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->