### PR TITLE
macro: fail fast on storage array declarations

### DIFF
--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -73,6 +73,17 @@ verity_contract Bytes32Smoke where
     let digest ← getStorage value
     return digest
 
+/--
+error: storage dynamic arrays are not supported yet (issue #1571); field uses Verity.Macro.ValueType.array (Verity.Macro.ValueType.uint256)
+-/
+#guard_msgs in
+verity_contract StorageArrayUnsupported where
+  storage
+    queue : Array Uint256 := slot 0
+
+  function size () : Uint256 := do
+    return 0
+
 verity_contract MappingWordSmoke where
   storage
     words : Uint256 → Uint256 := slot 0

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -222,6 +222,9 @@ private def storageTypeFromSyntax (ty : Term) : CommandElabM StorageType := do
   | _ => do
       let vt ← valueTypeFromSyntax ty
       match vt with
+      | .array elemTy =>
+          throwErrorAt ty
+            s!"storage dynamic arrays are not supported yet (issue #1571); field uses {reprStr (ValueType.array elemTy)}"
       | .tuple _ => throwErrorAt ty "storage fields cannot be Tuple; use mapping encodings"
       | _ => pure (.scalar vt)
 


### PR DESCRIPTION
## Summary
- reject `Array ...` storage fields at storage-type parsing time with an explicit issue `#1571` diagnostic
- keep the boundary fail-fast instead of letting unsupported storage arrays reach later compilation-model lowering
- add a `#guard_msgs` smoke fixture for `Array Uint256 := slot ...`

## Testing
- `lake build Verity.Macro.Translate Contracts.Smoke`
- `make check`

## Issue
Refs #1571

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes storage-type parsing to fail fast on `Array ...` storage declarations, which may break previously-accepted (but unsupported) contracts and affects macro elaboration paths.
> 
> **Overview**
> The macro translator now explicitly rejects dynamic array (`Array ...`) storage fields during storage-type parsing, emitting a targeted error that references issue `#1571` instead of allowing the unsupported type to reach later compilation stages.
> 
> Adds a `#guard_msgs` smoke test contract (`StorageArrayUnsupported`) to assert the exact diagnostic when a storage field is declared as `Array Uint256`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fa1691928c1481c555f03ba437603d8ab4114a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->