### PR TITLE
docs: sync Lean axiom boundary wording

### DIFF
--- a/Compiler/Proofs/README.md
+++ b/Compiler/Proofs/README.md
@@ -17,14 +17,14 @@ See `TRUST_ASSUMPTIONS.md` for the full trust boundary.
   `Compiler/TypedIRCompilerCorrectness.lean` and
   `Compiler/Proofs/IRGeneration/SupportedFragment.lean`. A generic whole-contract
   theorem surface now also exists in `Compiler/Proofs/IRGeneration/Contract.lean`,
-  but its function-level closure still depends on 2 narrower documented Layer-2
-  axioms in `Compiler.Proofs.IRGeneration.Function`. The initial-state
+  but its function-level closure still depends on 1 narrower documented Layer-2
+  axiom in `Compiler.Proofs.IRGeneration.Function`. The initial-state
   normalization step is now proved under an explicit transaction-context
   normalization hypothesis. Active end-to-end examples still rely on
   contract-specific theorems in `Contracts/Proofs/SemanticBridge.lean`.
 - **Layer 3: IR -> Yul**. Yul semantics, equivalence, and preservation proofs
   live in `Compiler/Proofs/YulGeneration/`. The proof surface is generic, but the
-  current full dispatch-preservation path still uses 1 documented bridge axiom.
+  current full dispatch-preservation path still uses 1 documented bridge hypothesis.
 
 ## Key Modules
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ EDSL contract (Lean)
 CompilationModel (declarative IR spec)
   ↓  Layer 2: CompilationModel → IR        [PARTIAL GENERIC, CONTRACT BRIDGES ACTIVE]
 Intermediate Representation
-  ↓  Layer 3: IR → Yul                     [GENERIC SURFACE, 1 AXIOM]
+  ↓  Layer 3: IR → Yul                     [GENERIC SURFACE, EXPLICIT BRIDGE HYPOTHESIS]
 Yul
   ↓  solc (trusted external compiler)
 EVM Bytecode
