### PR TITLE
compilation-model: add storage array indexed reads

### DIFF
--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -216,9 +216,10 @@ def validateCompileInputs (spec : CompilationModel) (selectors : List Nat) : Exc
       pure ()
   let mappingHelpersRequired := usesMapping fields
   let arrayHelpersRequired := contractUsesArrayElement spec
+  let storageArrayHelpersRequired := contractUsesStorageArrayElement spec
   let dynamicBytesEqHelpersRequired := contractUsesDynamicBytesEq spec
   match firstReservedExternalCollision
-      spec mappingHelpersRequired arrayHelpersRequired dynamicBytesEqHelpersRequired with
+      spec mappingHelpersRequired arrayHelpersRequired storageArrayHelpersRequired dynamicBytesEqHelpersRequired with
   | some name =>
       if name.startsWith internalFunctionPrefix then
         throw s!"Compilation error: external declaration '{name}' uses reserved prefix '{internalFunctionPrefix}' ({issue756Ref})."
@@ -243,6 +244,7 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat) : Exce
   let internalFns := spec.functions.filter (·.isInternal)
   let mappingHelpersRequired := usesMapping fields
   let arrayHelpersRequired := contractUsesArrayElement spec
+  let storageArrayHelpersRequired := contractUsesStorageArrayElement spec
   let dynamicBytesEqHelpersRequired := contractUsesDynamicBytesEq spec
   let fallbackSpec ← pickUniqueFunctionByName "fallback" spec.functions
   let receiveSpec ← pickUniqueFunctionByName "receive" spec.functions
@@ -252,6 +254,11 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat) : Exce
   let arrayElementHelpers :=
     if arrayHelpersRequired then
       [checkedArrayElementCalldataHelper, checkedArrayElementMemoryHelper]
+    else
+      []
+  let storageArrayElementHelpers :=
+    if storageArrayHelpersRequired then
+      [checkedStorageArrayElementHelper]
     else
       []
   let dynamicBytesEqHelpers :=
@@ -269,7 +276,7 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat) : Exce
     fallbackEntrypoint := fallbackEntrypoint
     receiveEntrypoint := receiveEntrypoint
     usesMapping := mappingHelpersRequired
-    internalFunctions := arrayElementHelpers ++ dynamicBytesEqHelpers ++ internalFuncDefs
+    internalFunctions := arrayElementHelpers ++ storageArrayElementHelpers ++ dynamicBytesEqHelpers ++ internalFuncDefs
   }
 
 def compile (spec : CompilationModel) (selectors : List Nat) : Except String IRContract := do

--- a/Compiler/CompilationModel/DynamicData.lean
+++ b/Compiler/CompilationModel/DynamicData.lean
@@ -20,6 +20,9 @@ def checkedArrayElementCalldataHelperName : String :=
 def checkedArrayElementMemoryHelperName : String :=
   "__verity_array_element_memory_checked"
 
+def checkedStorageArrayElementHelperName : String :=
+  "__verity_storage_array_element_checked"
+
 def dynamicBytesEqCalldataHelperName : String :=
   "__verity_dynamic_bytes_eq_calldata"
 
@@ -46,6 +49,21 @@ def checkedArrayElementCalldataHelper : YulStmt :=
 
 def checkedArrayElementMemoryHelper : YulStmt :=
   checkedArrayElementHelper checkedArrayElementMemoryHelperName "mload"
+
+def checkedStorageArrayElementHelper : YulStmt :=
+  YulStmt.funcDef checkedStorageArrayElementHelperName ["slot", "index"] ["word"] [
+    YulStmt.let_ "__array_len" (YulExpr.call "sload" [YulExpr.ident "slot"]),
+    YulStmt.if_ (YulExpr.call "iszero" [
+      YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "__array_len"]
+    ]) [
+      YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+    ],
+    YulStmt.expr (YulExpr.call "mstore" [YulExpr.lit 0, YulExpr.ident "slot"]),
+    YulStmt.let_ "__array_base" (YulExpr.call "keccak256" [YulExpr.lit 0, YulExpr.lit 32]),
+    YulStmt.assign "word" (YulExpr.call "sload" [
+      YulExpr.call "add" [YulExpr.ident "__array_base", YulExpr.ident "index"]
+    ])
+  ]
 
 private def dynamicBytesEqHelper (helperName loadOp : String) : YulStmt :=
   YulStmt.funcDef helperName

