### PR TITLE
test: infer dynamic equality macro property assertions

### DIFF
--- a/artifacts/macro_property_tests/PropertyBytesEqSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyBytesEqSmoke.t.sol
@@ -17,31 +17,35 @@ contract PropertyBytesEqSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: TODO decode and assert `same` result
-    function testTODO_Same_DecodeAndAssert() public {
+    // Property 1: same matches the expected dynamic-parameter comparison result
+    function testAuto_Same_ComparesDirectDynamicParamsEq() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("same(bytes,bytes)", hex"CAFE", hex"CAFE"));
         require(ok, "same reverted unexpectedly");
         assertEq(ret.length, 32, "same ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        bool actual = abi.decode(ret, (bool));
+        bool expected = true;
+        assertEq(actual, expected, "same should preserve the configured comparison result");
+        assertTrue(actual, "same should return true for the configured bytes comparison");
     }
-    // Property 2: TODO decode and assert `different` result
-    function testTODO_Different_DecodeAndAssert() public {
+    // Property 2: different matches the expected dynamic-parameter comparison result
+    function testAuto_Different_ComparesDirectDynamicParamsNeq() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("different(bytes,bytes)", hex"CAFE", hex"CAFE"));
         require(ok, "different reverted unexpectedly");
         assertEq(ret.length, 32, "different ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        bool actual = abi.decode(ret, (bool));
+        bool expected = false;
+        assertEq(actual, expected, "different should preserve the configured comparison result");
+        assertFalse(actual, "different should return false for the configured bytes comparison");
     }
-    // Property 3: TODO decode and assert `choose` result
-    function testTODO_Choose_DecodeAndAssert() public {
+    // Property 3: choose selects the expected branch for the configured dynamic inputs
+    function testAuto_Choose_SelectsDynamicComparisonBranch() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("choose(bytes,bytes)", hex"CAFE", hex"CAFE"));
         require(ok, "choose reverted unexpectedly");
         assertEq(ret.length, 32, "choose ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, 1, "choose should return the configured branch value");
     }
 }

--- a/artifacts/macro_property_tests/PropertyStringEqSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyStringEqSmoke.t.sol
@@ -17,31 +17,35 @@ contract PropertyStringEqSmokeTest is YulTestBase {
         require(target != address(0), "Deploy failed");
     }
 
-    // Property 1: TODO decode and assert `same` result
-    function testTODO_Same_DecodeAndAssert() public {
+    // Property 1: same matches the expected dynamic-parameter comparison result
+    function testAuto_Same_ComparesDirectDynamicParamsEq() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("same(string,string)", "verity", "verity"));
         require(ok, "same reverted unexpectedly");
         assertEq(ret.length, 32, "same ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        bool actual = abi.decode(ret, (bool));
+        bool expected = true;
+        assertEq(actual, expected, "same should preserve the configured comparison result");
+        assertTrue(actual, "same should return true for the configured string comparison");
     }
-    // Property 2: TODO decode and assert `different` result
-    function testTODO_Different_DecodeAndAssert() public {
+    // Property 2: different matches the expected dynamic-parameter comparison result
+    function testAuto_Different_ComparesDirectDynamicParamsNeq() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("different(string,string)", "verity", "verity"));
         require(ok, "different reverted unexpectedly");
         assertEq(ret.length, 32, "different ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        bool actual = abi.decode(ret, (bool));
+        bool expected = false;
+        assertEq(actual, expected, "different should preserve the configured comparison result");
+        assertFalse(actual, "different should return false for the configured string comparison");
     }
