### PR TITLE
proof: harden storage array support boundary

### DIFF
--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -72,6 +72,7 @@ mutual
     | .setMapping _ _ _ | .setMappingWord _ _ _ _ | .setMappingPackedWord _ _ _ _ _
     | .setMapping2 _ _ _ _ | .setMapping2Word _ _ _ _ _ | .setMappingUint _ _ _
     | .setStructMember _ _ _ _ | .setStructMember2 _ _ _ _ _
+    | .storageArrayPush _ _ | .storageArrayPop _ | .setStorageArrayElement _ _ _
     | .requireError _ _ _ | .revertError _ _ | .returnValues _ | .returnArray _
     | .returnBytes _ | .returnStorageWords _ | .calldatacopy _ _ _
     | .returndataCopy _ _ _ | .revertReturndata | .forEach _ _ _
@@ -171,6 +172,18 @@ theorem SupportedSpec.selectorFunctionReturnsSupported
 
 @[simp] theorem stmtListTouchesUnsupportedContractSurface_nil :
     stmtListTouchesUnsupportedContractSurface [] = false := rfl
+
+@[simp] theorem stmtTouchesUnsupportedContractSurface_storageArrayPush
+    (field : String) (value : Expr) :
+    stmtTouchesUnsupportedContractSurface (.storageArrayPush field value) = true := rfl
+
+@[simp] theorem stmtTouchesUnsupportedContractSurface_storageArrayPop
+    (field : String) :
+    stmtTouchesUnsupportedContractSurface (.storageArrayPop field) = true := rfl
+
+@[simp] theorem stmtTouchesUnsupportedContractSurface_setStorageArrayElement
+    (field : String) (index value : Expr) :
+    stmtTouchesUnsupportedContractSurface (.setStorageArrayElement field index value) = true := rfl
 
 @[simp] theorem selectorDispatchedFunctions_nil :
     selectorDispatchedFunctions

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1042,6 +1042,9 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.IRGeneration.SupportedSpec.selectorFunctionBodySupported
 #print axioms Compiler.Proofs.IRGeneration.SupportedSpec.selectorFunctionReturnsSupported
 #print axioms Compiler.Proofs.IRGeneration.stmtListTouchesUnsupportedContractSurface_nil
+#print axioms Compiler.Proofs.IRGeneration.stmtTouchesUnsupportedContractSurface_storageArrayPush
+#print axioms Compiler.Proofs.IRGeneration.stmtTouchesUnsupportedContractSurface_storageArrayPop
+#print axioms Compiler.Proofs.IRGeneration.stmtTouchesUnsupportedContractSurface_setStorageArrayElement
 #print axioms Compiler.Proofs.IRGeneration.selectorDispatchedFunctions_nil
 -- #print axioms Compiler.Proofs.IRGeneration.counter_noPackedFields  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.counter_noFallback  -- private
@@ -1154,4 +1157,4 @@ import Compiler.Proofs.YulGeneration.Equivalence
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_fuel_goal_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv_and_adequacy
 #print axioms Compiler.Proofs.YulGeneration.ir_yul_function_equiv_from_state_of_stmt_equiv
--- Total: 1026 theorems/lemmas (855 public, 171 private)
+-- Total: 1029 theorems/lemmas (858 public, 171 private)


### PR DESCRIPTION
Part of #1571.

## What changed
- mark `Stmt.storageArrayPush`, `Stmt.storageArrayPop`, and `Stmt.setStorageArrayElement` as explicitly outside the current generic `SupportedSpec` whole-contract Layer 2 fragment
- add `@[simp]` regression theorems so the fail-closed boundary cannot silently drift on future storage-array work
- regenerate `PrintAxioms.lean` so the new public lemmas stay tracked by the axiom audit surface

## Why
The repo already documented that storage dynamic arrays are still outside the generic whole-contract proof theorem. Read-side expressions were correctly excluded, but write-side storage-array statements were missing from `stmtTouchesUnsupportedContractSurface`, which made the explicit support-boundary scan incomplete. This PR makes that boundary accurate and auditable.

## Validation
- `make check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, proof-only changes that tighten the supported-surface scan; may cause previously-accepted specs using storage-array writes to be rejected by the `SupportedSpec` boundary checks.
> 
> **Overview**
> Tightens the `SupportedSpec` contract-surface “unsupported feature” scan by explicitly treating `Stmt.storageArrayPush`, `Stmt.storageArrayPop`, and `Stmt.setStorageArrayElement` as unsupported (fail-closed) operations.
> 
> Adds `@[simp]` regression lemmas asserting these statements always flag as unsupported, and updates `PrintAxioms.lean` to include the new public lemmas in the axiom-audit output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4d11d96247e65e7a6ce4754d9fb58ac41dbaced. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->