### PR TITLE
fix: add top-level main entrypoints for lean_exe targets

### DIFF
--- a/Compiler/Main.lean
+++ b/Compiler/Main.lean
@@ -238,3 +238,6 @@ unsafe def main (args : List String) : IO Unit := do
       throw e
 
 end Compiler.Main
+
+unsafe def main (args : List String) : IO Unit :=
+  Compiler.Main.main args

--- a/Compiler/MainTestRunner.lean
+++ b/Compiler/MainTestRunner.lean
@@ -7,3 +7,6 @@ unsafe def main (_args : List String) : IO UInt32 := do
   pure 0
 
 end Compiler.MainTestRunner
+
+unsafe def main (args : List String) : IO UInt32 :=
+  Compiler.MainTestRunner.main args


### PR DESCRIPTION
## Summary
- The switch to `clang+lld` (via `LEAN_CC`) in #1654 exposed a latent issue: `verity-compiler` and `compiler-main-test` defined `main` inside namespaces, so `lld` couldn't find the bare `main` symbol the C runtime requires
- Adds thin top-level `main` wrappers in `Compiler/Main.lean` and `Compiler/MainTestRunner.lean` that delegate to the namespaced implementations
- Matches the pattern `MainPatched.lean` already uses (which is why `verity-compiler-patched` linked successfully)
- Preserves all existing `Compiler.Main.main` call sites in `MainTest.lean`

**Cache impact**: Only 2 leaf `.lean` files change — the 350+ cached `.c.o` files on the sticky disk remain valid. Only `Main.c.o`, `MainTestRunner.c.o`, and the two final link steps will re-run.

## Test plan
- [ ] CI `build-compiler-binaries` job passes (both `verity-compiler` and `compiler-main-test` link successfully)
- [ ] Downstream jobs (`compiler-regressions`, `generate-yul`, `foundry`, etc.) run green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds thin top-level `main` entrypoints that delegate to existing namespaced implementations, primarily affecting linking/entrypoint resolution.
> 
> **Overview**
> Adds **top-level `main` entrypoints** in `Compiler/Main.lean` and `Compiler/MainTestRunner.lean` that delegate to the existing namespaced `Compiler.Main.main` and `Compiler.MainTestRunner.main` functions.
> 
> This ensures Lean executables export a bare `main` symbol for the linker/runtime without changing CLI parsing or test execution logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fb017f4de4dfb4941692863801d7830bce089ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->