### PR TITLE
fix: prevent EVM memory exhaustion in ERC721 differential 10k test

### DIFF
--- a/test/DifferentialERC721.t.sol
+++ b/test/DifferentialERC721.t.sol
@@ -879,27 +879,16 @@ contract DifferentialERC721 is YulTestBase, DiffTestConfig, DifferentialTestBase
 
         (uint256 startIndex, uint256 count) = _diffRandomLargeRange();
         uint256 seed = _diffRandomSeed("ERC721");
-        uint256 batchSize = 250;
 
         vm.pauseGasMetering();
-        for (uint256 offset = 0; offset < count; offset += batchSize) {
-            uint256 batchCount = count - offset;
-            if (batchCount > batchSize) {
-                batchCount = batchSize;
-            }
-            this.runRandomDifferentialBatch(startIndex + offset, batchCount, seed);
-        }
-        vm.resumeGasMetering();
-
-        if (_diffVerbose()) console2.log("Random tests passed:", testsPassed);
-        if (_diffVerbose()) console2.log("Random tests failed:", testsFailed);
-        assertEq(testsFailed, 0, "Some random tests failed");
-    }
-
-    function runRandomDifferentialBatch(uint256 startIndex, uint256 count, uint256 seed) external {
-        require(msg.sender == address(this), "self-call only");
-
         for (uint256 i = 0; i < count; i++) {
+            // Snapshot the free-memory pointer so we can reclaim temporary string
+            // allocations after each iteration.  Without this, the O(N^2) intermediate
+            // copies produced by _buildMapUintStateAll's string.concat loop accumulate
+            // across all 10 000 iterations and exhaust Foundry's memory_limit (4 GB).
+            uint256 freeMemBefore;
+            assembly ("memory-safe") { freeMemBefore := mload(0x40) }
+
             (
                 string memory funcName,
                 address sender,
@@ -910,6 +899,15 @@ contract DifferentialERC721 is YulTestBase, DiffTestConfig, DifferentialTestBase
 
             bool success = _executeRandomDifferentialTest(funcName, sender, arg0, arg1, arg2);
             _assertRandomSuccess(success, startIndex + i);
+
+            // Reclaim iteration-local memory.  All persistent state lives in storage
+            // (edslOwners, edslBalances, …), so nothing reachable is lost.
+            assembly ("memory-safe") { mstore(0x40, freeMemBefore) }
         }
+        vm.resumeGasMetering();
+
+        if (_diffVerbose()) console2.log("Random tests passed:", testsPassed);
+        if (_diffVerbose()) console2.log("Random tests failed:", testsFailed);
+        assertEq(testsFailed, 0, "Some random tests failed");
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `_buildMapUintStateAll()` uses `string.concat` in a loop over all minted tokens. Each concat copies the growing accumulator into a new allocation, producing O(N²) intermediate memory per call (where N = token count). Across 10,000 iterations with ~3,000 tokens eventually minted (30% mint rate), cumulative EVM memory far exceeds Foundry's 4 GB `memory_limit` and the test reverts with `EvmError: Revert`.
- Replaced the external batching pattern (`this.runRandomDifferentialBatch`) with a direct inline loop, matching every other differential test
- Added free-memory pointer save/restore at each iteration so temporary string allocations are reclaimed — all persistent state lives in storage mappings, so nothing reachable is lost

### Why the external batching didn't help
The original `batchSize = 250` external self-call was intended to reset EVM memory between batches (since `CALL` creates a fresh memory context). However, even within a single batch of 250 iterations, when ~2,900+ tokens exist, a single call to `_buildMapUintStateAll()` produces ~278 MB of intermediate concat allocations — and 250 such calls accumulate far beyond 4 GB.

### Why sharding to 1,250 iterations works
With 8 shards (`DIFFTEST_SHARD_COUNT=8`), each shard runs in a separate Forge invocation with its own EVM instance. At 1,250 iterations (~375 tokens), cumulative memory stays under ~1.9 GB.

## Test plan
- [x] `forge build` succeeds
- [ ] CI: `foundry-multi-seed` jobs pass (10,000 iterations, all seeds)
- [ ] CI: `foundry` sharded jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)