### PR TITLE
ci: drop removed Layer 2 plan from sync checks

### DIFF
--- a/Compiler/Proofs/README.md
+++ b/Compiler/Proofs/README.md
@@ -47,7 +47,6 @@ The `SupportedSpec` split and current boundary are recorded in [`artifacts/layer
 
 - Layer 2 completeness: [#1630](https://github.com/lfglabs-dev/verity/issues/1630)
 - Machine-readable boundary: [`artifacts/layer2_boundary_catalog.json`](../../artifacts/layer2_boundary_catalog.json)
-- Plan: [`docs/GENERIC_LAYER2_PLAN.md`](../../docs/GENERIC_LAYER2_PLAN.md)
 
 ## Build
 

--- a/artifacts/layer2_boundary_catalog.json
+++ b/artifacts/layer2_boundary_catalog.json
@@ -294,7 +294,6 @@
       "theorem_shape": 1510
     },
     "source_refs": [
-      "docs/GENERIC_LAYER2_PLAN.md",
       "docs/ROADMAP.md",
       "docs/VERIFICATION_STATUS.md"
     ]

--- a/docs/VERIFICATION_STATUS.md
+++ b/docs/VERIFICATION_STATUS.md
@@ -52,7 +52,7 @@ Tracking:
 - Theorem-shape milestone: [#1510](https://github.com/lfglabs-dev/verity/issues/1510)
 - Follow-on widening/completeness work: [#1630](https://github.com/lfglabs-dev/verity/issues/1630)
 - Axiom-elimination work completed in: [#1618](https://github.com/lfglabs-dev/verity/issues/1618)
-- Proof decomposition plan: [GENERIC_LAYER2_PLAN.md](./GENERIC_LAYER2_PLAN.md)
+- Machine-readable boundary catalog: [`artifacts/layer2_boundary_catalog.json`](../artifacts/layer2_boundary_catalog.json)
 
 **What is generic today**:
 - a structural theorem for raw statement lists inside the explicit `SupportedStmtList` fragment witness in [`TypedIRCompilerCorrectness.lean`](../Compiler/TypedIRCompilerCorrectness.lean), re-exported for the compiler-proof layer in [`SupportedFragment.lean`](../Compiler/Proofs/IRGeneration/SupportedFragment.lean)

--- a/scripts/check_layer2_boundary_catalog_sync.py
+++ b/scripts/check_layer2_boundary_catalog_sync.py
@@ -10,7 +10,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CATALOG = ROOT / "artifacts" / "layer2_boundary_catalog.json"
 TARGET_FILES = {
-    "GENERIC_PLAN": ROOT / "docs" / "GENERIC_LAYER2_PLAN.md",
     "ROADMAP": ROOT / "docs" / "ROADMAP.md",
     "VERIFICATION_STATUS": ROOT / "docs" / "VERIFICATION_STATUS.md",
     "COMPILER_PROOFS_README": ROOT / "Compiler" / "Proofs" / "README.md",
@@ -45,27 +44,6 @@ def expected_snippets(catalog: dict) -> dict[str, list[str]]:
     assert theorem_target["intended_claim"] == "proof_complete_macro_lowered_verity_contract_image"
     assert helper["current_fail_closed_gate"] == "SupportedBodyInterface.stmtList"
     return {
-        "GENERIC_PLAN": [
-            "`artifacts/layer2_boundary_catalog.json`",
-            "proof-complete `CompilationModel` subset",
-            "macro-lowered image of `verity_contract`",
-            "helper-free `SupportedStmtList` witness",
-            "`SupportedFunctionBodyWithHelpersIRPreservationGoal`",
-            "`SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal`",
-            "legacy-compatible external-body Yul subset",
-            "`InterpretIRWithInternalsZeroConservativeExtensionGoal`",
-            "`InterpretIRWithInternalsZeroConservativeExtensionDispatchGoal`",
-            "`interpretIRWithInternalsZeroConservativeExtensionGoal_of_dispatchGoal`",
-            "`InterpretIRWithInternalsZeroConservativeExtensionStmtSubgoals`",
-            "`interpretIRWithInternalsZeroConservativeExtensionInterfaces_of_stmtSubgoals`",
-            "`interpretIRWithInternalsZeroConservativeExtensionGoal_closed`",
-            "`compile_preserves_semantics_with_helper_proofs_and_helper_ir_goal`",
-            "`compile_preserves_semantics_with_helper_proofs_and_helper_ir_closed`",
-            "total fuel-indexed helper-aware IR semantics",
-            "`exprStmtUsesDedicatedBuiltinSemantics`",
-            "direct helper-free lemmas for `stop`, `mstore`, `revert`, `return`, and mapping-slot `sstore`",
-            "helper-free conservative-extension goal is now closed",
-        ],
         "ROADMAP": [
             "`artifacts/layer2_boundary_catalog.json`",
             "macro-lowered `verity_contract` image",

--- a/scripts/check_layer2_boundary_sync.py
+++ b/scripts/check_layer2_boundary_sync.py
@@ -10,7 +10,6 @@ ROOT = Path(__file__).resolve().parents[1]
 TARGETS = {
     "AXIOMS": ROOT / "AXIOMS.md",
     "COMPILER_PROOFS_README": ROOT / "Compiler" / "Proofs" / "README.md",
-    "GENERIC_PLAN": ROOT / "docs" / "GENERIC_LAYER2_PLAN.md",
     "VERIFICATION_STATUS": ROOT / "docs" / "VERIFICATION_STATUS.md",
     "ROADMAP": ROOT / "docs" / "ROADMAP.md",
     "ROOT_README": ROOT / "README.md",
@@ -38,10 +37,6 @@ def expected_snippets() -> dict[str, list[str]]:
         "COMPILER_PROOFS_README": [
             "Generic whole-contract theorem",
             "0 sorry, 0 axioms",
-        ],
-        "GENERIC_PLAN": [
-            "avoid any `post`/`hpost`/contract-specific bridge premise",
-            "The main objective of issue #1618 is therefore complete.",
         ],
         "VERIFICATION_STATUS": [
             "## Layer 2: CompilationModel → IR — GENERIC WHOLE-CONTRACT THEOREM",
@@ -112,9 +107,6 @@ def forbidden_snippets() -> dict[str, list[str]]:
             "Still axiomatized: generic supported body simulation and the `execIRFunctionFuel` to `execIRFunction` bridge",
             "PARTIAL GENERIC, 2 AXIOMS, CONTRACT BRIDGES ACTIVE",
             "there is not yet a single compiler-level theorem quantified over arbitrary supported `CompilationModel` programs and successful `CompilationModel.compile` output.",
-        ],
-        "GENERIC_PLAN": [
-            "use the old `hpost`-based bridge theorem as the solution",
         ],
         "ROADMAP": [
             "✅ **Layer 2 Complete**",

--- a/scripts/generate_layer2_boundary_catalog.py
+++ b/scripts/generate_layer2_boundary_catalog.py
@@ -27,7 +27,6 @@ def build_catalog() -> dict:
                 "helper_ir_semantics": 1638,
             },
             "source_refs": [
-                "docs/GENERIC_LAYER2_PLAN.md",
                 "docs/ROADMAP.md",
                 "docs/VERIFICATION_STATUS.md",
             ],

--- a/scripts/test_check_layer2_boundary_catalog_sync.py
+++ b/scripts/test_check_layer2_boundary_catalog_sync.py
@@ -40,28 +40,6 @@ class Layer2BoundaryCatalogSyncTests(unittest.TestCase):
         )
 
         docs = {
-            "GENERIC_PLAN": (
-                "`artifacts/layer2_boundary_catalog.json`\n"
-                "proof-complete `CompilationModel` subset\n"
-                "macro-lowered image of `verity_contract`\n"
-                "helper-free `SupportedStmtList` witness\n"
-                "`SupportedFunctionBodyWithHelpersIRPreservationGoal`\n"
-                "`SupportedFunctionBodyWithHelpersAndHelperIRPreservationGoal`\n"
-                "legacy-compatible external-body Yul subset\n"
-                "`InterpretIRWithInternalsZeroConservativeExtensionGoal`\n"
-                "`InterpretIRWithInternalsZeroConservativeExtensionDispatchGoal`\n"
-                "`interpretIRWithInternalsZeroConservativeExtensionGoal_of_dispatchGoal`\n"
-                "`InterpretIRWithInternalsZeroConservativeExtensionStmtSubgoals`\n"
-                "`interpretIRWithInternalsZeroConservativeExtensionInterfaces_of_stmtSubgoals`\n"
-                "`interpretIRWithInternalsZeroConservativeExtensionGoal_closed`\n"
-                "`compile_preserves_semantics_with_helper_proofs_and_helper_ir_goal`\n"
-                "`compile_preserves_semantics_with_helper_proofs_and_helper_ir_closed`\n"
-                "total fuel-indexed helper-aware IR semantics\n"
-                "`exprStmtUsesDedicatedBuiltinSemantics`\n"
-                "direct helper-free lemmas for `stop`, `mstore`, `revert`, `return`, and mapping-slot `sstore`\n"
-                "helper-free conservative-extension goal is now closed\n"
-                "`InterpretIRWithInternalsZeroConservativeExtensionInterfaces`\n"
-            ),
             "ROADMAP": (
                 "`artifacts/layer2_boundary_catalog.json`\n"
                 "macro-lowered `verity_contract` image\n"
@@ -136,7 +114,6 @@ class Layer2BoundaryCatalogSyncTests(unittest.TestCase):
             docs["ROADMAP"] = "stale roadmap\n"
 
         for label, rel in {
-            "GENERIC_PLAN": Path("docs/GENERIC_LAYER2_PLAN.md"),
             "ROADMAP": Path("docs/ROADMAP.md"),
             "VERIFICATION_STATUS": Path("docs/VERIFICATION_STATUS.md"),
             "COMPILER_PROOFS_README": Path("Compiler/Proofs/README.md"),
@@ -156,7 +133,6 @@ class Layer2BoundaryCatalogSyncTests(unittest.TestCase):
             check.ROOT = root
             check.CATALOG = root / "artifacts" / "layer2_boundary_catalog.json"
             check.TARGET_FILES = {
-                "GENERIC_PLAN": root / "docs" / "GENERIC_LAYER2_PLAN.md",
                 "ROADMAP": root / "docs" / "ROADMAP.md",
                 "VERIFICATION_STATUS": root / "docs" / "VERIFICATION_STATUS.md",
                 "COMPILER_PROOFS_README": root / "Compiler" / "Proofs" / "README.md",


### PR DESCRIPTION
## Summary
- remove the deleted `docs/GENERIC_LAYER2_PLAN.md` from Layer 2 boundary sync checks
- update the generated Layer 2 boundary catalog source refs and regenerated artifact
- remove stale documentation links to the deleted plan

## Why
PR #1734 deleted `docs/GENERIC_LAYER2_PLAN.md`, but `make check` still enforced that file through `scripts/check_layer2_boundary_sync.py` and `scripts/check_layer2_boundary_catalog_sync.py`. The failed CI job stopped at:

```text
Missing: docs/GENERIC_LAYER2_PLAN.md
make: *** [Makefile:118: check] Error 1
```

## Validation
- `python3 scripts/check_layer2_boundary_sync.py`
- `python3 scripts/check_layer2_boundary_catalog_sync.py`
- `python3 -m unittest scripts/test_check_layer2_boundary_sync.py scripts/test_check_layer2_boundary_catalog_sync.py scripts/test_generate_layer2_boundary_catalog.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation references, generated JSON metadata, and sync-check scripts/tests; no compiler/proof logic is modified.
> 
> **Overview**
> Updates the Layer 2 boundary maintenance tooling to **stop requiring the deleted** `docs/GENERIC_LAYER2_PLAN.md` during `make check`, by removing it from sync-check target lists and expected-snippet fixtures.
> 
> Regenerates `artifacts/layer2_boundary_catalog.json` and adjusts docs (`Compiler/Proofs/README.md`, `docs/VERIFICATION_STATUS.md`) so the machine-readable catalog and documentation no longer link to the removed plan file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82752e2be0d17f450520d59e034e043de03d86c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->