### PR TITLE
macro: fail fast on unsupported arrayElement types

### DIFF
--- a/Contracts/StringSmoke.lean
+++ b/Contracts/StringSmoke.lean
@@ -236,6 +236,28 @@ verity_contract BytesArrayReturnUnsupported where
   function echo (calls : Array Bytes) : Array Bytes := do
     returnArray calls
 
+/--
+error: arrayElement currently supports only arrays with single-word static elements on the compilation-model path, got Verity.Macro.ValueType.array (Verity.Macro.ValueType.string)
+-/
+#guard_msgs in
+verity_contract StringArrayElementUnsupported where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function first (messages : Array String) : String := do
+    return (arrayElement messages 0)
+
+/--
+error: arrayElement currently supports only arrays with single-word static elements on the compilation-model path, got Verity.Macro.ValueType.array (Verity.Macro.ValueType.bytes)
+-/
+#guard_msgs in
+verity_contract BytesArrayElementUnsupported where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function first (calls : Array Bytes) : Bytes := do
+    return (arrayElement calls 0)
+
 #check_contract StringSmoke
 #check_contract StringEqSmoke
 #check_contract BytesEqSmoke

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -958,6 +958,20 @@ private def requireSupportedReturnArrayType
   | _ =>
       throwErrorAt stx s!"{context} requires an Array value, got {renderValueType ty}"
 
+private def requireSupportedArrayElementSourceType
+    (stx : Syntax)
+    (context : String)
+    (ty : ValueType) : CommandElabM ValueType := do
+  match ty with
+  | .array elemTy =>
+      if isSingleWordStaticValueType elemTy then
+        pure elemTy
+      else
+        throwErrorAt stx
+          s!"{context} currently supports only arrays with single-word static elements on the compilation-model path, got {renderValueType ty}"
+  | _ =>
+      throwErrorAt stx s!"{context} requires an Array parameter, got {renderValueType ty}"
+
 private def directParamNameWithType?
     (params : Array ParamDecl)
     (stx : Term) : Option (String × ValueType) :=
@@ -1239,10 +1253,8 @@ private partial def inferPureExprType
       | none => throwErrorAt name "unknown array value"
   | `(term| arrayElement $name:term $index:term) => do
       requireWordLikeType index "arrayElement index" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index visitingConstants)
-      match lookupNamedValueType? constDecls immutableDecls params locals (← expectStringOrIdent name) with
-      | some (.array elemTy) => pure elemTy
-      | some ty => throwErrorAt name s!"arrayElement expects an Array value, got {renderValueType ty}"
-      | none => throwErrorAt name "unknown array value"
+      let sourceTy ← requireDirectParamRef name "arrayElement" params
+      requireSupportedArrayElementSourceType name "arrayElement" sourceTy
   | `(term| mulDivDown $a $b $c) | `(term| mulDivUp $a $b $c) => do
       for arg in [a, b, c] do
         requireWordLikeType arg "mulDiv" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg visitingConstants)


### PR DESCRIPTION
## Summary
- fail fast in `verity_contract` when `arrayElement` is used on arrays whose elements are not single-word static on the compilation-model path
- align macro elaboration with the existing compiler boundary instead of letting `Array String` / `Array Bytes` index expressions fail later
- add negative smoke coverage for `string[]` and `bytes[]` `arrayElement` usage

## Testing
- `lake build Verity.Macro.Translate Contracts.StringSmoke`
- `make check`

Closes #1159.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macro elaboration/type-checking rules for `arrayElement`, which can cause previously-accepted contracts to fail earlier at compile time. The change is localized but affects a core DSL surface used by contract authors.
> 
> **Overview**
> `arrayElement` now *fails during `verity_contract` elaboration* when used on arrays whose elements are not single-word static on the compilation-model path (e.g., `Array String` / `Array Bytes`), rather than letting these cases fail later in compilation.
> 
> The macro’s type inference for `arrayElement` was tightened to require a *direct parameter reference* and to validate the array element type via a shared helper, and `Contracts/StringSmoke.lean` adds `#guard_msgs` negative smoke coverage for unsupported `arrayElement` usage on `string[]` and `bytes[]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ac808dbdb7b238574dbe5f336e659a34677d0aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->