### PR TITLE
proofs: IR storage type refactor skeleton (Phase 0)

### DIFF
--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -15,6 +15,7 @@
 
 import Compiler.IR
 import Compiler.CompilationModel
+import Compiler.Proofs.IRGeneration.IRStorageWord
 import Compiler.Proofs.MappingSlot
 import Compiler.Proofs.YulGeneration.ReferenceOracle.Builtins
 import Verity.Core
@@ -84,8 +85,14 @@ private theorem internal_call_measure_decreases (fuel measure : Nat) :
 structure IRState where
   /-- Variable bindings (name → value) -/
   vars : List (String × Nat)
-  /-- Storage slots (slot → value) -/
-  storage : Nat → Nat
+  /-- Storage slots (slot → value).
+
+      Typed via `IRStorageWord` so Phase 1 of the IR storage refactor can
+      flip the carrier to a `UInt256`-bounded representation without
+      touching this signature. Currently `IRStorageWord` is an `abbrev`
+      for `Nat`, so this is definitionally `Nat → Nat` and existing
+      callsites continue to typecheck. -/
+  storage : Nat → IRStorageWord
   /-- Transient storage slots (slot → value). -/
   transientStorage : Nat → Nat := fun _ => 0
   /-- Memory words (offset → value) -/

--- a/Compiler/Proofs/IRGeneration/IRStorageWord.lean
+++ b/Compiler/Proofs/IRGeneration/IRStorageWord.lean
@@ -1,0 +1,79 @@
+/-
+  IRStorageWord: typed-storage helper surface for the IR storage carrier.
+
+  This module is **Phase 0** of the IR storage type refactor described in
+  `docs/IR_STORAGE_UINT256_REFACTOR.md`. It introduces a type alias plus
+  canonical injection / projection helpers and round-trip lemmas, *without*
+  changing the underlying carrier or any existing callsite.
+
+  Phase 0 goals (this PR):
+  - introduce `IRStorageWord`, currently `Nat`-backed,
+  - introduce `IRStorageWord.ofNat`, `IRStorageWord.toNat`, and
+    `IRStorageWord.toUInt256`,
+  - prove the obvious round-trip lemmas so future migrations can use them.
+
+  Phase 1 (follow-up PR):
+  - flip `IRStorageWord` to a `UInt256`-backed representation,
+  - migrate `IRState.storage : Nat → Nat` to use this helper surface,
+  - audit every site that produced an unbounded value into storage.
+
+  Phase 2 / Phase 3:
+  - discharge `simpleStorageNativeRetrieveHitBridge` and
+    `simpleStorageNativeStoreHitBridge` by reduction through the bounded
+    carrier, then drop the corresponding hypotheses from
+    `simpleStorage_endToEnd_native_evmYulLean`.
+
+  The full plan and acceptance signals live in
+  `docs/IR_STORAGE_UINT256_REFACTOR.md`.
+-/
+
+import EvmYul.UInt256
+
+namespace Compiler.Proofs.IRGeneration
+
+open EvmYul
+
+/-- The carrier of a single IR storage slot value.
+
+    Phase 0: `IRStorageWord := Nat`. This is the current behavior of
+    `IRState.storage`, exposed through a typed alias so Phase 1 can swap
+    the representation without touching callsites.
+
+    Phase 1 will redefine this as a `UInt256`-backed bounded type.
+
+    Treat this as opaque from callers: always go through `ofNat` /
+    `toNat` / `toUInt256` rather than relying on the alias being `Nat`. -/
+abbrev IRStorageWord : Type := Nat
+
+namespace IRStorageWord
+
+/-- Inject a `Nat` value into `IRStorageWord`.
+
+    Phase 0: identity. Phase 1: `% UInt256.size`. -/
+@[inline] def ofNat (n : Nat) : IRStorageWord := n
+
+/-- Project an `IRStorageWord` back to `Nat`.
+
+    Phase 0: identity. Phase 1: `UInt256.toNat`. -/
+@[inline] def toNat (w : IRStorageWord) : Nat := w
+
+/-- Project an `IRStorageWord` to the EVMYulLean `UInt256` representation.
+
+    This is the projection used by the native state bridge. Phase 0
+    truncates the underlying `Nat` by `% UInt256.size` exactly as
+    `UInt256.ofNat` does today; Phase 1 will make this projection lossless
+    by construction. -/
+@[inline] def toUInt256 (w : IRStorageWord) : UInt256 := UInt256.ofNat w
+
+/-! ## Round-trip lemmas
+
+    These hold in Phase 0 by definitional equality and are stated up
+    front so Phase 1's flip can preserve them as the migration contract. -/
+
+@[simp] theorem toNat_ofNat (n : Nat) : (ofNat n).toNat = n := rfl
+
+@[simp] theorem ofNat_toNat (w : IRStorageWord) : ofNat w.toNat = w := rfl
+
+end IRStorageWord
+
+end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/MappingSlot.lean
+++ b/Compiler/Proofs/MappingSlot.lean
@@ -1,8 +1,11 @@
 import EvmYul
 import Compiler.Constants
 import Compiler.Proofs.KeccakBound
+import Compiler.Proofs.IRGeneration.IRStorageWord
 
 namespace Compiler.Proofs
+
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 
 /-!
 Mapping slot abstraction used by proof interpreters.
@@ -67,31 +70,31 @@ def abstractNestedMappingSlot (baseSlot key1 key2 : Nat) : Nat :=
   abstractMappingSlot (abstractMappingSlot baseSlot key1) key2
 
 /-- Derived mapping-table view from flat storage. -/
-def storageAsMappings (storage : Nat → Nat) : Nat → Nat → Nat :=
+def storageAsMappings (storage : Nat → IRStorageWord) : Nat → Nat → IRStorageWord :=
   fun baseSlot key => storage (solidityMappingSlot baseSlot key)
 
 /-- Read a mapping entry directly from base slot and key. -/
 def abstractLoadMappingEntry
-    (storage : Nat → Nat)
-    (baseSlot key : Nat) : Nat :=
+    (storage : Nat → IRStorageWord)
+    (baseSlot key : Nat) : IRStorageWord :=
   storage (solidityMappingSlot baseSlot key)
 
 /-- Write a mapping entry directly from base slot and key. -/
 def abstractStoreMappingEntry
-    (storage : Nat → Nat)
-    (baseSlot key value : Nat) : Nat → Nat :=
+    (storage : Nat → IRStorageWord)
+    (baseSlot key value : Nat) : Nat → IRStorageWord :=
   fun s => if s = solidityMappingSlot baseSlot key then value else storage s
 
 /-- Read through the active mapping-slot backend from flat storage. -/
 def abstractLoadStorageOrMapping
-    (storage : Nat → Nat)
-    (slot : Nat) : Nat :=
+    (storage : Nat → IRStorageWord)
+    (slot : Nat) : IRStorageWord :=
   storage slot
 
 /-- Write through the active mapping-slot backend to flat storage. -/
 def abstractStoreStorageOrMapping
-    (storage : Nat → Nat)
-    (slot value : Nat) : Nat → Nat :=
+    (storage : Nat → IRStorageWord)
+    (slot value : Nat) : Nat → IRStorageWord :=
   fun s => if s = slot then value else storage s
 
 @[simp] theorem abstractMappingSlot_eq_solidity (baseSlot key : Nat) :
@@ -115,23 +118,23 @@ def abstractStoreStorageOrMapping
   simp [abstractNestedMappingSlot]
 
 @[simp] theorem abstractLoadMappingEntry_eq
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (baseSlot key : Nat) :
     abstractLoadMappingEntry storage baseSlot key = storage (solidityMappingSlot baseSlot key) := rfl
 
 @[simp] theorem abstractStoreMappingEntry_eq
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (baseSlot key value : Nat) :
     abstractStoreMappingEntry storage baseSlot key value =
       (fun s => if s = solidityMappingSlot baseSlot key then value else storage s) := rfl
 
 @[simp] theorem abstractLoadStorageOrMapping_eq
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (slot : Nat) :
     abstractLoadStorageOrMapping storage slot = storage slot := rfl
 
 @[simp] theorem abstractStoreStorageOrMapping_eq
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (slot value : Nat) :
     abstractStoreStorageOrMapping storage slot value =
       (fun s => if s = slot then value else storage s) := rfl

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean
@@ -1,5 +1,6 @@
 import Compiler.Yul.Ast
 import Compiler.Constants
+import Compiler.Proofs.IRGeneration.IRStorageWord
 import Compiler.Proofs.MappingSlot
 import Compiler.Proofs.YulGeneration.Calldata
 import EvmYul.Yul.Ast
@@ -9,6 +10,7 @@ import Mathlib.Data.Finmap
 namespace Compiler.Proofs.YulGeneration.Backends
 
 open Compiler.Yul
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 
 abbrev AdapterError := String
 