@@ -117,9 +117,9 @@ EVM Bytecode
 |-------|---------------|----------|
 | 1 | A generic typed-IR core plus contract-level bridge theorems establish EDSL execution = CompilationModel interpretation for the current supported contracts | [TypedIRCompilerCorrectness.lean](Compiler/TypedIRCompilerCorrectness.lean) |
 | 2 | A generic whole-contract theorem shape exists, but its non-core function-level closure still depends on 1 documented axiom; the proved core fragment already runs on structural fuel, and the theorem surface now explicitly assumes normalized transaction-context fields. The remaining closure work is tracked in [#1510](https://github.com/Th0rgal/verity/issues/1510), with the current proof plan in [docs/GENERIC_LAYER2_PLAN.md](docs/GENERIC_LAYER2_PLAN.md). | [Contract.lean](Compiler/Proofs/IRGeneration/Contract.lean) |
-| 3 | IR → Yul codegen is proved generically at the statement/function level, but the current full dispatch-preservation path still uses 1 documented bridge axiom; the checked contract-level theorem surface now makes dispatch-guard safety explicit for each selected function case | [Preservation.lean](Compiler/Proofs/YulGeneration/Preservation.lean) |
+| 3 | IR → Yul codegen is proved generically at the statement/function level, but the current full dispatch-preservation path still uses 1 documented bridge hypothesis; the checked contract-level theorem surface now makes dispatch-guard safety explicit for each selected function case | [Preservation.lean](Compiler/Proofs/YulGeneration/Preservation.lean) |
 
-There are currently 3 documented Lean axioms in total: 1 selector axiom, 1 generic non-core Layer 2 axiom, and 1 Layer 3 dispatch bridge axiom. See [AXIOMS.md](AXIOMS.md).
+There are currently 2 documented Lean axioms in total: 1 selector axiom and 1 generic non-core Layer 2 axiom. Layer 3 keeps its remaining dispatch bridge as an explicit theorem hypothesis rather than a Lean axiom. See [AXIOMS.md](AXIOMS.md).
 
 Layer 1 is the frontend EDSL-to-`CompilationModel` bridge. The per-contract files in `Contracts/<Name>/Proofs/` prove human-readable contract specifications; they are not what “Layer 1” means in the compiler stack. Layer 2 currently combines a generic supported-statement theorem with contract-specific full-contract bridges. Layers 2 and 3 (`CompilationModel → IR → Yul`) are verified with the current documented axioms and bridge boundaries; see [docs/VERIFICATION_STATUS.md](docs/VERIFICATION_STATUS.md), [docs/GENERIC_LAYER2_PLAN.md](docs/GENERIC_LAYER2_PLAN.md), and [AXIOMS.md](AXIOMS.md).
 

--- a/TRUST_ASSUMPTIONS.md
+++ b/TRUST_ASSUMPTIONS.md
@@ -10,13 +10,13 @@ EDSL (Lean)
 CompilationModel
   ↓ [Layer 2: PARTIAL GENERIC — CompilationModel → IR + contract bridges]
 IR
-  ↓ [Layer 3: GENERIC SURFACE, 1 axiom — IR → Yul]
+  ↓ [Layer 3: GENERIC SURFACE, explicit bridge hypothesis — IR → Yul]
 Yul
   ↓ [trusted — solc]
 EVM Bytecode
 ```
 
-The repository has no `sorry`, but it still has 3 documented Lean axioms. See [AXIOMS.md](AXIOMS.md) for the exact list and current elimination plan.
+The repository has no `sorry`, but it still has 2 documented Lean axioms. See [AXIOMS.md](AXIOMS.md) for the exact list and current elimination plan.
 
 ## What's Verified
 
@@ -25,7 +25,7 @@ The repository has no `sorry`, but it still has 3 documented Lean axioms. See [A
   contract-specific specification theorems in `Contracts/<Name>/Proofs/` are a
   separate proof layer about human-readable contract behavior.
 - **Layer 2**: A generic whole-contract theorem surface exists for supported `CompilationModel`s, and `supported_function_correct` is now a real theorem. The initial-state normalization step is proved, but whole-contract Layer 2 preservation still relies on contract-specific bridge theorems. The theorem surface still depends on 1 documented sub-axiom for generic body simulation, and it makes explicit that the observed transaction-context fields must already be normalized to the bounded source-side `Address`/`Uint256` domains.
-- **Layer 3**: IR → Yul preservation is generic at the proof surface, but the current full dispatch-preservation path still depends on 1 documented bridge axiom. The checked contract-level theorem surface now makes the dispatch-guard safety preconditions explicit: non-payable cases must see word-level zero `msg.value`, and each selected function case must have a non-wrapping calldata-width guard.
+- **Layer 3**: IR → Yul preservation is generic at the proof surface, but the current full dispatch-preservation path still depends on 1 documented bridge hypothesis. The checked contract-level theorem surface now makes the dispatch-guard safety preconditions explicit: non-payable cases must see word-level zero `msg.value`, and each selected function case must have a non-wrapping calldata-width guard.
 - **Cross-layer**: [`Contracts/Proofs/SemanticBridge.lean`](Contracts/Proofs/SemanticBridge.lean) has zero `sorry`, but it is a manual bridge layer for a subset of contracts rather than a fully generic replacement for Layers 1-3.
 
 Current theorem totals, property-test coverage, and proof status live in [docs/VERIFICATION_STATUS.md](docs/VERIFICATION_STATUS.md).
@@ -39,7 +39,7 @@ Current theorem totals, property-test coverage, and proof status live in [docs/V
 
 ### 2. Lean Axioms
 - **Role**: Bridge remaining proof obligations not yet fully discharged.
-- **Status**: 3 documented axioms in [AXIOMS.md](AXIOMS.md): 1 selector axiom, 1 generic non-core Layer 2 axiom, and 1 Layer 3 dispatch bridge axiom.
+- **Status**: 2 documented axioms in [AXIOMS.md](AXIOMS.md): 1 selector axiom and 1 generic non-core Layer 2 axiom. The Layer 3 dispatch bridge remains an explicit theorem hypothesis rather than a Lean axiom.
 - **Mitigation**: CI axiom reporting and location checks enforce explicit tracking.
 
 ### 3. Keccak-based Selector Computation

--- a/docs-site/content/compiler.mdx
+++ b/docs-site/content/compiler.mdx
@@ -32,7 +32,7 @@ Important: Verity has two different "spec" concepts.
 - **Layer 1 frontend bridge**: EDSL behavior is proven equivalent to its `CompilationModel`.
 - **Layer 2 boundary today**: a supported-statement `CompilationModel -> IR` theorem exists, but full-contract Layer 2 preservation still relies on contract-specific bridge theorems.
 - **Layer 2 framework proof**: a generic whole-contract theorem surface exists, but the remaining non-core closure still depends on 1 documented axiom.
-- **Layer 3 framework proof**: `IR -> Yul` preserves semantics.
+- **Layer 3 framework proof**: `IR -> Yul` preserves semantics, with the remaining dispatch bridge exposed as an explicit theorem hypothesis rather than a Lean axiom.
 - **Machine-checked proofs**: see [VERIFICATION_STATUS.md](https://github.com/Th0rgal/verity/blob/main/docs/VERIFICATION_STATUS.md) for the current proof-status snapshot and [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md) for documented axioms.
 - **Interpreter semantics**: Spec, IR, and Yul semantics defined and linked in Lean
 

--- a/docs-site/content/index.mdx
+++ b/docs-site/content/index.mdx
@@ -130,7 +130,7 @@ See [/verification](/verification) for the complete, always-current theorem list
 
 **What's `sorry`?** A placeholder in Lean that says "I'll prove this later." It's how incomplete proofs compile. This project currently has no `sorry` placeholders.
 
-**What are axioms?** Statements assumed true without proof. This project uses 1 documented axiom: `keccak256_first_4_bytes` for selector hashing (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)).
+**What are axioms?** Statements assumed true without proof. This project currently documents 2 Lean axioms: `keccak256_first_4_bytes` for selector hashing and `supported_function_body_correct_from_exact_state` for the remaining generic Layer 2 body-simulation gap (see [AXIOMS.md](https://github.com/Th0rgal/verity/blob/main/AXIOMS.md)). The Layer 3 dispatch bridge is kept as an explicit theorem hypothesis rather than a Lean axiom.
 
 Example proof technique (simplified):
 ```lean

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -18,7 +18,7 @@ Lean 4 EDSL for writing smart contracts with machine-checked proofs. Three-layer
 - **Core Size**: 400 lines
 - **Verified Contracts**: SimpleStorage, Counter, Owned, SimpleToken, OwnedCounter, Ledger, SafeCounter, ReentrancyExample (+ CryptoHash as unverified linker demo)
 - **Theorems**: 273 across 10 categories, 273 fully proven, 0 `sorry` placeholders (12 in SemanticBridge cross-layer proofs, 0 in Yul Preservation)
-- **Axioms**: 3 documented axioms (see AXIOMS.md) — 1 selector axiom, 1 generic non-core Layer 2 axiom, and 1 Layer 3 dispatch bridge axiom
+- **Axioms**: 2 documented Lean axioms (see AXIOMS.md) — 1 selector axiom and 1 generic non-core Layer 2 axiom. Layer 3 keeps an explicit dispatch bridge hypothesis rather than a Lean axiom.
 - **Tests**: 478 Foundry tests, multi-seed differential testing (7 seeds), 8-shard parallel CI
 - **Build**: `lake build` verifies all proofs
 - **Repository**: https://github.com/Th0rgal/verity
@@ -126,7 +126,7 @@ Add `.md` to any URL for raw markdown (saves tokens).
 See TRUST_ASSUMPTIONS.md for full analysis. Key trust boundaries:
 - **Verified**: EDSL -> CompilationModel -> IR -> Yul
 - **Trusted**: Yul -> Bytecode (via solc, validated by 90,000+ differential tests)
-- **Axioms**: 1 documented, with soundness justification
+- **Axioms**: 2 documented Lean axioms, with soundness justifications in AXIOMS.md
 - **External**: Lean 4 kernel, EVM specification alignment
 
 ## Known Limitations

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -10,7 +10,7 @@ EDSL contracts (Lean)
 CompilationModel (declarative compiler-facing model)
     ↓ Layer 2: CompilationModel → IR [PARTIAL GENERIC, 2 AXIOMS, CONTRACT BRIDGES ACTIVE]
 Intermediate Representation (IR)
-    ↓ Layer 3: IR → Yul [GENERIC SURFACE, 1 AXIOM]
+    ↓ Layer 3: IR → Yul [GENERIC SURFACE, EXPLICIT BRIDGE HYPOTHESIS]
 Yul (EVM Assembly)
     ↓ (Trusted: solc compiler)
 EVM Bytecode
@@ -101,7 +101,7 @@ Key files:
 
 ## Layer 3: IR → Yul — GENERIC, WITH EXPLICIT AXIOM BOUNDARY
 
-**What it proves today**: Yul code generation preserves IR semantics through a generic statement/function equivalence stack, but the current full dispatch-preservation path still depends on 1 documented bridge axiom in [`Preservation.lean`](../Compiler/Proofs/YulGeneration/Preservation.lean). The checked contract-level theorem surface now explicitly requires dispatch-guard safety for each selected function case: word-level zero `msg.value` on non-payable paths and a non-wrapping calldata-width bound for each case guard.
+**What it proves today**: Yul code generation preserves IR semantics through a generic statement/function equivalence stack, but the current full dispatch-preservation path still depends on 1 documented bridge hypothesis in [`Preservation.lean`](../Compiler/Proofs/YulGeneration/Preservation.lean). The checked contract-level theorem surface now explicitly requires dispatch-guard safety for each selected function case: word-level zero `msg.value` on non-payable paths and a non-wrapping calldata-width bound for each case guard.
 
 All 8 Yul statement types proven equivalent to IR counterparts. Universal dispatcher theorem:
 
@@ -190,7 +190,7 @@ Also note that the macro-generated `*_semantic_preservation` theorems are not co
 
 0 `sorry` remaining across `Compiler/**/*.lean` and `Verity/**/*.lean` proof modules.
 
-3 documented axioms remain.
+2 documented Lean axioms remain. The Layer 3 dispatch bridge is tracked as an explicit theorem hypothesis rather than a Lean axiom.
 
 ## Differential Testing
 

--- a/scripts/check_layer2_boundary_sync.py
+++ b/scripts/check_layer2_boundary_sync.py
@@ -50,13 +50,14 @@ def expected_snippets() -> dict[str, list[str]]:
             "Layer 2: CompilationModel → IR        [PARTIAL GENERIC, CONTRACT BRIDGES ACTIVE]",
             "Layer 2 currently combines a generic supported-statement theorem with contract-specific full-contract bridges.",
             "its non-core function-level closure still depends on 1 documented axiom",
-            "There are currently 3 documented Lean axioms in total: 1 selector axiom, 1 generic non-core Layer 2 axiom, and 1 Layer 3 dispatch bridge axiom.",
+            "There are currently 2 documented Lean axioms in total: 1 selector axiom and 1 generic non-core Layer 2 axiom.",
+            "Layer 3 keeps its remaining dispatch bridge as an explicit theorem hypothesis rather than a Lean axiom.",
         ],
         "TRUST_ASSUMPTIONS": [
             "Layer 2: PARTIAL GENERIC — CompilationModel → IR + contract bridges",
             "whole-contract Layer 2 preservation still relies on contract-specific bridge theorems.",
             "The theorem surface still depends on 1 documented sub-axiom for generic body simulation",
-            "it still has 3 documented Lean axioms",
+            "it still has 2 documented Lean axioms",
         ],
         "SEMANTIC_BRIDGE": [
             "This is not a generic compiler-correctness theorem for `CompilationModel.compile`.",
@@ -66,6 +67,7 @@ def expected_snippets() -> dict[str, list[str]]:
             "**Layer 2 boundary today**",
             "full-contract Layer 2 preservation still relies on contract-specific bridge theorems.",
             "the remaining non-core closure still depends on 1 documented axiom.",
+            "explicit theorem hypothesis rather than a Lean axiom",
         ],
         "DOCS_SITE_RESEARCH": [
             "Partial generic coverage only.",
@@ -76,7 +78,7 @@ def expected_snippets() -> dict[str, list[str]]:
         "LLMS": [
             "partial generic CompilationModel -> IR boundary",
             "generic supported-statement theorem plus contract-specific full-contract bridges.",
-            "3 documented axioms",
+            "2 documented Lean axioms",
         ],
     }
 
