### PR TITLE
macro: require direct param refs for return helpers

### DIFF
--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -106,6 +106,28 @@ verity_contract StorageWordsUnsupported where
   function extSloadsLike (slots : Array Address) : Array Uint256 := do
     returnStorageWords slots
 
+/--
+error: returnStorageWords currently requires a direct parameter reference on the compilation-model path
+-/
+#guard_msgs in
+verity_contract StorageWordsConstructedUnsupported where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function extSloadsLike (_ok : Bool, slots : Array Bytes32) : Array Uint256 := do
+    returnStorageWords ([] : Array Bytes32)
+
+/--
+error: returnArray currently requires a direct parameter reference on the compilation-model path
+-/
+#guard_msgs in
+verity_contract ReturnArrayConstructedUnsupported where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function echo (_ok : Bool, values : Array Uint256) : Array Uint256 := do
+    returnArray ([] : Array Uint256)
+
 verity_contract CustomErrorSmoke where
   storage
     sentinel : Uint256 := slot 0

--- a/Contracts/StringSmoke.lean
+++ b/Contracts/StringSmoke.lean
@@ -215,6 +215,17 @@ verity_contract ReturnBytesWordUnsupported where
     returnBytes amount
 
 /--
+error: returnBytes currently requires a direct parameter reference on the compilation-model path
+-/
+#guard_msgs in
+verity_contract ReturnBytesLiteralUnsupported where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function echo (_amount : Uint256) : String := do
+    returnBytes "hello"
+
+/--
 error: returnArray currently supports only arrays with single-word static elements on the compilation-model path, got Verity.Macro.ValueType.array (Verity.Macro.ValueType.bytes)
 -/
 #guard_msgs in

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -958,6 +958,29 @@ private def requireSupportedReturnArrayType
   | _ =>
       throwErrorAt stx s!"{context} requires an Array value, got {renderValueType ty}"
 
+private def directParamNameWithType?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × ValueType) :=
+  match stripParens stx with
+  | `(term| $id:ident) =>
+      let name := toString id.getId
+      params.findSome? fun p =>
+        if p.name == name then
+          some (name, p.ty)
+        else
+          none
+  | _ => none
+
+private def requireDirectParamRef
+    (stx : Term)
+    (context : String)
+    (params : Array ParamDecl) : CommandElabM ValueType := do
+  match directParamNameWithType? params stx with
+  | some (_, paramTy) => pure paramTy
+  | none =>
+      throwErrorAt stx
+        s!"{context} currently requires a direct parameter reference on the compilation-model path"
+
 private def requireSupportedReturnBytesType
     (stx : Syntax)
     (context : String)
@@ -2446,13 +2469,13 @@ private partial def validateEffectStmtExprTypes
         args "ECM argument"
       pure ()
   | `(term| returnArray $name:term) => do
-      let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals name
+      let ty ← requireDirectParamRef name "returnArray" params
       requireSupportedReturnArrayType name "returnArray" ty
   | `(term| returnBytes $name:term) => do
-      let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals name
+      let ty ← requireDirectParamRef name "returnBytes" params
       requireSupportedReturnBytesType name "returnBytes" ty
   | `(term| returnStorageWords $name:term) => do
-      let ty ← inferPureExprType fields constDecls immutableDecls externalDecls params locals name
+      let ty ← requireDirectParamRef name "returnStorageWords" params
       requireSupportedReturnStorageWordsType name "returnStorageWords" ty
   | `(term| internalCall $_fnName:term $args:term)
     | `(term| internalCallAssign $_names:term $_fnName:term $args:term)


### PR DESCRIPTION
## Summary
- fail fast when `returnArray`, `returnBytes`, or `returnStorageWords` are given anything other than a direct parameter reference
- keep the existing type-specific diagnostics for wrong parameter types by validating direct-parameter shape first, then the supported compilation-model type
- add negative macro smoke coverage for constructed/literal return-helper arguments that previously surfaced as generic unsupported-expression or later compilation-model failures

## Testing
- `lake build Verity.Macro.Translate Contracts.StringSmoke Contracts.Smoke`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it tightens compile-time validation for `returnArray`/`returnBytes`/`returnStorageWords`, potentially breaking contracts that previously passed non-parameter expressions. Runtime behavior is unchanged; impact is limited to macro elaboration and diagnostics.
> 
> **Overview**
> Tightens macro validation so `returnArray`, `returnBytes`, and `returnStorageWords` now **only accept a direct function parameter reference** (not literals, constructed values, or other expressions) on the compilation-model path, emitting a clear early error.
> 
> Adds new negative smoke tests in `Contracts/Smoke.lean` and `Contracts/StringSmoke.lean` to assert the new diagnostic for constructed/literal arguments while preserving the existing type-specific errors when a direct parameter has an unsupported type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73240b0d173d2ec17e164e379eb5f35382d4f2af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->