### PR TITLE
chore: disable automatic Vercel deployments

### DIFF
--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -1,3 +1,5 @@
 {
-  "ignoreCommand": "bash scripts/vercel-ignore-draft-pr.sh"
+  "git": {
+    "deploymentEnabled": false
+  }
 }


### PR DESCRIPTION
## Summary

- Replaces the `ignoreCommand` (draft-PR skip script) with `git.deploymentEnabled: false` in `docs-site/vercel.json`
- This **completely disables** automatic Vercel deployments on push/PR events

## How it works

Vercel's `git.deploymentEnabled` setting controls whether the Git integration triggers builds. Setting it to `false` means:
- Pushes to any branch: **no deploy**
- PRs opened/updated: **no deploy**
- Merges to main: **no deploy**

## How to deploy manually

Once this is merged, deploy the docs site by going to the Vercel dashboard:

1. Go to the project → **Deployments** tab
2. Find the most recent deployment
3. Click the **⋮** menu → **Redeploy**
4. Optionally check "Use existing build cache" for a faster build

Alternatively, use the Vercel CLI:
```bash
cd docs-site
npx vercel --prod
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it will stop all automatic Vercel builds/deploys for the docs site until manual redeploys are triggered.
> 
> **Overview**
> Disables automatic Vercel deployments for the docs site by replacing the previous `ignoreCommand` behavior with `git.deploymentEnabled: false` in `docs-site/vercel.json`, preventing deploys from push/PR events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46dd5a19a5747d151a8bf4f2f513516130a0c5a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->