@@ -102,13 +104,17 @@ def forbidden_snippets() -> dict[str, list[str]]:
             "Layer 2: CompilationModel → IR        [PROVEN]",
             "| 2 | CompilationModel → IR preserves behavior |",
             "depends on 2 documented axioms",
+            "documented bridge axiom",
+            "There are currently 3 documented Lean axioms in total",
             "There are currently 4 documented Lean axioms in total",
         ],
         "TRUST_ASSUMPTIONS": [
             "FULLY VERIFIED — CompilationModel → IR",
             "All three layers are proven in Lean",
             "2 documented sub-axioms for generic body simulation and the `execIRFunctionFuel`/`execIRFunction` bridge",
+            "3 documented Lean axioms",
             "4 documented Lean axioms",
+            "1 documented bridge axiom",
         ],
         "SEMANTIC_BRIDGE": [
             "proofs use placeholders until",
@@ -116,6 +122,7 @@ def forbidden_snippets() -> dict[str, list[str]]:
         "DOCS_SITE_COMPILER": [
             "**Layer 2 framework proof**: `CompilationModel -> IR` preserves semantics.",
             "depends on 2 documented axioms.",
+            "1 documented bridge axiom",
         ],
         "DOCS_SITE_RESEARCH": [
             "Complete for all 7 contracts",
@@ -124,6 +131,7 @@ def forbidden_snippets() -> dict[str, list[str]]:
         ],
         "LLMS": [
             "CompilationModel -> IR preservation",
+            "3 documented axioms",
             "4 documented axioms",
         ],
     }

