### PR TITLE
proof: fail-close spec frames on storage arrays

### DIFF
--- a/Contracts/Counter/Proofs/Basic.lean
+++ b/Contracts/Counter/Proofs/Basic.lean
@@ -67,7 +67,7 @@ theorem increment_meets_spec (s : ContractState) :
   · simp [increment, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind]
   · intro other h_neq
     simp [increment, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind, h_neq]
-  · simp [Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameContext, increment, count,
+  · simp [Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext, increment, count,
       getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind]
 
 theorem increment_adds_one (s : ContractState) :
@@ -85,7 +85,7 @@ theorem decrement_meets_spec (s : ContractState) :
   · simp [decrement, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind]
   · intro other h_neq
     simp [decrement, count, getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind, h_neq]
-  · simp [Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameContext, decrement, count,
+  · simp [Specs.sameStorageAddr, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext, decrement, count,
       getStorage, setStorage, Contract.run, ContractResult.snd, Verity.bind, Bind.bind]
 
 theorem decrement_subtracts_one (s : ContractState) :

--- a/Contracts/ERC20/Proofs/Basic.lean
+++ b/Contracts/ERC20/Proofs/Basic.lean
@@ -23,7 +23,7 @@ private def constructorCompat (initialOwner : Address) : Contract Unit := do
 /-- `constructor` sets owner slot 0 and initializes supply slot 1. -/
 theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
     constructor_spec initialOwner s ((constructorCompat initialOwner).runState s) := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · simp [constructorCompat, ownerSlot, setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
   · simp [constructorCompat, totalSupplySlot, setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind]
   · intro slotIdx h_neq
@@ -35,6 +35,8 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   · simp [Specs.sameStorageMap, constructorCompat, ownerSlot, totalSupplySlot, setStorageAddr, setStorage,
       Contract.runState, Verity.bind, Bind.bind]
   · simp [Specs.sameStorageMap2, constructorCompat, ownerSlot, totalSupplySlot, setStorageAddr, setStorage,
+      Contract.runState, Verity.bind, Bind.bind]
+  · simp [Specs.sameStorageArray, constructorCompat, ownerSlot, totalSupplySlot, setStorageAddr, setStorage,
       Contract.runState, Verity.bind, Bind.bind]
   · simp [Specs.sameContext, constructorCompat, ownerSlot, totalSupplySlot, setStorageAddr, setStorage,
       Contract.runState, Verity.bind, Bind.bind]
@@ -53,7 +55,8 @@ theorem approve_meets_spec (s : ContractState) (spender : Address) (amount : Uin
     · intro sp' h_neq
       simp [approve, allowancesSlot, setMapping2, msgSender, Contract.runState, Verity.bind, Bind.bind,
         h_neq]
-  · refine ⟨?_, ?_, ?_, ?_⟩
+  · refine ⟨?_, ?_, ?_, ?_, ?_⟩
+    · rfl
     · rfl
     · rfl
     · rfl
@@ -95,9 +98,10 @@ private theorem mint_unfold (s : ContractState) (to : Address) (amount : Uint256
         storageAddr := s.storageAddr,
         storageMap := fun slotIdx addr =>
           if (slotIdx == 2 && addr == to) = true then EVM.Uint256.add (s.storageMap 2 to) amount
-          else s.storageMap slotIdx addr,
+        else s.storageMap slotIdx addr,
         storageMapUint := s.storageMapUint,
         storageMap2 := s.storageMap2,
+        storageArray := s.storageArray,
         sender := s.sender,
         thisAddress := s.thisAddress,
         msgValue := s.msgValue,
@@ -129,7 +133,7 @@ theorem mint_meets_spec_when_owner (s : ContractState) (to : Address) (amount : 
   have h_unfold_apply := Contract.eq_of_run_success h_unfold
   simp only [Contract.runState, mint_spec]
   rw [h_unfold_apply]
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · simp
   · simp
   · refine ⟨?_, ?_⟩
@@ -139,6 +143,7 @@ theorem mint_meets_spec_when_owner (s : ContractState) (to : Address) (amount : 
       simp [h_ne]
   · intro slotIdx h_ne
     simp [h_ne]
+  · rfl
   · rfl
   · rfl
   · exact Specs.sameContext_rfl _
@@ -182,9 +187,10 @@ private theorem transfer_unfold_other (s : ContractState) (to : Address) (amount
         storageMap := fun slotIdx addr =>
           if (slotIdx == 2 && addr == to) = true then EVM.Uint256.add (s.storageMap 2 to) amount
           else if (slotIdx == 2 && addr == s.sender) = true then EVM.Uint256.sub (s.storageMap 2 s.sender) amount
-          else s.storageMap slotIdx addr,
+        else s.storageMap slotIdx addr,
         storageMapUint := s.storageMapUint,
         storageMap2 := s.storageMap2,
+        storageArray := s.storageArray,
         sender := s.sender,
         thisAddress := s.thisAddress,
         msgValue := s.msgValue,
@@ -216,7 +222,7 @@ theorem transfer_meets_spec_when_sufficient (s : ContractState) (to : Address) (
     have h_unfold_apply := Contract.eq_of_run_success h_unfold
     simp only [Contract.runState, transfer_spec]
     rw [h_unfold_apply]
-    refine ⟨h_balance, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    refine ⟨h_balance, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
     · simp [h_eq]
     · simp [h_eq]
     · simp [h_eq, Specs.storageMapUnchangedExceptKeyAtSlot,
@@ -224,13 +230,14 @@ theorem transfer_meets_spec_when_sufficient (s : ContractState) (to : Address) (
     · trivial
     · trivial
     · rfl
+    · rfl
     · exact Specs.sameContext_rfl _
   · have h_unfold := transfer_unfold_other s to amount h_balance h_eq (h_no_overflow h_eq)
     have h_unfold_apply := Contract.eq_of_run_success h_unfold
     simp only [Contract.runState, transfer_spec]
     rw [h_unfold_apply]
     have h_ne' := address_beq_false_of_ne s.sender to h_eq
-    refine ⟨h_balance, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    refine ⟨h_balance, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
     · simp [h_ne']
     · simp [h_ne']
     · simp [h_ne']
@@ -241,6 +248,7 @@ theorem transfer_meets_spec_when_sufficient (s : ContractState) (to : Address) (
         simp [h_neq]
     · trivial
     · trivial
+    · rfl
     · rfl
     · exact Specs.sameContext_rfl _
 

--- a/Contracts/ERC721/Proofs/Basic.lean
+++ b/Contracts/ERC721/Proofs/Basic.lean
@@ -36,7 +36,8 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
     simp [Contracts.ERC721.«constructor», Contracts.ERC721.owner,
       Contracts.ERC721.totalSupply, Contracts.ERC721.nextTokenId,
       setStorageAddr, setStorage, Contract.runState, Verity.bind, Bind.bind, h_slot1, h_slot2]
-  · refine ⟨?_, ?_, ?_, ?_⟩
+  · refine ⟨?_, ?_, ?_, ?_, ?_⟩
+    · rfl
     · rfl
     · rfl
     · rfl
@@ -95,7 +96,7 @@ theorem setApprovalForAll_meets_spec (s : ContractState) (operator : Address) (a
       simp [Contracts.ERC721.setApprovalForAll, Contracts.ERC721.operatorApprovals,
         setMapping2,
         msgSender, Contract.runState, Verity.bind, Bind.bind, h_neq]
-  · refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
     · simp [Specs.sameStorage, Contracts.ERC721.setApprovalForAll, Contracts.ERC721.operatorApprovals,
       setMapping2,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
@@ -106,6 +107,9 @@ theorem setApprovalForAll_meets_spec (s : ContractState) (operator : Address) (a
       setMapping2,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
     · simp [Specs.sameStorageMapUint, Contracts.ERC721.setApprovalForAll,
+      Contracts.ERC721.operatorApprovals, setMapping2,
+      msgSender, Contract.runState, Verity.bind, Bind.bind]
+    · simp [Specs.sameStorageArray, Contracts.ERC721.setApprovalForAll,
       Contracts.ERC721.operatorApprovals, setMapping2,
       msgSender, Contract.runState, Verity.bind, Bind.bind]
     · simp [Specs.sameContext, Contracts.ERC721.setApprovalForAll,

--- a/Contracts/Ledger/Invariants.lean
+++ b/Contracts/Ledger/Invariants.lean
@@ -20,6 +20,6 @@ abbrev context_preserved := Specs.sameContext
 
 /-- Non-mapping storage unchanged by all Ledger operations -/
 abbrev non_mapping_storage_unchanged (s s' : ContractState) :=
-  Specs.sameStorage s s' ∧ Specs.sameStorageAddr s s'
+  Specs.sameStorage s s' ∧ Specs.sameStorageAddr s s' ∧ Specs.sameStorageArray s s'
 
 end Contracts.Ledger.Invariants

--- a/Contracts/Ledger/Proofs/Basic.lean
+++ b/Contracts/Ledger/Proofs/Basic.lean
@@ -55,6 +55,7 @@ private theorem deposit_unfold (s : ContractState) (amount : Uint256) :
         else s.storageMap slotIdx addr,
       storageMapUint := s.storageMapUint,
       storageMap2 := s.storageMap2,
+      storageArray := s.storageArray,
       sender := s.sender,
       thisAddress := s.thisAddress,
       msgValue := s.msgValue,
@@ -80,7 +81,7 @@ theorem deposit_meets_spec (s : ContractState) (amount : Uint256) :
       simp [ContractResult.snd, beq_iff_eq, h_ne]
     · intro slotIdx h_ne addr
       simp [ContractResult.snd, beq_iff_eq, h_ne]
-  · exact ⟨rfl, rfl, Specs.sameContext_rfl _⟩
+  · exact ⟨rfl, rfl, rfl, Specs.sameContext_rfl _⟩
 
 theorem deposit_increases_balance (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd
@@ -107,6 +108,7 @@ private theorem withdraw_unfold (s : ContractState) (amount : Uint256)
         else s.storageMap slotIdx addr,
       storageMapUint := s.storageMapUint,
       storageMap2 := s.storageMap2,
+      storageArray := s.storageArray,
       sender := s.sender,
       thisAddress := s.thisAddress,
       msgValue := s.msgValue,
@@ -133,7 +135,7 @@ theorem withdraw_meets_spec (s : ContractState) (amount : Uint256)
       simp [ContractResult.snd, beq_iff_eq, h_ne]
     · intro slotIdx h_ne addr
       simp [ContractResult.snd, beq_iff_eq, h_ne]
-  · exact ⟨rfl, rfl, Specs.sameContext_rfl _⟩
+  · exact ⟨rfl, rfl, rfl, Specs.sameContext_rfl _⟩
 
 theorem withdraw_decreases_balance (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
@@ -173,6 +175,7 @@ private theorem transfer_unfold_other (s : ContractState) (to : Address) (amount
         else s.storageMap slotIdx addr,
       storageMapUint := s.storageMapUint,
       storageMap2 := s.storageMap2,
+      storageArray := s.storageArray,
       sender := s.sender,
       thisAddress := s.thisAddress,
       msgValue := s.msgValue,
@@ -205,7 +208,7 @@ theorem transfer_meets_spec (s : ContractState) (to : Address) (amount : Uint256
     · simp [h_eq]
     · simp [h_eq, Specs.storageMapUnchangedExceptKeyAtSlot,
         Specs.storageMapUnchangedExceptKey, Specs.storageMapUnchangedExceptSlot]
-    · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameContext]
+    · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray, Specs.sameContext]
   · rw [transfer_unfold_other s to amount h_balance h_eq]
     simp only [ContractResult.snd, transfer_spec]
     have h_ne' := address_beq_false_of_ne s.sender to h_eq
@@ -218,7 +221,7 @@ theorem transfer_meets_spec (s : ContractState) (to : Address) (amount : Uint256
         simp [h_ne_sender, h_ne_to]
       · intro slotIdx h_slot addr
         simp [h_slot]
-    · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameContext]
+    · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray, Specs.sameContext]
 
 theorem transfer_self_preserves_balance (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
@@ -270,6 +273,7 @@ theorem transfer_succeeds_recipient_overflow (s : ContractState) (to : Address) 
         else s.storageMap slotIdx addr,
       storageMapUint := s.storageMapUint,
       storageMap2 := s.storageMap2,
+      storageArray := s.storageArray,
       sender := s.sender,
       thisAddress := s.thisAddress,
       msgValue := s.msgValue,
@@ -289,14 +293,14 @@ theorem deposit_preserves_non_mapping (s : ContractState) (amount : Uint256) :
   let s' := ((deposit amount).run s).snd
   non_mapping_storage_unchanged s s' := by
   rw [deposit_unfold]
-  simp [ContractResult.snd, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr]
+  simp [ContractResult.snd, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray]
 
 theorem withdraw_preserves_non_mapping (s : ContractState) (amount : Uint256)
   (h_balance : s.storageMap 0 s.sender >= amount) :
   let s' := ((withdraw amount).run s).snd
   non_mapping_storage_unchanged s s' := by
   rw [withdraw_unfold s amount h_balance]
-  simp [ContractResult.snd, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr]
+  simp [ContractResult.snd, non_mapping_storage_unchanged, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray]
 
 theorem deposit_preserves_wellformedness (s : ContractState) (amount : Uint256)
   (h : WellFormedState s) :

--- a/Contracts/Owned/Proofs/Basic.lean
+++ b/Contracts/Owned/Proofs/Basic.lean
@@ -71,7 +71,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   · intro slotIdx h_neq
     simp [owner, h_neq]
   · simp [owner, Specs.sameStorageMapContext,
-      Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
+      Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
@@ -128,6 +128,7 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
       storageMap := s.storageMap,
       storageMapUint := s.storageMapUint,
       storageMap2 := s.storageMap2,
+      storageArray := s.storageArray,
       sender := s.sender,
       thisAddress := s.thisAddress,
       msgValue := s.msgValue,
@@ -150,7 +151,7 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   · intro slotIdx h_neq
     simp [ContractResult.snd, h_neq]
   · simp [ContractResult.snd, Specs.sameStorageMapContext,
-      Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
+      Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem transferOwnership_changes_owner_when_allowed (s : ContractState) (newOwner : Address)
   (h_is_owner : s.sender = s.storageAddr 0) :
@@ -176,7 +177,7 @@ theorem constructor_preserves_wellformedness (s : ContractState) (initialOwner :
   WellFormedState s' := by
   have h_spec := constructor_meets_spec s initialOwner
   rcases h_spec with ⟨h_owner_set, _h_other_addr, h_same⟩
-  rcases h_same with ⟨_h_storage, _h_map, h_ctx⟩
+  rcases h_same with ⟨_h_storage, _h_map, _h_array, h_ctx⟩
   have h_sender := h_ctx.1
   have h_this := h_ctx.2.1
   exact ⟨h_sender ▸ h.sender_nonzero, h_this ▸ h.contract_nonzero, h_owner_set ▸ h_owner⟩

--- a/Contracts/OwnedCounter/Proofs/Basic.lean
+++ b/Contracts/OwnedCounter/Proofs/Basic.lean
@@ -44,7 +44,7 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
   · intro slotIdx h_neq
     simp [setStorageAddr, owner, Contract.run, ContractResult.snd, h_neq]
   · simp [setStorageAddr, owner, Contract.run, ContractResult.snd,
-      Specs.sameStorageMapContext, Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
+      Specs.sameStorageMapContext, Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((setStorageAddr owner initialOwner).run s).snd
@@ -117,6 +117,7 @@ theorem increment_unfold (s : ContractState)
       storageMap := s.storageMap,
       storageMapUint := s.storageMapUint,
       storageMap2 := s.storageMap2,
+      storageArray := s.storageArray,
       sender := s.sender,
       thisAddress := s.thisAddress,
       msgValue := s.msgValue,
@@ -138,7 +139,7 @@ theorem increment_meets_spec_when_owner (s : ContractState)
   · intro slotIdx h_neq
     simp [ContractResult.snd, h_neq]
   · simp [ContractResult.snd, Specs.sameAddrMapContext, Specs.sameStorageAddr,
-      Specs.sameStorageMap, Specs.sameContext]
+      Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem increment_adds_one_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -164,6 +165,7 @@ theorem decrement_unfold (s : ContractState)
       storageMap := s.storageMap,
       storageMapUint := s.storageMapUint,
       storageMap2 := s.storageMap2,
+      storageArray := s.storageArray,
       sender := s.sender,
       thisAddress := s.thisAddress,
       msgValue := s.msgValue,
@@ -185,7 +187,7 @@ theorem decrement_meets_spec_when_owner (s : ContractState)
   · intro slotIdx h_neq
     simp [ContractResult.snd, h_neq]
   · simp [ContractResult.snd, Specs.sameAddrMapContext, Specs.sameStorageAddr,
-      Specs.sameStorageMap, Specs.sameContext]
+      Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem decrement_subtracts_one_when_owner (s : ContractState)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -210,6 +212,7 @@ theorem transferOwnership_unfold (s : ContractState) (newOwner : Address)
       storageMap := s.storageMap,
       storageMapUint := s.storageMapUint,
       storageMap2 := s.storageMap2,
+      storageArray := s.storageArray,
       sender := s.sender,
       thisAddress := s.thisAddress,
       msgValue := s.msgValue,
@@ -231,7 +234,7 @@ theorem transferOwnership_meets_spec_when_owner (s : ContractState) (newOwner : 
   · intro slotIdx h_neq
     simp [ContractResult.snd, h_neq]
   · simp [ContractResult.snd, Specs.sameStorageMapContext,
-      Specs.sameStorage, Specs.sameStorageMap, Specs.sameContext]
+      Specs.sameStorage, Specs.sameStorageMap, Specs.sameStorageArray, Specs.sameContext]
 
 theorem transferOwnership_changes_owner (s : ContractState) (newOwner : Address)
   (h_owner : s.sender = s.storageAddr 0) :
@@ -277,7 +280,7 @@ theorem constructor_preserves_wellformedness (s : ContractState) (initialOwner :
   WellFormedState s' := by
   have h_spec := constructor_meets_spec s initialOwner
   rcases h_spec with ⟨h_set, _h_other_addr, h_same⟩
-  rcases h_same with ⟨_h_storage, _h_map, h_ctx⟩
+  rcases h_same with ⟨_h_storage, _h_map, _h_array, h_ctx⟩
   exact ⟨h_ctx.1 ▸ h.sender_nonzero, h_ctx.2.1 ▸ h.contract_nonzero, h_set ▸ h_owner⟩
 
 theorem increment_preserves_wellformedness (s : ContractState)

--- a/Contracts/SafeCounter/Proofs/Basic.lean
+++ b/Contracts/SafeCounter/Proofs/Basic.lean
@@ -81,9 +81,10 @@ theorem increment_meets_spec (s : ContractState)
   increment_spec s s' := by
   rw [increment_unfold s h_no_overflow]
   simp only [ContractResult.snd, increment_spec]
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · simp [evm_add_eq_of_no_overflow (s.storage 0) 1 h_no_overflow]
   · intro k h_ne; simp [beq_iff_eq, h_ne]
+  · rfl
   · rfl
   · rfl
   · exact Specs.sameContext_rfl _
@@ -141,9 +142,10 @@ theorem decrement_meets_spec (s : ContractState)
   decrement_spec s s' := by
   rw [decrement_unfold s h_no_underflow]
   simp only [ContractResult.snd, decrement_spec]
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · simp [HSub.hSub, sub]
   · intro k h_ne; simp [beq_iff_eq, h_ne]
+  · rfl
   · rfl
   · rfl
   · exact Specs.sameContext_rfl _

--- a/Contracts/SimpleStorage/Proofs/Basic.lean
+++ b/Contracts/SimpleStorage/Proofs/Basic.lean
@@ -77,7 +77,7 @@ theorem store_meets_spec (s : ContractState) (value : Uint256) :
   · simp [storedData]
   · intro slotIdx h_neq
     simp [storedData, h_neq]
-  · simp [Specs.sameAddrMapContext, Specs.sameStorageAddr,
+  · simp [Specs.sameAddrMapContext, Specs.sameStorageAddr, Specs.sameStorageArray,
       Specs.sameStorageMap, Specs.sameContext]
 
 -- Main theorem: retrieve meets its specification

--- a/Contracts/SimpleToken/Proofs/Basic.lean
+++ b/Contracts/SimpleToken/Proofs/Basic.lean
@@ -111,9 +111,11 @@ theorem constructor_meets_spec (s : ContractState) (initialOwner : Address) :
     · rfl
   · rfl
   ·
-    verity_unfold simpleTokenConstructor
-    simp [Specs.sameContext, Contracts.SimpleToken.ownerSlot,
-      Contracts.SimpleToken.totalSupplySlot]
+    refine ⟨?_, ?_⟩
+    · rfl
+    ·
+      verity_unfold simpleTokenConstructor
+      simp [Specs.sameContext, Contracts.SimpleToken.ownerSlot, Contracts.SimpleToken.totalSupplySlot]
 
 theorem constructor_sets_owner (s : ContractState) (initialOwner : Address) :
   let s' := ((simpleTokenConstructor initialOwner).run s).snd
@@ -196,16 +198,15 @@ theorem mint_meets_spec_when_owner (s : ContractState) (to : Address) (amount : 
   simp only [Contract.run, ContractResult.snd, mint_spec]
   rw [h_unfold_apply]
   simp only [ContractResult.snd]
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   · simp -- balance of 'to' updated
   · simp -- supply updated
   · refine ⟨?_, ?_⟩
     · intro addr h_neq; simp [h_neq] -- other balances preserved
     · intro slotIdx h_neq; intro addr; simp [h_neq] -- other mapping slots
   · intro slotIdx h_neq; simp [h_neq] -- other uint storage
-  · refine ⟨?_, ?_⟩
-    · trivial -- owner preserved
-    · exact Specs.sameContext_rfl _
+  · trivial -- owner preserved
+  · exact Specs.sameContext_rfl _
 
 theorem mint_increases_balance (s : ContractState) (to : Address) (amount : Uint256)
   (h_owner : s.sender = s.storageAddr 0)
@@ -334,7 +335,7 @@ theorem transfer_meets_spec_when_sufficient (s : ContractState) (to : Address) (
     · simp [h_eq, beq_iff_eq, Specs.storageMapUnchangedExceptKeyAtSlot,
         Specs.storageMapUnchangedExceptKey, Specs.storageMapUnchangedExceptSlot]
     · rfl
-    · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameContext]
+    · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray, Specs.sameContext]
   · have h_unfold := transfer_unfold_other s to amount h_balance h_eq (h_no_overflow h_eq)
     have h_unfold_apply := Contract.eq_of_run_success h_unfold
     simp only [Contract.run, ContractResult.snd, transfer_spec]
@@ -350,7 +351,7 @@ theorem transfer_meets_spec_when_sufficient (s : ContractState) (to : Address) (
       · intro slotIdx h_neq addr'; simp [h_neq]
     · -- owner preserved
       trivial
-    · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameContext]
+    · simp [Specs.sameStorageAddrContext, Specs.sameStorage, Specs.sameStorageAddr, Specs.sameStorageArray, Specs.sameContext]
 
 theorem transfer_preserves_supply_when_sufficient (s : ContractState) (to : Address) (amount : Uint256)
   (h_balance : s.storageMap 1 s.sender ≥ amount)
@@ -488,7 +489,7 @@ theorem constructor_preserves_wellformedness (s : ContractState) (initialOwner :
   WellFormedState s' := by
   have h_spec := constructor_meets_spec s initialOwner
   simp [constructor_spec] at h_spec
-  obtain ⟨h_owner_set, h_supply_set, h_other_addr, h_other_uint, h_map, h_sender, h_this, _h_value, _h_time⟩ := h_spec
+  obtain ⟨h_owner_set, h_supply_set, h_other_addr, h_other_uint, h_map, _h_array, h_sender, h_this, _h_value, _h_time⟩ := h_spec
   exact ⟨h_sender ▸ h.sender_nonzero, h_this ▸ h.contract_nonzero, h_owner_set ▸ h_owner⟩
 
 theorem balanceOf_preserves_wellformedness (s : ContractState) (addr : Address) (h : WellFormedState s) :

--- a/Verity/Specs/Common.lean
+++ b/Verity/Specs/Common.lean
@@ -69,6 +69,12 @@ def sameStorageMap2 (s s' : ContractState) : Prop :=
 
 @[simp] theorem sameStorageMap2_rfl (s : ContractState) : sameStorageMap2 s s := rfl
 
+/-- Dynamic-array storage is unchanged. -/
+def sameStorageArray (s s' : ContractState) : Prop :=
+  s'.storageArray = s.storageArray
+
+@[simp] theorem sameStorageArray_rfl (s : ContractState) : sameStorageArray s s := rfl
+
 /-- Event log is unchanged. -/
 def sameEvents (s s' : ContractState) : Prop :=
   s'.events = s.events
@@ -85,45 +91,50 @@ def sameKnownAddresses (s s' : ContractState) : Prop :=
 def sameAddrMapContext (s s' : ContractState) : Prop :=
   sameStorageAddr s s' ∧
   sameStorageMap s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameAddrMapContext_rfl (s : ContractState) : sameAddrMapContext s s :=
-  ⟨rfl, rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
 
 /-- Uint256 storage, mapping storage, and context are unchanged. -/
 def sameStorageMapContext (s s' : ContractState) : Prop :=
   sameStorage s s' ∧
   sameStorageMap s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameStorageMapContext_rfl (s : ContractState) : sameStorageMapContext s s :=
-  ⟨rfl, rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
 
 /-- Uint256 storage, address storage, and context are unchanged. -/
 def sameStorageAddrContext (s s' : ContractState) : Prop :=
   sameStorage s s' ∧
   sameStorageAddr s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameStorageAddrContext_rfl (s : ContractState) : sameStorageAddrContext s s :=
-  ⟨rfl, rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
 
 /-- Mapping storage, double-mapping storage, and context are unchanged. -/
 def sameStorageMap2Context (s s' : ContractState) : Prop :=
   sameStorageMap s s' ∧
   sameStorageMap2 s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameStorageMap2Context_rfl (s : ContractState) : sameStorageMap2Context s s :=
-  ⟨rfl, rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
 
 /-- Mapping storage and context are unchanged. -/
 def sameMapContext (s s' : ContractState) : Prop :=
   sameStorageMap s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameMapContext_rfl (s : ContractState) : sameMapContext s s :=
-  ⟨rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, sameContext_rfl s⟩
 
 /-- One address slot and context are unchanged. -/
 def sameStorageAddrSlotContext (addrSlot : Nat) (s s' : ContractState) : Prop :=
@@ -138,11 +149,12 @@ def sameStorageAddrSlotContext (addrSlot : Nat) (s s' : ContractState) : Prop :=
 def sameStorageAddrSlotMap2Context (addrSlot : Nat) (s s' : ContractState) : Prop :=
   sameStorageAddrSlot addrSlot s s' ∧
   sameStorageMap2 s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameStorageAddrSlotMap2Context_rfl (addrSlot : Nat) (s : ContractState) :
     sameStorageAddrSlotMap2Context addrSlot s s :=
-  ⟨rfl, rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
 
 /-- One Uint256 slot, one address slot, double-mapping storage, and context are unchanged. -/
 def sameStorageSlotAddrSlotMap2Context
@@ -150,22 +162,24 @@ def sameStorageSlotAddrSlotMap2Context
   sameStorageSlot storageSlot s s' ∧
   sameStorageAddrSlot addrSlot s s' ∧
   sameStorageMap2 s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameStorageSlotAddrSlotMap2Context_rfl
     (storageSlot addrSlot : Nat) (s : ContractState) :
     sameStorageSlotAddrSlotMap2Context storageSlot addrSlot s s :=
-  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, rfl, rfl, sameContext_rfl s⟩
 
 /-- Uint256 storage, address storage, mapping storage, and context are unchanged. -/
 def sameStorageAddrMapContext (s s' : ContractState) : Prop :=
   sameStorage s s' ∧
   sameStorageAddr s s' ∧
   sameStorageMap s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameStorageAddrMapContext_rfl (s : ContractState) : sameStorageAddrMapContext s s :=
-  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, rfl, rfl, sameContext_rfl s⟩
 
 /-- Uint256/address storage, mapping storage (word+uint-keyed), and context are unchanged. -/
 def sameStorageAddrMapUintContext (s s' : ContractState) : Prop :=
@@ -173,20 +187,22 @@ def sameStorageAddrMapUintContext (s s' : ContractState) : Prop :=
   sameStorageAddr s s' ∧
   sameStorageMap s s' ∧
   sameStorageMapUint s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameStorageAddrMapUintContext_rfl (s : ContractState) : sameStorageAddrMapUintContext s s :=
-  ⟨rfl, rfl, rfl, rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, rfl, rfl, rfl, sameContext_rfl s⟩
 
 /-- Mapping storage (word + uint-keyed + double), and context are unchanged. -/
 def sameStorageMapsContext (s s' : ContractState) : Prop :=
   sameStorageMap s s' ∧
   sameStorageMapUint s s' ∧
   sameStorageMap2 s s' ∧
+  sameStorageArray s s' ∧
   sameContext s s'
 
 @[simp] theorem sameStorageMapsContext_rfl (s : ContractState) : sameStorageMapsContext s s :=
-  ⟨rfl, rfl, rfl, sameContext_rfl s⟩
+  ⟨rfl, rfl, rfl, rfl, sameContext_rfl s⟩
 
 /-- All storage slots except `slot` are unchanged. -/
 def storageUnchangedExcept (slot : Nat) (s s' : ContractState) : Prop :=
@@ -367,16 +383,17 @@ def storageMapTransferFromSpec
   storageMap2UnchangedExceptKeyPair allowanceSlot fromAddr spender s s' ∧
   frame s s'
 
-/-- All storage (uint256, addr, map, mapUint, map2) is unchanged. -/
+/-- All storage (uint256, addr, map, mapUint, map2, array) is unchanged. -/
 def sameAllStorage (s s' : ContractState) : Prop :=
   sameStorage s s' ∧
   sameStorageAddr s s' ∧
   sameStorageMap s s' ∧
   sameStorageMapUint s s' ∧
-  sameStorageMap2 s s'
+  sameStorageMap2 s s' ∧
+  sameStorageArray s s'
 
 @[simp] theorem sameAllStorage_rfl (s : ContractState) : sameAllStorage s s :=
-  ⟨rfl, rfl, rfl, rfl, rfl⟩
+  ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 /-- Everything except the event log is unchanged. -/
 def sameExceptEvents (s s' : ContractState) : Prop :=


### PR DESCRIPTION
Part of #1571.

## Summary
- add `Specs.sameStorageArray` and thread storage-array preservation through the shared frame predicates in `Verity.Specs.Common`
- tighten contract proof invariants so non-array operations now fail closed if they drop `ContractState.storageArray`
- update the affected handwritten proof states across the contract proof suite so the stricter frame obligations compile cleanly

## Validation
- `lake build Contracts.Counter.Proofs.Basic Contracts.SimpleStorage.Proofs.Basic Contracts.SafeCounter.Proofs.Basic Contracts.Owned.Proofs.Basic Contracts.OwnedCounter.Proofs.Basic Contracts.Ledger.Proofs.Basic Contracts.ERC20.Proofs.Basic Contracts.ERC721.Proofs.Basic Contracts.SimpleToken.Proofs.Basic`
- `make check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared spec/frame predicates in `Verity.Specs.Common`, so downstream contract specs/proofs may fail or become too strict if any operation legitimately mutates `storageArray`. Changes are proof-level but broad and could cause subtle obligation mismatches across the suite.
> 
> **Overview**
> **Tightens spec framing to fail-closed on `ContractState.storageArray`.** `Verity.Specs.Common` adds `sameStorageArray` and threads it through the standard frame predicates (e.g. `sameAddrMapContext`, `sameStorageMapContext`, `sameAllStorage`), expanding their tuple shapes accordingly.
> 
> Updates the handwritten proof suite (Counter, SafeCounter, SimpleStorage, Owned, OwnedCounter, Ledger, ERC20, ERC721, SimpleToken) to discharge the new frame obligations—typically by asserting `rfl`/`simp` for `sameStorageArray` and ensuring unfolded success states explicitly carry `storageArray := s.storageArray`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 990e2deb109d39567b7dee83ade5102d60999785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->