### PR TITLE
test: infer direct-return macro property assertions

### DIFF
--- a/artifacts/macro_property_tests/PropertyCustomErrorSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyCustomErrorSmoke.t.sol
@@ -17,13 +17,13 @@ contract PropertyCustomErrorSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: TODO decode and assert `echo` result
-    function testTODO_Echo_DecodeAndAssert() public {
+    // Property 1: echo returns the direct parameter value
+    function testAuto_Echo_ReturnsDirectParam() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("echo(uint256)", uint256(1)));
         require(ok, "echo reverted unexpectedly");
         assertEq(ret.length, 32, "echo ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, uint256(1), "echo should preserve the expected value");
     }
 }

--- a/artifacts/macro_property_tests/PropertyImmutableSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyImmutableSmoke.t.sol
@@ -35,13 +35,13 @@ contract PropertyImmutableSmokeTest is YulTestBase {
         // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
         ret;
     }
-    // Property 3: TODO decode and assert `shadowed` result
-    function testTODO_Shadowed_DecodeAndAssert() public {
+    // Property 3: shadowed returns the direct parameter value
+    function testAuto_Shadowed_ReturnsDirectParam() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("shadowed(uint256)", uint256(1)));
         require(ok, "shadowed reverted unexpectedly");
         assertEq(ret.length, 32, "shadowed ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, uint256(1), "shadowed should preserve the expected value");
     }
 }

--- a/artifacts/macro_property_tests/PropertyStatelessSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyStatelessSmoke.t.sol
@@ -17,22 +17,22 @@ contract PropertyStatelessSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: TODO decode and assert `echoWord` result
-    function testTODO_EchoWord_DecodeAndAssert() public {
+    // Property 1: echoWord returns the direct parameter value
+    function testAuto_EchoWord_ReturnsDirectParam() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("echoWord(uint256)", uint256(1)));
         require(ok, "echoWord reverted unexpectedly");
         assertEq(ret.length, 32, "echoWord ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, uint256(1), "echoWord should preserve the expected value");
     }
-    // Property 2: TODO decode and assert `whoAmI` result
-    function testTODO_WhoAmI_DecodeAndAssert() public {
+    // Property 2: whoAmI returns the active caller
+    function testAuto_WhoAmI_ReturnsMsgSender() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("whoAmI()"));
         require(ok, "whoAmI reverted unexpectedly");
         assertEq(ret.length, 32, "whoAmI ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        address actual = abi.decode(ret, (address));
+        assertEq(actual, alice, "whoAmI should preserve the expected value");
     }
 }

--- a/artifacts/macro_property_tests/PropertyStringSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyStringSmoke.t.sol
@@ -17,40 +17,40 @@ contract PropertyStringSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: TODO decode and assert `echoString` result
-    function testTODO_EchoString_DecodeAndAssert() public {
+    // Property 1: echoString returns the direct dynamic parameter payload
+    function testAuto_EchoString_ReturnsDirectDynamicParam() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("echoString(string)", "verity"));
         require(ok, "echoString reverted unexpectedly");
         require(ret.length >= 64, "echoString ABI return payload unexpectedly short");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        string actual = abi.decode(ret, (string));
+        assertEq(actual, "verity", "echoString should preserve the expected value");
     }
-    // Property 2: TODO decode and assert `echoStringAfterUint` result
-    function testTODO_EchoStringAfterUint_DecodeAndAssert() public {
+    // Property 2: echoStringAfterUint returns the direct dynamic parameter payload
+    function testAuto_EchoStringAfterUint_ReturnsDirectDynamicParam() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("echoStringAfterUint(uint256,string)", uint256(1), "verity"));
         require(ok, "echoStringAfterUint reverted unexpectedly");
         require(ret.length >= 64, "echoStringAfterUint ABI return payload unexpectedly short");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        string actual = abi.decode(ret, (string));
+        assertEq(actual, "verity", "echoStringAfterUint should preserve the expected value");
     }
-    // Property 3: TODO decode and assert `echoStringBeforeUint` result
-    function testTODO_EchoStringBeforeUint_DecodeAndAssert() public {
+    // Property 3: echoStringBeforeUint returns the direct dynamic parameter payload
+    function testAuto_EchoStringBeforeUint_ReturnsDirectDynamicParam() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("echoStringBeforeUint(string,uint256)", "verity", uint256(1)));
         require(ok, "echoStringBeforeUint reverted unexpectedly");
         require(ret.length >= 64, "echoStringBeforeUint ABI return payload unexpectedly short");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        string actual = abi.decode(ret, (string));