--- a/scripts/test_check_layer2_boundary_sync.py
+++ b/scripts/test_check_layer2_boundary_sync.py
@@ -67,6 +67,39 @@ class Layer2BoundarySyncTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("still over-claims the Layer 2 boundary", output)
 
+    def test_detects_stale_axiom_count_language(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self._write_fixture_tree(root, use_expected=True, add_forbidden=False)
+            target = root / check.TARGETS["ROOT_README"].relative_to(check.ROOT)
+            target.write_text(
+                target.read_text(encoding="utf-8").replace(
+                    "There are currently 2 documented Lean axioms in total: 1 selector axiom and 1 generic non-core Layer 2 axiom.",
+                    "There are currently 3 documented Lean axioms in total: 1 selector axiom, 1 generic non-core Layer 2 axiom, and 1 Layer 3 dispatch bridge axiom.",
+                ),
+                encoding="utf-8",
+            )
+
+            old_root = check.ROOT
+            old_targets = check.TARGETS
+            check.ROOT = root
+            check.TARGETS = {
+                label: root / path.relative_to(old_root)
+                for label, path in old_targets.items()
+            }
+            try:
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    rc = check.main()
+                output = stdout.getvalue() + stderr.getvalue()
+            finally:
+                check.ROOT = old_root
+                check.TARGETS = old_targets
+
+        self.assertEqual(rc, 1)
+        self.assertIn("There are currently 3 documented Lean axioms in total", output)
+
     def test_compiler_proofs_readme_stale_axiom_wording_is_forbidden(self) -> None:
         forbidden = check.forbidden_snippets()
         self.assertIn("COMPILER_PROOFS_README", forbidden)


### PR DESCRIPTION
## Summary
- sync public proof-boundary docs with the current AXIOMS.md state
- stop labeling the Layer 3 dispatch bridge as a Lean axiom
- extend the existing Layer 2 boundary sync check to catch stale axiom-count wording

## Testing
- python3 scripts/test_check_layer2_boundary_sync.py
- python3 scripts/check_layer2_boundary_sync.py
- python3 scripts/check_axioms.py --locations
- python3 scripts/check_verification_status_doc.py

Closes #1510

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation wording and a Python doc-sync checker/test, with no compiler/proof logic modified.
> 
> **Overview**
> Clarifies the public proof-boundary narrative by **removing Layer 3 dispatch preservation from the “Lean axioms” bucket** and consistently describing it as an explicit bridge *hypothesis*, updating the reported axiom count from **3 → 2** across `README.md`, `TRUST_ASSUMPTIONS.md`, `docs/VERIFICATION_STATUS.md`, and the docs site.
> 
> Extends `scripts/check_layer2_boundary_sync.py` (and its tests) to require the new axiom-count/hypothesis wording and to forbid stale “Layer 3 bridge axiom” phrasing, including a new test that fails when old axiom-count language reappears.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 075436c7f275f90c8ae8545b518babd7222e7f4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->