### PR TITLE
ci: reuse root Lake package cache for split builds

### DIFF
--- a/scripts/check_split_package_builds.py
+++ b/scripts/check_split_package_builds.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -41,6 +42,24 @@ def display_path(package_dir: Path) -> Path:
         return package_dir
 
 
+def seed_packages_dir(package_dir: Path) -> None:
+    root_packages_dir = ROOT / ".lake" / "packages"
+    if not root_packages_dir.is_dir():
+        return
+
+    package_lake_dir = package_dir / ".lake"
+    package_lake_dir.mkdir(exist_ok=True)
+    package_packages_dir = package_lake_dir / "packages"
+    if package_packages_dir.exists():
+        return
+
+    try:
+        package_packages_dir.symlink_to(root_packages_dir, target_is_directory=True)
+    except OSError:
+        # Fall back to a local copy when symlinks are unavailable.
+        shutil.copytree(root_packages_dir, package_packages_dir, symlinks=True)
+
+
 def run_lake_build(package_dir: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["lake", "build"],
@@ -66,6 +85,7 @@ def check_split_package_builds(package_dirs: list[Path]) -> int:
             continue
 
         print(f"Building {rel_path}...")
+        seed_packages_dir(package_dir)
         proc = run_lake_build(package_dir)
         if proc.returncode == 0:
             print(f"  OK {rel_path}")

--- a/scripts/test_check_split_package_builds.py
+++ b/scripts/test_check_split_package_builds.py
@@ -36,6 +36,38 @@ class CheckSplitPackageBuildsTests(unittest.TestCase):
         outside = Path("/tmp/verity-edsl")
         self.assertEqual(check.display_path(outside), outside)
 
+    def test_seed_packages_dir_reuses_root_lake_packages(self) -> None:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as tmpdir:
+            root = Path(tmpdir)
+            root_packages = root / ".lake" / "packages"
+            root_packages.mkdir(parents=True, exist_ok=True)
+            (root_packages / "marker.txt").write_text("cached\n", encoding="utf-8")
+            package_dir = root / "packages" / "verity-edsl"
+            package_dir.mkdir(parents=True, exist_ok=True)
+
+            with patch.object(check, "ROOT", root):
+                check.seed_packages_dir(package_dir)
+
+            package_packages = package_dir / ".lake" / "packages"
+            self.assertTrue(package_packages.exists())
+            self.assertEqual((package_packages / "marker.txt").read_text(encoding="utf-8"), "cached\n")
+
+    def test_seed_packages_dir_leaves_existing_package_cache_untouched(self) -> None:
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as tmpdir:
+            root = Path(tmpdir)
+            root_packages = root / ".lake" / "packages"
+            root_packages.mkdir(parents=True, exist_ok=True)
+            (root_packages / "marker.txt").write_text("root\n", encoding="utf-8")
+            package_dir = root / "packages" / "verity-edsl"
+            package_packages = package_dir / ".lake" / "packages"
+            package_packages.mkdir(parents=True, exist_ok=True)
+            (package_packages / "marker.txt").write_text("local\n", encoding="utf-8")
+
+            with patch.object(check, "ROOT", root):
+                check.seed_packages_dir(package_dir)
+
+            self.assertEqual((package_packages / "marker.txt").read_text(encoding="utf-8"), "local\n")
+
     def test_check_split_package_builds_passes_when_all_builds_succeed(self) -> None:
         with tempfile.TemporaryDirectory(dir=SCRIPT_DIR.parent) as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary
- seed each split package's `.lake/packages` from the restored root workspace cache before running `lake build`
- keep the existing behavior when a package already has its own cache
- add unit tests for cache seeding and the no-clobber case

## Why
The `build-audits` job in run `23352074575` failed in `Build split Lake packages independently` before Lean compilation:
- `packages/verity-edsl` failed while cloning `evmyul`
- `packages/verity-examples` failed while cloning `LeanSearchClient`

That audit job already restores the prepared root Lake workspace from the earlier `build` job, but `scripts/check_split_package_builds.py` built each package with its own fresh `.lake/packages` directory. In CI that forced redundant network clones for every isolated package build, and the job failed on `git` exit 128 instead of checking package boundaries.

This change reuses the restored root package cache for split-package builds, so the audit stays focused on package isolation/build correctness rather than extra dependency fetches.

## Verification
- `python3 -m unittest scripts/test_check_split_package_builds.py -v`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/script change, but it alters how split package builds source their dependency cache (symlink/copy), which could surface platform-specific filesystem behavior.
> 
> **Overview**
> Improves `scripts/check_split_package_builds.py` by seeding each package’s `.lake/packages` from the root workspace cache before running `lake build`, using a symlink when possible and falling back to copying when symlinks aren’t available; existing per-package caches are left untouched.
> 
> Adds unit tests covering cache seeding and the no-clobber behavior to ensure split build checks avoid redundant network dependency clones in CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4c9504a204a18f1591ca998582db961839adbe4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->