@@ -1043,7 +1045,7 @@ def evalPureBuiltinViaEvmYulLean
     `abstractLoadStorageOrMapping`, the shared Verity/Phase-2 storage-read
     helper whose EVMYulLean-state correspondence is witnessed by
     `storageLookup_projectStorage` in `EvmYulLeanStateBridge.lean` (projecting
-    the abstract `storage : Nat → Nat` into EVMYulLean's `Storage` recovers the
+    the abstract `storage : Nat → IRStorageWord` into EVMYulLean's `Storage` recovers the
     same value). `mappingSlot` is bridged by routing through
     `abstractMappingSlot` — the same keccak-faithful Solidity mapping-slot
     derivation used by Verity's `evalBuiltinCallWithContext`; both backends
@@ -1051,7 +1053,7 @@ def evalPureBuiltinViaEvmYulLean
     context-dependent builtins (`caller`, `address`, `timestamp`, ...) are
     routed at the `evalBuiltinCallWithBackendContext` level. -/
 def evalBuiltinCallViaEvmYulLean
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (_sender : Nat)
     (selector : Nat)
     (calldata : List Nat)

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean
@@ -6,6 +6,7 @@ import Mathlib.Data.Nat.Bitwise
 namespace Compiler.Proofs.YulGeneration.Backends
 
 open Compiler.Proofs.YulGeneration
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 
 private theorem word_lt_uint256_size (x : Nat) :
     x % EvmYul.UInt256.size < 2 ^ 256 := by
