### PR TITLE
docs: add Giveth donation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ verity/
 └── docs-site/           # Published documentation site sources
 ```
 
+## Support
+
+Verity is a public good. If you'd like to support the project, you can donate via Giveth:
+
+[verity: Smart Contracts Security for the Age of AI](https://giveth.io/project/verity:-smart-contracts-security-for-the-age-of-ai)
+
 ## License
 
 MIT - See [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
## Summary

- Adds a "Support" section to README.md with a link to the Verity Giveth project page for donations
- Link: https://giveth.io/project/verity:-smart-contracts-security-for-the-age-of-ai

## Test plan

- [x] Verify link renders correctly in GitHub markdown preview
- [x] No functional code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)