### PR TITLE
test: add low-level tryCatch runtime parity

### DIFF
--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,9 +10,9 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 110000,
-    "foundry_functions": 517,
+    "foundry_functions": 520,
     "property_functions": 239,
-    "suites": 48
+    "suites": 49
   },
   "theorems": {
     "categories": 11,

--- a/test/LowLevelTryCatchSmoke.t.sol
+++ b/test/LowLevelTryCatchSmoke.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "forge-std/Test.sol";
+import "./yul/YulTestBase.sol";
+
+contract LowLevelTryCatchSmokeReference {
+    uint256 public lastOutcome;
+
+    function catchFailure() external returns (uint256 current) {
+        (bool ok,) = address(0).call{gas: 0}("");
+        if (!ok) {
+            lastOutcome = 7;
+        }
+        current = lastOutcome;
+    }
+
+    function skipCatchOnSuccess() external returns (uint256 current) {
+        (bool ok,) = address(0).call{gas: 1}("");
+        if (!ok) {
+            lastOutcome = 9;
+        }
+        current = lastOutcome;
+    }
+
+    function catchFailureWithShadowedParam(uint256 /* verity_try_success */ ) external returns (uint256 current) {
+        (bool ok,) = address(0).call{gas: 0}("");
+        if (!ok) {
+            lastOutcome = 11;
+        }
+        current = lastOutcome;
+    }
+}
+
+contract LowLevelTryCatchSmokeTest is Test, YulTestBase {
+    address internal lowLevelTryCatchSmoke;
+    LowLevelTryCatchSmokeReference internal referenceContract;
+
+    function setUp() public {
+        lowLevelTryCatchSmoke = deployCompiledVerityModule(
+            "Contracts.Smoke",
+            "LowLevelTryCatchSmoke",
+            "artifacts/test-low-level-trycatch-smoke"
+        );
+        referenceContract = new LowLevelTryCatchSmokeReference();
+    }
+
+    function _assertCallParity(bytes memory callData, uint256 expectedReturn, uint256 expectedStorage) internal {
+        (bool yulSuccess, bytes memory yulData) = lowLevelTryCatchSmoke.call(callData);
+        (bool refSuccess, bytes memory refData) = address(referenceContract).call(callData);
+
+        assertEq(yulSuccess, refSuccess, "success mismatch");
+        assertEq(yulData, refData, "return data mismatch");
+        assertEq(readStorage(lowLevelTryCatchSmoke, 0), readStorage(address(referenceContract), 0), "storage mismatch");
+
+        assertTrue(yulSuccess, "expected success");
+        assertEq(abi.decode(yulData, (uint256)), expectedReturn, "decoded return mismatch");
+        assertEq(readStorage(lowLevelTryCatchSmoke, 0), expectedStorage, "storage value mismatch");
+    }
+
+    function testCatchFailureParity() public {
+        _assertCallParity(abi.encodeWithSignature("catchFailure()"), 7, 7);
+    }
+
+    function testSkipCatchOnSuccessParity() public {
+        _assertCallParity(abi.encodeWithSignature("skipCatchOnSuccess()"), 0, 0);
+    }
+
+    function testCatchFailureWithShadowedParamParity() public {
+        _assertCallParity(abi.encodeWithSignature("catchFailureWithShadowedParam(uint256)", 0), 11, 11);
+        _assertCallParity(abi.encodeWithSignature("catchFailureWithShadowedParam(uint256)", type(uint256).max), 11, 11);
+    }
+}


### PR DESCRIPTION
## Summary
- add Foundry runtime parity coverage for the current low-level `tryCatch` surface in `Contracts.Smoke.LowLevelTryCatchSmoke`
- compare generated Yul behavior against an equivalent Solidity reference for failed call, successful call, and synthetic-temp shadowing cases
- refresh `artifacts/verification_status.json` for the new suite

Closes #1161

## Validation
- `lake build Contracts.Smoke`
- `python3 scripts/generate_verification_status.py`
- `python3 scripts/generate_verification_status.py --check`
- `python3 scripts/check_verification_status_doc.py`

## Note
- `FOUNDRY_PROFILE=difftest forge test --match-contract LowLevelTryCatchSmokeTest` is blocked in this fresh worktree because `lake build verity-compiler` crashes in the toolchain while compiling `Compiler.Yul.PatchRules.c.o` with clang.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Foundry parity test suite and updates the generated verification status counters, without changing production/compiler logic.
> 
> **Overview**
> Adds a new Foundry smoke test (`LowLevelTryCatchSmoke.t.sol`) that deploys the compiled Verity Yul artifact for `Contracts.Smoke.LowLevelTryCatchSmoke` and asserts runtime parity against a Solidity reference for failed-call catch behavior, success-path no-op, and a parameter-shadowing edge case.
> 
> Refreshes `artifacts/verification_status.json` to reflect the additional test suite and functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d904d4a00c6d1118b82a237c09f41e138f580a65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->