### PR TITLE
docs: fix Layer 2 bridge positioning

### DIFF
--- a/Contracts/Proofs/SemanticBridge.lean
+++ b/Contracts/Proofs/SemanticBridge.lean
@@ -11,12 +11,12 @@
 
     ∀ slot, (edslFinalState.storage slot).val = irResult.finalStorage slot
 
-  **Status (post-evalBuiltinCall refactor, e5da6c7f)**: All proofs in this file
-  used `simp` to unfold the full IR execution chain including `evalBuiltinCall`.
-  After the refactor added `callvalue`/`calldatasize` support, `evalBuiltinCall`
-  became too large for `simp`/`isDefEq` to reduce within the heartbeat limit.
-  The theorem *statements* are preserved; proofs use placeholders until
-  `evalBuiltinCall` is factored into smaller pieces.
+  **Status**: This file is the contract-specific Layer 2 client/example layer.
+  The bridge theorems below are intentionally concrete per contract function:
+  they demonstrate how to connect EDSL execution, compiled IR execution, and
+  Layer 3 preservation without claiming a single generic
+  `CompilationModel.compile` correctness theorem for arbitrary supported
+  contracts.
 
   **Why a separate file**: The macro-generated theorems cannot import
   `Compiler.Proofs.IRGeneration.IRInterpreter` (it would transitively pull

--- a/docs-site/content/research.mdx
+++ b/docs-site/content/research.mdx
@@ -99,18 +99,18 @@ But `private theorem` isn't accessible from other files. Isolation proofs in sep
 ## Verification Structure
 
 Each contract has:
-- `Verity/Examples/X.lean` — Implementation (EDSL)
-- `Verity/Specs/X/Spec.lean` — Pre/postconditions for each operation
-- `Verity/Specs/X/Invariants.lean` — State properties that should hold
-- `Verity/Proofs/X/Basic.lean` — Contract-specific spec conformance and basic properties
-- `Verity/Proofs/X/Correctness.lean` — Contract-specific revert proofs, composition, and end-to-end properties
-- `Compiler/TypedIRCompilerCorrectness.lean` — Compilation correctness (generic theorem, 36 supported fragments)
+- `Contracts/X/X.lean` — Implementation (EDSL)
+- `Contracts/X/Spec.lean` — Pre/postconditions for each operation
+- `Contracts/X/Invariants.lean` — State properties that should hold
+- `Contracts/X/SpecProofs.lean` — Contract-specific spec conformance and end-to-end proof layer
+- `Compiler/TypedIRCompilerCorrectness.lean` — Layer 1 typed-IR compilation correctness for the supported statement fragment
+- `Contracts/Proofs/SemanticBridge.lean` — Contract-level Layer 2 bridge theorems (client/example layer, not the generic compiler proof)
+- `Compiler/Proofs/IRGeneration/Contract.lean` — Partial generic Layer 2 theorem spine; the remaining whole-contract gap is tracked in [#1510](https://github.com/Th0rgal/verity/issues/1510)
 
 Some contracts have additional proof files:
-- `Verity/Proofs/SimpleToken/Supply.lean` — Supply conservation equations
-- `Verity/Proofs/SimpleToken/Isolation.lean` — Storage isolation across slot types
-- `Verity/Proofs/Ledger/Conservation.lean` — Balance conservation equations
-- `Verity/Proofs/OwnedCounter/Isolation.lean` — Cross-pattern storage isolation
+- `Contracts/SimpleToken/SpecProofs.lean` — Supply and transfer reasoning
+- `Contracts/Ledger/SpecProofs.lean` — Balance accounting and conservation equations
+- `Contracts/OwnedCounter/SpecProofs.lean` — Cross-pattern ownership and counter invariants
 
 Conservation proofs use `List.countOcc` to account for duplicate addresses. For `NoDup` lists, transfer preserves exact sum. For general lists, exact equations with `countOcc` multipliers are proven.
 

--- a/docs/GENERIC_LAYER2_PLAN.md
+++ b/docs/GENERIC_LAYER2_PLAN.md
@@ -81,6 +81,8 @@ Keep `SupportedFragment.lean` as a lower-level statement theorem only.
 
 Keep `Contracts/Proofs/SemanticBridge.lean` only as:
 
+`Contracts/Proofs/SemanticBridge.lean` becomes client/example layer only.
+
 - examples
 - regressions
 - composition wrappers for already-proved generic theorems

--- a/scripts/check_layer2_boundary_sync.py
+++ b/scripts/check_layer2_boundary_sync.py
@@ -9,10 +9,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 TARGETS = {
     "COMPILER_PROOFS_README": ROOT / "Compiler" / "Proofs" / "README.md",
+    "GENERIC_PLAN": ROOT / "docs" / "GENERIC_LAYER2_PLAN.md",
     "VERIFICATION_STATUS": ROOT / "docs" / "VERIFICATION_STATUS.md",
     "ROADMAP": ROOT / "docs" / "ROADMAP.md",
     "ROOT_README": ROOT / "README.md",
     "TRUST_ASSUMPTIONS": ROOT / "TRUST_ASSUMPTIONS.md",
+    "SEMANTIC_BRIDGE": ROOT / "Contracts" / "Proofs" / "SemanticBridge.lean",
     "DOCS_SITE_COMPILER": ROOT / "docs-site" / "content" / "compiler.mdx",
     "DOCS_SITE_RESEARCH": ROOT / "docs-site" / "content" / "research.mdx",
     "LLMS": ROOT / "docs-site" / "public" / "llms.txt",
@@ -29,6 +31,10 @@ def expected_snippets() -> dict[str, list[str]]:
             "there is not yet a single generic theorem saying `CompilationModel.compile` preserves semantics for every supported full contract.",
             "`Contracts/Proofs/SemanticBridge.lean`: contract-level bridge theorems",
             "it still depends on 1 documented axiom in `Compiler.Proofs.IRGeneration.Function`",
+        ],
+        "GENERIC_PLAN": [
+            "avoid any `post`/`hpost`/contract-specific bridge premise",
+            "`Contracts/Proofs/SemanticBridge.lean` becomes client/example layer only.",
         ],
         "VERIFICATION_STATUS": [
             "## Layer 2: CompilationModel → IR — PARTIAL GENERIC",
@@ -52,6 +58,10 @@ def expected_snippets() -> dict[str, list[str]]:
             "The theorem surface still depends on 1 documented sub-axiom for generic body simulation",
             "it still has 3 documented Lean axioms",
         ],
+        "SEMANTIC_BRIDGE": [
+            "This is not a generic compiler-correctness theorem for `CompilationModel.compile`.",
+            "The actual semantic work still lives in the contract-specific bridge theorem passed in as `hpost`.",
+        ],
         "DOCS_SITE_COMPILER": [
             "**Layer 2 boundary today**",
             "full-contract Layer 2 preservation still relies on contract-specific bridge theorems.",
@@ -60,6 +70,8 @@ def expected_snippets() -> dict[str, list[str]]:
         "DOCS_SITE_RESEARCH": [
             "Partial generic coverage only.",
             "generic `CompilationModel.compile` theorem is tracked in [#1510]",
+            "`Contracts/Proofs/SemanticBridge.lean`",
+            "`Compiler/Proofs/IRGeneration/Contract.lean`",
         ],
         "LLMS": [
             "partial generic CompilationModel -> IR boundary",
@@ -80,6 +92,9 @@ def forbidden_snippets() -> dict[str, list[str]]:
             "it still depends on 2 documented Layer-2 axioms",
             "Still axiomatized: generic supported body simulation and the `execIRFunctionFuel` to `execIRFunction` bridge",
         ],
+        "GENERIC_PLAN": [
+            "use the old `hpost`-based bridge theorem as the solution",
+        ],
         "ROADMAP": [
             "✅ **Layer 2 Complete**",
         ],
@@ -95,12 +110,17 @@ def forbidden_snippets() -> dict[str, list[str]]:
             "2 documented sub-axioms for generic body simulation and the `execIRFunctionFuel`/`execIRFunction` bridge",
             "4 documented Lean axioms",
         ],
+        "SEMANTIC_BRIDGE": [
+            "proofs use placeholders until",
+        ],
         "DOCS_SITE_COMPILER": [
             "**Layer 2 framework proof**: `CompilationModel -> IR` preserves semantics.",
             "depends on 2 documented axioms.",
         ],
         "DOCS_SITE_RESEARCH": [
             "Complete for all 7 contracts",
+            "`Verity/Examples/X.lean`",
+            "`Compiler/TypedIRCompilerCorrectness.lean` — Compilation correctness (generic theorem, 36 supported fragments)",
         ],
         "LLMS": [
             "CompilationModel -> IR preservation",


### PR DESCRIPTION
## Summary
- fix stale Layer 2 positioning in `Contracts/Proofs/SemanticBridge.lean`
- update the public research page to point at current proof-file locations and the actual generic-vs-bridge split
- extend `check_layer2_boundary_sync.py` so `SemanticBridge.lean`, `docs/GENERIC_LAYER2_PLAN.md`, and the research page cannot drift back to the old story

## Testing
- `python3 scripts/test_check_layer2_boundary_sync.py`
- `python3 scripts/check_layer2_boundary_sync.py`

Partially addresses #1510.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates plus a boundary-sync script change; low risk aside from potential CI failures if snippets drift.
> 
> **Overview**
> Repositions `Contracts/Proofs/SemanticBridge.lean` as a *client/example* Layer-2 bridge layer (not a generic `CompilationModel.compile` correctness result) and updates the public research page to reflect the current generic-vs-bridge split and file locations.
> 
> Extends `scripts/check_layer2_boundary_sync.py` to enforce this messaging across docs by checking for new required/forbidden snippets, adding `docs/GENERIC_LAYER2_PLAN.md` and `Contracts/Proofs/SemanticBridge.lean` to the synced targets so the Layer 2 boundary claims can’t drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9d71e2c882b2be0fda07f2d3dd8caa3af7d6b0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->