### PR TITLE
ci: verify clang link dependencies

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -513,14 +513,28 @@ jobs:
 
       - name: Ensure compiler acceleration toolchain
         run: |
-          if command -v clang >/dev/null && command -v ld.lld >/dev/null && command -v ccache >/dev/null; then
+          if \
+            command -v clang >/dev/null && \
+            command -v clang++ >/dev/null && \
+            command -v ld.lld >/dev/null && \
+            command -v ccache >/dev/null && \
+            printf 'int main() { return 0; }\n' | clang++ -x c++ - -fuse-ld=lld -stdlib=libc++ -lc++abi -o /tmp/verity-clang-smoke >/dev/null 2>&1 && \
+            printf 'int main() { return 0; }\n' | clang -x c - -fuse-ld=lld -luv -o /tmp/verity-libuv-smoke >/dev/null 2>&1
+          then
             clang --version
             ld.lld --version
             ccache --version
             exit 0
           fi
           sudo apt-get update
-          sudo apt-get install -y clang lld ccache
+          sudo apt-get install -y clang lld ccache libc++-dev libc++abi-dev libuv1-dev
+
+          printf 'int main() { return 0; }\n' | clang++ -x c++ - -fuse-ld=lld -stdlib=libc++ -lc++abi -o /tmp/verity-clang-smoke
+          printf 'int main() { return 0; }\n' | clang -x c - -fuse-ld=lld -luv -o /tmp/verity-libuv-smoke
+
+          clang --version
+          ld.lld --version
+          ccache --version
 
       - name: Prepare ccache directory
         run: mkdir -p "$CCACHE_DIR"


### PR DESCRIPTION
## Summary
- make the compiler acceleration check validate the actual clang/lld/libc++/libuv link path Lean uses
- install the missing libc++/libc++abi/libuv dev packages when that smoke test fails
- print the tool versions after either the fast path or install path succeeds

## Testing
- python3 scripts/generate_verify_sync_spec.py --check
- python3 scripts/check_verify_sync.py
- python3 -m unittest scripts.test_check_verify_sync scripts.test_generate_verify_sync_spec
- local clang/lld smoke checks for libc++/libc++abi and libuv linking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that tightens toolchain validation and adds missing Ubuntu dev packages; main risk is potential new failures due to stricter smoke tests or package install issues on runners.
> 
> **Overview**
> Improves the `verify.yml` compiler toolchain “fast path” by *actually smoke-testing* the clang/lld link configuration Lean relies on (C++ compile/link against `libc++`/`libc++abi`, and C compile/link against `libuv`) instead of only checking tool binaries exist.
> 
> When the smoke tests fail, CI now installs the additional missing dev packages (`libc++-dev`, `libc++abi-dev`, `libuv1-dev`) and reruns the checks, and it consistently prints `clang`/`ld.lld`/`ccache` versions after either path succeeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2f1eb3a5d21aa34b5969898916295b729a428e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->