--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -264,6 +264,19 @@ def compileExpr (fields : List Field)
               throw s!"Compilation error: field '{field}' is not a storage dynamic array; use Expr.storageArrayLength only with FieldType.dynamicArray"
       | none =>
           throw s!"Compilation error: unknown storage field '{field}'"
+  | Expr.storageArrayElement field index =>
+      match findFieldWithResolvedSlot fields field with
+      | some (f, slot) =>
+          match f.ty with
+          | .dynamicArray _ => do
+              pure (YulExpr.call checkedStorageArrayElementHelperName [
+                YulExpr.lit slot,
+                ← compileExpr fields dynamicSource index
+              ])
+          | _ =>
+              throw s!"Compilation error: field '{field}' is not a storage dynamic array; use Expr.storageArrayElement only with FieldType.dynamicArray"
+      | none =>
+          throw s!"Compilation error: unknown storage field '{field}'"
   | Expr.dynamicBytesEq lhsName rhsName =>
       let helperName := match dynamicSource with
         | .calldata => dynamicBytesEqCalldataHelperName

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -18,6 +18,7 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
   | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _
   | Expr.structMember2 _ key1 key2 _ =>
       exprContainsCallLike key1 || exprContainsCallLike key2
+  | Expr.storageArrayElement _ index
   | Expr.arrayElement _ index =>
       exprContainsCallLike index
   | Expr.dynamicBytesEq _ _ =>
@@ -103,7 +104,7 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
   | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _
   | Expr.structMember2 _ key1 key2 _ =>
       exprContainsUnsafeLogicalCallLike key1 || exprContainsUnsafeLogicalCallLike key2
-  | Expr.arrayElement _ index | Expr.returndataOptionalBoolAt index =>
+  | Expr.storageArrayElement _ index | Expr.arrayElement _ index | Expr.returndataOptionalBoolAt index =>
       exprContainsUnsafeLogicalCallLike index
   | Expr.dynamicBytesEq _ _ =>
       false

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -111,6 +111,8 @@ def validateScopedExprIdentifiers
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayLength"
   | Expr.storageArrayLength _ =>
       pure ()
+  | Expr.storageArrayElement _ index => do
+      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
   | Expr.arrayElement name index => do
       match findParamType params name with
       | some ty@(ParamType.array elemTy) =>

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -57,6 +57,7 @@ private partial def collectLowLevelExprMechanics : Expr → List String
   | .structMember2 _ key1 key2 _ =>
       collectLowLevelExprMechanics key1 ++ collectLowLevelExprMechanics key2
   | .mappingUint _ key
+  | .storageArrayElement _ key
   | .arrayElement _ key =>
       collectLowLevelExprMechanics key
   | .mload key =>
@@ -119,6 +120,7 @@ private partial def collectAxiomatizedExprPrimitives : Expr → List String
   | .structMember2 _ key1 key2 _ =>
       collectAxiomatizedExprPrimitives key1 ++ collectAxiomatizedExprPrimitives key2
   | .mappingUint _ key