-    // Property 3: TODO decode and assert `choose` result
-    function testTODO_Choose_DecodeAndAssert() public {
+    // Property 3: choose selects the expected branch for the configured dynamic inputs
+    function testAuto_Choose_SelectsDynamicComparisonBranch() public {
         vm.prank(alice);
         (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("choose(string,string)", "verity", "verity"));
         require(ok, "choose reverted unexpectedly");
         assertEq(ret.length, 32, "choose ABI return length mismatch (expected 32 bytes)");
-        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
-        ret;
+        uint256 actual = abi.decode(ret, (uint256));
+        assertEq(actual, 1, "choose should return the configured branch value");
     }
 }

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -50,6 +50,12 @@ NON_ZERO_REQUIRE_RE = re.compile(
 BUILTIN_READ_RE = re.compile(
     r"let\s+([A-Za-z_][A-Za-z0-9_]*)\s*←\s*(msgSender|msgValue)$"
 )
+PARAM_COMPARE_RETURN_RE = re.compile(
+    r"return\s+\(?([A-Za-z_][A-Za-z0-9_]*)\s*(==|!=)\s*([A-Za-z_][A-Za-z0-9_]*)\)?$"
+)
+PARAM_COMPARE_BRANCH_RE = re.compile(
+    r"if\s+([A-Za-z_][A-Za-z0-9_]*)\s*(==|!=)\s*([A-Za-z_][A-Za-z0-9_]*)\s+then$"
+)
 
 
 @dataclass(frozen=True)
@@ -546,14 +552,75 @@ def _render_direct_return_assertion(
 """
 
 
+def _render_dynamic_param_compare_assertion(
+    fn: FunctionDecl,
+    idx: int,
+    encode_args: str,
+    decoded_type: str,
+    expected_expr: str,
+    summary: str,
+    suffix: str,
+    assertion_expr: str,
+    assertion_msg: str,
+) -> str:
+    ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+    return f"""    // Property {idx}: {summary}
+    function testAuto_{_fn_camel(fn.name)}_{suffix}() public {{
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature({encode_args}));
+        require(ok, \"{fn.name} reverted unexpectedly\");
+{ret_assert}
+        {decoded_type} actual = abi.decode(ret, ({decoded_type}));
+        {decoded_type} expected = {expected_expr};
+        assertEq(actual, expected, \"{assertion_msg}\");
+        {assertion_expr}
+    }}
+"""
+
+
 def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx: int, encode_args: str) -> str | None:
     fn_camel = _fn_camel(fn.name)
     body = list(fn.body)
     ty = _normalize_type(fn.return_type)
     param_examples = {param.name: _example_value(param.lean_type) for param in fn.params}
     decoded_type = _sol_type(fn.return_type)
+    param_types = {param.name: _normalize_type(param.lean_type) for param in fn.params}
 
     if len(body) == 1:
+        compare_match = PARAM_COMPARE_RETURN_RE.fullmatch(body[0])
+        if compare_match and ty == "Bool":
+            lhs_name, op, rhs_name = compare_match.groups()
+            lhs_ty = param_types.get(lhs_name)
+            rhs_ty = param_types.get(rhs_name)
+            lhs_example = param_examples.get(lhs_name)
+            rhs_example = param_examples.get(rhs_name)
+            if (
+                lhs_ty is not None
+                and rhs_ty is not None
+                and lhs_ty == rhs_ty
+                and lhs_ty in {"String", "Bytes"}
+                and lhs_example is not None
+                and rhs_example is not None
+            ):
+                examples_match = lhs_example == rhs_example
+                expected_expr = "true" if (examples_match if op == "==" else not examples_match) else "false"
+                compare_kind = lhs_ty.lower()
+                return _render_dynamic_param_compare_assertion(
+                    fn,
+                    idx,
+                    encode_args,
+                    decoded_type,
+                    expected_expr,
+                    f"{fn.name} matches the expected dynamic-parameter comparison result",
+                    "ComparesDirectDynamicParamsEq" if op == "==" else "ComparesDirectDynamicParamsNeq",
+                    (
+                        f'assertTrue(actual, "{fn.name} should return true for the configured {compare_kind} comparison");'
+                        if expected_expr == "true"
+                        else f'assertFalse(actual, "{fn.name} should return false for the configured {compare_kind} comparison");'
+                    ),
+                    f"{fn.name} should preserve the configured comparison result",
+                )
+
         direct_return_match = re.fullmatch(r"return\s+([A-Za-z_][A-Za-z0-9_]*)", body[0])
         if direct_return_match:
             returned_name = direct_return_match.group(1)
@@ -768,6 +835,42 @@ def _render_inferred_non_unit_test(contract: ContractDecl, fn: FunctionDecl, idx
             )
 
     if len(body) == 4:
+        branch_match = PARAM_COMPARE_BRANCH_RE.fullmatch(body[0])
+        then_match = re.fullmatch(r"return\s+(.+)", body[1])
+        else_match = re.fullmatch(r"return\s+(.+)", body[3])
+        if branch_match and body[2] == "else" and then_match and else_match:
+            lhs_name, op, rhs_name = branch_match.groups()
+            lhs_ty = param_types.get(lhs_name)
+            rhs_ty = param_types.get(rhs_name)
+            lhs_example = param_examples.get(lhs_name)
+            rhs_example = param_examples.get(rhs_name)
+            if (
+                lhs_ty is not None
+                and rhs_ty is not None
+                and lhs_ty == rhs_ty
+                and lhs_ty in {"String", "Bytes"}
+                and lhs_example is not None
+                and rhs_example is not None
+            ):
+                examples_match = lhs_example == rhs_example
+                take_then = examples_match if op == "==" else not examples_match
+                expected_expr = _literal_expr(
+                    then_match.group(1).strip() if take_then else else_match.group(1).strip(),
+                    ty,
+                )
+                if expected_expr is not None:
+                    ret_assert = _return_shape_assertion(fn.return_type, fn.name)
+                    return f"""    // Property {idx}: {fn.name} selects the expected branch for the configured dynamic inputs
+    function testAuto_{fn_camel}_SelectsDynamicComparisonBranch() public {{
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature({encode_args}));
+        require(ok, \"{fn.name} reverted unexpectedly\");
+{ret_assert}
+        {decoded_type} actual = abi.decode(ret, ({decoded_type}));
+        assertEq(actual, {expected_expr}, \"{fn.name} should return the configured branch value\");
+    }}
+"""
+
         precondition_read = _parse_read_accessor(body[0])
         require_match = NON_ZERO_REQUIRE_RE.fullmatch(body[1])
         result_read = _parse_read_accessor(body[2])

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -440,6 +440,74 @@ class RenderTests(unittest.TestCase):
         self.assertIn('assertEq(actual0, uint256(1), "getPair tuple element 0 mismatch");', rendered)
         self.assertIn('assertEq(actual1, uint256(1), "getPair tuple element 1 mismatch");', rendered)
 
+    def test_render_string_eq_predicate_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="StringEqSmoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "same",
+                    (
+                        gen.ParamDecl("lhs", "String"),
+                        gen.ParamDecl("rhs", "String"),
+                    ),
+                    "Bool",
+                    body=("return (lhs == rhs)",),
+                ),
+            ),
+            storage_slots={},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_Same_ComparesDirectDynamicParamsEq()", rendered)
+        self.assertIn("bool expected = true;", rendered)
+        self.assertIn('assertTrue(actual, "same should return true for the configured string comparison");', rendered)
+
+    def test_render_bytes_neq_predicate_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="BytesEqSmoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "different",
+                    (
+                        gen.ParamDecl("lhs", "Bytes"),
+                        gen.ParamDecl("rhs", "Bytes"),
+                    ),
+                    "Bool",
+                    body=("return (lhs != rhs)",),
+                ),
+            ),
+            storage_slots={},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_Different_ComparesDirectDynamicParamsNeq()", rendered)
+        self.assertIn("bool expected = false;", rendered)
+        self.assertIn('assertFalse(actual, "different should return false for the configured bytes comparison");', rendered)
+
+    def test_render_string_eq_branch_infers_assertion(self) -> None:
+        contract = gen.ContractDecl(
+            name="StringEqSmoke",
+            constructor=None,
+            source=gen.ROOT / "Contracts/Sample/Sample.lean",
+            functions=(
+                gen.FunctionDecl(
+                    "choose",
+                    (
+                        gen.ParamDecl("lhs", "String"),
+                        gen.ParamDecl("rhs", "String"),
+                    ),
+                    "Uint256",
+                    body=("if lhs == rhs then", "return 1", "else", "return 0"),
+                ),
+            ),
+            storage_slots={},
+        )
+        rendered = gen.render_contract_test(contract)
+        self.assertIn("function testAuto_Choose_SelectsDynamicComparisonBranch()", rendered)
+        self.assertIn('assertEq(actual, 1, "choose should return the configured branch value");', rendered)
+
     def test_render_mapping_getter_infers_assertion(self) -> None:
         contract = gen.ContractDecl(
             name="UintMapSmoke",


### PR DESCRIPTION
## Summary
- teach `generate_macro_property_tests.py` to infer assertions for direct `String`/`Bytes` equality predicates
- infer simple dynamic-comparison branch assertions for `if lhs == rhs then return ... else return ...`
- regenerate the `StringEqSmoke` and `BytesEqSmoke` property suites and add focused generator regressions

## Testing
- `python3 scripts/test_generate_macro_property_tests.py`
- `python3 scripts/check_macro_property_test_generation.py`
- `python3 scripts/check_macro_property_test_generation.py --check`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test generation and regenerated test artifacts, with no production/runtime logic impact beyond potentially stricter or newly-failing tests.
> 
> **Overview**
> Auto-generated macro property tests now *infer concrete assertions* for functions that directly compare dynamic parameters (`String`/`Bytes`) via `==`/`!=`, instead of emitting TODO stubs.
> 
> The generator also detects simple `if lhs == rhs then return X else return Y` (and `!=`) patterns for dynamic params and emits a branch-selection assertion; the `StringEqSmoke` and `BytesEqSmoke` suites are regenerated accordingly, and new Python regression tests cover these inference cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8911d7f85b6412df43b6bc3e0fb37f5623dc978. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->