+        assertEq(actual, "verity", "echoStringBeforeUint should preserve the expected value");
     }
-    // Property 4: TODO decode and assert `echoSecondString` result
-    function testTODO_EchoSecondString_DecodeAndAssert() public {
+    // Property 4: echoSecondString returns the direct dynamic parameter payload
+    function testAuto_EchoSecondString_ReturnsDirectDynamicParam() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("echoSecondString(string,string)", "verity", "verity"));
         require(ok, "echoSecondString reverted unexpectedly");
         require(ret.length >= 64, "echoSecondString ABI return payload unexpectedly short");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        string actual = abi.decode(ret, (string));
+        assertEq(actual, "verity", "echoSecondString should preserve the expected value");
     }
 }

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -47,6 +47,9 @@ MAPPING_WORD_READ_RE = re.compile(
 NON_ZERO_REQUIRE_RE = re.compile(
     r'require\s+\(([A-Za-z_][A-Za-z0-9_]*)\s*!=\s*0\)\s+"[^"]+"$'
 )
+BUILTIN_READ_RE = re.compile(
+    r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*(msgSender|msgValue)$"
+)
 
 
 @dataclass(frozen=True)
@@ -183,6 +186,9 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
 
         if current_name is None:
             continue
+
+        if current_function is not None and line.strip() and not line.startswith("    "):
+            flush_function()
 
         if line.strip() == "storage":
             in_storage_block = True
@@ -518,6 +524,28 @@ def _render_decoded_assertion(
 """
 
 
+def _render_direct_return_assertion(
+    fn: FunctionDecl,
+    idx: int,
+    encode_args: str,
+    decoded_type: str,
+    expected_expr: str,
+    summary: str,
+    suffix: str,
+) -> str:
+    ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+    return f"""    // Property {idx}: {summary}
+    function testAuto_{_fn_camel(fn.name)}_{suffix}() public {{
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature({encode_args}));
+        require(ok, \"{fn.name} reverted unexpectedly\");
+{ret_assert}
+        {decoded_type} actual = abi.decode(ret, ({decoded_type}));
+        assertEq(actual, {expected_expr}, \"{fn.name} should preserve the expected value\");
+    }}
+"""
+
+
 def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx: int, encode_args: str) -> str | None:
     fn_camel = _fn_camel(fn.name)
     body = list(fn.body)
@@ -526,6 +554,34 @@ def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx
     decoded_type = _sol_type(fn.return_type)
 
     if len(body) == 1:
+        direct_return_match = re.fullmatch(r"return\s+([A-Za-z_][A-Za-z0-9_]*)", body[0])
+        if direct_return_match:
+            returned_name = direct_return_match.group(1)
+            if returned_name in param_examples:
+                return _render_direct_return_assertion(
+                    fn,
+                    idx,
+                    encode_args,
+                    decoded_type,
+                    param_examples[returned_name],
+                    f"{fn.name} returns the direct parameter value",
+                    "ReturnsDirectParam",
+                )
+
+        return_bytes_match = re.fullmatch(r"returnBytes\s+([A-Za-z_][A-Za-z0-9_]*)", body[0])
+        if return_bytes_match:
+            returned_name = return_bytes_match.group(1)
+            if returned_name in param_examples:
+                return _render_direct_return_assertion(
+                    fn,
+                    idx,
+                    encode_args,
+                    decoded_type,
+                    param_examples[returned_name],
+                    f"{fn.name} returns the direct dynamic parameter payload",
+                    "ReturnsDirectDynamicParam",
+                )
+
         literal_match = re.fullmatch(r"return\s+(.+)", body[0])
         if literal_match:
             literal_expr = _literal_expr(literal_match.group(1).strip(), ty)
@@ -575,6 +631,26 @@ def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx
 """
 
     if len(body) == 2:
+        builtin_read_match = BUILTIN_READ_RE.fullmatch(body[0])
+        if builtin_read_match and body[1] == f"return {builtin_read_match.group(1)}":
+            builtin_name = builtin_read_match.group(2)
+            expected_expr = "alice" if builtin_name == "msgSender" else "0"
+            summary = (
+                f"{fn.name} returns the active caller"
+                if builtin_name == "msgSender"
+                else f"{fn.name} returns the active call value"
+            )
+            suffix = "ReturnsMsgSender" if builtin_name == "msgSender" else "ReturnsMsgValue"
+            return _render_direct_return_assertion(
+                fn,
+                idx,
+                encode_args,
+                decoded_type,
+                expected_expr,
+                summary,
+                suffix,
+            )
+
         read = _parse_read_accessor(body[0])
         if read and body[1] == f"return {read.var_name}":
             ret_assert = _return_shape_assertion(fn.return_type, fn.name)

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -110,6 +110,23 @@ class ParseContractsTests(unittest.TestCase):
         parsed = gen.parse_contracts(src, Path("dummy.lean"))
         self.assertEqual(sorted(parsed.keys()), ["HappyPath"])
 
+    def test_parse_contracts_stops_function_body_at_top_level_defs(self) -> None:
+        src = textwrap.dedent(
+            """
+            verity_contract StringSmoke where
+              storage
+                sentinel : Uint256 := slot 0
+
+              function echoSecondString (_prefix : String, message : String) : String := do
+                returnBytes message
+
+            def helper : Bool :=
+              true
+            """
+        )
+        parsed = gen.parse_contracts(src, Path("dummy.lean"))
+        self.assertEqual(parsed["StringSmoke"].functions[0].body, ("returnBytes message",))
+
 
 class RenderTests(unittest.TestCase):
     def test_render_unit_and_non_unit_tests(self) -> None:
@@ -341,6 +358,66 @@ class RenderTests(unittest.TestCase):
         self.assertIn("function testAuto_SigV_ReturnsDeclaredConstant()", rendered)
         self.assertIn("uint8 actual = abi.decode(ret, (uint8));", rendered)
         self.assertIn('assertEq(actual, 27, "sigV should return the declared constant");', rendered)
+
+    def test_render_direct_param_return_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="StatelessSmoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "echoWord",
+                    (gen.ParamDecl("value", "Uint256"),),
+                    "Uint256",
+                    body=("return value",),
+                ),
+            ),
+            storage_slots={},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_EchoWord_ReturnsDirectParam()", rendered)
+        self.assertIn("uint256 actual = abi.decode(ret, (uint256));", rendered)
+        self.assertIn('assertEq(actual, uint256(1), "echoWord should preserve the expected value");', rendered)
+
+    def test_render_return_bytes_direct_param_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="StringSmoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "echoString",
+                    (gen.ParamDecl("message", "String"),),
+                    "String",
+                    body=("returnBytes message",),
+                ),
+            ),
+            storage_slots={},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_EchoString_ReturnsDirectDynamicParam()", rendered)
+        self.assertIn("string actual = abi.decode(ret, (string));", rendered)
+        self.assertIn('assertEq(actual, "verity", "echoString should preserve the expected value");', rendered)
+
+    def test_render_msg_sender_return_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="StatelessSmoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "whoAmI",
+                    (),
+                    "Address",
+                    body=("let sender ← msgSender", "return sender"),
+                ),
+            ),
+            storage_slots={},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_WhoAmI_ReturnsMsgSender()", rendered)
+        self.assertIn("address actual = abi.decode(ret, (address));", rendered)
+        self.assertIn('assertEq(actual, alice, "whoAmI should preserve the expected value");', rendered)
 
     def test_render_tuple_return_values_infers_assertion(self) -> None:
         contract = gen.ContractDecl(


### PR DESCRIPTION
## Summary
- infer concrete property assertions for direct parameter returns, `returnBytes` passthroughs, and `msgSender`/`msgValue` passthroughs in `generate_macro_property_tests.py`
- stop the macro-contract parser from letting the last function body absorb later top-level defs, which was hiding some inferable cases
- refresh generated macro property-test artifacts for the newly covered contracts

## Validation
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py`
- `python3 scripts/check_macro_property_test_generation.py --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test-generation tooling and regenerated property-test artifacts, with added unit tests covering the new inference and parsing behavior.
> 
> **Overview**
> Improves `generate_macro_property_tests.py` to auto-generate concrete assertions for more non-`Unit` functions by inferring *direct passthrough* returns (e.g., `return <param>`, `returnBytes <param>`, and `msgSender`/`msgValue` read-then-return patterns) instead of emitting TODO stubs.
> 
> Fixes a parsing edge case where a function body could accidentally absorb later top-level Lean definitions, and adds unit tests for the new parsing and inference behavior. Regenerates several `artifacts/macro_property_tests/*Smoke*.t.sol` files to decode return values and assert expected passthrough results (including dynamic string payloads and `msg.sender`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6cc2769c165aff36f5da0f85eff6b8ff0919759. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->