+  | .storageArrayElement _ key
   | .arrayElement _ key =>
       collectAxiomatizedExprPrimitives key
   | .externalCall _ args

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -310,6 +310,7 @@ inductive Expr
   | arrayLength (name : String)  -- Length of a dynamic array parameter (#180)
   | arrayElement (name : String) (index : Expr)  -- Checked element access of a dynamic array parameter (revert on out-of-range) (#180)
   | storageArrayLength (field : String)  -- Read the length word of a storage dynamic array (#1571)
+  | storageArrayElement (field : String) (index : Expr)  -- Checked element access of a storage dynamic array (#1571)
   /-- Equality on direct `bytes` / `string` parameters loaded from calldata or memory.
       The names refer to the dynamic parameter base names (`foo`, not `foo_offset`). -/
   | dynamicBytesEq (lhsName rhsName : String)

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -71,6 +71,8 @@ def exprUsesArrayElement : Expr → Bool
   | Expr.returndataOptionalBoolAt outOffset => exprUsesArrayElement outOffset
   | Expr.externalCall _ args | Expr.internalCall _ args =>
       exprListUsesArrayElement args
+  | Expr.storageArrayElement _ index =>
+      exprUsesArrayElement index
   | Expr.dynamicBytesEq _ _ =>
       false
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
@@ -168,6 +170,130 @@ def contractUsesArrayElement (spec : CompilationModel) : Bool :=
   constructorUsesArrayElement spec.constructor || spec.functions.any functionUsesArrayElement
 
 mutual
+def exprUsesStorageArrayElement : Expr → Bool
+  | Expr.storageArrayElement _ _ => true
+  | Expr.mapping _ key => exprUsesStorageArrayElement key
+  | Expr.mappingWord _ key _ => exprUsesStorageArrayElement key
+  | Expr.mappingPackedWord _ key _ _ => exprUsesStorageArrayElement key
+  | Expr.mappingChain _ keys => exprListUsesStorageArrayElement keys
+  | Expr.structMember _ key _ => exprUsesStorageArrayElement key
+  | Expr.mapping2 _ key1 key2 | Expr.mapping2Word _ key1 key2 _
+  | Expr.structMember2 _ key1 key2 _ => exprUsesStorageArrayElement key1 || exprUsesStorageArrayElement key2
+  | Expr.mappingUint _ key => exprUsesStorageArrayElement key
+  | Expr.call gas target value inOffset inSize outOffset outSize =>
+      exprUsesStorageArrayElement gas || exprUsesStorageArrayElement target || exprUsesStorageArrayElement value ||
+      exprUsesStorageArrayElement inOffset || exprUsesStorageArrayElement inSize ||
+      exprUsesStorageArrayElement outOffset || exprUsesStorageArrayElement outSize
+  | Expr.staticcall gas target inOffset inSize outOffset outSize =>
+      exprUsesStorageArrayElement gas || exprUsesStorageArrayElement target ||
+      exprUsesStorageArrayElement inOffset || exprUsesStorageArrayElement inSize ||
+      exprUsesStorageArrayElement outOffset || exprUsesStorageArrayElement outSize
+  | Expr.delegatecall gas target inOffset inSize outOffset outSize =>
+      exprUsesStorageArrayElement gas || exprUsesStorageArrayElement target ||
+      exprUsesStorageArrayElement inOffset || exprUsesStorageArrayElement inSize ||
+      exprUsesStorageArrayElement outOffset || exprUsesStorageArrayElement outSize
+  | Expr.extcodesize addr => exprUsesStorageArrayElement addr
+  | Expr.mload offset => exprUsesStorageArrayElement offset
+  | Expr.tload offset => exprUsesStorageArrayElement offset
+  | Expr.calldataload offset => exprUsesStorageArrayElement offset
+  | Expr.keccak256 offset size => exprUsesStorageArrayElement offset || exprUsesStorageArrayElement size
+  | Expr.returndataOptionalBoolAt outOffset => exprUsesStorageArrayElement outOffset
+  | Expr.externalCall _ args | Expr.internalCall _ args =>
+      exprListUsesStorageArrayElement args
+  | Expr.dynamicBytesEq _ _ =>
+      false
+  | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
+  | Expr.mod a b | Expr.smod a b |
+    Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b
+  | Expr.sar a b | Expr.signextend a b |
+    Expr.eq a b | Expr.ge a b | Expr.gt a b | Expr.sgt a b | Expr.lt a b | Expr.slt a b | Expr.le a b |
+    Expr.logicalAnd a b | Expr.logicalOr a b |
+    Expr.wMulDown a b | Expr.wDivUp a b | Expr.min a b | Expr.max a b =>
+      exprUsesStorageArrayElement a || exprUsesStorageArrayElement b
+  | Expr.mulDivDown a b c | Expr.mulDivUp a b c =>
+      exprUsesStorageArrayElement a || exprUsesStorageArrayElement b || exprUsesStorageArrayElement c
+  | Expr.bitNot a | Expr.logicalNot a =>
+      exprUsesStorageArrayElement a
+  | Expr.ite cond thenVal elseVal =>
+      exprUsesStorageArrayElement cond || exprUsesStorageArrayElement thenVal || exprUsesStorageArrayElement elseVal
+  | Expr.literal _ | Expr.param _ | Expr.constructorArg _ | Expr.storage _ | Expr.storageAddr _
+  | Expr.caller | Expr.contractAddress | Expr.chainid | Expr.msgValue | Expr.blockTimestamp
+  | Expr.blockNumber | Expr.blobbasefee
+  | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
+  | Expr.arrayElement _ _ =>
+      false
+termination_by e => sizeOf e
+decreasing_by all_goals simp_wf; all_goals omega
+
+def exprListUsesStorageArrayElement : List Expr → Bool
+  | [] => false
+  | e :: es => exprUsesStorageArrayElement e || exprListUsesStorageArrayElement es
+termination_by es => sizeOf es
+decreasing_by all_goals simp_wf; all_goals omega
+
+def stmtUsesStorageArrayElement : Stmt → Bool
+  | Stmt.letVar _ value | Stmt.assignVar _ value | Stmt.setStorage _ value | Stmt.setStorageAddr _ value |
+    Stmt.storageArrayPush _ value |
+    Stmt.return value | Stmt.require value _ =>
+      exprUsesStorageArrayElement value
+  | Stmt.setStorageArrayElement _ index value =>
+      exprUsesStorageArrayElement index || exprUsesStorageArrayElement value
+  | Stmt.storageArrayPop _ =>
+      false
+  | Stmt.requireError cond _ args =>
+      exprUsesStorageArrayElement cond || exprListUsesStorageArrayElement args
+  | Stmt.revertError _ args | Stmt.emit _ args | Stmt.returnValues args =>
+      exprListUsesStorageArrayElement args
+  | Stmt.mstore offset value =>
+      exprUsesStorageArrayElement offset || exprUsesStorageArrayElement value
+  | Stmt.tstore offset value =>
+      exprUsesStorageArrayElement offset || exprUsesStorageArrayElement value
+  | Stmt.calldatacopy destOffset sourceOffset size =>
+      exprUsesStorageArrayElement destOffset || exprUsesStorageArrayElement sourceOffset || exprUsesStorageArrayElement size
+  | Stmt.returndataCopy destOffset sourceOffset size =>
+      exprUsesStorageArrayElement destOffset || exprUsesStorageArrayElement sourceOffset || exprUsesStorageArrayElement size
+  | Stmt.setMapping _ key value | Stmt.setMappingWord _ key _ value | Stmt.setMappingPackedWord _ key _ _ value | Stmt.setMappingUint _ key value
+  | Stmt.setStructMember _ key _ value =>
+      exprUsesStorageArrayElement key || exprUsesStorageArrayElement value
+  | Stmt.setMappingChain _ keys value =>
+      exprListUsesStorageArrayElement keys || exprUsesStorageArrayElement value
+  | Stmt.setMapping2 _ key1 key2 value | Stmt.setMapping2Word _ key1 key2 _ value
+  | Stmt.setStructMember2 _ key1 key2 _ value =>
+      exprUsesStorageArrayElement key1 || exprUsesStorageArrayElement key2 || exprUsesStorageArrayElement value
+  | Stmt.ite cond thenBranch elseBranch =>
+      exprUsesStorageArrayElement cond || stmtListUsesStorageArrayElement thenBranch || stmtListUsesStorageArrayElement elseBranch
+  | Stmt.forEach _ count body =>
+      exprUsesStorageArrayElement count || stmtListUsesStorageArrayElement body
+  | Stmt.internalCall _ args | Stmt.internalCallAssign _ _ args | Stmt.externalCallBind _ _ args =>
+      exprListUsesStorageArrayElement args
+  | Stmt.rawLog topics dataOffset dataSize =>
+      exprListUsesStorageArrayElement topics || exprUsesStorageArrayElement dataOffset || exprUsesStorageArrayElement dataSize
+  | Stmt.ecm _ args =>
+      exprListUsesStorageArrayElement args
+  | Stmt.returnArray _ | Stmt.returnBytes _ | Stmt.returnStorageWords _
+  | Stmt.revertReturndata | Stmt.stop =>
+      false
+termination_by s => sizeOf s
+decreasing_by all_goals simp_wf; all_goals omega
+
+def stmtListUsesStorageArrayElement : List Stmt → Bool
+  | [] => false
+  | s :: ss => stmtUsesStorageArrayElement s || stmtListUsesStorageArrayElement ss
+termination_by ss => sizeOf ss
+decreasing_by all_goals simp_wf; all_goals omega
+end
+
+def functionUsesStorageArrayElement (fn : FunctionSpec) : Bool :=
+  fn.body.any stmtUsesStorageArrayElement
+
+def constructorUsesStorageArrayElement : Option ConstructorSpec → Bool
+  | none => false
+  | some ctor => ctor.body.any stmtUsesStorageArrayElement
+
+def contractUsesStorageArrayElement (spec : CompilationModel) : Bool :=
+  constructorUsesStorageArrayElement spec.constructor || spec.functions.any functionUsesStorageArrayElement
+
+mutual
 def exprUsesDynamicBytesEq : Expr → Bool
   | Expr.dynamicBytesEq _ _ => true
   | Expr.mapping _ key => exprUsesDynamicBytesEq key
@@ -198,7 +324,7 @@ def exprUsesDynamicBytesEq : Expr → Bool
   | Expr.returndataOptionalBoolAt outOffset => exprUsesDynamicBytesEq outOffset
   | Expr.externalCall _ args | Expr.internalCall _ args =>
       exprListUsesDynamicBytesEq args
-  | Expr.arrayElement _ index => exprUsesDynamicBytesEq index
+  | Expr.storageArrayElement _ index | Expr.arrayElement _ index => exprUsesDynamicBytesEq index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
   | Expr.mod a b | Expr.smod a b
   | Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -211,6 +211,7 @@ def exprReadsStateOrEnv : Expr → Bool
   | Expr.externalCall _ _ | Expr.internalCall _ _ => true
   | Expr.arrayLength _ => false
   | Expr.storageArrayLength _ => true
+  | Expr.storageArrayElement _ index => true || exprReadsStateOrEnv index
   | Expr.arrayElement _ index => exprReadsStateOrEnv index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
   | Expr.mod a b | Expr.smod a b |
@@ -272,6 +273,8 @@ def exprWritesState : Expr → Bool
       exprWritesState addr
   | Expr.storageArrayLength _ =>
       false
+  | Expr.storageArrayElement _ index =>
+      exprWritesState index
   | Expr.arrayElement _ index =>
       exprWritesState index
   | _ =>

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -12,11 +12,16 @@ import Compiler.CompilationModel.UsageAnalysis
 namespace Compiler.CompilationModel
 
 def reservedExternalNames
-    (mappingHelpersRequired arrayHelpersRequired dynamicBytesEqHelpersRequired : Bool) : List String :=
+    (mappingHelpersRequired arrayHelpersRequired storageArrayHelpersRequired dynamicBytesEqHelpersRequired : Bool) : List String :=
   let mappingHelpers := if mappingHelpersRequired then ["mappingSlot"] else []
   let arrayHelpers :=
     if arrayHelpersRequired then
       [checkedArrayElementCalldataHelperName, checkedArrayElementMemoryHelperName]
+    else
+      []
+  let storageArrayHelpers :=
+    if storageArrayHelpersRequired then
+      [checkedStorageArrayElementHelperName]
     else
       []
   let dynamicBytesEqHelpers :=
@@ -25,14 +30,14 @@ def reservedExternalNames
     else
       []
   let entrypoints := ["fallback", "receive"]
-  (mappingHelpers ++ arrayHelpers ++ dynamicBytesEqHelpers ++ entrypoints).eraseDups
+  (mappingHelpers ++ arrayHelpers ++ storageArrayHelpers ++ dynamicBytesEqHelpers ++ entrypoints).eraseDups
 
 def firstReservedExternalCollision
     (spec : CompilationModel)
-    (mappingHelpersRequired arrayHelpersRequired dynamicBytesEqHelpersRequired : Bool) : Option String :=
+    (mappingHelpersRequired arrayHelpersRequired storageArrayHelpersRequired dynamicBytesEqHelpersRequired : Bool) : Option String :=
   (spec.externals.map (·.name)).find? (fun name =>
     name.startsWith internalFunctionPrefix ||
-      (reservedExternalNames mappingHelpersRequired arrayHelpersRequired dynamicBytesEqHelpersRequired).contains name)
+      (reservedExternalNames mappingHelpersRequired arrayHelpersRequired storageArrayHelpersRequired dynamicBytesEqHelpersRequired).contains name)
 
 def firstInternalDynamicParam
     (fns : List FunctionSpec) : Option (String × String × ParamType) :=
@@ -117,6 +122,7 @@ def validateInternalCallShapesInExpr
       validateInternalCallShapesInExpr functions callerName key2
   | Expr.mappingUint _ key =>
       validateInternalCallShapesInExpr functions callerName key
+  | Expr.storageArrayElement _ index
   | Expr.arrayElement _ index =>
       validateInternalCallShapesInExpr functions callerName index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b | Expr.mod a b | Expr.smod a b |
@@ -328,6 +334,7 @@ def validateExternalCallTargetsInExpr
       validateExternalCallTargetsInExpr externals context key
   | Expr.internalCall _ args =>
       validateExternalCallTargetsInExprList externals context args
+  | Expr.storageArrayElement _ index
   | Expr.arrayElement _ index =>
       validateExternalCallTargetsInExpr externals context index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b | Expr.mod a b | Expr.smod a b |

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -79,6 +79,7 @@ def collectExprNames : Expr → List String
   | Expr.arrayLength name => [name]
   | Expr.arrayElement name index => name :: collectExprNames index
   | Expr.storageArrayLength field => [field]
+  | Expr.storageArrayElement field index => field :: collectExprNames index
   | Expr.dynamicBytesEq lhsName rhsName => [lhsName, rhsName]
   | Expr.add a b => collectExprNames a ++ collectExprNames b
   | Expr.sub a b => collectExprNames a ++ collectExprNames b

--- a/Compiler/CompilationModel/ValidationInterop.lean
+++ b/Compiler/CompilationModel/ValidationInterop.lean
@@ -81,6 +81,8 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
   | Expr.mappingUint _ key => validateInteropExpr context key
   | Expr.internalCall _ args =>
       validateInteropExprList context args
+  | Expr.storageArrayElement _ index =>
+      validateInteropExpr context index
   | Expr.arrayElement _ index =>
       validateInteropExpr context index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b | Expr.mod a b | Expr.smod a b |

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -1868,6 +1868,11 @@ private def storageArrayUint256SmokeSpec : CompilationModel := {
       returnType := some FieldType.uint256
       body := [Stmt.return (Expr.storageArrayLength "queue")]
     },
+    { name := "head"
+      params := []
+      returnType := some FieldType.uint256
+      body := [Stmt.return (Expr.storageArrayElement "queue" (Expr.literal 0))]
+    },
     { name := "enqueue"
       params := [{ name := "value", ty := ParamType.uint256 }]
       returnType := none
@@ -2515,6 +2520,9 @@ set_option maxRecDepth 4096 in
     expectCompileToYul "storage uint256[] smoke spec" storageArrayUint256SmokeSpec
   expectTrue "storage uint256[] length lowers to sload(slot)"
     (contains storageArrayUint256Yul "sload(7)")
+  expectTrue "storage uint256[] indexed reads use the checked storage-array helper"
+    ((contains storageArrayUint256Yul checkedStorageArrayElementHelperName) &&
+      (contains storageArrayUint256Yul "function __verity_storage_array_element_checked(slot, index)"))
   expectTrue "storage uint256[] push computes the Solidity base slot and bumps length"
     ((contains storageArrayUint256Yul "mstore(0, 7)") &&
       (contains storageArrayUint256Yul "keccak256(0, 32)") &&

--- a/Compiler/Proofs/IRGeneration/FunctionBody.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody.lean
@@ -38,6 +38,8 @@ def exprBoundNames : Expr → List String
   | .externalCall _ args | .internalCall _ args => exprListBoundNames args
   | .arrayElement name index => name :: exprBoundNames index
   | .arrayLength name => [name]
+  | .storageArrayLength name => [name]
+  | .storageArrayElement name index => name :: exprBoundNames index
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .eq a b
   | .ge a b | .gt a b | .sgt a b | .lt a b | .slt a b | .le a b

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -50,7 +50,8 @@ def exprTouchesUnsupportedContractSurface : Expr → Bool
   | .call _ _ _ _ _ _ _ | .staticcall _ _ _ _ _ _ | .delegatecall _ _ _ _ _ _
   | .calldatasize | .calldataload _ | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
-  | .arrayLength _ | .arrayElement _ _ | .mulDivDown _ _ _ | .mulDivUp _ _ _ | .shl _ _
+  | .arrayLength _ | .arrayElement _ _ | .storageArrayLength _ | .storageArrayElement _ _
+  | .mulDivDown _ _ _ | .mulDivUp _ _ _ | .shl _ _
   | .shr _ _ | .sdiv _ _ | .smod _ _ | .sar _ _ | .signextend _ _ | .sgt _ _ | .slt _ _ => true
 
 mutual

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -121,7 +121,7 @@ Delivery policy for unsupported features:
 | If/else branching | #179 | `Stmt.ite` | `execStmt` mutual recursion |
 | ForEach loops | #179 | `Stmt.forEach` | `execStmtsFuel` + `expandForEach` desugaring |
 | Array/bytes params | #180 | `ParamType.bytes32`, `.array`, `.fixedArray`, `.bytes` | `arrayParams` in `EvalContext` |
-| Storage dynamic arrays | #1571 | `FieldType.dynamicArray`, `Expr.storageArrayLength`, `Stmt.storageArrayPush` / `.storageArrayPop` / `.setStorageArrayElement` | compile-time/Yul lowering only so far; interpreter + proofs still pending |
+| Storage dynamic arrays | #1571 | `FieldType.dynamicArray`, `Expr.storageArrayLength` / `.storageArrayElement`, `Stmt.storageArrayPush` / `.storageArrayPop` / `.setStorageArrayElement` | compile-time/Yul lowering only so far; interpreter + proofs still pending |
 | Internal function calls | #181 | `Stmt.internalCall`, `Expr.internalCall`, `FunctionSpec.isInternal` | Statement + expression evaluation |
 | Multi-mapping types | #154 | `Expr.mapping2`, `Stmt.setMapping2`, `MappingType`, `FieldType.mappingTyped` | `storageMap2`/`storageMapUint` in `ContractState` |
 | Events/logs | #153 | `EventDef`, `EventParam`, `Stmt.emit` | `Event` struct, `emitEvent`, LOG opcodes in codegen |


### PR DESCRIPTION
## Summary
- add `Expr.storageArrayElement` for checked indexed reads from `FieldType.dynamicArray`
- lower storage-array reads through a dedicated Yul helper with Solidity-style bounds checks
- wire the new expression through helper reservation, usage analysis, validation, and smoke coverage

## Why
`#1571` already had length reads and write-side lowering from `#1609`, but it still could not model `queue[i]` reads in the `CompilationModel`. This closes that compile-time/Yul gap with a narrow incremental PR.

## Validation
- `lake build Compiler.CompilationModelFeatureTest`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compilation and validation paths and introduces new storage slot computation logic, so mistakes could generate incorrect Yul or miss reserved-name collisions; changes are scoped and covered by a smoke test.
> 
> **Overview**
> Adds `Expr.storageArrayElement` to the `CompilationModel` DSL and lowers it to Yul via a new `__verity_storage_array_element_checked` helper that performs Solidity-style bounds checks and `keccak256`-based slot computation.
> 
> Wires this new expression through compilation, helper-name reservation/collision checks, scoping/validation/purity/trust-surface analysis, and usage analysis so the helper is emitted only when needed; updates feature tests and roadmap docs to cover indexed storage-array reads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cde68687e4ba0e0a20d1ec730ea66930b12cc7e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->