### PR TITLE
macro: fail fast on unsupported return helpers

### DIFF
--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -95,6 +95,17 @@ verity_contract StorageWordsSmoke where
   function extSloadsLike (slots : Array Bytes32) : Array Uint256 := do
     returnStorageWords slots
 
+/--
+error: returnStorageWords requires an Array Bytes32 or Array Uint256 parameter on the compilation-model path, got Verity.Macro.ValueType.array (Verity.Macro.ValueType.address)
+-/
+#guard_msgs in
+verity_contract StorageWordsUnsupported where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function extSloadsLike (slots : Array Address) : Array Uint256 := do
+    returnStorageWords slots
+
 verity_contract CustomErrorSmoke where
   storage
     sentinel : Uint256 := slot 0

--- a/Contracts/StringSmoke.lean
+++ b/Contracts/StringSmoke.lean
@@ -204,6 +204,17 @@ verity_contract StringArrayReturnUnsupported where
     returnArray messages
 
 /--
+error: returnBytes requires a Bytes or String parameter on the compilation-model path, got Verity.Macro.ValueType.uint256
+-/
+#guard_msgs in
+verity_contract ReturnBytesWordUnsupported where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function echo (amount : Uint256) : Bytes := do
+    returnBytes amount
+
+/--
 error: returnArray currently supports only arrays with single-word static elements on the compilation-model path, got Verity.Macro.ValueType.array (Verity.Macro.ValueType.bytes)
 -/
 #guard_msgs in

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -958,6 +958,24 @@ private def requireSupportedReturnArrayType
   | _ =>
       throwErrorAt stx s!"{context} requires an Array value, got {renderValueType ty}"
 
+private def requireSupportedReturnBytesType
+    (stx : Syntax)
+    (context : String)
+    (ty : ValueType) : CommandElabM Unit := do
+  unless ty == .bytes || ty == .string do
+    throwErrorAt stx
+      s!"{context} requires a Bytes or String parameter on the compilation-model path, got {renderValueType ty}"
+
+private def requireSupportedReturnStorageWordsType
+    (stx : Syntax)
+    (context : String)
+    (ty : ValueType) : CommandElabM Unit := do
+  match ty with
+  | .array .bytes32 | .array .uint256 => pure ()
+  | _ =>
+      throwErrorAt stx
+        s!"{context} requires an Array Bytes32 or Array Uint256 parameter on the compilation-model path, got {renderValueType ty}"
+
 private def requireEqComparableTypes (stx : Syntax) (lhsTy rhsTy : ValueType) : CommandElabM Unit := do
   let bothWordLike := isWordLikeValueType lhsTy && isWordLikeValueType rhsTy
   let bothBool := lhsTy == .bool && rhsTy == .bool
@@ -2326,7 +2344,7 @@ private partial def validateEffectStmtExprTypes
       for arg in [token, spender, amount] do
         requireWordLikeType arg "ERC-20 helper" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg)
   | `(term| setStorage $_field:ident $value:term) | `(term| setStorageAddr $_field:ident $value:term)
-    | `(term| require $value:term $_msg) | `(term| returnStorageWords $value:term) =>
+    | `(term| require $value:term $_msg) =>
       let _ ← inferPureExprType fields constDecls immutableDecls externalDecls params locals value
       pure ()
   | `(term| setMapping $_field:ident $key:term $value:term) | `(term| setMappingAddr $_field:ident $key:term $value:term)
@@ -2374,8 +2392,12 @@ private partial def validateEffectStmtExprTypes
   | `(term| returnArray $name:term) => do
       let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals name
       requireSupportedReturnArrayType name "returnArray" ty
-  | `(term| returnBytes $_name:term) =>
-      pure ()
+  | `(term| returnBytes $name:term) => do
+      let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals name
+      requireSupportedReturnBytesType name "returnBytes" ty
+  | `(term| returnStorageWords $name:term) => do
+      let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals name
+      requireSupportedReturnStorageWordsType name "returnStorageWords" ty
   | `(term| internalCall $_fnName:term $args:term)
     | `(term| internalCallAssign $_names:term $_fnName:term $args:term)
     | `(term| externalCallBind $_names:term $_fnName:term $args:term) =>


### PR DESCRIPTION
## Summary
- add macro-side fail-fast validation for `returnBytes` and `returnStorageWords`
- reject unsupported parameter types before lowering to `CompilationModel`
- add negative smoke fixtures covering the new guardrails

## Why
`verity_contract` already fails fast for several macro/compiler boundary mismatches, including dynamic equality, dynamic custom-error payloads, and unsupported `returnArray` element types. `returnBytes` and `returnStorageWords` were still inconsistent: the macro accepted obviously unsupported parameter types and only failed later in `CompilationModel` validation.

This keeps the macro-only authoring path honest and makes the boundary clearer at the declaration site.

## Validation
- `lake build Verity.Macro.Translate Contracts.StringSmoke Contracts.Smoke`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to compile-time macro validation and test fixtures; runtime/compiled contract behavior is unaffected aside from earlier, clearer failures for invalid code.
> 
> **Overview**
> Adds macro-side fail-fast validation for `returnBytes` and `returnStorageWords`, inferring the argument type and emitting clear errors when the compilation-model path can’t support it (only `Bytes`/`String` for `returnBytes`, and `Array Bytes32`/`Array Uint256` for `returnStorageWords`).
> 
> Extends smoke tests with new `#guard_msgs` contracts in `Contracts/StringSmoke.lean` and `Contracts/Smoke.lean` to assert the new diagnostics for unsupported parameter types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2c674cdfff21c39f2ecb3762220e6ee22b0a0a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->