### PR TITLE
fix: allowlist long proofs + add elan curl retry

### DIFF
--- a/.github/actions/setup-lean/action.yml
+++ b/.github/actions/setup-lean/action.yml
@@ -100,7 +100,7 @@ runs:
         if [ -x "$HOME/.elan/bin/elan" ]; then
           exit 0
         fi
-        curl -sSfL "https://raw.githubusercontent.com/leanprover/elan/${ELAN_VERSION}/elan-init.sh" -o elan-init.sh
+        curl -sSfL --retry 3 --retry-delay 5 "https://raw.githubusercontent.com/leanprover/elan/${ELAN_VERSION}/elan-init.sh" -o elan-init.sh
         echo "${ELAN_INIT_SHA256}  elan-init.sh" | sha256sum -c -
         bash elan-init.sh -y --default-toolchain none
         rm elan-init.sh

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -530,6 +530,23 @@ ALLOWLIST: set[str] = {
     "execStmtList_terminal_core_ite_else_eq",
     "SupportedBodyInterface.helperFreeStepInterface",
     "legacyCompatibleExternalStmtList_of_compileSetStructMember2_ok",
+    # PR #1670 sorry-reduction pass 5 — transient-storage and memory-write
+    # singleton bridges: mechanical compiled-step proofs that thread the
+    # tstore/mstore IR evaluation witnesses through the generic induction
+    # interface; line count comes from spelling out the concrete compiled
+    # block shape, not from proof complexity.
+    "compiledStmtStep_tstore_single_preserves",
+    "compiledStmtStep_mstore_single_preserves",
+    "stmtListGenericCore_singleton_tstore_single",
+    "stmtListGenericCore_of_supportedStmtList_tstoreSingle_of_surface",
+    # PR #1670 — struct-member-2 singleton slot-safety bridge without the
+    # `_preserves` suffix: mirrors the existing `_preserves` variant but
+    # packages the slot-safety witness into the generic body interface.
+    "compiledStmtStep_setStructMember2_singleSlot_of_slotSafety",
+    # PR #1670 — FunctionBody aux lemma for compileStmt_ok under any scope:
+    # long due to explicit scope-discipline threading through the full
+    # compiled statement list; decomposition is follow-up cleanup.
+    "compileStmt_ok_any_scope_aux",
 }
 
 # Directories containing proof files to scan.


### PR DESCRIPTION
## Summary
- **Allowlist 6 long proofs** in `scripts/check_proof_length.py` that were introduced by the sorry-reduction pass 5 work on this branch (`codex/reduce-sorries-pass-5`) but not added to the allowlist, causing `make check` to fail on every CI run
- **Add `--retry 3 --retry-delay 5`** to the elan-init.sh curl download in `.github/actions/setup-lean/action.yml` to mitigate intermittent HTTP 429 rate-limiting from `raw.githubusercontent.com` that has been breaking `macro-fuzz` CI shards

### Proofs added to allowlist
| Theorem | Lines | File |
|---------|-------|------|
| `stmtListGenericCore_of_supportedStmtList_tstoreSingle_of_surface` | 222 | GenericInduction.lean |
| `compiledStmtStep_setStructMember2_singleSlot_of_slotSafety` | 160 | GenericInduction.lean |
| `compiledStmtStep_tstore_single_preserves` | 115 | GenericInduction.lean |
| `stmtListGenericCore_singleton_tstore_single` | 109 | GenericInduction.lean |
| `compileStmt_ok_any_scope_aux` | 97 | FunctionBody.lean |
| `compiledStmtStep_mstore_single_preserves` | 97 | GenericInduction.lean |

### CI failures addressed
1. **`check_proof_length.py` failure** (every run): 6 proofs exceed the 50-line hard limit without allowlist entries — blocks the `checks` job which gates all downstream CI
2. **Elan HTTP 429** (intermittent): parallel CI jobs hit GitHub's rate limit when downloading `elan-init.sh`, causing `macro-fuzz` shards and `build` jobs to fail

## Test plan
- [x] `python3 scripts/check_proof_length.py` passes locally
- [x] `make check` passes locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to CI tooling (GitHub Action and a proof-length gate) and only relax a lint-style check plus add network retries, without affecting runtime logic.
> 
> **Overview**
> Improves CI stability by adding retries (`--retry 3 --retry-delay 5`) to the `curl` download of `elan-init.sh` in `.github/actions/setup-lean/action.yml` to reduce flaky failures from transient HTTP errors/rate limiting.
> 
> Unblocks `make check` by extending `scripts/check_proof_length.py`’s `ALLOWLIST` with several newly introduced long proofs (with justification comments), so the proof-length gate no longer fails on these mechanically long theorems.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a08d3dc85d2e0b4e02c0521003d1d8b71c912cec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->