### PR TITLE
ci: add force_full_run manual verify override

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -65,6 +65,11 @@ on:
         required: false
         default: false
         type: boolean
+      force_full_run:
+        description: 'Bypass change filters and run the full verification workflow for prewarming or manual validation'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -78,6 +83,7 @@ env:
   SOLC_URL: "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21"
   SOLC_SHA256: "1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468"
   VERIFY_CLEAN_BUILD: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_build && 'true' || 'false' }}
+  VERIFY_FORCE_FULL_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.force_full_run && 'true' || 'false' }}
   VERIFY_USE_STICKY_DISKS: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_build && 'false' || 'true' }}
   VERIFY_DISABLE_LAKE_CACHE_RESTORE: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_build && 'true' || 'false' }}
   VERIFY_CACHE_BUCKET: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref_name) }}
@@ -87,10 +93,10 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     outputs:
-      code: ${{ steps.filter.outputs.code }}
-      build: ${{ steps.filter.outputs.build }}
-      compiler: ${{ steps.filter.outputs.compiler }}
-      macro_fuzz: ${{ steps.filter.outputs.macro_fuzz }}
+      code: ${{ steps.effective.outputs.code }}
+      build: ${{ steps.effective.outputs.build }}
+      compiler: ${{ steps.effective.outputs.compiler }}
+      macro_fuzz: ${{ steps.effective.outputs.macro_fuzz }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -167,6 +173,33 @@ jobs:
               - 'lakefile.lean'
               - 'lake-manifest.json'
               - 'lean-toolchain'
+      - name: Resolve effective change flags
+        id: effective
+        env:
+          FORCE_FULL_RUN: ${{ env.VERIFY_FORCE_FULL_RUN }}
+          CODE_CHANGED: ${{ steps.filter.outputs.code }}
+          BUILD_CHANGED: ${{ steps.filter.outputs.build }}
+          COMPILER_CHANGED: ${{ steps.filter.outputs.compiler }}
+          MACRO_FUZZ_CHANGED: ${{ steps.filter.outputs.macro_fuzz }}
+        run: |
+          if [ "$FORCE_FULL_RUN" = "true" ]; then
+            code=true
+            build=true
+            compiler=true
+            macro_fuzz=true
+          else
+            code="$CODE_CHANGED"
+            build="$BUILD_CHANGED"
+            compiler="$COMPILER_CHANGED"
+            macro_fuzz="$MACRO_FUZZ_CHANGED"
+          fi
+
+          {
+            echo "code=$code"
+            echo "build=$build"
+            echo "compiler=$compiler"
+            echo "macro_fuzz=$macro_fuzz"
+          } >> "$GITHUB_OUTPUT"
 
   checks:
     runs-on: blacksmith-2vcpu-ubuntu-2404

--- a/scripts/verify_sync_spec.json
+++ b/scripts/verify_sync_spec.json
@@ -242,10 +242,10 @@
   },
   "expected_job_outputs": {
     "changes": {
-      "code": "${{ steps.filter.outputs.code }}",
-      "build": "${{ steps.filter.outputs.build }}",
-      "compiler": "${{ steps.filter.outputs.compiler }}",
-      "macro_fuzz": "${{ steps.filter.outputs.macro_fuzz }}"
+      "code": "${{ steps.effective.outputs.code }}",
+      "build": "${{ steps.effective.outputs.build }}",
+      "compiler": "${{ steps.effective.outputs.compiler }}",
+      "macro_fuzz": "${{ steps.effective.outputs.macro_fuzz }}"
     }
   },
   "expected_job_permissions": {
@@ -270,6 +270,7 @@
     "SOLC_URL": "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21",
     "SOLC_SHA256": "1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468",
     "VERIFY_CLEAN_BUILD": "${{ github.event_name == 'workflow_dispatch' && inputs.clean_build && 'true' || 'false' }}",
+    "VERIFY_FORCE_FULL_RUN": "${{ github.event_name == 'workflow_dispatch' && inputs.force_full_run && 'true' || 'false' }}",
     "VERIFY_USE_STICKY_DISKS": "${{ github.event_name == 'workflow_dispatch' && inputs.clean_build && 'false' || 'true' }}",
     "VERIFY_DISABLE_LAKE_CACHE_RESTORE": "${{ github.event_name == 'workflow_dispatch' && inputs.clean_build && 'true' || 'false' }}",
     "VERIFY_CACHE_BUCKET": "${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref_name) }}"
@@ -288,6 +289,18 @@
       {
         "id": "filter",
         "uses": "dorny/paths-filter@v3"
+      },
+      {
+        "id": "effective",
+        "name": "Resolve effective change flags",
+        "run": "if [ \"$FORCE_FULL_RUN\" = \"true\" ]; then\n  code=true\n  build=true\n  compiler=true\n  macro_fuzz=true\nelse\n  code=\"$CODE_CHANGED\"\n  build=\"$BUILD_CHANGED\"\n  compiler=\"$COMPILER_CHANGED\"\n  macro_fuzz=\"$MACRO_FUZZ_CHANGED\"\nfi\n\n{\n  echo \"code=$code\"\n  echo \"build=$build\"\n  echo \"compiler=$compiler\"\n  echo \"macro_fuzz=$macro_fuzz\"\n} >> \"$GITHUB_OUTPUT\"",
+        "env": {
+          "FORCE_FULL_RUN": "${{ env.VERIFY_FORCE_FULL_RUN }}",
+          "CODE_CHANGED": "${{ steps.filter.outputs.code }}",
+          "BUILD_CHANGED": "${{ steps.filter.outputs.build }}",
+          "COMPILER_CHANGED": "${{ steps.filter.outputs.compiler }}",
+          "MACRO_FUZZ_CHANGED": "${{ steps.filter.outputs.macro_fuzz }}"
+        }
       }
     ],
     "checks": [

--- a/scripts/verify_sync_spec_source.py
+++ b/scripts/verify_sync_spec_source.py
@@ -225,10 +225,10 @@ SPEC = {'check_only_paths': ['.github/workflows/**',
                            'foundry-patched': 15,
                            'foundry-multi-seed': 25},
  'expected_job_strategy_fail_fast': {'macro-fuzz': False, 'foundry': False, 'foundry-multi-seed': False},
- 'expected_job_outputs': {'changes': {'code': '${{ steps.filter.outputs.code }}',
-                                      'build': '${{ steps.filter.outputs.build }}',
-                                      'compiler': '${{ steps.filter.outputs.compiler }}',
-                                      'macro_fuzz': '${{ steps.filter.outputs.macro_fuzz }}'}},
+ 'expected_job_outputs': {'changes': {'code': '${{ steps.effective.outputs.code }}',
+                                      'build': '${{ steps.effective.outputs.build }}',
+                                      'compiler': '${{ steps.effective.outputs.compiler }}',
+                                      'macro_fuzz': '${{ steps.effective.outputs.macro_fuzz }}'}},
  'expected_job_permissions': {'timeout-watchdog': {'actions': 'read', 'contents': 'read'},
                               'failure-hints': {'contents': 'read', 'pull-requests': 'write'}},
  'expected_workflow_permissions': {'contents': 'read'},
@@ -238,6 +238,7 @@ SPEC = {'check_only_paths': ['.github/workflows/**',
                            'SOLC_URL': 'https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.33+commit.64118f21',
                            'SOLC_SHA256': '1274e5c4621ae478090c5a1f48466fd3c5f658ed9e14b15a0b213dc806215468',
                            'VERIFY_CLEAN_BUILD': "${{ github.event_name == 'workflow_dispatch' && inputs.clean_build && 'true' || 'false' }}",
+                           'VERIFY_FORCE_FULL_RUN': "${{ github.event_name == 'workflow_dispatch' && inputs.force_full_run && 'true' || 'false' }}",
                            'VERIFY_USE_STICKY_DISKS': "${{ github.event_name == 'workflow_dispatch' && inputs.clean_build && 'false' || 'true' }}",
                            'VERIFY_DISABLE_LAKE_CACHE_RESTORE': "${{ github.event_name == 'workflow_dispatch' && inputs.clean_build && 'true' || 'false' }}",
                            'VERIFY_CACHE_BUCKET': "${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref_name) }}"},
@@ -246,7 +247,32 @@ SPEC = {'check_only_paths': ['.github/workflows/**',
                               'generate-yul-patched',
                               'gas-report'],
  'expected_step_contracts': {'changes': [{'uses': 'actions/checkout@v4'},
-                                         {'id': 'filter', 'uses': 'dorny/paths-filter@v3'}],
+                                         {'id': 'filter', 'uses': 'dorny/paths-filter@v3'},
+                                         {'id': 'effective',
+                                          'name': 'Resolve effective change flags',
+                                          'run': 'if [ "$FORCE_FULL_RUN" = "true" ]; then\n'
+                                                 '  code=true\n'
+                                                 '  build=true\n'
+                                                 '  compiler=true\n'
+                                                 '  macro_fuzz=true\n'
+                                                 'else\n'
+                                                 '  code="$CODE_CHANGED"\n'
+                                                 '  build="$BUILD_CHANGED"\n'
+                                                 '  compiler="$COMPILER_CHANGED"\n'
+                                                 '  macro_fuzz="$MACRO_FUZZ_CHANGED"\n'
+                                                 'fi\n'
+                                                 '\n'
+                                                 '{\n'
+                                                 '  echo "code=$code"\n'
+                                                 '  echo "build=$build"\n'
+                                                 '  echo "compiler=$compiler"\n'
+                                                 '  echo "macro_fuzz=$macro_fuzz"\n'
+                                                 '} >> "$GITHUB_OUTPUT"',
+                                          'env': {'FORCE_FULL_RUN': '${{ env.VERIFY_FORCE_FULL_RUN }}',
+                                                  'CODE_CHANGED': '${{ steps.filter.outputs.code }}',
+                                                  'BUILD_CHANGED': '${{ steps.filter.outputs.build }}',
+                                                  'COMPILER_CHANGED': '${{ steps.filter.outputs.compiler }}',
+                                                  'MACRO_FUZZ_CHANGED': '${{ steps.filter.outputs.macro_fuzz }}'}}],
                              'checks': [{'uses': 'actions/checkout@v4'},
                                         {'name': 'Run all checks', 'run': 'make check'}],
                              'timeout-watchdog': [{'name': 'Warn on timeout-risk trend',


### PR DESCRIPTION
## Summary

- add a `workflow_dispatch.force_full_run` input to `verify.yml`
- override the `changes` job outputs during manual dispatch so gated jobs run without changing normal push/PR behavior
- keep the verify sync spec in lockstep with the workflow update

## Testing

- `python3 scripts/check_verify_sync.py`
- `python3 -m unittest scripts/test_check_verify_sync.py scripts/test_workflow_jobs.py`
- manual `verify.yml` dispatch on `ci-force-full-run` with `force_full_run=true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow wiring and only alter job gating when `verify.yml` is manually dispatched with `force_full_run=true`. Main push/PR change filtering remains unchanged unless the new flag is used.
> 
> **Overview**
> Adds a new `workflow_dispatch` input, `force_full_run`, to `verify.yml` to **bypass `paths-filter` gating** and force all change flags (`code`/`build`/`compiler`/`macro_fuzz`) to `true` on manual runs.
> 
> Updates the `changes` job to publish outputs from a new `Resolve effective change flags` step (instead of directly from `dorny/paths-filter`) and keeps the verify sync spec (`verify_sync_spec.json` + `verify_sync_spec_source.py`) in lockstep with the new env var and step/output expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f822d3d6fa651622702d4b236c358e2db602d57f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->