### PR TITLE
proof: fail-close typed IR storage array scalar access

### DIFF
--- a/Compiler/TypedIRCompiler.lean
+++ b/Compiler/TypedIRCompiler.lean
@@ -101,7 +101,11 @@ private def ensureTypedIRScalarStorageFieldSupported (fieldName : String) (field
         match context with
         | "Expr.storage" =>
             "use Expr.storageArrayLength or Expr.storageArrayElement instead"
+        | "Expr.storageAddr" =>
+            "use Expr.storageArrayLength or Expr.storageArrayElement instead"
         | "Stmt.setStorage" =>
+            "use Stmt.storageArrayPush, Stmt.storageArrayPop, or Stmt.setStorageArrayElement instead"
+        | "Stmt.setStorageAddr" =>
             "use Stmt.storageArrayPush, Stmt.storageArrayPop, or Stmt.setStorageArrayElement instead"
         | _ =>
             "use storage dynamic-array helpers instead"
@@ -122,6 +126,7 @@ private def compileStorageRead (fields : List Field) (fieldName : String)
       throw s!"Typed IR compile error: unknown storage field '{fieldName}'"
   | some (field, slot) =>
       if requireAddressField then
+        ensureTypedIRScalarStorageFieldSupported fieldName field "Expr.storageAddr"
         match field.ty with
         | .address => ensureTypedIRAddressFieldSupported fieldName field
         | _ =>
@@ -295,6 +300,7 @@ private def compileStmt (fields : List Field) : Stmt → CompileM Unit
       | none =>
           throw s!"Typed IR compile error: unknown storage field '{fieldName}'"
       | some (field, slot) =>
+          liftExcept <| ensureTypedIRScalarStorageFieldSupported fieldName field "Stmt.setStorageAddr"
           match (← fieldTypeToTy field.ty), rhs with
           | Ty.address, ⟨Ty.address, expr⟩ => do
               liftExcept <| ensureTypedIRAddressFieldSupported fieldName field

--- a/Contracts/TypedIRTests.lean
+++ b/Contracts/TypedIRTests.lean
@@ -239,11 +239,30 @@ def compileStorageRejectsDynamicArrayField : Bool :=
   | .error msg =>
       msg = "Typed IR compile error: storage field 'queue' is a storage dynamic array; use Expr.storageArrayLength or Expr.storageArrayElement instead"
 
+def compileStorageAddrRejectsDynamicArrayField : Bool :=
+  let fields : List Compiler.CompilationModel.Field :=
+    [{ name := "queue", ty := Compiler.CompilationModel.FieldType.dynamicArray .uint256 }]
+  match (compileStmts fields
+      [Compiler.CompilationModel.Stmt.return
+        (Compiler.CompilationModel.Expr.storageAddr "queue")]).run {} with
+  | .ok _ => false
+  | .error msg =>
+      msg = "Typed IR compile error: storage field 'queue' is a storage dynamic array; use Expr.storageArrayLength or Expr.storageArrayElement instead"
+
 def compileSetStorageRejectsDynamicArrayField : Bool :=
   let fields : List Compiler.CompilationModel.Field :=
     [{ name := "queue", ty := Compiler.CompilationModel.FieldType.dynamicArray .uint256 }]
   match (compileStmts fields
       [Compiler.CompilationModel.Stmt.setStorage "queue" (Compiler.CompilationModel.Expr.literal 1)]).run {} with
+  | .ok _ => false
+  | .error msg =>
+      msg = "Typed IR compile error: storage field 'queue' is a storage dynamic array; use Stmt.storageArrayPush, Stmt.storageArrayPop, or Stmt.setStorageArrayElement instead"
+
+def compileSetStorageAddrRejectsDynamicArrayField : Bool :=
+  let fields : List Compiler.CompilationModel.Field :=
+    [{ name := "queue", ty := Compiler.CompilationModel.FieldType.dynamicArray .uint256 }]
+  match (compileStmts fields
+      [Compiler.CompilationModel.Stmt.setStorageAddr "queue" Compiler.CompilationModel.Expr.caller]).run {} with
   | .ok _ => false
   | .error msg =>
       msg = "Typed IR compile error: storage field 'queue' is a storage dynamic array; use Stmt.storageArrayPush, Stmt.storageArrayPop, or Stmt.setStorageArrayElement instead"
@@ -392,8 +411,14 @@ example : compileSetStorageAddrRejectsPackedAddressField = true := by native_dec
 /-- Typed-IR rejects scalar-style reads from storage dynamic arrays. -/
 example : compileStorageRejectsDynamicArrayField = true := by native_decide
 
+/-- Typed-IR rejects address-style reads from storage dynamic arrays. -/
+example : compileStorageAddrRejectsDynamicArrayField = true := by native_decide
+
 /-- Typed-IR rejects scalar-style writes to storage dynamic arrays. -/
 example : compileSetStorageRejectsDynamicArrayField = true := by native_decide
+
+/-- Typed-IR rejects address-style writes to storage dynamic arrays. -/
+example : compileSetStorageAddrRejectsDynamicArrayField = true := by native_decide
 
 /-- Yul address-field reads preserve packed masking when the field is sub-word. -/
 example : compileYulStorageAddrMasksPackedAddressField = true := by native_decide


### PR DESCRIPTION
Part of #1571.

## Summary
- fail closed in the typed-IR compiler when `Expr.storage` or `Stmt.setStorage` target a `FieldType.dynamicArray`
- return explicit diagnostics that point callers to the first-class storage-array operations instead of silently treating the length slot like scalar storage
- add typed-IR regression coverage for both the read and write rejection paths

## Why
`FieldType.dynamicArray` already has dedicated `CompilationModel` operations (`storageArrayLength`, `storageArrayElement`, `storageArrayPush`, `storageArrayPop`, `setStorageArrayElement`).
The typed-IR compiler was still accepting scalar-style `Expr.storage` / `Stmt.setStorage` on those fields, which risks proof/compiler boundary drift by compiling the array length slot as if it were ordinary scalar storage.

## Validation
- `git diff --check`
- attempted narrow Lean validation on the touched typed-IR surface

## Notes
Repo-local Lake builds are currently blocked by pre-existing unrelated proof failures on `main` in multiple `Contracts/*/Proofs/Basic.lean` files that have not been updated for `ContractState.storageArray`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiler behavior by turning previously-accepted scalar-style dynamic-array storage access into hard errors, which may break existing models that relied on the old (incorrect) behavior.
> 
> **Overview**
> **Typed IR compilation now fail-closes on `FieldType.dynamicArray` when accessed via scalar storage ops.** The compiler adds `ensureTypedIRScalarStorageFieldSupported` and wires it into `Expr.storage`, `Expr.storageAddr`, `Stmt.setStorage`, and `Stmt.setStorageAddr`, returning targeted diagnostics that point callers to the dedicated storage-array operations.
> 
> Adds regression tests asserting these read/write rejection paths and exact error messages in `Contracts/TypedIRTests.lean`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9da5be6bdcf906381b6e7480696786dd0c58825. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->