@@ -20,7 +21,7 @@ private theorem uint256_ofNat_mod_evmModulus (n : Nat) :
   simp only [Fin.ofNat, EvmYul.UInt256.size, evmModulus, Nat.mod_mod]
 
 private theorem verity_eval_add_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "add" [a, b] =
       some ((a + b) % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -33,7 +34,7 @@ private theorem bridge_eval_add_normalized (a b : Nat) :
   simp [Fin.val_add, Nat.add_mod]
 
 private theorem verity_eval_sub_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sub" [a, b] =
       some ((evmModulus + a % evmModulus - b % evmModulus) % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -48,7 +49,7 @@ private theorem bridge_eval_sub_normalized (a b : Nat) :
   simp [Fin.sub_def, Nat.add_mod]
 
 private theorem verity_eval_mul_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mul" [a, b] =
       some ((a * b) % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -61,7 +62,7 @@ private theorem bridge_eval_mul_normalized (a b : Nat) :
   simp [Fin.mul_def, Nat.mul_mod]
 
 private theorem verity_eval_div_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "div" [a, b] =
       (if b % evmModulus = 0 then some 0 else some ((a % evmModulus) / (b % evmModulus))) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -78,7 +79,7 @@ private theorem bridge_eval_div_normalized (a b : Nat) :
   · simp [hb]
 
 private theorem verity_eval_mod_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mod" [a, b] =
       (if b % evmModulus = 0 then some 0 else some ((a % evmModulus) % (b % evmModulus))) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -109,7 +110,7 @@ private theorem bridge_eval_mod_normalized (a b : Nat) :
     rfl
 
 private theorem verity_eval_eq_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "eq" [a, b] =
       some (if a % evmModulus = b % evmModulus then 1 else 0) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -120,7 +121,7 @@ private theorem bridge_eval_eq_normalized (a b : Nat) :
   rfl
 
 private theorem verity_eval_iszero_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "iszero" [a] =
       some (if a % evmModulus = 0 then 1 else 0) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -132,7 +133,7 @@ private theorem bridge_eval_iszero_normalized (a : Nat) :
 
 set_option maxHeartbeats 2000000 in
 private theorem verity_eval_lt_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "lt" [a, b] =
       some (if a % evmModulus < b % evmModulus then 1 else 0) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -144,7 +145,7 @@ private theorem bridge_eval_lt_normalized (a b : Nat) :
 
 set_option maxHeartbeats 2000000 in
 private theorem verity_eval_gt_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "gt" [a, b] =
       some (if a % evmModulus > b % evmModulus then 1 else 0) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -291,14 +292,14 @@ private theorem bridge_eval_shr_normalized (shift value : Nat) :
     simp [hs, EvmYul.UInt256.shiftRight, EvmYul.UInt256.toNat, hs']
 
 @[simp] theorem evalBuiltinCall_add_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "add" [a, b] =
       evalPureBuiltinViaEvmYulLean "add" [a, b] := by
   rw [verity_eval_add_normalized, bridge_eval_add_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCall_sub_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sub" [a, b] =
       evalPureBuiltinViaEvmYulLean "sub" [a, b] := by
   rw [verity_eval_sub_normalized, bridge_eval_sub_normalized]
@@ -310,21 +311,21 @@ private theorem bridge_eval_shr_normalized (shift value : Nat) :
   simp [EvmYul.UInt256.size, evmModulus, hsub]
 
 @[simp] theorem evalBuiltinCall_mul_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mul" [a, b] =
       evalPureBuiltinViaEvmYulLean "mul" [a, b] := by
   rw [verity_eval_mul_normalized, bridge_eval_mul_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCall_div_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "div" [a, b] =
       evalPureBuiltinViaEvmYulLean "div" [a, b] := by
   rw [verity_eval_div_normalized, bridge_eval_div_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCall_mod_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mod" [a, b] =
       evalPureBuiltinViaEvmYulLean "mod" [a, b] := by
   rw [verity_eval_mod_normalized, bridge_eval_mod_normalized]
@@ -333,7 +334,7 @@ private theorem bridge_eval_shr_normalized (shift value : Nat) :
 /-- Universal bridge theorem for `eq`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_eq_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "eq" [a, b] =
       evalPureBuiltinViaEvmYulLean "eq" [a, b] := by
   rw [verity_eval_eq_normalized, bridge_eval_eq_normalized]
@@ -342,7 +343,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `iszero`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_iszero_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "iszero" [a] =
       evalPureBuiltinViaEvmYulLean "iszero" [a] := by
   rw [verity_eval_iszero_normalized, bridge_eval_iszero_normalized]
@@ -351,7 +352,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `lt`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_lt_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "lt" [a, b] =
       evalPureBuiltinViaEvmYulLean "lt" [a, b] := by
   rw [verity_eval_lt_normalized, bridge_eval_lt_normalized]
@@ -360,7 +361,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `gt`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_gt_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "gt" [a, b] =
       evalPureBuiltinViaEvmYulLean "gt" [a, b] := by
   rw [verity_eval_gt_normalized, bridge_eval_gt_normalized]
@@ -369,7 +370,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `and`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_and_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "and" [a, b] =
       evalPureBuiltinViaEvmYulLean "and" [a, b] := by
   rw [show evalBuiltinCall storage sender selector calldata "and" [a, b] =
@@ -380,7 +381,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `or`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_or_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "or" [a, b] =
       evalPureBuiltinViaEvmYulLean "or" [a, b] := by
   rw [show evalBuiltinCall storage sender selector calldata "or" [a, b] =
@@ -391,7 +392,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `xor`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_xor_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "xor" [a, b] =
       evalPureBuiltinViaEvmYulLean "xor" [a, b] := by
   change some (Nat.bitwise bne (a % evmModulus) (b % evmModulus)) =
@@ -403,7 +404,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `not`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_not_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "not" [a] =
       evalPureBuiltinViaEvmYulLean "not" [a] := by
   change some (a % evmModulus ^^^ (evmModulus - 1)) =
@@ -414,7 +415,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `shl`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_shl_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "shl" [shift, value] =
       evalPureBuiltinViaEvmYulLean "shl" [shift, value] := by
   rw [show evalBuiltinCall storage sender selector calldata "shl" [shift, value] =
@@ -428,7 +429,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `shr`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_shr_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "shr" [shift, value] =
       evalPureBuiltinViaEvmYulLean "shr" [shift, value] := by
   rw [show evalBuiltinCall storage sender selector calldata "shr" [shift, value] =
@@ -440,105 +441,105 @@ EVMYulLean UInt256 semantics on all inputs. -/
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_add_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "add" [a, b] =
       evalBuiltinCall storage sender selector calldata "add" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_add_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_sub_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "sub" [a, b] =
       evalBuiltinCall storage sender selector calldata "sub" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_sub_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_mul_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "mul" [a, b] =
       evalBuiltinCall storage sender selector calldata "mul" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_mul_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_div_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "div" [a, b] =
       evalBuiltinCall storage sender selector calldata "div" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_div_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_mod_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "mod" [a, b] =
       evalBuiltinCall storage sender selector calldata "mod" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_mod_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_eq_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "eq" [a, b] =
       evalBuiltinCall storage sender selector calldata "eq" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_eq_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_iszero_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "iszero" [a] =
       evalBuiltinCall storage sender selector calldata "iszero" [a] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_iszero_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_lt_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "lt" [a, b] =
       evalBuiltinCall storage sender selector calldata "lt" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_lt_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_gt_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "gt" [a, b] =
       evalBuiltinCall storage sender selector calldata "gt" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_gt_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_and_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "and" [a, b] =
       evalBuiltinCall storage sender selector calldata "and" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_and_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_or_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "or" [a, b] =
       evalBuiltinCall storage sender selector calldata "or" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_or_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_xor_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "xor" [a, b] =
       evalBuiltinCall storage sender selector calldata "xor" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_xor_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_not_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "not" [a] =
       evalBuiltinCall storage sender selector calldata "not" [a] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_not_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_shl_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "shl" [shift, value] =
       evalBuiltinCall storage sender selector calldata "shl" [shift, value] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_shl_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_shr_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "shr" [shift, value] =
       evalBuiltinCall storage sender selector calldata "shr" [shift, value] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -551,7 +552,7 @@ The key proof obligation is showing that the intermediate result is already
 < UInt256.size when the modulus is nonzero, so the outer `% size` is a no-op. -/
 
 private theorem verity_eval_addmod_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCall storage sender selector calldata "addmod" [a, b, n] =
       (if n % evmModulus = 0 then some 0 else some (((a % evmModulus) + (b % evmModulus)) % (n % evmModulus))) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -610,7 +611,7 @@ private theorem bridge_eval_addmod_normalized (a b n : Nat) :
       (by unfold EvmYul.UInt256.size; simp))))
 
 private theorem verity_eval_mulmod_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCall storage sender selector calldata "mulmod" [a, b, n] =
       (if n % evmModulus = 0 then some 0 else some (((a % evmModulus) * (b % evmModulus)) % (n % evmModulus))) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -645,7 +646,7 @@ private theorem bridge_eval_mulmod_normalized (a b n : Nat) :
 /-- Universal bridge theorem for `addmod`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_addmod_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCall storage sender selector calldata "addmod" [a, b, n] =
       evalPureBuiltinViaEvmYulLean "addmod" [a, b, n] := by
   rw [verity_eval_addmod_normalized, bridge_eval_addmod_normalized]
@@ -654,21 +655,21 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `mulmod`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_mulmod_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCall storage sender selector calldata "mulmod" [a, b, n] =
       evalPureBuiltinViaEvmYulLean "mulmod" [a, b, n] := by
   rw [verity_eval_mulmod_normalized, bridge_eval_mulmod_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_addmod_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "addmod" [a, b, n] =
       evalBuiltinCall storage sender selector calldata "addmod" [a, b, n] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_addmod_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_mulmod_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "mulmod" [a, b, n] =
       evalBuiltinCall storage sender selector calldata "mulmod" [a, b, n] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -690,7 +691,7 @@ private theorem nat_land_0xFF (n : Nat) : Nat.land n 255 = n % 256 := by
 
 set_option maxHeartbeats 4000000 in
 private theorem verity_eval_byte_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
     evalBuiltinCall storage sender selector calldata "byte" [i, x] =
       (if i % evmModulus > 31 then some 0
        else some ((x % evmModulus / 2 ^ ((31 - i % evmModulus) * 8)) % 256)) := by
@@ -760,14 +761,14 @@ private theorem bridge_eval_byte_normalized (i x : Nat) :
 /-- Universal bridge theorem for `byte`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_byte_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
     evalBuiltinCall storage sender selector calldata "byte" [i, x] =
       evalPureBuiltinViaEvmYulLean "byte" [i, x] := by
   rw [verity_eval_byte_normalized, bridge_eval_byte_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_byte_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "byte" [i, x] =
       evalBuiltinCall storage sender selector calldata "byte" [i, x] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -784,7 +785,7 @@ set_option maxHeartbeats 4000000 in
 /-- Helper: Verity's signed less-than on raw Nat inputs reduces to a comparison
 via `Int256.toInt`. This normalizes `evalBuiltinCallWithContext` for `slt`. -/
 private theorem verity_eval_slt_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "slt" [a, b] =
       some (if Verity.Core.Int256.toInt
               (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (a % evmModulus))) <
@@ -804,7 +805,7 @@ set_option maxHeartbeats 4000000 in
 /-- Helper: Verity's signed greater-than on raw Nat inputs reduces to a comparison
 via `Int256.toInt`. This normalizes `evalBuiltinCallWithContext` for `sgt`. -/
 private theorem verity_eval_sgt_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sgt" [a, b] =
       some (if Verity.Core.Int256.toInt
               (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (b % evmModulus))) <
@@ -892,7 +893,7 @@ private theorem slt_int256_eq_sltBool (a b : Nat) (ha : a < evmModulus) (hb : b 
 /-- Universal bridge theorem for `slt`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_slt_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "slt" [a, b] =
       evalPureBuiltinViaEvmYulLean "slt" [a, b] := by
   rw [verity_eval_slt_normalized, bridge_eval_slt_normalized]
@@ -915,7 +916,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
   exact slt_int256_eq_sltBool (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_slt_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "slt" [a, b] =
       evalBuiltinCall storage sender selector calldata "slt" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -953,7 +954,7 @@ private theorem sgt_int256_eq_sgtBool (a b : Nat) (ha : a < evmModulus) (hb : b 
 /-- Universal bridge theorem for `sgt`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_sgt_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sgt" [a, b] =
       evalPureBuiltinViaEvmYulLean "sgt" [a, b] := by
   rw [verity_eval_sgt_normalized, bridge_eval_sgt_normalized]
@@ -976,7 +977,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
   exact sgt_int256_eq_sgtBool (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_sgt_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "sgt" [a, b] =
       evalBuiltinCall storage sender selector calldata "sgt" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -993,7 +994,7 @@ The core equivalence requires showing both repeated-squaring loops compute
 the same result. This needs an induction proof matching the loop invariants. -/
 
 private theorem verity_eval_exp_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "exp" [a, b] =
       some (natModPow (a % evmModulus) (b % evmModulus) evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -1103,7 +1104,7 @@ private theorem exp_natModPow_eq_uint256Exp (a b : Nat)
 /-- Universal bridge theorem for `exp`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_exp_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "exp" [a, b] =
       evalPureBuiltinViaEvmYulLean "exp" [a, b] := by
   rw [verity_eval_exp_normalized, bridge_eval_exp_normalized]
@@ -1119,7 +1120,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
   exact exp_natModPow_eq_uint256Exp (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_exp_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "exp" [a, b] =
       evalBuiltinCall storage sender selector calldata "exp" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -1133,7 +1134,7 @@ implement EVM SDIV: signed division with truncation toward zero, where
 `sdiv(MIN_INT256, -1) = MIN_INT256`. -/
 
 private theorem verity_eval_sdiv_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sdiv" [a, b] =
       some (Verity.Core.Int256.div
         (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (a % evmModulus)))
@@ -1364,7 +1365,7 @@ private theorem sdiv_int256_eq_uint256Sdiv (a b : Nat)
 
 /-- Universal bridge theorem for `sdiv`. -/
 @[simp] theorem evalBuiltinCall_sdiv_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sdiv" [a, b] =
       evalPureBuiltinViaEvmYulLean "sdiv" [a, b] := by
   rw [verity_eval_sdiv_normalized, bridge_eval_sdiv_normalized]
@@ -1385,7 +1386,7 @@ private theorem sdiv_int256_eq_uint256Sdiv (a b : Nat)
   exact sdiv_int256_eq_uint256Sdiv (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_sdiv_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "sdiv" [a, b] =
       evalBuiltinCall storage sender selector calldata "sdiv" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -1397,7 +1398,7 @@ The `smod` bridge connects Verity's `Int256.mod` (sign-magnitude remainder via I
 with EVMYulLean's `UInt256.smod` (sign/abs decomposition with `sgn`/`toSigned`). -/
 
 private theorem verity_eval_smod_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "smod" [a, b] =
       some (Verity.Core.Int256.mod
         (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (a % evmModulus)))
@@ -1911,7 +1912,7 @@ private theorem smod_int256_eq_uint256Smod (a b : Nat)
 
 /-- Universal bridge theorem for `smod`. -/
 @[simp] theorem evalBuiltinCall_smod_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "smod" [a, b] =
       evalPureBuiltinViaEvmYulLean "smod" [a, b] := by
   rw [verity_eval_smod_normalized, bridge_eval_smod_normalized]
@@ -1932,7 +1933,7 @@ private theorem smod_int256_eq_uint256Smod (a b : Nat)
   exact smod_int256_eq_uint256Smod (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_smod_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "smod" [a, b] =
       evalBuiltinCall storage sender selector calldata "smod" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -1944,7 +1945,7 @@ The `sar` bridge connects Verity's `Int256.sar` (floor division by 2^shift via I
 with EVMYulLean's `UInt256.sar` (complement-shift-complement for negatives). -/
 
 private theorem verity_eval_sar_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "sar" [shift, value] =
       some (Verity.Core.Int256.sar
         (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (shift % evmModulus)))
@@ -2286,7 +2287,7 @@ private theorem sar_int256_eq_uint256Sar (shift value : Nat)
 
 /-- Universal bridge theorem for `sar`. -/
 @[simp] theorem evalBuiltinCall_sar_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "sar" [shift, value] =
       evalPureBuiltinViaEvmYulLean "sar" [shift, value] := by
   rw [verity_eval_sar_normalized, bridge_eval_sar_normalized]
@@ -2307,7 +2308,7 @@ private theorem sar_int256_eq_uint256Sar (shift value : Nat)
   exact sar_int256_eq_uint256Sar (shift % evmModulus) (value % evmModulus) hs hv
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_sar_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "sar" [shift, value] =
       evalBuiltinCall storage sender selector calldata "sar" [shift, value] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -2320,7 +2321,7 @@ Nat arithmetic) with EVMYulLean's `UInt256.signextend` (shift-based bit test).
 Both implement EVM SIGNEXTEND: extending the sign bit at byte position `b`. -/
 
 private theorem verity_eval_signextend_normalized
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
     evalBuiltinCall storage sender selector calldata "signextend" [byteIdx, value] =
       some (Verity.Core.Uint256.signextend
         (Verity.Core.Uint256.ofNat (byteIdx % evmModulus))
@@ -2610,7 +2611,7 @@ private theorem signextend_uint256_eq (byteIdx value : Nat)
 
 /-- Universal bridge theorem for `signextend`. -/
 @[simp] theorem evalBuiltinCall_signextend_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
     evalBuiltinCall storage sender selector calldata "signextend" [byteIdx, value] =
       evalPureBuiltinViaEvmYulLean "signextend" [byteIdx, value] := by
   rw [verity_eval_signextend_normalized, bridge_eval_signextend_normalized]
@@ -2631,7 +2632,7 @@ private theorem signextend_uint256_eq (byteIdx value : Nat)
   exact signextend_uint256_eq (byteIdx % evmModulus) (value % evmModulus) hb hv
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_signextend_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "signextend" [byteIdx, value] =
       evalBuiltinCall storage sender selector calldata "signextend" [byteIdx, value] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -2733,7 +2734,7 @@ fallback covers all builtins. -/
 /-- `calldataload` is bridged at the full adapter boundary because it depends
     on the selector/calldata context rather than only on argument words. -/
 @[simp] theorem evalBuiltinCall_calldataload_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (offset : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (offset : Nat) :
     evalBuiltinCall storage sender selector calldata "calldataload" [offset] =
       evalBuiltinCallViaEvmYulLean storage sender selector calldata "calldataload" [offset] := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext, evalBuiltinCallViaEvmYulLean]
@@ -2744,7 +2745,7 @@ fallback covers all builtins. -/
     that helper is witnessed by `storageLookup_projectStorage` in
     `EvmYulLeanStateBridge.lean`. -/
 @[simp] theorem evalBuiltinCall_sload_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (slot : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (slot : Nat) :
     evalBuiltinCall storage sender selector calldata "sload" [slot] =
       evalBuiltinCallViaEvmYulLean storage sender selector calldata "sload" [slot] := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext, evalBuiltinCallViaEvmYulLean]
@@ -2756,7 +2757,7 @@ fallback covers all builtins. -/
     ultimately invoke the same kernel-computable `KeccakEngine.keccak256`,
     the two sides are definitionally equal. -/
 @[simp] theorem evalBuiltinCall_mappingSlot_bridge
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (base key : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (base key : Nat) :
     evalBuiltinCall storage sender selector calldata "mappingSlot" [base, key] =
       evalBuiltinCallViaEvmYulLean storage sender selector calldata "mappingSlot" [base, key] := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext, evalBuiltinCallViaEvmYulLean]
@@ -2797,7 +2798,7 @@ These are the key composition lemmas for Phase 4 (retargeting the theorem
 stack to EVMYulLean). -/
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_add_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "add" [a, b] =
@@ -2808,7 +2809,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sub_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sub" [a, b] =
@@ -2819,7 +2820,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_mul_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "mul" [a, b] =
@@ -2830,7 +2831,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_div_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "div" [a, b] =
@@ -2841,7 +2842,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_mod_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "mod" [a, b] =
@@ -2852,7 +2853,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_eq_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "eq" [a, b] =
@@ -2863,7 +2864,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_iszero_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "iszero" [a] =
@@ -2874,7 +2875,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_lt_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "lt" [a, b] =
@@ -2885,7 +2886,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_gt_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "gt" [a, b] =
@@ -2896,7 +2897,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_slt_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "slt" [a, b] =
@@ -2907,7 +2908,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sgt_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sgt" [a, b] =
@@ -2918,7 +2919,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_and_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "and" [a, b] =
@@ -2929,7 +2930,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_or_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "or" [a, b] =
@@ -2940,7 +2941,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_xor_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "xor" [a, b] =
@@ -2951,7 +2952,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_not_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "not" [a] =
@@ -2962,7 +2963,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_shl_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "shl" [a, b] =
@@ -2973,7 +2974,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_shr_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "shr" [a, b] =
@@ -2984,7 +2985,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_addmod_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b c : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "addmod" [a, b, c] =
@@ -2995,7 +2996,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_mulmod_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b c : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "mulmod" [a, b, c] =
@@ -3006,7 +3007,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_byte_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (i x : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "byte" [i, x] =
@@ -3017,7 +3018,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_exp_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "exp" [a, b] =
@@ -3028,7 +3029,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sdiv_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sdiv" [a, b] =
@@ -3039,7 +3040,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_smod_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "smod" [a, b] =
@@ -3050,7 +3051,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sar_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sar" [shift, value] =
@@ -3061,7 +3062,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_signextend_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (byteIdx value : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "signextend" [byteIdx, value] =
@@ -3089,7 +3090,7 @@ These lemmas define the exact Phase-3 boundary that later retargeting proofs
 can rewrite against. -/
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sload_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (slot : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sload" [slot] =
@@ -3098,7 +3099,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext, evalBuiltinCallViaEvmYulLean]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_caller_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "caller" [] =
@@ -3107,7 +3108,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_address_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "address" [] =
@@ -3116,7 +3117,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_callvalue_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "callvalue" [] =
@@ -3125,7 +3126,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_timestamp_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "timestamp" [] =
@@ -3134,7 +3135,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_number_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "number" [] =
@@ -3143,7 +3144,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_blobbasefee_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "blobbasefee" [] =
@@ -3152,7 +3153,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_chainid_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "chainid" [] =
@@ -3161,7 +3162,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_calldataload_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (offset : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "calldataload" [offset] =
@@ -3172,7 +3173,7 @@ can rewrite against. -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_calldatasize_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "calldatasize" [] =
@@ -3181,7 +3182,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_mappingSlot_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (base key : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "mappingSlot" [base, key] =
@@ -3214,7 +3215,7 @@ separately when the builtin is known to be in the bridged pure fragment. -/
     per-builtin bridge lemmas are applied after this routing rewrite when the
     builtin is known to lie in the bridged pure fragment. -/
 theorem evalBuiltinCallWithBackendContext_evmYulLean_pure_bridge
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (func : String) (argVals : List Nat)
     (hCaller : func ≠ "caller")
     (hAddress : func ≠ "address")

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
@@ -21,9 +21,10 @@ namespace Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeTest
 
 open Compiler.Proofs.YulGeneration
 open Compiler.Proofs.YulGeneration.Backends
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 
 -- Shared test parameters (state-independent for pure builtins)
-private def testStorage : Nat → Nat := fun _ => 0
+private def testStorage : Nat → IRStorageWord := fun _ => 0
 private def testSender : Nat := 42
 private def testMsgValue : Nat := 99
 private def testThisAddress : Nat := 0xC0FFEE
@@ -164,55 +165,55 @@ example : verityEval "iszero" [Compiler.Constants.evmModulus] =
           bridgeEval "iszero" [Compiler.Constants.evmModulus] := by native_decide
 
 /-- Universal bridge theorem for `add` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "add" [a, b] =
       evalPureBuiltinViaEvmYulLean "add" [a, b] := by
   exact evalBuiltinCall_add_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `sub` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sub" [a, b] =
       evalPureBuiltinViaEvmYulLean "sub" [a, b] := by
   exact evalBuiltinCall_sub_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `mul` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mul" [a, b] =
       evalPureBuiltinViaEvmYulLean "mul" [a, b] := by
   exact evalBuiltinCall_mul_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `div` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "div" [a, b] =
       evalPureBuiltinViaEvmYulLean "div" [a, b] := by
   exact evalBuiltinCall_div_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `mod` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mod" [a, b] =
       evalPureBuiltinViaEvmYulLean "mod" [a, b] := by
   exact evalBuiltinCall_mod_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `eq` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "eq" [a, b] =
       evalPureBuiltinViaEvmYulLean "eq" [a, b] := by
   exact evalBuiltinCall_eq_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `iszero` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "iszero" [a] =
       evalPureBuiltinViaEvmYulLean "iszero" [a] := by
   exact evalBuiltinCall_iszero_bridge storage sender selector calldata a
 
 /-- Universal bridge theorem for `lt` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "lt" [a, b] =
       evalPureBuiltinViaEvmYulLean "lt" [a, b] := by
   exact evalBuiltinCall_lt_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `gt` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "gt" [a, b] =
       evalPureBuiltinViaEvmYulLean "gt" [a, b] := by
   exact evalBuiltinCall_gt_bridge storage sender selector calldata a b
@@ -249,19 +250,19 @@ example : verityEval "xor" [Compiler.Constants.evmModulus, 0] =
           bridgeEval "xor" [Compiler.Constants.evmModulus, 0] := by native_decide
 
 /-- Universal bridge theorem for `and` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "and" [a, b] =
       evalPureBuiltinViaEvmYulLean "and" [a, b] := by
   exact evalBuiltinCall_and_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `or` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "or" [a, b] =
       evalPureBuiltinViaEvmYulLean "or" [a, b] := by
   exact evalBuiltinCall_or_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `xor` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "xor" [a, b] =
       evalPureBuiltinViaEvmYulLean "xor" [a, b] := by
   exact evalBuiltinCall_xor_bridge storage sender selector calldata a b
@@ -274,7 +275,7 @@ example : verityEval "not" [Compiler.Constants.evmModulus] =
           bridgeEval "not" [Compiler.Constants.evmModulus] := by native_decide
 
 /-- Universal bridge theorem for `not` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "not" [a] =
       evalPureBuiltinViaEvmYulLean "not" [a] := by
   exact evalBuiltinCall_not_bridge storage sender selector calldata a
@@ -291,7 +292,7 @@ example : verityEval "shl" [Compiler.Constants.evmModulus - 1, 3] =
           bridgeEval "shl" [Compiler.Constants.evmModulus - 1, 3] := by native_decide
 
 /-- Universal bridge theorem for `shl` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "shl" [shift, value] =
       evalPureBuiltinViaEvmYulLean "shl" [shift, value] := by
   exact evalBuiltinCall_shl_bridge storage sender selector calldata shift value
@@ -308,7 +309,7 @@ example : verityEval "shr" [Compiler.Constants.evmModulus - 1, 12345] =
           bridgeEval "shr" [Compiler.Constants.evmModulus - 1, 12345] := by native_decide
 
 /-- Universal bridge theorem for `shr` (symbolic, not vector-based). -/
-example (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "shr" [shift, value] =
       evalPureBuiltinViaEvmYulLean "shr" [shift, value] := by
   exact evalBuiltinCall_shr_bridge storage sender selector calldata shift value

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -11,6 +11,7 @@ open Compiler.Yul
 open Compiler.Proofs.YulGeneration
 open Compiler.Proofs.YulGeneration.Backends.StateBridge
 open Lean Elab Tactic Meta
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 
 /-!
 Executable native EVMYulLean runtime harness for #1737.
@@ -33,7 +34,7 @@ external-call semantics.
 def initialState
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.Yul.State :=
   let verityState := YulState.initial tx storage
@@ -6199,9 +6200,9 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_without_default_fuel
     mkBlockHeader, EvmYul.State.chainId]
 
 /-- Project the account storage for the current contract back to Verity's
-    `Nat → Nat` storage view. -/
+    `Nat → IRStorageWord` storage view. -/
 def projectStorageFromState (tx : YulTransaction) (state : EvmYul.Yul.State) :
-    Nat → Nat :=
+    Nat → IRStorageWord :=
   extractStorage state.sharedState (natToAddress tx.thisAddress)
 
 /-- Projecting final native storage reads the current contract account storage
@@ -7209,7 +7210,7 @@ theorem callDispatcher_succ_eq_callDispatcherBlockResult
     back to the supplied initial storage function. -/
 def projectResult
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (result :
       Except EvmYul.Yul.Exception
@@ -9826,7 +9827,7 @@ def interpretRuntimeNative
     (fuel : Nat)
     (runtimeCode : List YulStmt)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (events : List (List Nat) := []) :
     Except AdapterError YulResult := do

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanRetarget.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanRetarget.lean
@@ -328,7 +328,7 @@ private theorem backends_agree_calldatasize s se mv ta bt bn ci bb sl cd av :
   | _ :: _ => rfl
 
 -- Unary builtin: sload (state-dependent, routed through the same
--- `storage : Nat → Nat` lookup used by Verity's `evalBuiltinCallWithContext`)
+-- `storage : Nat → IRStorageWord` lookup used by Verity's `evalBuiltinCallWithContext`)
 private theorem backends_agree_sload s se mv ta bt bn ci bb sl cd av :
     evalBuiltinCallWithBackendContext .verity s se mv ta bt bn ci bb sl cd "sload" av =
     evalBuiltinCallWithBackendContext .evmYulLean s se mv ta bt bn ci bb sl cd "sload" av := by
@@ -368,7 +368,7 @@ All bridged builtin dependencies are fully proven in `EvmYulLeanBridgeLemmas.lea
     This theorem is sorry-free, composing the fully proven per-builtin bridge
     lemmas in `EvmYulLeanBridgeLemmas.lean`. -/
 theorem backends_agree_on_bridged_builtins
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat)
     (func : String) (argVals : List Nat)
     (hBridged : func ∈ bridgedBuiltins) :
@@ -440,7 +440,7 @@ set_option maxHeartbeats 1000000 in
     program that evaluates `keccak256(...)` through this interpreter halts
     identically on both sides.  -/
 private theorem backends_agree_on_keccak256
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (argVals : List Nat) :
     evalBuiltinCallWithBackendContext .verity storage sender msgValue thisAddress
@@ -2655,7 +2655,8 @@ noncomputable def execYulStmtsWithBackend
 noncomputable def interpretYulRuntimeWithBackendFuel
     (backend : BuiltinBackend) (fuel : Nat)
     (runtimeCode : List Compiler.Yul.YulStmt)
-    (tx : YulTransaction) (storage : Nat → Nat) (events : List (List Nat) := []) :
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (events : List (List Nat) := []) :
     YulResult :=
   let initialState := YulState.initial tx storage events
   yulResultOfExecWithRollback initialState
@@ -2663,14 +2664,16 @@ noncomputable def interpretYulRuntimeWithBackendFuel
 
 noncomputable def interpretYulRuntimeWithBackend
     (backend : BuiltinBackend) (runtimeCode : List Compiler.Yul.YulStmt)
-    (tx : YulTransaction) (storage : Nat → Nat) (events : List (List Nat) := []) :
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (events : List (List Nat) := []) :
     YulResult :=
   interpretYulRuntimeWithBackendFuel backend (sizeOf runtimeCode + 1)
     runtimeCode tx storage events
 
 @[simp] theorem interpretYulRuntimeWithBackend_eq_fuel
     (backend : BuiltinBackend) (runtimeCode : List Compiler.Yul.YulStmt)
-    (tx : YulTransaction) (storage : Nat → Nat) (events : List (List Nat) := []) :
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (events : List (List Nat) := []) :
     interpretYulRuntimeWithBackend backend runtimeCode tx storage events =
       interpretYulRuntimeWithBackendFuel backend (sizeOf runtimeCode + 1)
         runtimeCode tx storage events := by
@@ -2678,7 +2681,7 @@ noncomputable def interpretYulRuntimeWithBackend
 
 theorem interpretYulRuntimeWithBackend_verity_eq
     (runtimeCode : List Compiler.Yul.YulStmt) (tx : YulTransaction)
-    (storage : Nat → Nat) (events : List (List Nat) := []) :
+    (storage : Nat → IRStorageWord) (events : List (List Nat) := []) :
     interpretYulRuntimeWithBackend .verity runtimeCode tx storage events =
     interpretYulRuntime runtimeCode tx storage events := by
   unfold interpretYulRuntimeWithBackend interpretYulRuntimeWithBackendFuel

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
@@ -39,6 +39,7 @@ import Batteries.Data.RBMap.Lemmas
 namespace Compiler.Proofs.YulGeneration.Backends.StateBridge
 
 open Compiler.Proofs.YulGeneration
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 open EvmYul
 
 /-! ## Nat ↔ UInt256 Conversions -/
@@ -108,7 +109,7 @@ def storageWrite (s : EvmYul.Storage) (slot val : UInt256) : EvmYul.Storage :=
 (equivalently `slot < 2^256`). Without this, distinct `Nat` slots differing by
 multiples of `2^256` alias to the same RBMap key via `natToUInt256`. The
 `storageLookup_projectStorage` theorem enforces this via its `hRange` hypothesis. -/
-def projectStorage (storage : Nat → Nat) (slots : List Nat) : EvmYul.Storage :=
+def projectStorage (storage : Nat → IRStorageWord) (slots : List Nat) : EvmYul.Storage :=
   slots.foldl (init := Batteries.RBMap.empty) fun acc slot =>
     let key := natToUInt256 slot
     let val := natToUInt256 (storage slot)
@@ -461,7 +462,7 @@ def toSharedState (state : YulState) (observableSlots : List Nat) :
 at `slot >= 2^256` alias onto low-bit keys. Bridge equivalence proofs
 should carry an in-range hypothesis (`slot < UInt256.size`). -/
 def extractStorage (sharedState : SharedState .Yul) (addr : AccountAddress) :
-    Nat → Nat :=
+    Nat → IRStorageWord :=
   fun slot =>
     match sharedState.accountMap.find? addr with
     | some account =>
@@ -639,7 +640,7 @@ theorem compare_natToUInt256_ne {a b : Nat}
 
 /-- Helper: folding inserts over a list of slots that does NOT contain `slot`
     preserves whatever `find?` value the accumulator had for `natToUInt256 slot`. -/
-theorem foldl_insert_find_not_mem (storage : Nat → Nat)
+theorem foldl_insert_find_not_mem (storage : Nat → IRStorageWord)
     (slots : List Nat) (slot : Nat) (hNotMem : slot ∉ slots)
     (hRange : ∀ s ∈ slots, s < UInt256.size)
     (hSlotRange : slot < UInt256.size)
@@ -662,7 +663,7 @@ theorem foldl_insert_find_not_mem (storage : Nat → Nat)
 
     This generalizes `storageLookup_projectStorage` to work with any
     accumulator (not just `empty`), which is needed for the induction. -/
-theorem foldl_insert_find (storage : Nat → Nat)
+theorem foldl_insert_find (storage : Nat → IRStorageWord)
     (slots : List Nat) (slot : Nat) (hSlot : slot ∈ slots)
     (hRange : ∀ s ∈ slots, s < UInt256.size)
     (acc : EvmYul.Storage) :
@@ -693,7 +694,7 @@ theorem foldl_insert_find (storage : Nat → Nat)
     slot list (EVM storage slots are always < 2^256). Without it, two
     distinct Nat slots could collide under modular reduction and the
     last-write-wins semantics of `foldl` would make the theorem false. -/
-theorem storageLookup_projectStorage (storage : Nat → Nat)
+theorem storageLookup_projectStorage (storage : Nat → IRStorageWord)
     (slots : List Nat) (slot : Nat) (hSlot : slot ∈ slots)
     (hRange : ∀ s ∈ slots, s < UInt256.size) :
     uint256ToNat (storageLookup (projectStorage storage slots) (natToUInt256 slot)) =

--- a/Compiler/Proofs/YulGeneration/Preservation.lean
+++ b/Compiler/Proofs/YulGeneration/Preservation.lean
@@ -27,7 +27,7 @@ See `TRUST_ASSUMPTIONS.md` for the full trust-boundary description.
   rfl
 
 @[simp] private theorem interpretYulRuntime_eq_yulResultOfExecWithRollback_initial
-    (runtimeCode : List YulStmt) (tx : YulTransaction) (storage : Nat → Nat)
+    (runtimeCode : List YulStmt) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (events : List (List Nat)) :
     interpretYulRuntime runtimeCode tx storage events =
       yulResultOfExecWithRollback (YulState.initial tx storage events)

--- a/Compiler/Proofs/YulGeneration/ReferenceOracle/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/ReferenceOracle/Builtins.lean
@@ -16,6 +16,7 @@ current retargeting path; this file is not part of that trust boundary.
 -/
 
 open Compiler.Proofs
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 export Compiler.Constants (evmModulus selectorModulus selectorShift)
 
 /-- Auxiliary loop for modular exponentiation via repeated squaring.
@@ -35,7 +36,7 @@ def natModPow (base exp modulus : Nat) : Nat :=
   else modPowAux modulus (base % modulus) exp 1
 
 def evalBuiltinCallWithContext
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (sender : Nat)
     (msgValue : Nat)
     (thisAddress : Nat)
@@ -256,7 +257,7 @@ abbrev defaultBuiltinBackend : BuiltinBackend := .verity
 
 def evalBuiltinCallWithBackendContext
     (backend : BuiltinBackend)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (sender : Nat)
     (msgValue : Nat)
     (thisAddress : Nat)
@@ -311,7 +312,7 @@ def evalBuiltinCallWithBackendContext
 
 def evalBuiltinCallWithBackend
     (backend : BuiltinBackend)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (sender : Nat)
     (selector : Nat)
     (calldata : List Nat)
@@ -320,7 +321,7 @@ def evalBuiltinCallWithBackend
   evalBuiltinCallWithBackendContext backend storage sender 0 0 0 0 0 0 selector calldata func argVals
 
 def evalBuiltinCall
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (sender : Nat)
     (selector : Nat)
     (calldata : List Nat)
@@ -329,60 +330,60 @@ def evalBuiltinCall
   evalBuiltinCallWithContext storage sender 0 0 0 0 0 0 selector calldata func argVals
 
 @[simp] theorem evalBuiltinCall_callvalue_nil
-    (storage : Nat → Nat) (sender thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender 0 thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "callvalue" [] =
       some 0 := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_callvalue_context
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "callvalue" [] =
       some (msgValue % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_calldatasize_nil
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) :
     evalBuiltinCall storage sender selector calldata "calldatasize" [] =
       some ((4 + calldata.length * 32) % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_caller_nil
-    (storage : Nat → Nat) (sender selector : Nat) (calldata : List Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) :
     evalBuiltinCall storage sender selector calldata "caller" [] = some sender := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_address_nil
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "address" [] =
       some (thisAddress % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_timestamp_nil
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "timestamp" [] =
       some (blockTimestamp % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_number_nil
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "number" [] =
       some (blockNumber % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_chainid_nil
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "chainid" [] =
       some (chainId % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_blobbasefee_nil
-    (storage : Nat → Nat) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "blobbasefee" [] =
       some (blobBaseFee % evmModulus) := by
@@ -394,12 +395,12 @@ def evalBuiltinCall
   simp [calldataloadWord]
 
 @[simp] theorem evalBuiltinCall_calldataload_offset4_single
-    (storage : Nat → Nat) (sender selector value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector value : Nat) :
     evalBuiltinCall storage sender selector [value] "calldataload" [4] = some (value % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext, calldataloadWord]
 
 @[simp] theorem evalBuiltinCallWithBackend_calldataload_offset4_single
-    (storage : Nat → Nat) (sender selector value : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector value : Nat) :
     evalBuiltinCallWithBackend
         defaultBuiltinBackend
         storage
@@ -413,13 +414,13 @@ def evalBuiltinCall
     calldataloadWord]
 
 @[simp] theorem evalBuiltinCall_sload_single
-    (storage : Nat → Nat) (sender selector : Nat) (slot : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (slot : Nat) :
     evalBuiltinCall storage sender selector [] "sload" [slot] =
       some (Compiler.Proofs.abstractLoadStorageOrMapping storage slot) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackend_sload_single
-    (storage : Nat → Nat) (sender selector : Nat) (slot : Nat) :
+    (storage : Nat → IRStorageWord) (sender selector : Nat) (slot : Nat) :
     evalBuiltinCallWithBackend
         defaultBuiltinBackend
         storage

--- a/Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
+++ b/Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
@@ -342,8 +342,8 @@ noncomputable def execYulStmts (state : YulState) (stmts : List YulStmt) : YulEx
 structure YulResult where
   success : Bool
   returnValue : Option Nat
-  finalStorage : Nat → Nat
-  finalMappings : Nat → Nat → Nat
+  finalStorage : Nat → IRStorageWord
+  finalMappings : Nat → Nat → IRStorageWord
   events : List (List Nat)
 
 /-- Execute a Yul runtime program with selector-aware calldata -/

--- a/Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
+++ b/Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
@@ -73,7 +73,7 @@ structure YulTransaction where
     (YulTransaction.ofIR tx).args = tx.args := rfl
 
 /-- Initial state for Yul execution. -/
-def YulState.initial (tx : YulTransaction) (storage : Nat → Nat)
+def YulState.initial (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (events : List (List Nat) := []) : YulState :=
   { vars := []
     storage := storage
@@ -348,7 +348,7 @@ structure YulResult where
 
 /-- Execute a Yul runtime program with selector-aware calldata -/
 noncomputable def interpretYulRuntime (runtimeCode : List YulStmt) (tx : YulTransaction)
-    (storage : Nat → Nat) (events : List (List Nat) := []) : YulResult :=
+    (storage : Nat → IRStorageWord) (events : List (List Nat) := []) : YulResult :=
   let initialState := YulState.initial tx storage events
   match execYulStmts initialState runtimeCode with
   | .continue s =>
@@ -378,7 +378,7 @@ noncomputable def interpretYulRuntime (runtimeCode : List YulStmt) (tx : YulTran
 
 /-- Interpret a Yul object by executing its runtime code. -/
 noncomputable def interpretYulObject (obj : YulObject) (tx : YulTransaction)
-    (storage : Nat → Nat) (events : List (List Nat) := []) : YulResult :=
+    (storage : Nat → IRStorageWord) (events : List (List Nat) := []) : YulResult :=
   interpretYulRuntime obj.runtimeCode tx storage events
 
 end Compiler.Proofs.YulGeneration

--- a/Compiler/Proofs/YulGeneration/ReferenceOracle/State.lean
+++ b/Compiler/Proofs/YulGeneration/ReferenceOracle/State.lean
@@ -1,10 +1,14 @@
+import Compiler.Proofs.IRGeneration.IRStorageWord
+
 namespace Compiler.Proofs.YulGeneration
+
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 
 /-! Shared state structures for the reference-oracle Yul runtime. -/
 
 structure YulState where
   vars : List (String × Nat)
-  storage : Nat → Nat
+  storage : Nat → IRStorageWord
   transientStorage : Nat → Nat := fun _ => 0
   memory : Nat → Nat
   calldata : List Nat

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -41,6 +41,7 @@ import Compiler.Proofs.IRGeneration.Function
 import Compiler.Proofs.IRGeneration.FunctionBody
 import Compiler.Proofs.IRGeneration.GenericInduction
 import Compiler.Proofs.IRGeneration.IRInterpreter
+import Compiler.Proofs.IRGeneration.IRStorageWord
 import Compiler.Proofs.IRGeneration.ParamLoading
 import Compiler.Proofs.IRGeneration.SourceSemantics
 import Compiler.Proofs.IRGeneration.SupportedSpec
@@ -1882,6 +1883,10 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.IRGeneration.applyIRTransactionContext_sender
 #print axioms Compiler.Proofs.IRGeneration.applyIRTransactionContext_calldata
 
+-- Compiler/Proofs/IRGeneration/IRStorageWord.lean
+#print axioms Compiler.Proofs.IRGeneration.IRStorageWord.toNat_ofNat
+#print axioms Compiler.Proofs.IRGeneration.IRStorageWord.ofNat_toNat
+
 -- Compiler/Proofs/IRGeneration/ParamLoading.lean
 #print axioms Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
 #print axioms Compiler.Proofs.IRGeneration.ParamLoading.wordNormalize_eq_mod
@@ -3519,4 +3524,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3346 theorems/lemmas (2415 public, 931 private, 0 sorry'd)
+-- Total: 3348 theorems/lemmas (2417 public, 931 private, 0 sorry'd)

--- a/docs/IR_STORAGE_UINT256_REFACTOR.md
+++ b/docs/IR_STORAGE_UINT256_REFACTOR.md
@@ -1,0 +1,194 @@
+# IR Storage Type Refactor: `Nat → Nat` ⇒ `Nat → UInt256`
+
+Tracking the structural refactor that closes the retrieve-hit and store-hit
+sub-bridges of `simpleStorageNativeCallDispatcherBridge` — and, more
+generally, every per-case native dispatcher bridge that observes a value
+read from storage.
+
+## Why this exists
+
+The first executable instantiation of the native dispatcher bridge
+discharges `simpleStorageNativeSelectorMissBridge` but leaves
+`simpleStorageNativeRetrieveHitBridge` and
+`simpleStorageNativeStoreHitBridge` as explicit hypotheses on the public
+theorem `simpleStorage_endToEnd_native_evmYulLean`.
+
+Those two cases cannot be discharged inside the current public theorem
+signature because of a type-level mismatch:
+
+- The Verity proof oracle `interpretYulRuntimeWithBackend .evmYulLean` reads
+  from `IRState.storage : Nat → Nat` (see
+  [`Compiler/Proofs/IRGeneration/IRInterpreter.lean`](../Compiler/Proofs/IRGeneration/IRInterpreter.lean)).
+  The carrier is unbounded.
+- The native path executes against EVMYulLean's `SharedState`, whose
+  storage carrier is `UInt256`. The native projection
+  (`projectStorageFromState` → `extractStorage` → `.toNat` in
+  [`EvmYulLeanNativeHarness.lean`](../Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean))
+  therefore truncates every observed value by `% UInt256.size`.
+- The retrieve-hit return value is computed by `projectHaltReturn` from 32
+  bytes the native path wrote with `mstore` of a `UInt256`. The raw
+  unbounded value has been destroyed at the `mstore` step and cannot be
+  recovered from the returned byte buffer alone.
+
+Adding a pre-state slot-bound hypothesis to the public theorem is rejected
+by the transition design (the public hypothesis surface is intentionally
+fixed). Routing an "expected return" through `projectResult` would make
+the bridge tautological. The only resolution that closes both the
+return-value and final-storage gaps without weakening the public theorem
+is to bound `IRState.storage` (and the associated read/write paths) by
+construction.
+
+## Goal
+
+Change the IR-side storage carrier from `Nat → Nat` to a `UInt256`-typed
+carrier, so that:
+
+- `IRState.storage slot` and the EVMYulLean `SharedState` storage slot
+  agree on every observable slot up to a coercion that is provably
+  injective on the IR side.
+- The retrieve-hit `mstore` chain on the native side and the layer-3
+  oracle's storage read produce the same 32 bytes / `UInt256` payload by
+  reducing through a single bounded representation.
+- The selector-miss bridge and any non-storage bridges remain unaffected.
+
+## Non-goals
+
+- Changing the EVMYulLean fork's storage representation. The refactor is
+  on the IR side only.
+- Changing `verity_contract` user-facing surface syntax. Any widening of
+  what users can write should land in separate PRs.
+- Touching transient storage / memory unless the same gap is observable
+  there (memory is internally `mstore`-driven and already `UInt256`-flat
+  in the byte buffer; transient storage is currently untouched by the
+  failing bridges).
+
+## Phased plan
+
+The refactor is invasive enough that it must land in well-scoped phases.
+Each phase ships independently, with `lake build` and `make check` green
+at every step.
+
+### Phase 0 — type alias and adapter surface
+
+Introduce a typed alias `IRStorageWord` (initially `:= Nat`) with
+canonical injection/projection helpers and migrate existing
+`IRState.storage : Nat → Nat` consumers to call those helpers without
+changing semantics. This is a no-op rename that makes Phase 1 a single
+internal-type swap.
+
+Deliverables:
+- `Compiler/Proofs/IRGeneration/IRStorageWord.lean` — defines
+  `IRStorageWord`, `IRStorageWord.ofNat`, `IRStorageWord.toNat`,
+  `IRStorageWord.toUInt256`, plus the obvious round-trip lemmas.
+- Migrate every direct `IRState.storage` field access through the new
+  helpers; keep the underlying carrier `Nat` so no proof has to change.
+
+Exit criteria: `lake build` clean; `simpleStorage_endToEnd_native_evmYulLean`
+still has both `hRetrieveHit` and `hStoreHit` premises.
+
+### Phase 1 — flip the carrier to `UInt256`
+
+Change `IRStorageWord` from `Nat` to `UInt256` (or a structurally
+equivalent bounded record). Audit every site that produced an unbounded
+value into storage and add the (already-true on the supported fragment)
+masking step. Update the IR interpreter's `sload`/`sstore` semantics to
+go through the typed helpers.
+
+Deliverables:
+- Updated `IRStorageWord` with canonical `UInt256` representation.
+- `IRInterpreter` updates so that every value entering / leaving the
+  storage carrier is `UInt256`-bounded.
+- Audit log of every former `Nat → Nat` callsite, listed in this doc.
+
+Exit criteria: `lake build` clean; every existing per-contract spec
+proof in `Contracts/<Name>/Proofs/` still passes (no spec regressions).
+
+### Phase 2 — discharge `simpleStorageNativeRetrieveHitBridge`
+
+With storage values bounded by construction on the IR side, the native
+projection's `% UInt256.size` truncation becomes the identity on the
+relevant slot. The retrieve-hit return-value chain reduces because the
+`mstore`'d native bytes and the IR-oracle return word agree.
+
+Deliverables:
+- A proved `simpleStorageNativeRetrieveHitBridge_proved` lemma analogous
+  to `simpleStorageNativeSelectorMissBridge_proved`.
+- Drop the `hRetrieveHit` premise from
+  `simpleStorage_endToEnd_native_evmYulLean`.
+
+Exit criteria: `PrintAxioms` for the public theorem no longer lists the
+retrieve-hit bridge; `lake build` clean; `make check` clean.
+
+### Phase 3 — discharge `simpleStorageNativeStoreHitBridge`
+
+Same argument as Phase 2 for the store-hit case: the written value
+flows through bounded storage and the re-read of any other materialized
+observable slot agrees. The calldata round-trip was already 32-byte
+bounded, so the writeback case becomes mechanical.
+
+Deliverables:
+- A proved `simpleStorageNativeStoreHitBridge_proved` lemma.
+- Drop the `hStoreHit` premise from
+  `simpleStorage_endToEnd_native_evmYulLean`.
+
+Exit criteria: the public SimpleStorage native theorem has zero
+remaining bridge premises beyond what the selector dispatcher already
+discharges; `simpleStorageNativeCallDispatcherBridge_of_per_case` is
+the only remaining surface and it is fully closed.
+
+### Phase 4 — generalize and retire the per-case bridge surface
+
+Replace the per-contract `simpleStorageNative*Bridge` family with a
+generic, dispatcher-shape-driven bridge so future contracts inherit
+discharge automatically.
+
+Deliverables:
+- Generic `nativeCallDispatcherBridge_of_typed_storage` lemma over the
+  supported lowered-dispatcher fragment.
+- `simpleStorage_endToEnd_native_evmYulLean` re-derived from the generic
+  surface; no SimpleStorage-specific bridge file remains beyond the test
+  harness.
+
+## Acceptance signals
+
+- `simpleStorage_endToEnd_native_evmYulLean` has no `hRetrieveHit` or
+  `hStoreHit` premise.
+- `PrintAxioms` for the public theorem reports no bridge axioms beyond
+  the trusted `EvmYulLean` builtin axioms inherited from the existing
+  bridge-lemma set.
+- `Contracts/SimpleStorage/Proofs/` spec theorems are unchanged.
+- A second contract (e.g. Counter) lifts to the native theorem under the
+  generic Phase-4 surface without contract-specific bridge code.
+
+## Risks and rollback
+
+- **Spec drift.** Phase 1's flip changes the IR storage carrier; any
+  spec proof that implicitly relied on `Nat`-shaped storage must be
+  updated. Mitigation: keep Phase 0's helper surface stable so spec
+  proofs only see the helper API.
+- **Performance.** `UInt256` arithmetic in the IR interpreter is heavier
+  than `Nat` arithmetic for `decide`-style proof automation. Mitigation:
+  expose `simp` lemmas that re-export bounded results as `Nat` only at
+  the spec boundary.
+- **Rollback.** Phase 0 is a pure rename; Phase 1 is the only
+  destructive step. If Phase 1 hits an unexpected proof regression that
+  cannot be repaired in the same PR, revert the Phase 1 commit and keep
+  the helper surface in place for a later attempt.
+
+## Out-of-scope follow-ups
+
+- Memory carrier typing. Memory is currently `Nat → Nat` for similar
+  reasons and benefits from the same treatment, but the failing bridges
+  do not depend on it.
+- Transient storage carrier typing. Same caveat.
+- EVMYulLean fork changes. The refactor stays on the Verity side.
+
+## See also
+
+- [`NATIVE_EVMYULLEAN_TRANSITION.md`](NATIVE_EVMYULLEAN_TRANSITION.md)
+  — the parent transition plan and the per-case bridge status section.
+- [`Compiler/Proofs/EndToEnd.lean`](../Compiler/Proofs/EndToEnd.lean)
+  — `simpleStorage_endToEnd_native_evmYulLean` and the
+  `simpleStorageNative*Bridge` family.
+- [`Compiler/Proofs/IRGeneration/IRInterpreter.lean`](../Compiler/Proofs/IRGeneration/IRInterpreter.lean)
+  — the current `IRState.storage : Nat → Nat` definition.

--- a/docs/IR_STORAGE_UINT256_REFACTOR.md
+++ b/docs/IR_STORAGE_UINT256_REFACTOR.md
@@ -86,6 +86,17 @@ Deliverables:
 Exit criteria: `lake build` clean; `simpleStorage_endToEnd_native_evmYulLean`
 still has both `hRetrieveHit` and `hStoreHit` premises.
 
+Status:
+- Helper module `IRStorageWord.lean` landed (commit `5de766e2`).
+- `IRState.storage` field retyped to `Nat → IRStorageWord` so the
+  signature is already in the Phase-1-ready shape; with the current
+  `abbrev IRStorageWord := Nat` this is rfl-identical to `Nat → Nat`,
+  so no callsite needed updating.
+- The "route every read/write through `IRStorageWord.ofNat` /
+  `IRStorageWord.toNat`" deliverable is intentionally folded into
+  Phase 1: under `abbrev` the routing is a no-op rename, and routing
+  only becomes semantically meaningful once the abbrev is removed.
+
 ### Phase 1 — flip the carrier to `UInt256`
 
 Change `IRStorageWord` from `Nat` to `UInt256` (or a structurally


### PR DESCRIPTION
## Summary
- Adds `Compiler.Proofs.IRGeneration.IRStorageWord`, a typed-alias helper surface for the IR storage value carrier with `ofNat` / `toNat` / `toUInt256` helpers and round-trip lemmas.
- Ships [`docs/IR_STORAGE_UINT256_REFACTOR.md`](../blob/codex/ir-storage-uint256-refactor-skeleton/docs/IR_STORAGE_UINT256_REFACTOR.md) — the phased design doc for the long-term refactor.
- No existing callsites are migrated. This is the Phase 0 no-op rename surface so the Phase 1 carrier flip is a single internal-type swap.

## Why

PR #1743 instantiates the first per-case native dispatcher bridge for SimpleStorage. It discharges `simpleStorageNativeSelectorMissBridge` but leaves `simpleStorageNativeRetrieveHitBridge` and `simpleStorageNativeStoreHitBridge` as explicit hypotheses on the public theorem `simpleStorage_endToEnd_native_evmYulLean`.

Those two cases cannot be discharged inside the current public theorem signature for a structural reason:

- `interpretYulRuntimeWithBackend .evmYulLean` reads from `IRState.storage : Nat → Nat` (unbounded).
- The native path executes against EVMYulLean's `SharedState`, whose storage is `UInt256`-typed; the native projection (`projectStorageFromState` → `extractStorage` → `.toNat`) truncates by `% UInt256.size`.
- The retrieve-hit return value is built by `mstore` of a `UInt256`, so the raw unbounded value is destroyed at the `mstore` step and cannot be recovered from the returned byte buffer alone.

Adding a pre-state slot-bound hypothesis to the public theorem is rejected by the transition design — the public hypothesis surface is intentionally fixed. Routing an "expected return" through `projectResult` would make the bridge tautological. The clean resolution is to bound the IR storage representation by construction.

## Phased plan

| Phase | Scope | Exit signal |
|-------|-------|-------------|
| **0 (this PR)** | Add `IRStorageWord` typed-alias helper surface; no callsite migration. | Module builds; round-trip lemmas hold. |
| 1 | Flip `IRStorageWord` to `UInt256`; migrate `IRState.storage`; audit callsites. | All existing spec proofs still pass. |
| 2 | Discharge `simpleStorageNativeRetrieveHitBridge` through bounded carrier. | Drop `hRetrieveHit` from `simpleStorage_endToEnd_native_evmYulLean`. |
| 3 | Discharge `simpleStorageNativeStoreHitBridge` similarly. | Drop `hStoreHit`; PrintAxioms shows zero remaining bridge premises. |
| 4 | Generalize: replace per-contract bridge family with dispatcher-shape-driven generic. | Second contract (e.g. Counter) lifts to native theorem without per-contract bridge code. |

Full plan, acceptance signals, risks, and rollback procedure live in [`docs/IR_STORAGE_UINT256_REFACTOR.md`](../blob/codex/ir-storage-uint256-refactor-skeleton/docs/IR_STORAGE_UINT256_REFACTOR.md).

## Relation to PR #1743

- PR #1743 lands the dispatcher-bridge instantiation, the selector-miss discharge, and the documentation describing the storage-modulo gap.
- This follow-up PR opens Phase 0 of the resolution. It does **not** depend on #1743 merging first; the doc is duplicated cleanly between the two branches and will merge without conflict if both land in either order.

## Test plan
- [x] `lake build Compiler.Proofs.IRGeneration.IRStorageWord` — clean.
- [x] `make check` — clean.
- [x] `python3 scripts/generate_print_axioms.py --check` — up to date.

## Status

**Draft.** Phase 0 is intentionally a no-op rename surface; promote out of draft only if maintainers confirm the phased plan before Phase 1 work begins.

Refs #1737. Refs #1722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a no-op alias (`IRStorageWord := Nat`), but it touches many proof/bridge signatures around storage and could cause subtle typeclass/simp breakage or mismatched expectations when projecting storage to `UInt256`. No runtime semantics should change in this phase.
> 
> **Overview**
> Adds `IRStorageWord` (currently `Nat`) with `ofNat`/`toNat`/`toUInt256` helpers and round-trip lemmas as the Phase 0 scaffold for a future `UInt256`-bounded storage refactor.
> 
> Retypes the storage carrier from `Nat → Nat` to `Nat → IRStorageWord` across `IRState`, Yul reference-oracle state/results, mapping-slot helpers, and the EVMYulLean adapter/bridge/native harness/retargeting lemmas, plus updates `PrintAxioms` and adds a design doc (`docs/IR_STORAGE_UINT256_REFACTOR.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9bca673ab9995db30d4b60f1c82964056edef79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->