### PR TITLE
proofs: discharge retrieve-hit bridge (Phase 2)

### DIFF
--- a/Compiler/CompilationModel/LayoutValidation.lean
+++ b/Compiler/CompilationModel/LayoutValidation.lean
@@ -353,23 +353,24 @@ where
       match f.ty with
       | FieldType.adt _ maxFields =>
           (List.range (maxFields + 1)).map fun offset =>
-            (slot + offset,
-             if offset == 0 then f.name else s!"{f.name}.payload[{offset - 1}]",
-             none)
-      | _ => [(slot, f.name, f.packedBits)]
-    canonical ++
-      (f.aliasSlots.zipIdx.flatMap (fun (aliasSlot, aliasIdx) =>
-        match f.ty with
-        | FieldType.adt _ maxFields =>
-            (List.range (maxFields + 1)).map fun offset =>
-              (aliasSlot + offset,
-               if offset == 0 then
-                 s!"{f.name}.aliasSlots[{aliasIdx}]"
-               else
-                 s!"{f.name}.aliasSlots[{aliasIdx}].payload[{offset - 1}]",
+            ((slot + offset) % Compiler.Constants.evmModulus,
+               if offset == 0 then f.name else s!"{f.name}.payload[{offset - 1}]",
                none)
-        | _ =>
-            [(aliasSlot, s!"{f.name}.aliasSlots[{aliasIdx}]", f.packedBits)]))
+        | _ => [(slot % Compiler.Constants.evmModulus, f.name, f.packedBits)]
+      canonical ++
+        (f.aliasSlots.zipIdx.flatMap (fun (aliasSlot, aliasIdx) =>
+          match f.ty with
+          | FieldType.adt _ maxFields =>
+              (List.range (maxFields + 1)).map fun offset =>
+                ((aliasSlot + offset) % Compiler.Constants.evmModulus,
+                 if offset == 0 then
+                   s!"{f.name}.aliasSlots[{aliasIdx}]"
+                 else
+                   s!"{f.name}.aliasSlots[{aliasIdx}].payload[{offset - 1}]",
+                 none)
+          | _ =>
+              [(aliasSlot % Compiler.Constants.evmModulus,
+                s!"{f.name}.aliasSlots[{aliasIdx}]", f.packedBits)]))
 
 /-- Stepping lemma: firstInFieldConflict on nil. -/
 theorem firstFieldWriteSlotConflict_firstInFieldConflict_nil

--- a/Compiler/Proofs/ArithmeticProfile.lean
+++ b/Compiler/Proofs/ArithmeticProfile.lean
@@ -25,7 +25,7 @@ import EvmYul.UInt256
 namespace Compiler.Proofs.ArithmeticProfile
 
 open Compiler.Constants (evmModulus)
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 open Compiler.Proofs.YulGeneration (evalBuiltinCall)
 open Compiler.Proofs.YulGeneration.Backends (evalPureBuiltinViaEvmYulLean)
 
@@ -45,7 +45,7 @@ theorem evmyullean_size_eq_verity_modulus :
 -- ============================================================================
 
 -- Dummy state parameters (arithmetic builtins are state-independent).
-private def s : Nat → IRStorageWord := fun _ => 0
+private def s : IRStorageSlot → IRStorageWord := fun _ => 0
 private def sender : Nat := 0
 private def sel : Nat := 0
 private def cd : List Nat := []

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -82,7 +82,8 @@ def yulResultsAgreeOn
     (observableSlots : List Nat) (left right : YulResult) : Prop :=
   left.success = right.success ∧
   left.returnValue = right.returnValue ∧
-  (∀ slot, slot ∈ observableSlots → left.finalStorage slot = right.finalStorage slot) ∧
+  (∀ slot, slot ∈ observableSlots →
+    left.finalStorage (IRStorageSlot.ofNat slot) = right.finalStorage (IRStorageSlot.ofNat slot)) ∧
   left.events = right.events
 
 /-- Observable result comparison surface for native EVMYulLean execution. -/
@@ -95,7 +96,8 @@ def nativeResultsMatchOn
   | .ok yul =>
       ir.success = yul.success ∧
       ir.returnValue = yul.returnValue ∧
-      (∀ slot, slot ∈ observableSlots → ir.finalStorage slot = yul.finalStorage slot) ∧
+      (∀ slot, slot ∈ observableSlots →
+        ir.finalStorage (IRStorageSlot.ofNat slot) = yul.finalStorage (IRStorageSlot.ofNat slot)) ∧
       ir.events = yul.events
   | .error _ => False
 
@@ -111,7 +113,7 @@ theorem nativeResultsMatchOn_ok_of_resultsMatch_of_yulResultsAgreeOn
     hreturnValue.trans hnativeReturnValue.symm,
     (by
       intro slot hslot
-      exact (hstorage slot).trans (hnativeStorage slot hslot).symm),
+      exact (hstorage (IRStorageSlot.ofNat slot)).trans (hnativeStorage slot hslot).symm),
     hevents.trans hnativeEvents.symm
   ⟩
 
@@ -127,7 +129,7 @@ theorem yulResultsAgreeOn_of_resultsMatch_of_nativeResultsMatchOn
     hnativeReturnValue.symm.trans hreturnValue,
     (by
       intro slot hslot
-      exact (hnativeStorage slot hslot).symm.trans (hstorage slot)),
+      exact (hnativeStorage slot hslot).symm.trans (hstorage (IRStorageSlot.ofNat slot))),
     hnativeEvents.symm.trans hevents
   ⟩
 
@@ -705,7 +707,7 @@ private def paramLoadErasure (fn : IRFunction) (tx : IRTransaction) (state : IRS
 /-- Result wrapping equivalence: `interpretYulRuntime` produces the same `YulResult`
 as `yulResultOfExecWithRollback` when the rollback storage matches. -/
 theorem interpretYulRuntime_eq_yulResultOfExec
-    (stmts : List Yul.YulStmt) (tx : YulTransaction) (stor : Nat → IRStorageWord)
+    (stmts : List Yul.YulStmt) (tx : YulTransaction) (stor : IRStorageSlot → IRStorageWord)
     (events : List (List Nat)) :
     interpretYulRuntime stmts tx stor events =
       yulResultOfExecWithRollback (YulState.initial tx stor events)
@@ -1632,7 +1634,7 @@ harness's per-selector body lemmas already speak about, in preparation for
 discharging the bridge from those lemmas. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_innerBlock_exec
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat) :
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
         (Nat.succ (Nat.succ (Nat.succ peeledFuel)))
         Compiler.SimpleStorageNativeWitness.nativeContract
@@ -1976,7 +1978,7 @@ spine using the pinned named witnesses. This combines
 existential let/if/if shape with a concrete equation in named witnesses. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_named_let_if_if_block_exec
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat) :
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
         (Nat.succ (Nat.succ (Nat.succ peeledFuel)))
         Compiler.SimpleStorageNativeWitness.nativeContract
@@ -2534,7 +2536,7 @@ through later case-dispatch peels using
 `exec_lowerNativeSwitchBlock_simpleStorageConcrete_*` lemmas. -/
 theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativeSwitchBlock_exec
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (switchId : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -2579,7 +2581,7 @@ where the lowered default body of the inner switch is pinned to
 in place of the unpinned existential variant. -/
 theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativeSwitchBlock_revert_default_exec
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (switchId : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
@@ -2626,7 +2628,7 @@ Built by switching the underlying `if2Body` decomposition to its sourceLowered
 companion. -/
 theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
@@ -2676,7 +2678,7 @@ a singleton lowered-switch block at fuel `peeledFuel + 8` on
 `(initialOk).insert "__has_selector" 1`. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_exec
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (switchId : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -2719,7 +2721,7 @@ store-parametric `exec_lowerNativeSwitchBlock_selector_find_none_with_revert_def
 endpoint. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (switchId : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
@@ -2763,7 +2765,7 @@ into the lowered `cases'.find?` results required by the `_via_reduction`
 endpoint. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
@@ -2813,7 +2815,7 @@ the direct selector-miss discharge composing into
 theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_via_reduction
     (fuel selector switchId : Nat)
     (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hSelectorRange : selector < EvmYul.UInt256.size)
@@ -3292,7 +3294,7 @@ remaining selector-miss obligation in the SimpleStorage native dispatcher
 bridge to a purely source-level statement. -/
 theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert
     (fuel selector : Nat)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hSelectorRange : selector < EvmYul.UInt256.size)
@@ -3341,7 +3343,7 @@ theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert
 flag set: the input state shape consumed by the selected body inside the
 lowered native switch's hit branch. -/
 def simpleStorageDispatcherHitBodyInputState
-    (switchId : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (switchId : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) : EvmYul.Yul.State :=
   ((((.Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             Compiler.SimpleStorageNativeWitness.nativeContract
@@ -3365,7 +3367,7 @@ theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_via_reduction
     (fuel switchId : Nat)
     (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (storeBody' retrieveBody' : List EvmYul.Yul.Ast.Stmt)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector :
       0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -3420,7 +3422,7 @@ def simpleStorageLoweredHitCasesShape
     .ok ([(0x6057361d, storeBody'), (0x2e64cec1, retrieveBody')], midN)
 
 theorem simpleStorageNativeContract_dispatcherExec_storeHit_error
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3490,7 +3492,7 @@ only has to discharge the body-exec obligation on the *fixed* lowered body
 parametric premise. This strictly weakens the hit-case obligation that the
 dispatcher bridge proof has to supply. -/
 theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concrete
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3515,7 +3517,7 @@ theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concrete
   exact hBody reservedNames n0
 
 theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concrete_tail
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3546,7 +3548,7 @@ the 5-statement `simpleStorageLoweredStoreCaseBodyTail` at fuel `+8`. Strictly
 shrinks the dispatcher hit-case body-exec obligation under the natural Solidity
 assumption that non-payable functions are called with `msg.value = 0`. -/
 theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concrete_tail2
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3587,7 +3589,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_via_reducti
     (fuel switchId : Nat)
     (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (storeBody' retrieveBody' : List EvmYul.Yul.Ast.Stmt)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector :
       0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -3634,7 +3636,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_via_reducti
   · simpa [simpleStorageDispatcherHitBodyInputState] using hBody
 
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3683,7 +3685,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error
       | cons _ _ => simp at hRest
 
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3708,7 +3710,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete
   exact hBody reservedNames n0
 
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3733,7 +3735,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_ta
 
 /-- Retrieve-case dual of `_storeHit_error_concrete_tail2`. -/
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail2
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3778,7 +3780,7 @@ the callvalue and lt-calldatasize guards via the strip lemmas. The
 calldata-size assumptions are derived automatically from `hNoWrap` and
 `initialState_calldataSize`. -/
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail3
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (fuel : Nat) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3837,21 +3839,22 @@ theorem simpleStorageNativeDispatcherFuel_ge_25 :
 class. Given the raw selector match (`= 0x2e64cec1`), `interpretIR` enters the
 `retrieve` body which is read-only on storage: it loads slot 0 via `sload`,
 mirrors it into memory[0..32] via `mstore`, and returns those 32 bytes. The
-returned word equals `(state.storage 0).toNat` (where `state` is
+returned word equals `(state.storage (IRStorageSlot.ofNat 0)).toNat` (where `state` is
 `initialState.withTx tx`). Storage and events are unchanged.
 
-After Phase 1 of the IR storage refactor, `state.storage 0 : IRStorageWord`
-is `UInt256`-bounded, so `(state.storage 0).toNat < 2^256`. This is the
+  After Phase 1 of the IR storage refactor,
+  `state.storage (IRStorageSlot.ofNat 0) : IRStorageWord` is `UInt256`-bounded,
+  so `(state.storage (IRStorageSlot.ofNat 0)).toNat < 2^256`. This is the
 IR-side input to `simpleStorageNativeRetrieveHitBridge` Step A. -/
 theorem interpretIR_simpleStorage_retrieveHit
     (tx : IRTransaction) (initialState : IRState)
     (hSel : tx.functionSelector = 0x2e64cec1) :
-    interpretIR simpleStorageIRContract tx initialState =
-      { success := true
-        returnValue := some (initialState.storage 0).toNat
-        finalStorage := initialState.storage
-        finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
-        events := initialState.events } := by
+      interpretIR simpleStorageIRContract tx initialState =
+        { success := true
+          returnValue := some ((initialState.storage (IRStorageSlot.ofNat 0)).toNat)
+          finalStorage := initialState.storage
+          finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
+          events := initialState.events } := by
   have hstore : (0x6057361d == tx.functionSelector) = false := by
     simp [BEq.beq, hSel]
   have hretrieve : (0x2e64cec1 == tx.functionSelector) = true := by
@@ -3863,8 +3866,9 @@ theorem interpretIR_simpleStorage_retrieveHit
             [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
          Yul.YulStmt.expr (Yul.YulExpr.call "return"
             [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] =
-        .return (s.storage 0).toNat
-          { s with memory := fun o => if o = 0 then (s.storage 0).toNat else s.memory o } := by
+          .return ((s.storage (IRStorageSlot.ofNat 0)).toNat)
+            { s with memory := fun o =>
+                if o = 0 then (s.storage (IRStorageSlot.ofNat 0)).toNat else s.memory o } := by
     intro n s hn
     obtain ⟨k, rfl⟩ : ∃ k, n = k + 2 := ⟨n - 2, by omega⟩
     -- Fuel `k + 2 + 1 = k + 3` is `Nat.succ (Nat.succ (Nat.succ k))`, allowing
@@ -3907,7 +3911,7 @@ universally quantifies over `(reservedNames, n0)` against a single fixed
 `err`, which is incompatible with the switchId-dependent varStore inside
 the halt-error term. -/
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
     (hMsgValue : tx.msgValue = 0) :
@@ -4062,7 +4066,7 @@ shared state with empty memory. The native projected return value is the
 `Nat`-normalized form of the loaded slot-zero word; storage and logs are
 read off the halt's `sharedState` directly. -/
 theorem projectResult_retrieveHit_eq
-    (tx : YulTransaction) (initialStorage : Nat → IRStorageWord)
+    (tx : YulTransaction) (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (shared : EvmYul.SharedState .Yul) (store : EvmYul.Yul.VarStore)
     (hMemory : shared.memory = ByteArray.empty) :

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -3739,7 +3739,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_ta
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
-    (hMsgValue : tx.msgValue = 0)
+    (hMsgValue : tx.msgValue % EvmYul.UInt256.size = 0)
     (hTail2 : ∀ (reservedNames : List String) (n0 : Nat),
         EvmYul.Yul.exec (fuel + 6)
           (.Block simpleStorageLoweredRetrieveCaseBodyTail2)
@@ -3762,9 +3762,11 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_ta
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
         observableSlots).sharedState.executionEnv.weiValue =
       (⟨0⟩ : EvmYul.Literal) := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue,
-        hMsgValue]
-    rfl
+    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue]
+    apply congrArg EvmYul.UInt256.mk
+    apply Fin.ext
+    simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256,
+      EvmYul.UInt256.ofNat, Fin.ofNat] using hMsgValue
   have hT2 := hTail2 reservedNames n0
   show EvmYul.Yul.exec (fuel + 7) (.Block simpleStorageLoweredRetrieveCaseBodyTail)
     (some Compiler.SimpleStorageNativeWitness.nativeContract)
@@ -3784,7 +3786,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_ta
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
-    (hMsgValue : tx.msgValue = 0)
+    (hMsgValue : tx.msgValue % EvmYul.UInt256.size = 0)
     (hTail3 : ∀ (reservedNames : List String) (n0 : Nat),
         EvmYul.Yul.exec (fuel + 9)
           (.Block simpleStorageLoweredRetrieveCaseBodyTail3)
@@ -3914,7 +3916,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
     (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
-    (hMsgValue : tx.msgValue = 0) :
+    (hMsgValue : tx.msgValue % EvmYul.UInt256.size = 0) :
     let shared := (Compiler.Proofs.YulGeneration.Backends.Native.initialState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
         observableSlots).sharedState
@@ -3979,9 +3981,11 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage
         observableSlots).sharedState.executionEnv.weiValue =
       (⟨0⟩ : EvmYul.Literal) := by
-    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue,
-        hMsgValue]
-    rfl
+    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue]
+    apply congrArg EvmYul.UInt256.mk
+    apply Fin.ext
+    simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256,
+      EvmYul.UInt256.ofNat, Fin.ofNat] using hMsgValue
   have hSize :
       (Compiler.Proofs.YulGeneration.Backends.Native.initialState
         Compiler.SimpleStorageNativeWitness.nativeContract tx storage

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -3213,6 +3213,40 @@ theorem exec_block_simpleStorageLoweredRetrieveCaseBodyTail3_closed
   rw [hF] at hSeam
   simpa [simpleStorageLoweredRetrieveCaseBodyTail3] using hSeam
 
+/-- Composed body-level closed form for the SimpleStorage retrieve hit-case.
+Stacks the three guard-strip lemmas (head no-op, callvalue, lt-calldatasize)
+on top of `_Tail3_closed` to characterize the full lowered retrieve body's
+exec output as the closed-form halt error produced by
+`mstore(0, sload(0)); return(0, 32)`. The `shared3` form mirrors `_Tail3_closed`. -/
+theorem exec_block_simpleStorageLoweredRetrieveCaseBody_halt
+    (fuel : Nat) (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (shared : EvmYul.SharedState .Yul) (store : EvmYul.Yul.VarStore)
+    (hWei : shared.executionEnv.weiValue = (⟨0⟩ : EvmYul.Literal))
+    (hSize : shared.executionEnv.calldata.size < EvmYul.UInt256.size)
+    (hGe : 4 ≤ shared.executionEnv.calldata.size) :
+    EvmYul.Yul.exec (fuel + 12) (.Block simpleStorageLoweredRetrieveCaseBody)
+        codeOverride (.Ok shared store) =
+      let (state', value) := shared.sload (EvmYul.UInt256.ofNat 0)
+      let shared1 : EvmYul.SharedState .Yul := { shared with toState := state' }
+      let shared2 : EvmYul.SharedState .Yul :=
+        { shared1 with
+          toMachineState :=
+            shared1.toMachineState.mstore (EvmYul.UInt256.ofNat 0) value }
+      let shared3 : EvmYul.SharedState .Yul :=
+        { shared2 with
+          toMachineState :=
+            shared2.toMachineState.evmReturn
+              (EvmYul.UInt256.ofNat 0) (EvmYul.UInt256.ofNat 32) }
+      .error (EvmYul.Yul.Exception.YulHalt (.Ok shared3 store) ⟨1⟩) := by
+  have hTail3 := exec_block_simpleStorageLoweredRetrieveCaseBodyTail3_closed
+    fuel codeOverride shared store
+  have hTail2 := exec_block_simpleStorageLoweredRetrieveCaseBodyTail2_lt_strip_error
+    fuel codeOverride shared store _ hSize hGe hTail3
+  have hTail := exec_block_simpleStorageLoweredRetrieveCaseBodyTail_callvalue_strip_error
+    (fuel + 4) codeOverride shared store _ hWei hTail2
+  exact exec_block_simpleStorageLoweredRetrieveCaseBody_head_strip_error
+    (fuel + 10) codeOverride (.Ok shared store) _ hTail
+
 /-- Concrete characterization of the lowered SimpleStorage source switch
 cases. Both bodies are straight-line, so the lowering is deterministic and
 the threaded `nextSwitchId` returns unchanged. Strengthens `_lowered_shape`
@@ -3790,6 +3824,306 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_ta
 noncomputable def simpleStorageNativeDispatcherFuel : Nat :=
   sizeOf [Compiler.CodegenCommon.buildSwitch
     simpleStorageIRContract.functions none none]
+
+/-- Lower bound on the SimpleStorage native dispatcher fuel constant for
+the retrieve-hit and store-hit bridges, which use the `_concrete_tail3`
+chain that produces dispatcher exec at `fuel + 25`. -/
+theorem simpleStorageNativeDispatcherFuel_ge_25 :
+    simpleStorageNativeDispatcherFuel ≥ 25 := by
+  unfold simpleStorageNativeDispatcherFuel
+  decide
+
+/-- Closed-form `interpretIR` reduction for the SimpleStorage retrieve-hit
+class. Given the raw selector match (`= 0x2e64cec1`), `interpretIR` enters the
+`retrieve` body which is read-only on storage: it loads slot 0 via `sload`,
+mirrors it into memory[0..32] via `mstore`, and returns those 32 bytes. The
+returned word equals `(state.storage 0).toNat` (where `state` is
+`initialState.withTx tx`). Storage and events are unchanged.
+
+After Phase 1 of the IR storage refactor, `state.storage 0 : IRStorageWord`
+is `UInt256`-bounded, so `(state.storage 0).toNat < 2^256`. This is the
+IR-side input to `simpleStorageNativeRetrieveHitBridge` Step A. -/
+theorem interpretIR_simpleStorage_retrieveHit
+    (tx : IRTransaction) (initialState : IRState)
+    (hSel : tx.functionSelector = 0x2e64cec1) :
+    interpretIR simpleStorageIRContract tx initialState =
+      { success := true
+        returnValue := some (initialState.storage 0).toNat
+        finalStorage := initialState.storage
+        finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
+        events := initialState.events } := by
+  have hstore : (0x6057361d == tx.functionSelector) = false := by
+    simp [BEq.beq, hSel]
+  have hretrieve : (0x2e64cec1 == tx.functionSelector) = true := by
+    simp [BEq.beq, hSel]
+  -- Closed-form evaluation of the retrieve body for any fuel ≥ 2.
+  have hbody : ∀ (n : Nat) (s : IRState), 2 ≤ n →
+      execIRStmts (n + 1) s
+        [Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+            [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
+         Yul.YulStmt.expr (Yul.YulExpr.call "return"
+            [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] =
+        .return (s.storage 0).toNat
+          { s with memory := fun o => if o = 0 then (s.storage 0).toNat else s.memory o } := by
+    intro n s hn
+    obtain ⟨k, rfl⟩ : ∃ k, n = k + 2 := ⟨n - 2, by omega⟩
+    -- Fuel `k + 2 + 1 = k + 3` is `Nat.succ (Nat.succ (Nat.succ k))`, allowing
+    -- both the outer `execIRStmts` and the inner `execIRStmt` to step.
+    simp +decide only [execIRStmts, execIRStmt, evalIRExpr, evalIRCall, evalIRExprs,
+      Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackendContext,
+      Compiler.Proofs.YulGeneration.evalBuiltinCallWithContext,
+      Compiler.Proofs.abstractLoadStorageOrMapping,
+      Option.bind_some, bind, pure, ↓reduceIte]
+  -- The retrieve body has at least 2 statements, so `sizeOf body ≥ 2` by
+  -- direct computation on the auto-derived size measure.
+  have hsize : 2 ≤ sizeOf
+      ([Yul.YulStmt.expr (Yul.YulExpr.call "mstore"
+            [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
+        Yul.YulStmt.expr (Yul.YulExpr.call "return"
+            [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])] : List Yul.YulStmt) := by
+    decide
+  unfold interpretIR
+  simp only [simpleStorageIRContract, List.find?, hstore, hretrieve,
+    List.length_nil, Nat.zero_le, ↓reduceDIte]
+  -- Now goal involves `execIRFunction retrieveFn tx.args state'`.
+  unfold execIRFunction
+  simp only [List.zip_nil_left, List.foldl_nil]
+  -- Goal: `match execIRStmts (sizeOf body + 1) state' body with ... = ...`.
+  rw [hbody _ _ hsize]
+
+/-- Native dispatcher exec at exactly `simpleStorageNativeDispatcherFuel`
+reduces to `.error (YulHalt (.Ok shared3 _) ⟨1⟩)` for the retrieve-hit class,
+where `shared3` is the closed-form shared state after the
+`mstore(0, sload(0))` and `return(0, 32)` updates. The Yul varStore inside
+the halt state depends on the fresh switch identifier (which the dispatcher
+chose internally), so it is left existentially quantified — `projectResult`
+on `.error (YulHalt _ _)` ignores the varStore, so this is sufficient for
+the bridge proof. Composes the body-level closed form
+`exec_block_simpleStorageLoweredRetrieveCaseBody_halt` with
+`_retrieveHit_error_via_reduction` after opening the `_sourceLowered`
+existential and pinning `cases'` via `_lowered_shape` and
+`_lowered_concrete`. The `_concrete_tail*` chain is bypassed because it
+universally quantifies over `(reservedNames, n0)` against a single fixed
+`err`, which is incompatible with the switchId-dependent varStore inside
+the halt-error term. -/
+theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hMsgValue : tx.msgValue = 0) :
+    let shared := (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState
+    let p := shared.sload (EvmYul.UInt256.ofNat 0)
+    let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
+    let shared2 : EvmYul.SharedState .Yul :=
+      { shared1 with
+        toMachineState :=
+          shared1.toMachineState.mstore (EvmYul.UInt256.ofNat 0) p.2 }
+    let shared3 : EvmYul.SharedState .Yul :=
+      { shared2 with
+        toMachineState :=
+          shared2.toMachineState.evmReturn
+            (EvmYul.UInt256.ofNat 0) (EvmYul.UInt256.ofNat 32) }
+    ∃ store : EvmYul.Yul.VarStore,
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+          simpleStorageNativeDispatcherFuel
+          Compiler.SimpleStorageNativeWitness.nativeContract
+          (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+            Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+            observableSlots) =
+        .error (EvmYul.Yul.Exception.YulHalt (.Ok shared3 store) ⟨1⟩) := by
+  -- Bring the let-bound names from the goal into the local context.
+  intro shared p shared1 shared2 shared3
+  -- Reshape dispatcher fuel to `g + 25` where `g := dispatcherFuel - 25`.
+  set g := simpleStorageNativeDispatcherFuel - 25 with hg_def
+  have hReshape : simpleStorageNativeDispatcherFuel = g + 25 :=
+    (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_25).symm
+  rw [hReshape]
+  -- Open the `_sourceLowered` existential at `peeledFuel := g + 11`, so the
+  -- dispatcher LHS lands at `(g + 11) + 14 = g + 25`.
+  obtain ⟨reservedNames, n0, cases', midN, hExec, hLowerCases⟩ :=
+    simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
+      (g + 11) tx storage observableSlots hNoWrap
+  -- Pin `cases'` to the two-element shape.
+  obtain ⟨storeBody', retrieveBody', hCases⟩ :=
+    simpleStorageBuildSwitchSourceCases_lowered_shape reservedNames _ midN
+      cases' hLowerCases
+  subst hCases
+  -- Pin the lowered bodies to the concrete forms.
+  obtain ⟨hStoreBody, hRetrieveBody⟩ :=
+    simpleStorageLoweredHitCasesShape_concrete hLowerCases
+  subst hStoreBody
+  subst hRetrieveBody
+  -- The chained-insert varStore for the dispatcher hit-body input state.
+  set switchId := Backends.freshNativeSwitchId reservedNames n0 with hSw
+  let store_body : EvmYul.Yul.VarStore :=
+    ((((∅ : EvmYul.Yul.VarStore).insert "__has_selector"
+            (EvmYul.UInt256.ofNat 1)).insert
+          (Backends.nativeSwitchDiscrTempName switchId)
+          (EvmYul.UInt256.ofNat
+            (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+        (Backends.nativeSwitchMatchedTempName switchId)
+        (EvmYul.UInt256.ofNat 0)).insert
+      (Backends.nativeSwitchMatchedTempName switchId)
+      (EvmYul.UInt256.ofNat 1)
+  -- Provide `store := store_body` for the existential.
+  refine ⟨store_body, ?_⟩
+  -- Discharge the body-level closed form via `_RetrieveCaseBody_halt`.
+  have hWei :
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState.executionEnv.weiValue =
+      (⟨0⟩ : EvmYul.Literal) := by
+    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue,
+        hMsgValue]
+    rfl
+  have hSize :
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState.executionEnv.calldata.size <
+      EvmYul.UInt256.size := by
+    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+    exact hNoWrap
+  have hGe :
+      4 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState.executionEnv.calldata.size := by
+    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+    exact Nat.le_add_right 4 _
+  have hBodyHalt :=
+    exec_block_simpleStorageLoweredRetrieveCaseBody_halt g
+      (some Compiler.SimpleStorageNativeWitness.nativeContract)
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState
+      store_body hWei hSize hGe
+  -- Reshape `hExec` into the form expected by `_via_reduction`'s
+  -- `hReduction` parameter.
+  have hReduction := hExec
+  rw [show (g + 11 + 14 : Nat) = (g + 4) + 2 + 19 from by omega,
+      show (g + 11 + 8 : Nat) = (g + 4) + 2 + 13 from by omega,
+      show (2 : Nat) = ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
+        (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
+        List (Nat × List EvmYul.Yul.Ast.Stmt)).length from rfl] at hReduction
+  -- Body-execution premise of `_via_reduction`: only valid decomposition is
+  -- `pre = [(0x6057361d, store)]`, `suffix = []`. Body fuel is
+  -- `(g + 4 + 1) + 0 + 7 = g + 12`, matching `hBodyHalt`.
+  have hBodyExec : ∀ pre suffix,
+      ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
+        (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
+        List (Nat × List EvmYul.Yul.Ast.Stmt)) =
+        pre ++ (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody) :: suffix →
+      EvmYul.Yul.exec (((g + 4) + 1) + suffix.length + 7)
+        (.Block simpleStorageLoweredRetrieveCaseBody)
+        (some Compiler.SimpleStorageNativeWitness.nativeContract)
+        (simpleStorageDispatcherHitBodyInputState switchId tx storage
+          observableSlots) =
+        .error (EvmYul.Yul.Exception.YulHalt (.Ok shared3 store_body) ⟨1⟩) := by
+    rintro pre suffix hDecomp
+    cases pre with
+    | nil =>
+      simp only [List.nil_append, List.cons.injEq, Prod.mk.injEq] at hDecomp
+      exfalso
+      exact absurd hDecomp.1.1 (by decide)
+    | cons _ rest =>
+      simp only [List.cons_append, List.cons.injEq] at hDecomp
+      obtain ⟨_, hRest⟩ := hDecomp
+      cases rest with
+      | nil =>
+        simp only [List.nil_append, List.cons.injEq] at hRest
+        obtain ⟨_, hSuf⟩ := hRest
+        subst hSuf
+        simpa [simpleStorageDispatcherHitBodyInputState] using hBodyHalt
+      | cons _ _ => simp at hRest
+  -- Apply `_retrieveHit_error_via_reduction` at `fuel := g + 4` with
+  -- `err := YulHalt (.Ok shared3 store_body) ⟨1⟩`.
+  have h := simpleStorageNativeContract_dispatcherExec_retrieveHit_error_via_reduction
+    (g + 4) switchId
+    [(0x6057361d, simpleStorageLoweredStoreCaseBody),
+     (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)]
+    simpleStorageLoweredStoreCaseBody simpleStorageLoweredRetrieveCaseBody
+    tx storage observableSlots
+    (EvmYul.Yul.Exception.YulHalt (.Ok shared3 store_body) ⟨1⟩)
+    hSelector rfl hBodyExec hReduction
+  -- `h` has dispatcher fuel `(g + 4) + cases'.length + 19`. Reshape to `g + 25`.
+  have hLen :
+      ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
+        (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
+        List (Nat × List EvmYul.Yul.Ast.Stmt)).length = 2 := rfl
+  rw [hLen, show (g + 4) + 2 + 19 = g + 25 from by omega] at h
+  exact h
+
+/-- Closed-form evaluation of `projectResult` on the retrieve-hit halt error
+produced by the lowered SimpleStorage retrieve body. The halt state is built
+by chaining `sload(0)` (toState override), `mstore(0, _)` (toMachineState
+override), and `evmReturn(0, 32)` (toMachineState override) starting from a
+shared state with empty memory. The native projected return value is the
+`Nat`-normalized form of the loaded slot-zero word; storage and logs are
+read off the halt's `sharedState` directly. -/
+theorem projectResult_retrieveHit_eq
+    (tx : YulTransaction) (initialStorage : Nat → IRStorageWord)
+    (initialEvents : List (List Nat))
+    (shared : EvmYul.SharedState .Yul) (store : EvmYul.Yul.VarStore)
+    (hMemory : shared.memory = ByteArray.empty) :
+    let p := shared.sload (EvmYul.UInt256.ofNat 0)
+    let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
+    let shared2 : EvmYul.SharedState .Yul :=
+      { shared1 with
+        toMachineState :=
+          shared1.toMachineState.mstore (EvmYul.UInt256.ofNat 0) p.2 }
+    let shared3 : EvmYul.SharedState .Yul :=
+      { shared2 with
+        toMachineState :=
+          shared2.toMachineState.evmReturn
+            (EvmYul.UInt256.ofNat 0) (EvmYul.UInt256.ofNat 32) }
+    Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+        tx initialStorage initialEvents
+        (.error (EvmYul.Yul.Exception.YulHalt
+          (EvmYul.Yul.State.Ok shared3 store) ⟨1⟩)) =
+      { success := true,
+        returnValue := some p.2.toNat,
+        finalStorage :=
+          Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+            tx (EvmYul.Yul.State.Ok shared3 store),
+        finalMappings :=
+          Compiler.Proofs.storageAsMappings
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+              tx (EvmYul.Yul.State.Ok shared3 store)),
+        events :=
+          initialEvents ++
+            Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
+              (EvmYul.Yul.State.Ok shared3 store) } := by
+  intro p shared1 shared2 shared3
+  -- shared1 inherits memory from shared because only `toState` was overridden.
+  have hMemory1 : shared1.memory = ByteArray.empty := hMemory
+  -- The harness helpers describe the result via `setMachineState` chains;
+  -- those equal the structural overrides used in `shared3`.
+  have hSize :
+      (EvmYul.Yul.State.Ok shared3 store).sharedState.H_return.size = 32 := by
+    have h := Compiler.Proofs.YulGeneration.Backends.Native.mstore0_then_return32_hReturn_size
+      shared1 store p.2
+    simpa [shared3, shared2, EvmYul.Yul.State.setMachineState,
+      EvmYul.Yul.State.toMachineState, EvmYul.Yul.State.sharedState] using h
+  have hH_return :
+      (EvmYul.Yul.State.Ok shared3 store).sharedState.H_return = p.2.toByteArray := by
+    have h :=
+      Compiler.Proofs.YulGeneration.Backends.Native.mstore0_then_return32_emptyMemory_hReturn_eq_toByteArray
+        shared1 store p.2 hMemory1
+    simpa [shared3, shared2, EvmYul.Yul.State.setMachineState,
+      EvmYul.Yul.State.toMachineState, EvmYul.Yul.State.sharedState] using h
+  have hHaltNotZero : (⟨1⟩ : EvmYul.Yul.Ast.Literal) ≠ ⟨0⟩ := by
+    intro h
+    norm_num [EvmYul.UInt256.size] at h
+  have hReturnValue :
+      Compiler.Proofs.YulGeneration.Backends.Native.projectHaltReturn
+          (EvmYul.Yul.State.Ok shared3 store) ⟨1⟩ = some p.2.toNat := by
+    rw [Compiler.Proofs.YulGeneration.Backends.Native.projectHaltReturn_32ByteReturn
+      (EvmYul.Yul.State.Ok shared3 store) ⟨1⟩ hHaltNotZero hSize]
+    rw [hH_return,
+      Compiler.Proofs.YulGeneration.Backends.Native.byteArrayWord_uint256_toByteArray]
+  simp only [Compiler.Proofs.YulGeneration.Backends.Native.projectResult,
+    hReturnValue]
 
 /-- Named SimpleStorage native dispatcher bridge obligation.
 

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -4206,6 +4206,191 @@ def simpleStorageNativeSelectorMissBridge
     simpleStorageIRContract tx initialState observableSlots
     Compiler.SimpleStorageNativeWitness.nativeContract
 
+/-- Retrieve-hit native dispatcher bridge discharged against the existing
+public entry preconditions. The native initial state materializes literal
+storage reads from the emitted runtime, so slot zero is present independently of
+the caller's observable slot list. -/
+theorem simpleStorageNativeRetrieveHitBridge_proved
+    (tx : IRTransaction) (initialState : IRState) (observableSlots : List Nat)
+    (hselector : tx.functionSelector < selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < evmModulus)
+    (hvars : initialState.vars = [])
+    (hmemory : initialState.memory = fun _ => 0)
+    (htransient : initialState.transientStorage = fun _ => 0)
+    (hreturn : initialState.returnValue = none)
+    (hdispatchGuardSafe : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      HasSelectorDeadBridge fn.body)
+    (hparamErase : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      paramLoadErasure fn tx (initialState.withTx tx)) :
+    simpleStorageNativeRetrieveHitBridge tx initialState observableSlots := by
+  intro hRetrieve
+  have hSelectorEq : tx.functionSelector = 0x2e64cec1 := by
+    have hmod := Nat.mod_eq_of_lt hselector
+    rw [hmod] at hRetrieve
+    exact hRetrieve
+  have hMsgValue : tx.msgValue % EvmYul.UInt256.size = 0 := by
+    let retrieveFn : IRFunction :=
+      { name := "retrieve"
+        selector := 0x2e64cec1
+        params := []
+        ret := IRType.uint256
+        body := [
+          Yul.YulStmt.expr (Yul.YulExpr.call "mstore" [Yul.YulExpr.lit 0, Yul.YulExpr.call "sload" [Yul.YulExpr.lit 0]]),
+          Yul.YulStmt.expr (Yul.YulExpr.call "return" [Yul.YulExpr.lit 0, Yul.YulExpr.lit 32])
+        ] }
+    have hmem : retrieveFn ∈ simpleStorageIRContract.functions := by
+      simp [retrieveFn, simpleStorageIRContract]
+    have hguards := hdispatchGuardSafe retrieveFn hmem
+    have hzero : tx.msgValue % evmModulus = 0 := by
+      rcases hguards with ⟨hValue, _⟩
+      rcases hValue with hPayable | hZero
+      · simp [retrieveFn] at hPayable
+      · exact hZero
+    simpa [evmModulus, EvmYul.UInt256.size] using hzero
+  have hLayer :
+      Compiler.Proofs.YulGeneration.resultsMatch
+        (interpretIR simpleStorageIRContract tx initialState)
+        (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackend
+          .evmYulLean (Compiler.emitYul simpleStorageIRContract).runtimeCode
+          (YulTransaction.ofIR tx) initialState.storage initialState.events) :=
+    layer3_contract_preserves_semantics_evmYulLean simpleStorageIRContract tx initialState
+      hselector hNoWrap hvars hmemory htransient hreturn hparamErase
+      hdispatchGuardSafe hNoHasSelector hHasSelectorDead
+      (by intro fn hmem; simp [simpleStorageIRContract] at hmem ⊢; rcases hmem with rfl | rfl <;> rfl)
+      (by intro s hs; simp [simpleStorageIRContract] at hs) rfl rfl
+      simpleStorage_functions_bridged
+  have hIR := interpretIR_simpleStorage_retrieveHit tx initialState hSelectorEq
+  have hLayerFuel :
+      Compiler.Proofs.YulGeneration.resultsMatch
+        { success := true
+          returnValue := some ((initialState.storage (IRStorageSlot.ofNat 0)).toNat)
+          finalStorage := initialState.storage
+          finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
+          events := initialState.events }
+        (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackendFuel
+          .evmYulLean (Nat.succ simpleStorageNativeDispatcherFuel)
+          (Compiler.emitYul simpleStorageIRContract).runtimeCode
+          (YulTransaction.ofIR tx) initialState.storage initialState.events) := by
+    simpa [hIR, Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackend,
+      simpleStorageNativeDispatcherFuel, simpleStorage_runtimeCode_eq_single_dispatcher]
+      using hLayer
+  let yulTx := YulTransaction.ofIR tx
+  let slots :=
+    Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+      (Compiler.runtimeCode simpleStorageIRContract) observableSlots
+  let shared :=
+    (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      Compiler.SimpleStorageNativeWitness.nativeContract yulTx
+      initialState.storage slots).sharedState
+  let p := shared.sload (EvmYul.UInt256.ofNat 0)
+  let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
+  let shared2 : EvmYul.SharedState .Yul :=
+    { shared1 with
+      toMachineState :=
+        shared1.toMachineState.mstore (EvmYul.UInt256.ofNat 0) p.2 }
+  let shared3 : EvmYul.SharedState .Yul :=
+    { shared2 with
+      toMachineState :=
+        shared2.toMachineState.evmReturn
+          (EvmYul.UInt256.ofNat 0) (EvmYul.UInt256.ofNat 32) }
+  obtain ⟨store, hExec⟩ :=
+    simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
+      yulTx initialState.storage slots
+      (by
+        simp [yulTx]
+        exact hRetrieve.symm)
+      (by simpa [yulTx, YulTransaction.ofIR, evmModulus] using hNoWrap)
+      (by simpa [yulTx, YulTransaction.ofIR] using hMsgValue)
+  have hSlotZero : 0 ∈ slots := by
+    simp [slots, Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots]
+  have hp :
+      p.2 = initialState.storage (IRStorageSlot.ofNat 0) := by
+    have hload :=
+      Compiler.Proofs.YulGeneration.Backends.Native.initialState_sload_materializedSlot_value
+        Compiler.SimpleStorageNativeWitness.nativeContract yulTx initialState.storage
+        slots 0 hSlotZero
+    simpa [p, shared, Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256]
+      using hload
+  have hProject :
+      Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+        (YulTransaction.ofIR tx) initialState.storage initialState.events
+        (.error (EvmYul.Yul.Exception.YulHalt
+          (EvmYul.Yul.State.Ok shared3 store) ⟨1⟩)) =
+      { success := true,
+        returnValue := some p.2.toNat,
+        finalStorage :=
+          Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+            (YulTransaction.ofIR tx) (EvmYul.Yul.State.Ok shared3 store),
+        finalMappings :=
+          Compiler.Proofs.storageAsMappings
+            (Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+              (YulTransaction.ofIR tx) (EvmYul.Yul.State.Ok shared3 store)),
+        events :=
+          initialState.events ++
+            Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
+              (EvmYul.Yul.State.Ok shared3 store) } := by
+    have hMemory : shared.memory = ByteArray.empty := by
+      simp [shared, Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+        Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
+        YulState.initial, EvmYul.Yul.State.sharedState]
+    simpa [yulTx, shared, p, shared1, shared2, shared3] using
+      projectResult_retrieveHit_eq yulTx initialState.storage initialState.events
+        shared store hMemory
+  have hLogs :
+      Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
+        (EvmYul.Yul.State.Ok shared3 store) = [] := by
+    simp [Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState,
+      shared3, shared2, shared1, p, shared,
+      Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+      Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
+      YulState.initial, EvmYul.State.sload, EvmYul.State.addAccessedStorageKey,
+      EvmYul.Substate.addAccessedStorageKey, EvmYul.Yul.State.sharedState]
+    rfl
+  have hAgree :
+      yulResultsAgreeOn observableSlots
+        { success := true,
+          returnValue := some p.2.toNat,
+          finalStorage :=
+            Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+              (YulTransaction.ofIR tx) (EvmYul.Yul.State.Ok shared3 store),
+          finalMappings :=
+            Compiler.Proofs.storageAsMappings
+              (Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+                (YulTransaction.ofIR tx) (EvmYul.Yul.State.Ok shared3 store)),
+          events :=
+            initialState.events ++
+              Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
+                (EvmYul.Yul.State.Ok shared3 store) }
+        (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackendFuel
+          .evmYulLean (Nat.succ simpleStorageNativeDispatcherFuel)
+          (Compiler.emitYul simpleStorageIRContract).runtimeCode
+          (YulTransaction.ofIR tx) initialState.storage initialState.events) := by
+    rcases hLayerFuel with ⟨hsuccess, hreturnValue, hstorage, _hmappings, hevents⟩
+    refine ⟨?_, ?_, ?_, ?_⟩
+    · exact hsuccess
+    · simpa [hp] using hreturnValue
+    · intro slot hslot
+      have hslot' : slot ∈ slots := by
+        simp [slots, Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots,
+          hslot]
+      have hNative :=
+        Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState_retrieveHit_initialState_materialized
+          Compiler.SimpleStorageNativeWitness.nativeContract yulTx initialState.storage
+          slots store slot hslot'
+      exact (hNative.trans (hstorage (IRStorageSlot.ofNat slot)))
+    · rw [hLogs, List.append_nil]
+      exact hevents
+  apply nativeDispatcherExecAgreesWithInterpreterPositive_of_exec_yulHalt_project_eq_agree
+    (haltState := EvmYul.Yul.State.Ok shared3 store) (haltValue := ⟨1⟩)
+  · simpa [simpleStorage_runtimeCode_eq_single_dispatcher, yulTx, slots,
+      shared, p, shared1, shared2, shared3] using hExec
+  · exact hProject
+  · exact hAgree
+
 /-- Recover the monolithic `simpleStorageNativeCallDispatcherBridge` from the
 three per-case sub-bridges by case analysis on
 `tx.functionSelector % selectorModulus`. -/
@@ -4350,8 +4535,6 @@ theorem simpleStorage_endToEnd_native_evmYulLean
       HasSelectorDeadBridge fn.body)
     (hparamErase : ∀ fn, fn ∈ simpleStorageIRContract.functions →
       paramLoadErasure fn tx (initialState.withTx tx))
-    (hRetrieveHit :
-      simpleStorageNativeRetrieveHitBridge tx initialState observableSlots)
     (hStoreHit :
       simpleStorageNativeStoreHitBridge tx initialState observableSlots)
     (hSelectorMiss :
@@ -4375,7 +4558,11 @@ theorem simpleStorage_endToEnd_native_evmYulLean
             rw [simpleStorage_runtimeCode_eq_single_dispatcher]
             exact simpleStorageNativeCallDispatcherBridge_of_per_case
               tx initialState observableSlots
-              hRetrieveHit hStoreHit hSelectorMiss))))
+              (simpleStorageNativeRetrieveHitBridge_proved tx initialState
+                observableSlots hselector hNoWrap hvars hmemory htransient
+                hreturn hdispatchGuardSafe hNoHasSelector hHasSelectorDead
+                hparamErase)
+              hStoreHit hSelectorMiss))))
 
 /-! ## Universal Pure Arithmetic Bridge
 

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -425,10 +425,10 @@ theorem interpretFunction_eq_execResultToIRResult_of_body
           selector := tx.functionSelector }
         fn.body = sourceResult)
     (hrollbackStorage :
-      rollback.storage = fun s =>
-        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-          (SourceSemantics.encodeStorage model
-            (SourceSemantics.withTransactionContext initialWorld tx) s))
+        rollback.storage = fun s =>
+          Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+            (SourceSemantics.encodeStorage model
+              (SourceSemantics.withTransactionContext initialWorld tx) s.toNat))
     (hrollbackEvents :
       rollback.events =
         SourceSemantics.encodeEvents
@@ -476,10 +476,10 @@ theorem interpretFunctionWithHelpers_eq_execResultToIRResultWithInternals_of_bod
           selector := tx.functionSelector }
         fn.body = sourceResult)
     (hrollbackStorage :
-      rollback.storage = fun s =>
-        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-          (SourceSemantics.encodeStorage model
-            (SourceSemantics.withTransactionContext initialWorld tx) s))
+        rollback.storage = fun s =>
+          Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+            (SourceSemantics.encodeStorage model
+              (SourceSemantics.withTransactionContext initialWorld tx) s.toNat))
     (hrollbackEvents :
       rollback.events =
         SourceSemantics.encodeEvents
@@ -1217,10 +1217,10 @@ theorem compileFunctionSpec_correct_of_body
     rw [hcompile] at hcompiled
     injection hcompiled with hirFn
   have hrollbackStorage :
-      initialState.storage = fun s =>
-        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-          (SourceSemantics.encodeStorage model
-            (SourceSemantics.withTransactionContext initialWorld tx) s) := by
+        initialState.storage = fun s =>
+          Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+            (SourceSemantics.encodeStorage model
+              (SourceSemantics.withTransactionContext initialWorld tx) s.toNat) := by
     funext s
     simp [initialState, FunctionBody.initialIRStateForTx,
       FunctionBody.encodeStorage_withTransactionContext]
@@ -1306,10 +1306,10 @@ theorem compileFunctionSpec_correct_of_body_normalized_extraFuel
     rw [hcompile'] at hcompiled
     injection hcompiled with hirFn
   have hrollbackStorage :
-      initialState.storage = fun s =>
-        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-          (SourceSemantics.encodeStorage model
-            (SourceSemantics.withTransactionContext initialWorld tx) s) := by
+        initialState.storage = fun s =>
+          Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+            (SourceSemantics.encodeStorage model
+              (SourceSemantics.withTransactionContext initialWorld tx) s.toNat) := by
     funext s
     simp [initialState, FunctionBody.initialIRStateForTx,
       FunctionBody.encodeStorage_withTransactionContext]
@@ -1791,10 +1791,10 @@ theorem supported_function_correct_with_helper_proofs_body_goal
     rw [hcompile] at hcompiled
     injection hcompiled
   have hrollbackStorage :
-      initialState.storage = fun s =>
-        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-          (SourceSemantics.encodeStorage model
-            (SourceSemantics.withTransactionContext initialWorld tx) s) := by
+        initialState.storage = fun s =>
+          Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+            (SourceSemantics.encodeStorage model
+              (SourceSemantics.withTransactionContext initialWorld tx) s.toNat) := by
     funext s
     simp [initialState, FunctionBody.initialIRStateForTx,
       FunctionBody.encodeStorage_withTransactionContext]
@@ -2519,10 +2519,10 @@ theorem supported_constructor_body_correct_with_body_interface
       exact hEq.symm
     subst bodyIR
     have hrollbackStorage :
-        initialState.storage = fun s =>
-          Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-            (SourceSemantics.encodeStorage model
-              (SourceSemantics.withTransactionContext initialWorld tx) s) := by
+          initialState.storage = fun s =>
+            Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+              (SourceSemantics.encodeStorage model
+                (SourceSemantics.withTransactionContext initialWorld tx) s.toNat) := by
       funext s
       simp [initialState, FunctionBody.initialIRStateForTx,
         FunctionBody.encodeStorage_withTransactionContext]

--- a/Compiler/Proofs/IRGeneration/FunctionBody.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody.lean
@@ -101,7 +101,7 @@ def runtimeStateMatchesIR
     (runtime : SourceSemantics.RuntimeState)
     (state : IRState) : Prop :=
   state.storage = (fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-    (SourceSemantics.encodeStorageAt fields runtime.world s)) ∧
+    (SourceSemantics.encodeStorageAt fields runtime.world s.toNat)) ∧
   state.transientStorage = (fun slot => (runtime.world.transientStorage slot).val) ∧
   state.sender = runtime.world.sender.val ∧
   state.msgValue = runtime.world.msgValue.val ∧
@@ -126,7 +126,7 @@ def constructorRuntimeStateMatchesIR
     (runtime : SourceSemantics.RuntimeState)
     (state : IRState) : Prop :=
   state.storage = (fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-    (SourceSemantics.encodeStorageAt fields runtime.world s)) ∧
+    (SourceSemantics.encodeStorageAt fields runtime.world s.toNat)) ∧
   state.transientStorage = (fun slot => (runtime.world.transientStorage slot).val) ∧
   state.sender = runtime.world.sender.val ∧
   state.msgValue = runtime.world.msgValue.val ∧
@@ -148,7 +148,7 @@ def initialIRStateForTx
     (initialWorld : Verity.ContractState) : IRState :=
   { vars := []
     storage := fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-      (SourceSemantics.encodeStorage spec initialWorld s)
+      (SourceSemantics.encodeStorage spec initialWorld s.toNat)
     transientStorage := fun slot => (initialWorld.transientStorage slot).val
     memory := fun o => (initialWorld.memory o).val
     calldata := tx.args
@@ -1230,7 +1230,7 @@ theorem evalIRExpr_sload_of_runtimeStateMatchesIR
     (hmatch : runtimeStateMatchesIR fields runtime state)
     (slot : Nat) :
     evalIRExpr state (YulExpr.call "sload" [YulExpr.lit slot]) =
-      some (SourceSemantics.encodeStorageAt fields runtime.world slot
+      some (SourceSemantics.encodeStorageAt fields runtime.world (IRStorageSlot.ofNat slot).toNat
         % EvmYul.UInt256.size) := by
   rcases hmatch with ⟨hstorage, _, _, _, _, _, _, _, _, _, _⟩
   simp [evalIRExpr, evalIRCall, evalIRExprs,
@@ -7389,7 +7389,7 @@ def sourceResultMatchesIRResult
     (ir : IRResult) : Prop :=
   source.success = ir.success ∧
   source.returnValue = ir.returnValue ∧
-  (fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (source.finalStorage s)) =
+  (fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (source.finalStorage s.toNat)) =
     ir.finalStorage ∧
   source.events = ir.events
 
@@ -14767,7 +14767,7 @@ theorem stmtResultToSourceResult_matches_irExecResult
     (irResult : IRExecResult)
     (hrollbackStorage :
       rollback.storage = fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-        (SourceSemantics.encodeStorage spec initialWorld s))
+        (SourceSemantics.encodeStorage spec initialWorld s.toNat))
     (hrollbackEvents :
       rollback.events = SourceSemantics.encodeEvents initialWorld.events)
     (hfields : fields = SourceSemantics.effectiveFields spec)

--- a/Compiler/Proofs/IRGeneration/GenericInduction.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction.lean
@@ -5236,13 +5236,15 @@ private theorem encodeStorageAt_writeUintSlots_singleton_other
     {fields : List Field}
     {world : Verity.ContractState}
     {slot query value : Nat}
-    (hneq : query ≠ slot) :
+    (hneq : query ≠ SourceSemantics.wordNormalize slot) :
     SourceSemantics.encodeStorageAt fields
       (SourceSemantics.writeUintSlots world [slot] value)
       query =
       SourceSemantics.encodeStorageAt fields world query := by
   apply SourceSemantics.encodeStorageAt_congr
-  · simp [SourceSemantics.writeUintSlots, hneq]
+  · have hneq' : query ≠ slot % Compiler.Constants.evmModulus := by
+      simpa [SourceSemantics.wordNormalize] using hneq
+    simp [SourceSemantics.writeUintSlots, SourceSemantics.wordNormalize, hneq']
   · simp [SourceSemantics.writeUintSlots]
   · simp [SourceSemantics.writeUintSlots]
 
@@ -5251,14 +5253,15 @@ private theorem encodeStorageAt_writeUintSlots_other
     {world : Verity.ContractState}
     {slots : List Nat}
     {query value : Nat}
-    (hnotMem : query ∉ slots) :
+    (hnotMem : query ∉ slots.map SourceSemantics.wordNormalize) :
     SourceSemantics.encodeStorageAt fields
       (SourceSemantics.writeUintSlots world slots value)
       query =
       SourceSemantics.encodeStorageAt fields world query := by
   apply SourceSemantics.encodeStorageAt_congr
   · simp only [SourceSemantics.writeUintSlots]
-    rw [show slots.contains query = false from by simpa using hnotMem]
+    rw [show (slots.map SourceSemantics.wordNormalize).contains query = false from by
+      simpa using hnotMem]
     simp
   · simp [SourceSemantics.writeUintSlots]
   · simp [SourceSemantics.writeUintSlots]
@@ -5268,15 +5271,30 @@ private theorem encodeStorageAt_writeUintKeyedMappingSlots_singleton_other
     {fields : List Field}
     {world : Verity.ContractState}
     {slot key query value : Nat}
-    (hneq : query ≠ Compiler.Proofs.abstractMappingSlot slot key) :
+    (hquery : query < Compiler.Constants.evmModulus)
+    (hneq : query ≠ SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot slot key)) :
     SourceSemantics.encodeStorageAt fields
       (SourceSemantics.writeUintKeyedMappingSlots world [slot] key value)
       query =
       SourceSemantics.encodeStorageAt fields world query := by
   apply SourceSemantics.encodeStorageAt_congr
   · simp only [SourceSemantics.writeUintKeyedMappingSlots, List.foldl_cons, List.foldl_nil]
-    simp [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot] at hneq ⊢
-    simp [hneq]
+    have hneq' :
+        query ≠ Compiler.Proofs.solidityMappingSlot slot key % Compiler.Constants.evmModulus := by
+      simpa [SourceSemantics.wordNormalize, Compiler.Proofs.abstractMappingSlot_eq_solidity] using hneq
+    have hslotNe :
+        IRStorageSlot.ofNat query ≠
+          IRStorageSlot.ofNat (Compiler.Proofs.solidityMappingSlot slot key) := by
+      intro h
+      apply hneq'
+      have hnat := congrArg IRStorageSlot.toNat h
+      simpa [IRStorageSlot.toNat_ofNat, SourceSemantics.wordNormalize,
+        Compiler.Constants.evmModulus, EvmYul.UInt256.size, Nat.mod_eq_of_lt hquery] using hnat
+    have hqueryMod : query % Verity.Core.UINT256_MODULUS = query := by
+      simpa [Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS] using
+        Nat.mod_eq_of_lt hquery
+    simp [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot,
+      hneq', hslotNe, hqueryMod, SourceSemantics.wordNormalize]
     apply Verity.Core.Uint256.ext
     simp [Verity.Core.Uint256.modulus, Nat.mod_eq_of_lt (world.storage query).isLt]
   · simp [SourceSemantics.writeUintKeyedMappingSlots]
@@ -5288,13 +5306,17 @@ private theorem encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_oth
     {slot : Nat}
     {keys : List Nat}
     {query value : Nat}
-    (hneq : query ≠ SourceSemantics.mappingSlotChain slot keys) :
+    (hneq : query ≠ SourceSemantics.wordNormalize (SourceSemantics.mappingSlotChain slot keys)) :
     SourceSemantics.encodeStorageAt fields
       (SourceSemantics.writeAddressKeyedMappingChainSlots world [slot] keys value)
       query =
       SourceSemantics.encodeStorageAt fields world query := by
   apply SourceSemantics.encodeStorageAt_congr
-  · simp [SourceSemantics.writeAddressKeyedMappingChainSlots, hneq]
+  · have hneq' :
+        query ≠ SourceSemantics.mappingSlotChain slot keys % Compiler.Constants.evmModulus := by
+      simpa [SourceSemantics.wordNormalize] using hneq
+    simp [SourceSemantics.writeAddressKeyedMappingChainSlots,
+      SourceSemantics.wordNormalize, hneq']
   · simp [SourceSemantics.writeAddressKeyedMappingChainSlots]
   · simp [SourceSemantics.writeAddressKeyedMappingChainSlots]
 
@@ -5306,6 +5328,53 @@ private def mapping2WordTargetSlot (slot key1 key2 wordOffset : Nat) : Nat :=
     (Compiler.Proofs.abstractMappingSlot
       (Compiler.Proofs.abstractMappingSlot slot key1)
       key2 + wordOffset)
+
+private theorem IRStorageSlot.toNat_ofNat_wordNormalize (slot : Nat) :
+    (IRStorageSlot.ofNat slot).toNat = SourceSemantics.wordNormalize slot := by
+  rfl
+
+private theorem IRStorageSlot.toNat_ofNat_wordNormalize_arg (slot : Nat) :
+    (IRStorageSlot.ofNat (SourceSemantics.wordNormalize slot)).toNat =
+      SourceSemantics.wordNormalize slot := by
+  simp [IRStorageSlot.toNat_ofNat_wordNormalize, SourceSemantics.wordNormalize,
+    Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS]
+
+private theorem IRStorageSlot.ofNat_wordNormalize (slot : Nat) :
+    IRStorageSlot.ofNat (SourceSemantics.wordNormalize slot) = IRStorageSlot.ofNat slot := by
+  apply IRStorageSlot.eq_of_toNat_eq
+  simp [IRStorageSlot.toNat_ofNat_wordNormalize, SourceSemantics.wordNormalize,
+    Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS]
+
+private theorem SourceSemantics.wordNormalize_lt_evmModulus (slot : Nat) :
+    SourceSemantics.wordNormalize slot < Compiler.Constants.evmModulus := by
+  unfold SourceSemantics.wordNormalize
+  exact Nat.mod_lt _ (by norm_num [Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS])
+
+private theorem IRStorageSlot.toNat_ofNat_of_lt {slot : Nat}
+    (hslot : slot < Compiler.Constants.evmModulus) :
+    (IRStorageSlot.ofNat slot).toNat = slot := by
+  simpa [IRStorageSlot.toNat_ofNat_wordNormalize, SourceSemantics.wordNormalize,
+    Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS] using
+    Nat.mod_eq_of_lt hslot
+
+private theorem IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat
+    {query : IRStorageSlot} {slot : Nat}
+    (hneq : query ≠ IRStorageSlot.ofNat slot) :
+    query.toNat ≠ SourceSemantics.wordNormalize slot := by
+  intro h
+  apply hneq
+  apply IRStorageSlot.eq_of_toNat_eq
+  simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using h
+
+private theorem IRStorageSlot.ne_toNat_of_ne_ofNat_of_lt
+    {query : IRStorageSlot} {slot : Nat}
+    (hneq : query ≠ IRStorageSlot.ofNat slot)
+    (hslot : slot < Compiler.Constants.evmModulus) :
+    query.toNat ≠ slot := by
+  intro h
+  exact IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hneq
+    (by simpa [SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+      Verity.Core.UINT256_MODULUS, Nat.mod_eq_of_lt hslot] using h)
 
 private theorem uint256_add_val_eq_mod (a b : Nat) :
     (Verity.Core.Uint256.ofNat a + Verity.Core.Uint256.ofNat b).val =
@@ -5409,7 +5478,9 @@ private def findResolvedFieldAtSlotCopy (fields : List Field) (slot : Nat) : Opt
     | [] => none
     | field :: rest =>
         let resolvedSlot := field.slot.getD idx
-        if resolvedSlot = slot || field.aliasSlots.contains slot then
+        if SourceSemantics.wordNormalize resolvedSlot = SourceSemantics.wordNormalize slot ||
+            (field.aliasSlots.map SourceSemantics.wordNormalize).contains
+              (SourceSemantics.wordNormalize slot) then
           some field
         else
           go rest (idx + 1)
@@ -5421,17 +5492,58 @@ private def findResolvedFieldAtSlotCopyFrom
   | [] => none
   | field :: rest =>
       let resolvedSlot := field.slot.getD idx
-      if resolvedSlot = slot || field.aliasSlots.contains slot then
+      if SourceSemantics.wordNormalize resolvedSlot = SourceSemantics.wordNormalize slot ||
+          (field.aliasSlots.map SourceSemantics.wordNormalize).contains
+            (SourceSemantics.wordNormalize slot) then
         some field
       else
-        findResolvedFieldAtSlotCopyFrom rest (idx + 1) slot
+      findResolvedFieldAtSlotCopyFrom rest (idx + 1) slot
+
+private theorem SourceSemantics.wordNormalize_idem (slot : Nat) :
+    SourceSemantics.wordNormalize (SourceSemantics.wordNormalize slot) =
+      SourceSemantics.wordNormalize slot := by
+  simp [SourceSemantics.wordNormalize, Compiler.Constants.evmModulus]
+
+private theorem findResolvedFieldAtSlotCopyFrom_wordNormalize
+    (fields : List Field) (idx slot : Nat) :
+    findResolvedFieldAtSlotCopyFrom fields idx (SourceSemantics.wordNormalize slot) =
+      findResolvedFieldAtSlotCopyFrom fields idx slot := by
+  induction fields generalizing idx with
+  | nil => rfl
+  | cons field rest ih =>
+      simp only [findResolvedFieldAtSlotCopyFrom]
+      rw [SourceSemantics.wordNormalize_idem]
+      split <;> simp_all
+
+private theorem findResolvedFieldAtSlotCopy_wordNormalize
+    (fields : List Field) (slot : Nat) :
+    findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) =
+      findResolvedFieldAtSlotCopy fields slot := by
+  have hgo :
+      ∀ (remaining : List Field) (idx : Nat),
+      findResolvedFieldAtSlotCopy.go (SourceSemantics.wordNormalize slot) remaining idx =
+          findResolvedFieldAtSlotCopy.go slot remaining idx := by
+    intro remaining
+    induction remaining with
+    | nil =>
+        intro idx
+        rfl
+    | cons field rest ih =>
+        intro idx
+        simp only [findResolvedFieldAtSlotCopy.go]
+        rw [SourceSemantics.wordNormalize_idem]
+        split
+        · rfl
+        · exact ih (idx + 1)
+  simp only [findResolvedFieldAtSlotCopy]
+  exact hgo fields 0
 
 private def findDynamicArrayElementAtSlotCopy
     (fields : List Field) (world : Verity.ContractState) (targetSlot : Nat) : Option Nat :=
   let rec scanElements (baseSlot : Nat) : List Verity.Core.Uint256 → Nat → Option Nat
     | [], _ => none
     | value :: rest, idx =>
-        if Compiler.Proofs.solidityMappingSlot baseSlot idx = targetSlot then
+        if Compiler.Proofs.solidityMappingSlot baseSlot idx = SourceSemantics.wordNormalize targetSlot then
           some value.val
         else
           scanElements baseSlot rest (idx + 1)
@@ -5513,6 +5625,43 @@ private theorem findDynamicArrayElementAtSlotCopy_eq
   simp only [SourceSemantics.findDynamicArrayElementAtSlot, findDynamicArrayElementAtSlotCopy]
   exact findDynamicArrayElementAtSlot_go_eq_copy fields world 0 targetSlot
 
+private theorem findDynamicArrayElementAtSlotCopy_scanElements_wordNormalize
+    (baseSlot : Nat) (elems : List Verity.Core.Uint256) (idx targetSlot : Nat) :
+    findDynamicArrayElementAtSlotCopy.scanElements
+        (SourceSemantics.wordNormalize targetSlot) baseSlot elems idx =
+      findDynamicArrayElementAtSlotCopy.scanElements targetSlot baseSlot elems idx := by
+  induction elems generalizing idx with
+  | nil => rfl
+  | cons _ rest ih =>
+      simp only [findDynamicArrayElementAtSlotCopy.scanElements]
+      rw [SourceSemantics.wordNormalize_idem]
+      split
+      · rfl
+      · exact ih (idx + 1)
+
+private theorem findDynamicArrayElementAtSlotCopy_go_wordNormalize
+    (remaining : List Field) (world : Verity.ContractState) (idx targetSlot : Nat) :
+    findDynamicArrayElementAtSlotCopy.go world (SourceSemantics.wordNormalize targetSlot)
+        remaining idx =
+      findDynamicArrayElementAtSlotCopy.go world targetSlot remaining idx := by
+  induction remaining generalizing idx with
+  | nil => rfl
+  | cons field rest ih =>
+      simp only [findDynamicArrayElementAtSlotCopy.go]
+      rw [findDynamicArrayElementAtSlotCopy_scanElements_wordNormalize]
+      split
+      · split
+        · rfl
+        · exact ih (idx + 1)
+      · exact ih (idx + 1)
+
+private theorem findDynamicArrayElementAtSlotCopy_wordNormalize
+    (fields : List Field) (world : Verity.ContractState) (targetSlot : Nat) :
+    findDynamicArrayElementAtSlotCopy fields world (SourceSemantics.wordNormalize targetSlot) =
+      findDynamicArrayElementAtSlotCopy fields world targetSlot := by
+  simp only [findDynamicArrayElementAtSlotCopy]
+  exact findDynamicArrayElementAtSlotCopy_go_wordNormalize fields world 0 targetSlot
+
 private theorem encodeStorageAt_eq_copy
     {fields : List Field}
     {world : Verity.ContractState}
@@ -5530,10 +5679,17 @@ private def fieldWriteEntriesAt
 
 private theorem fieldWriteEntriesAt_base_mem
     (idx : Nat) (field : Field) :
-    field.slot.getD idx ∈ (fieldWriteEntriesAt idx field).map (fun entry => entry.1) := by
+    SourceSemantics.wordNormalize (field.slot.getD idx) ∈
+      (fieldWriteEntriesAt idx field).map (fun entry => entry.1) := by
   obtain ⟨name, ty, slotOpt, packedBits, aliasSlots⟩ := field
-  cases ty <;>
-    simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots]
+  cases ty with
+  | adt _ maxFields =>
+      simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots,
+        SourceSemantics.wordNormalize]
+      exact Or.inl ⟨0, by omega, by simp⟩
+  | _ =>
+      simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots,
+        SourceSemantics.wordNormalize]
 
 private theorem exists_mem_zipIdx_of_mem
     {α : Type} {x : α} {xs : List α} {start : Nat}
@@ -5551,32 +5707,40 @@ private theorem exists_mem_zipIdx_of_mem
 private theorem fieldWriteEntriesAt_alias_mem
     {idx : Nat} {field : Field} {slot : Nat}
     (hmem : slot ∈ field.aliasSlots) :
-    slot ∈ (fieldWriteEntriesAt idx field).map (fun entry => entry.1) := by
-  obtain ⟨name, ty, slotOpt, packedBits, aliasSlots⟩ := field
-  obtain ⟨aliasIdx, halias⟩ : ∃ i, (slot, i) ∈ aliasSlots.zipIdx :=
-    exists_mem_zipIdx_of_mem hmem
-  cases ty with
-  | uint256 =>
-      simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots]
-      exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
-  | address =>
-      simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots]
-      exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
-  | adt _ maxFields =>
-      simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots]
-      exact Or.inr ⟨s!"{name}.aliasSlots[{aliasIdx}]", none, slot, aliasIdx, halias, 0, by omega, by simp⟩
-  | dynamicArray _ =>
-      simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots]
-      exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
-  | mappingTyped _ =>
-      simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots]
-      exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
-  | mappingStruct _ _ =>
-      simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots]
-      exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
-  | mappingStruct2 _ _ _ =>
-      simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots]
-      exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
+    SourceSemantics.wordNormalize slot ∈
+      (fieldWriteEntriesAt idx field).map (fun entry => entry.1) := by
+    obtain ⟨name, ty, slotOpt, packedBits, aliasSlots⟩ := field
+    obtain ⟨aliasIdx, halias⟩ : ∃ i, (slot, i) ∈ aliasSlots.zipIdx :=
+      exists_mem_zipIdx_of_mem hmem
+    cases ty with
+    | uint256 =>
+        simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots,
+          SourceSemantics.wordNormalize]
+        exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
+    | address =>
+        simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots,
+          SourceSemantics.wordNormalize]
+        exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
+    | adt _ maxFields =>
+        simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots,
+          SourceSemantics.wordNormalize]
+        exact Or.inr ⟨s!"{name}.aliasSlots[{aliasIdx}]", none, slot, aliasIdx, halias, 0, by omega, by simp⟩
+    | dynamicArray _ =>
+        simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots,
+          SourceSemantics.wordNormalize]
+        exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
+    | mappingTyped _ =>
+        simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots,
+          SourceSemantics.wordNormalize]
+        exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
+    | mappingStruct _ _ =>
+        simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots,
+          SourceSemantics.wordNormalize]
+        exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
+    | mappingStruct2 _ _ _ =>
+        simp [fieldWriteEntriesAt, firstFieldWriteSlotConflict.fieldOccupiedSlots,
+          SourceSemantics.wordNormalize]
+        exact Or.inr ⟨_, _, _, _, halias, rfl, rfl, rfl⟩
 
 private theorem fieldWriteEntriesAt_packed_none_of_unpacked
     {idx : Nat} {field : Field} {packed : Option PackedBits}
@@ -5689,7 +5853,7 @@ private theorem firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_member
     {slot : Nat}
     {writeSlots : List Nat}
     {targetSlot : Nat}
-    (hseen : targetSlot ∈ seen.map (fun entry => entry.1))
+    (hseen : SourceSemantics.wordNormalize targetSlot ∈ seen.map (fun entry => entry.1))
     (hfind :
       findFieldWithResolvedSlotCopyFrom fields idx fieldName = some (f, slot))
     (hwrite :
@@ -5713,7 +5877,8 @@ private theorem firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_member
         -- fieldWriteEntriesAt produces entries with first components matching writeSlots
         -- and all packed bits = field.packedBits = none
         have htarget_in_entries :
-            targetSlot ∈ (fieldWriteEntriesAt idx field).map (fun entry => entry.1) := by
+            SourceSemantics.wordNormalize targetSlot ∈
+              (fieldWriteEntriesAt idx field).map (fun entry => entry.1) := by
           simp only [List.mem_cons] at hslot
           rcases hslot with hslot | halias
           · subst targetSlot
@@ -5732,8 +5897,9 @@ private theorem firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_member
       · -- field.name doesn't match: recurse
         simp [hname] at hfind hwrite
         have hseen' :
-            targetSlot ∈ ((fieldWriteEntriesAt idx field).reverse ++ seen).map
-              (fun entry => entry.1) := by
+              SourceSemantics.wordNormalize targetSlot ∈
+                ((fieldWriteEntriesAt idx field).reverse ++ seen).map
+                (fun entry => entry.1) := by
           rw [List.map_append, List.mem_append]
           exact Or.inr hseen
         cases hc : firstInFieldConflictCopy seen (fieldWriteEntriesAt idx field) with
@@ -5747,7 +5913,7 @@ private theorem firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_singleton
     {fieldName : String}
     {f : Field}
     {slot : Nat}
-    (hseen : slot ∈ seen.map (fun entry => entry.1))
+    (hseen : SourceSemantics.wordNormalize slot ∈ seen.map (fun entry => entry.1))
     (hfind :
       findFieldWithResolvedSlotCopyFrom fields idx fieldName = some (f, slot))
     (hwrite :
@@ -5784,11 +5950,16 @@ private theorem findResolvedFieldAtSlotCopyFrom_of_member
     · -- field.name matches: f = field, writeSlots = slot :: aliasSlots
       simp [hname] at hfind hwrite
       obtain ⟨rfl, rfl⟩ := hfind
-      subst hwrite
+      subst writeSlots
       simp only [List.mem_cons] at hslot
       rcases hslot with rfl | hmem
       · simp
-      · simp [hmem]
+      · rw [show
+          (List.map SourceSemantics.wordNormalize field.aliasSlots).contains
+            (SourceSemantics.wordNormalize targetSlot) = true by
+            rw [List.contains_eq_mem]
+            exact decide_eq_true (List.mem_map.mpr ⟨targetSlot, hmem, rfl⟩)]
+        simp
     · -- field.name doesn't match: recurse
       simp [hname] at hfind hwrite
       cases hc : firstInFieldConflictCopy seen (fieldWriteEntriesAt idx field) with
@@ -5797,22 +5968,41 @@ private theorem findResolvedFieldAtSlotCopyFrom_of_member
         rw [hc] at hnoConflict
         -- After simp, condition is Prop-level: = or ∈
         by_cases hcapture :
-            field.slot.getD idx = targetSlot ∨ targetSlot ∈ field.aliasSlots
+            SourceSemantics.wordNormalize (field.slot.getD idx) =
+              SourceSemantics.wordNormalize targetSlot ∨
+            ∃ a ∈ field.aliasSlots,
+              SourceSemantics.wordNormalize a = SourceSemantics.wordNormalize targetSlot
         · exfalso
           have htargetInEntries :
-              targetSlot ∈ (fieldWriteEntriesAt idx field).map (fun entry => entry.1) := by
-            rcases hcapture with rfl | h
-            · exact fieldWriteEntriesAt_base_mem idx field
-            · exact fieldWriteEntriesAt_alias_mem h
+              SourceSemantics.wordNormalize targetSlot ∈
+                (fieldWriteEntriesAt idx field).map (fun entry => entry.1) := by
+            rcases hcapture with hbase | ⟨a, haMem, haEq⟩
+            · have hb := fieldWriteEntriesAt_base_mem idx field
+              rw [hbase] at hb
+              exact hb
+            · have haIn := fieldWriteEntriesAt_alias_mem (idx := idx) (field := field) haMem
+              rw [haEq] at haIn
+              exact haIn
           have htargetInSeen :
-              targetSlot ∈ ((fieldWriteEntriesAt idx field).reverse ++ seen).map
+              SourceSemantics.wordNormalize targetSlot ∈
+              ((fieldWriteEntriesAt idx field).reverse ++ seen).map
                 (fun entry => entry.1) := by
             rw [List.map_append, List.mem_append, List.map_reverse]
             exact Or.inl (List.mem_reverse.mpr htargetInEntries)
-          exact firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_member
-            htargetInSeen hfind hwrite hslot hunpacked hnoConflict
+          exact (firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_member
+            htargetInSeen hfind hwrite hslot hunpacked) hnoConflict
         · push_neg at hcapture
-          simp [hcapture.1, hcapture.2]
+          rw [show
+            (decide (SourceSemantics.wordNormalize (field.slot.getD idx) =
+                SourceSemantics.wordNormalize targetSlot) ||
+              (List.map SourceSemantics.wordNormalize field.aliasSlots).contains
+                (SourceSemantics.wordNormalize targetSlot)) = false by
+            simp only [Bool.or_eq_false_iff, decide_eq_false_iff_not,
+              List.contains_eq_mem, List.mem_map]
+            exact ⟨hcapture.1, by
+              intro hmem
+              rcases hmem with ⟨a, haMem, haEq⟩
+              exact hcapture.2 a haMem haEq⟩]
           exact ih hnoConflict hfind hwrite
 
 private theorem findResolvedFieldAtSlotCopy_go_eq_CopyFrom
@@ -5936,28 +6126,35 @@ private theorem encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
       findDynamicArrayElementAtSlotCopy fields world
         (Compiler.Proofs.abstractMappingSlot slot key) = none)
     (hvalue : value < Verity.Core.Uint256.modulus) :
-    SourceSemantics.encodeStorageAt fields
-      (SourceSemantics.writeUintKeyedMappingSlots world [slot] key value)
-      (Compiler.Proofs.abstractMappingSlot slot key) = value := by
+      SourceSemantics.encodeStorageAt fields
+        (SourceSemantics.writeUintKeyedMappingSlots world [slot] key value)
+        (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot slot key)) = value := by
   rw [encodeStorageAt_eq_copy]
-  simp only [encodeStorageAtCopy, hresolved]
+  have hresolved' :
+      findResolvedFieldAtSlotCopy fields
+        (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot slot key)) = none := by
+    rw [findResolvedFieldAtSlotCopy_wordNormalize]
+    exact hresolved
+  simp only [encodeStorageAtCopy, hresolved']
   have harray : (SourceSemantics.writeUintKeyedMappingSlots
       world [slot] key value).storageArray = world.storageArray := by
     simp [SourceSemantics.writeUintKeyedMappingSlots]
   have hdyn' : findDynamicArrayElementAtSlotCopy fields
       (SourceSemantics.writeUintKeyedMappingSlots world [slot] key value)
-      (Compiler.Proofs.abstractMappingSlot slot key) = none := by
+      (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot slot key)) = none := by
     have h1 := findDynamicArrayElementAtSlotCopy_eq fields
       (SourceSemantics.writeUintKeyedMappingSlots world [slot] key value)
-      (Compiler.Proofs.abstractMappingSlot slot key)
+      (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot slot key))
     have h2 := findDynamicArrayElementAtSlotCopy_eq fields world
-      (Compiler.Proofs.abstractMappingSlot slot key)
+      (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot slot key))
     rw [← h1, SourceSemantics.findDynamicArrayElementAtSlot_congr_storageArray _ _ _ _ harray,
-        h2, hdyn]
+        h2]
+    rw [findDynamicArrayElementAtSlotCopy_wordNormalize]
+    exact hdyn
   simp only [hdyn']
   simp only [SourceSemantics.writeUintKeyedMappingSlots, List.foldl_cons, List.foldl_nil]
   simp only [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot]
-  simp only [ite_true, Verity.Core.Uint256.val_ofNat,
+  simp only [IRStorageSlot.ofNat_wordNormalize, ite_true, Verity.Core.Uint256.val_ofNat,
     Compiler.Proofs.IRGeneration.IRStorageWord.toNat_ofNat,
     SourceSemantics.UInt256_size_eq_UINT256_MODULUS]
   have hvalue' : value < Verity.Core.UINT256_MODULUS := hvalue
@@ -5977,24 +6174,31 @@ private theorem encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_eq_
       findDynamicArrayElementAtSlotCopy fields world
         (SourceSemantics.mappingSlotChain slot keys) = none)
     (hvalue : value < Verity.Core.Uint256.modulus) :
-    SourceSemantics.encodeStorageAt fields
-      (SourceSemantics.writeAddressKeyedMappingChainSlots world [slot] keys value)
-      (SourceSemantics.mappingSlotChain slot keys) = value := by
+      SourceSemantics.encodeStorageAt fields
+        (SourceSemantics.writeAddressKeyedMappingChainSlots world [slot] keys value)
+        (SourceSemantics.wordNormalize (SourceSemantics.mappingSlotChain slot keys)) = value := by
   rw [encodeStorageAt_eq_copy]
-  simp only [encodeStorageAtCopy, hresolved]
+  have hresolved' :
+      findResolvedFieldAtSlotCopy fields
+        (SourceSemantics.wordNormalize (SourceSemantics.mappingSlotChain slot keys)) = none := by
+    rw [findResolvedFieldAtSlotCopy_wordNormalize]
+    exact hresolved
+  simp only [encodeStorageAtCopy, hresolved']
   have harray : (SourceSemantics.writeAddressKeyedMappingChainSlots
       world [slot] keys value).storageArray = world.storageArray := by
     simp [SourceSemantics.writeAddressKeyedMappingChainSlots]
   have hdyn' : findDynamicArrayElementAtSlotCopy fields
       (SourceSemantics.writeAddressKeyedMappingChainSlots world [slot] keys value)
-      (SourceSemantics.mappingSlotChain slot keys) = none := by
+      (SourceSemantics.wordNormalize (SourceSemantics.mappingSlotChain slot keys)) = none := by
     have h1 := findDynamicArrayElementAtSlotCopy_eq fields
       (SourceSemantics.writeAddressKeyedMappingChainSlots world [slot] keys value)
-      (SourceSemantics.mappingSlotChain slot keys)
+      (SourceSemantics.wordNormalize (SourceSemantics.mappingSlotChain slot keys))
     have h2 := findDynamicArrayElementAtSlotCopy_eq fields world
-      (SourceSemantics.mappingSlotChain slot keys)
+      (SourceSemantics.wordNormalize (SourceSemantics.mappingSlotChain slot keys))
     rw [← h1, SourceSemantics.findDynamicArrayElementAtSlot_congr_storageArray _ _ _ _ harray,
-        h2, hdyn]
+        h2]
+    rw [findDynamicArrayElementAtSlotCopy_wordNormalize]
+    exact hdyn
   simp only [hdyn']
   simp only [SourceSemantics.writeAddressKeyedMappingChainSlots, List.map_cons, List.map_nil,
     List.contains_cons, List.contains_nil, Bool.or_false, beq_iff_eq, ite_true]
@@ -6012,28 +6216,44 @@ private theorem encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_eq_w
       findDynamicArrayElementAtSlotCopy fields world
         (mappingWordTargetSlot slot key wordOffset) = none)
     (hvalue : value < Verity.Core.Uint256.modulus) :
-    SourceSemantics.encodeStorageAt fields
-      (SourceSemantics.writeAddressKeyedMappingWordSlots world [slot] key wordOffset value)
-      (mappingWordTargetSlot slot key wordOffset) = value := by
+      SourceSemantics.encodeStorageAt fields
+        (SourceSemantics.writeAddressKeyedMappingWordSlots world [slot] key wordOffset value)
+        (SourceSemantics.wordNormalize (mappingWordTargetSlot slot key wordOffset)) = value := by
   rw [encodeStorageAt_eq_copy]
-  simp only [encodeStorageAtCopy, hresolved]
+  have hresolved' :
+      findResolvedFieldAtSlotCopy fields
+        (SourceSemantics.wordNormalize (mappingWordTargetSlot slot key wordOffset)) = none := by
+    rw [findResolvedFieldAtSlotCopy_wordNormalize]
+    exact hresolved
+  simp only [encodeStorageAtCopy, hresolved']
   have harray : (SourceSemantics.writeAddressKeyedMappingWordSlots
       world [slot] key wordOffset value).storageArray = world.storageArray := by
     simp [SourceSemantics.writeAddressKeyedMappingWordSlots]
   have hdyn' : findDynamicArrayElementAtSlotCopy fields
       (SourceSemantics.writeAddressKeyedMappingWordSlots world [slot] key wordOffset value)
-      (mappingWordTargetSlot slot key wordOffset) = none := by
+      (SourceSemantics.wordNormalize (mappingWordTargetSlot slot key wordOffset)) = none := by
     have h1 := findDynamicArrayElementAtSlotCopy_eq fields
       (SourceSemantics.writeAddressKeyedMappingWordSlots world [slot] key wordOffset value)
-      (mappingWordTargetSlot slot key wordOffset)
+      (SourceSemantics.wordNormalize (mappingWordTargetSlot slot key wordOffset))
     have h2 := findDynamicArrayElementAtSlotCopy_eq fields world
-      (mappingWordTargetSlot slot key wordOffset)
+      (SourceSemantics.wordNormalize (mappingWordTargetSlot slot key wordOffset))
     rw [← h1, SourceSemantics.findDynamicArrayElementAtSlot_congr_storageArray _ _ _ _ harray,
-        h2, hdyn]
+        h2]
+    rw [findDynamicArrayElementAtSlotCopy_wordNormalize]
+    exact hdyn
   rw [hdyn']
   simp [SourceSemantics.writeAddressKeyedMappingWordSlots, mappingWordTargetSlot,
     SourceSemantics.wordNormalize, Verity.Core.Uint256.val_ofNat]
-  exact hvalue
+  have htargetLt :
+      (Verity.Core.Uint256.ofNat wordOffset +
+          Verity.Core.Uint256.ofNat (Compiler.Proofs.solidityMappingSlot slot key)).val <
+        Compiler.Constants.evmModulus :=
+    (Verity.Core.Uint256.ofNat wordOffset +
+      Verity.Core.Uint256.ofNat (Compiler.Proofs.solidityMappingSlot slot key)).isLt
+  simp [Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS,
+    htargetLt, Nat.mod_eq_of_lt hvalue]
+  simpa [Verity.Core.Uint256.modulus, Compiler.Constants.evmModulus,
+    Verity.Core.UINT256_MODULUS] using hvalue
 
 private theorem encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_eq_written
     {fields : List Field}
@@ -6092,23 +6312,36 @@ private theorem encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleto
 private theorem encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_other
     {fields : List Field}
     {world : Verity.ContractState}
-    {slot key1 key2 query value : Nat}
-    (hneq :
-      query ≠ Compiler.Proofs.abstractMappingSlot
-        (Compiler.Proofs.abstractMappingSlot slot key1)
-        key2) :
-    SourceSemantics.encodeStorageAt fields
-      (SourceSemantics.writeAddressKeyedMapping2Slots world [slot] key1 key2 value)
-      query =
-      SourceSemantics.encodeStorageAt fields world query := by
-  apply SourceSemantics.encodeStorageAt_congr
-  · simp only [SourceSemantics.writeAddressKeyedMapping2Slots, List.foldl_cons, List.foldl_nil]
-    simp [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot] at hneq ⊢
-    simp [hneq]
-    apply Verity.Core.Uint256.ext
-    simp [Verity.Core.Uint256.modulus, Nat.mod_eq_of_lt (world.storage query).isLt]
-  · simp [SourceSemantics.writeAddressKeyedMapping2Slots]
-  · simp [SourceSemantics.writeAddressKeyedMapping2Slots]
+        {slot key1 key2 query value : Nat}
+        (hquery : query < Compiler.Constants.evmModulus)
+        (hneq :
+          IRStorageSlot.ofNat query ≠
+            IRStorageSlot.ofNat (Compiler.Proofs.abstractMappingSlot
+            (Compiler.Proofs.abstractMappingSlot slot key1)
+            key2)) :
+      SourceSemantics.encodeStorageAt fields
+        (SourceSemantics.writeAddressKeyedMapping2Slots world [slot] key1 key2 value)
+        query =
+        SourceSemantics.encodeStorageAt fields world query := by
+      apply SourceSemantics.encodeStorageAt_congr
+      · simp only [SourceSemantics.writeAddressKeyedMapping2Slots, List.foldl_cons, List.foldl_nil]
+        have hneq' :
+            ¬IRStorageSlot.ofNat query =
+              IRStorageSlot.ofNat (Compiler.Proofs.solidityMappingSlot
+                (Compiler.Proofs.solidityMappingSlot slot key1) key2) := by
+          simpa [Compiler.Proofs.abstractMappingSlot_eq_solidity] using hneq
+        simp [Compiler.Proofs.abstractStoreMappingEntry, hneq', Nat.mod_eq_of_lt hquery,
+          Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS]
+        apply Verity.Core.Uint256.ext
+        have hltLit :
+            (world.storage query).val <
+              115792089237316195423570985008687907853269984665640564039457584007913129639936 := by
+          simpa [Verity.Core.Uint256.modulus, Verity.Core.UINT256_MODULUS] using
+            (world.storage query).isLt
+        simp [Verity.Core.Uint256.modulus, Verity.Core.UINT256_MODULUS,
+          Nat.mod_eq_of_lt (world.storage query).isLt, Nat.mod_eq_of_lt hltLit]
+      · simp [SourceSemantics.writeAddressKeyedMapping2Slots]
+      · simp [SourceSemantics.writeAddressKeyedMapping2Slots]
 
 private theorem encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_eq_written
     {fields : List Field}
@@ -6125,33 +6358,41 @@ private theorem encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_eq_writ
           (Compiler.Proofs.abstractMappingSlot slot key1)
           key2) = none)
     (hvalue : value < Verity.Core.Uint256.modulus) :
-    SourceSemantics.encodeStorageAt fields
-      (SourceSemantics.writeAddressKeyedMapping2Slots world [slot] key1 key2 value)
-      (Compiler.Proofs.abstractMappingSlot
-        (Compiler.Proofs.abstractMappingSlot slot key1)
-        key2) = value := by
+      SourceSemantics.encodeStorageAt fields
+        (SourceSemantics.writeAddressKeyedMapping2Slots world [slot] key1 key2 value)
+        (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot
+          (Compiler.Proofs.abstractMappingSlot slot key1)
+          key2)) = value := by
   rw [encodeStorageAt_eq_copy]
-  simp only [encodeStorageAtCopy, hresolved]
+  have hresolved' :
+      findResolvedFieldAtSlotCopy fields
+        (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot
+            (Compiler.Proofs.abstractMappingSlot slot key1) key2)) = none := by
+    rw [findResolvedFieldAtSlotCopy_wordNormalize]
+    exact hresolved
+  simp only [encodeStorageAtCopy, hresolved']
   have harray : (SourceSemantics.writeAddressKeyedMapping2Slots
       world [slot] key1 key2 value).storageArray = world.storageArray := by
     simp [SourceSemantics.writeAddressKeyedMapping2Slots]
   have hdyn' : findDynamicArrayElementAtSlotCopy fields
       (SourceSemantics.writeAddressKeyedMapping2Slots world [slot] key1 key2 value)
-      (Compiler.Proofs.abstractMappingSlot
-        (Compiler.Proofs.abstractMappingSlot slot key1) key2) = none := by
+      (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot
+        (Compiler.Proofs.abstractMappingSlot slot key1) key2)) = none := by
     have h1 := findDynamicArrayElementAtSlotCopy_eq fields
       (SourceSemantics.writeAddressKeyedMapping2Slots world [slot] key1 key2 value)
-      (Compiler.Proofs.abstractMappingSlot
-        (Compiler.Proofs.abstractMappingSlot slot key1) key2)
+      (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot
+        (Compiler.Proofs.abstractMappingSlot slot key1) key2))
     have h2 := findDynamicArrayElementAtSlotCopy_eq fields world
-      (Compiler.Proofs.abstractMappingSlot
-        (Compiler.Proofs.abstractMappingSlot slot key1) key2)
+      (SourceSemantics.wordNormalize (Compiler.Proofs.abstractMappingSlot
+        (Compiler.Proofs.abstractMappingSlot slot key1) key2))
     rw [← h1, SourceSemantics.findDynamicArrayElementAtSlot_congr_storageArray _ _ _ _ harray,
-        h2, hdyn]
+        h2]
+    rw [findDynamicArrayElementAtSlotCopy_wordNormalize]
+    exact hdyn
   simp only [hdyn']
   simp only [SourceSemantics.writeAddressKeyedMapping2Slots, List.foldl_cons, List.foldl_nil]
   simp only [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot]
-  simp only [ite_true, Verity.Core.Uint256.val_ofNat,
+  simp only [IRStorageSlot.ofNat_wordNormalize, ite_true, Verity.Core.Uint256.val_ofNat,
     Compiler.Proofs.IRGeneration.IRStorageWord.toNat_ofNat,
     SourceSemantics.UInt256_size_eq_UINT256_MODULUS]
   have hvalue' : value < Verity.Core.UINT256_MODULUS := hvalue
@@ -6218,33 +6459,55 @@ private theorem encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_
       findDynamicArrayElementAtSlotCopy fields world
         (mapping2WordTargetSlot slot key1 key2 wordOffset) = none)
     (hvalue : value < Verity.Core.Uint256.modulus) :
-    SourceSemantics.encodeStorageAt fields
-      (SourceSemantics.writeAddressKeyedMapping2WordSlots world [slot] key1 key2 wordOffset value)
-      (mapping2WordTargetSlot slot key1 key2 wordOffset) = value := by
+      SourceSemantics.encodeStorageAt fields
+        (SourceSemantics.writeAddressKeyedMapping2WordSlots world [slot] key1 key2 wordOffset value)
+        (SourceSemantics.wordNormalize (mapping2WordTargetSlot slot key1 key2 wordOffset)) = value := by
   rw [encodeStorageAt_eq_copy]
-  simp only [encodeStorageAtCopy, hresolved]
+  have hresolved' :
+      findResolvedFieldAtSlotCopy fields
+        (SourceSemantics.wordNormalize (mapping2WordTargetSlot slot key1 key2 wordOffset)) = none := by
+    rw [findResolvedFieldAtSlotCopy_wordNormalize]
+    exact hresolved
+  simp only [encodeStorageAtCopy, hresolved']
   have harray : (SourceSemantics.writeAddressKeyedMapping2WordSlots
       world [slot] key1 key2 wordOffset value).storageArray = world.storageArray := by
     simp [SourceSemantics.writeAddressKeyedMapping2WordSlots]
   have hdyn' : findDynamicArrayElementAtSlotCopy fields
       (SourceSemantics.writeAddressKeyedMapping2WordSlots world [slot] key1 key2 wordOffset value)
-      (mapping2WordTargetSlot slot key1 key2 wordOffset) = none := by
+      (SourceSemantics.wordNormalize (mapping2WordTargetSlot slot key1 key2 wordOffset)) = none := by
     have h1 := findDynamicArrayElementAtSlotCopy_eq fields
       (SourceSemantics.writeAddressKeyedMapping2WordSlots world [slot] key1 key2 wordOffset value)
-      (mapping2WordTargetSlot slot key1 key2 wordOffset)
+      (SourceSemantics.wordNormalize (mapping2WordTargetSlot slot key1 key2 wordOffset))
     have h2 := findDynamicArrayElementAtSlotCopy_eq fields world
-      (mapping2WordTargetSlot slot key1 key2 wordOffset)
+      (SourceSemantics.wordNormalize (mapping2WordTargetSlot slot key1 key2 wordOffset))
     rw [← h1, SourceSemantics.findDynamicArrayElementAtSlot_congr_storageArray _ _ _ _ harray,
-        h2, hdyn]
+        h2]
+    rw [findDynamicArrayElementAtSlotCopy_wordNormalize]
+    exact hdyn
   rw [hdyn']
   simp [SourceSemantics.writeAddressKeyedMapping2WordSlots, mapping2WordTargetSlot,
     SourceSemantics.wordNormalize, Verity.Core.Uint256.val_ofNat]
-  exact hvalue
+  have htargetLt :
+      (Verity.Core.Uint256.ofNat wordOffset +
+          Verity.Core.Uint256.ofNat
+            (Compiler.Proofs.solidityMappingSlot
+              (Compiler.Proofs.solidityMappingSlot slot key1) key2)).val <
+        Compiler.Constants.evmModulus :=
+    (Verity.Core.Uint256.ofNat wordOffset +
+      Verity.Core.Uint256.ofNat
+        (Compiler.Proofs.solidityMappingSlot
+          (Compiler.Proofs.solidityMappingSlot slot key1) key2)).isLt
+  simp [Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS,
+    htargetLt, Nat.mod_eq_of_lt hvalue]
+  simpa [Verity.Core.Uint256.modulus, Compiler.Constants.evmModulus,
+    Verity.Core.UINT256_MODULUS] using hvalue
 
 private def abstractStoreStorageOrMappingMany
-    (storage : Nat → Compiler.Proofs.IRGeneration.IRStorageWord)
+    (storage : Compiler.Proofs.IRGeneration.IRStorageSlot →
+      Compiler.Proofs.IRGeneration.IRStorageWord)
     (slots : List Nat) (value : Nat) :
-    Nat → Compiler.Proofs.IRGeneration.IRStorageWord :=
+    Compiler.Proofs.IRGeneration.IRStorageSlot →
+      Compiler.Proofs.IRGeneration.IRStorageWord :=
   match slots with
   | [] => storage
   | slot :: rest =>
@@ -6254,24 +6517,24 @@ private def abstractStoreStorageOrMappingMany
         value
 
 private theorem abstractStoreStorageOrMappingMany_eq
-    {storage : Nat → Compiler.Proofs.IRGeneration.IRStorageWord}
+    {storage : Compiler.Proofs.IRGeneration.IRStorageSlot →
+      Compiler.Proofs.IRGeneration.IRStorageWord}
     {slots : List Nat}
-    {value query : Nat} :
+    {value : Nat} {query : Compiler.Proofs.IRGeneration.IRStorageSlot} :
     abstractStoreStorageOrMappingMany storage slots value query =
-      if slots.contains query then
+      if ∃ slot ∈ slots, query = Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat slot then
         Compiler.Proofs.IRGeneration.IRStorageWord.ofNat value
       else storage query := by
   induction slots generalizing storage with
   | nil =>
       simp [abstractStoreStorageOrMappingMany]
   | cons slot rest ih =>
-      by_cases hEq : query = slot
+      simp only [abstractStoreStorageOrMappingMany]
+      rw [ih]
+      by_cases hEq : query = Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat slot
       · subst hEq
-        simpa [abstractStoreStorageOrMappingMany, Compiler.Proofs.abstractStoreStorageOrMapping_eq] using
-          (ih (storage := fun s => if s = query then
-            Compiler.Proofs.IRGeneration.IRStorageWord.ofNat value else storage s))
-      · simp [abstractStoreStorageOrMappingMany, ih,
-          Compiler.Proofs.abstractStoreStorageOrMapping_eq, hEq]
+        simp [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
+      · simp [Compiler.Proofs.abstractStoreStorageOrMapping_eq, hEq]
 
 private theorem runtimeStateMatchesIR_writeUintSlot
     {fields : List Field}
@@ -6292,18 +6555,27 @@ private theorem runtimeStateMatchesIR_writeUintSlot
     ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   funext query
-  by_cases hEq : query = slot
-  · subst hEq
-    rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
-    rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved hnotAddr hnotDyn]
-    simp [SourceSemantics.writeUintSlots, Verity.Core.Uint256.val_ofNat]
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-      (Nat.mod_eq_of_lt hvalue).symm
-  · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
-    simp only [hEq, ↓reduceIte]
-    rw [hstorage]
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-      (encodeStorageAt_writeUintSlots_singleton_other hEq).symm
+  ·
+    by_cases hEq : query = IRStorageSlot.ofNat slot
+    · subst hEq
+      rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
+      have hresolved' :
+          findResolvedFieldAtSlotCopy fields (IRStorageSlot.ofNat slot).toNat = some f := by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using
+          (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) = some f from
+            by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
+      rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved' hnotAddr hnotDyn]
+      simp [SourceSemantics.writeUintSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
+        SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+        Verity.Core.UINT256_MODULUS, Verity.Core.Uint256.val_ofNat]
+      exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+        (Nat.mod_eq_of_lt hvalue).symm
+    · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
+      simp only [hEq, ↓reduceIte]
+      rw [hstorage]
+      exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+        (encodeStorageAt_writeUintSlots_singleton_other
+          (IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq)).symm
 
 private theorem runtimeStateMatchesIR_writeAddressSlot
     {fields : List Field}
@@ -6321,29 +6593,40 @@ private theorem runtimeStateMatchesIR_writeAddressSlot
       { state with
           storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage slot
             (value &&& Compiler.Constants.addressMask) } := by
-  rcases hruntime with
-    ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
-  funext query
-  by_cases hEq : query = slot
-  · subst hEq
-    rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
-    rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved haddr hnotDyn]
-    simp [SourceSemantics.writeAddressSlots, Verity.wordToAddress, Verity.Core.Address.ofNat,
-          Verity.Core.Uint256.val_ofNat, Verity.Core.Address.modulus, Compiler.Constants.addressMask]
-    rw [Nat.mod_eq_of_lt hvalue]
-    refine congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat ?_
-    simpa [Compiler.Constants.addressMask, Verity.Core.Address.modulus] using
-      (Nat.and_two_pow_sub_one_eq_mod (n := 160) value)
-  · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
-    simp only [hEq, ↓reduceIte]
-    rw [hstorage]
-    symm
-    refine congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat ?_
-    apply SourceSemantics.encodeStorageAt_congr
-    · simp [SourceSemantics.writeAddressSlots]
-    · simp [SourceSemantics.writeAddressSlots, hEq]
-    · simp [SourceSemantics.writeAddressSlots]
+    rcases hruntime with
+      ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
+    funext query
+    by_cases hEq : query = IRStorageSlot.ofNat slot
+    · subst hEq
+      rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
+      have hresolved' :
+          findResolvedFieldAtSlotCopy fields (IRStorageSlot.ofNat slot).toNat = some f := by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using
+          (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) = some f from
+            by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
+      rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved' haddr hnotDyn]
+      simp [SourceSemantics.writeAddressSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
+        SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+        Verity.Core.UINT256_MODULUS,
+        Verity.wordToAddress, Verity.Core.Address.ofNat, Verity.Core.Uint256.val_ofNat,
+        Verity.Core.Address.modulus, Compiler.Constants.addressMask]
+      rw [Nat.mod_eq_of_lt hvalue]
+      refine congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat ?_
+      simpa [Compiler.Constants.addressMask, Verity.Core.Address.modulus] using
+        (Nat.and_two_pow_sub_one_eq_mod (n := 160) value)
+    · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
+      simp only [hEq, ↓reduceIte]
+      rw [hstorage]
+      symm
+      refine congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat ?_
+      have hneqNat := IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq
+      have hneqNat' : query.toNat ≠ slot % Compiler.Constants.evmModulus := by
+        simpa [SourceSemantics.wordNormalize] using hneqNat
+      apply SourceSemantics.encodeStorageAt_congr
+      · simp [SourceSemantics.writeAddressSlots]
+      · simp [SourceSemantics.writeAddressSlots, SourceSemantics.wordNormalize, hneqNat']
+      · simp [SourceSemantics.writeAddressSlots]
 
 private theorem runtimeStateMatchesIR_writeUintSlots
     {fields : List Field}
@@ -6366,16 +6649,41 @@ private theorem runtimeStateMatchesIR_writeUintSlots
   refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   funext query
   simp only [abstractStoreStorageOrMappingMany_eq]
-  by_cases hmem : slots.contains query = true
-  · simp only [hmem, ↓reduceIte]
-    have hq : query ∈ slots := by simpa using hmem
-    rw [encodeStorageAt_eq_storage_of_resolvedSlot (hresolved query hq) hnotAddr hnotDyn]
-    simp only [SourceSemantics.writeUintSlots, hmem, ↓reduceIte, Verity.Core.Uint256.val_ofNat]
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (Nat.mod_eq_of_lt hvalue).symm
-  · simp only [hmem, ↓reduceIte]
-    rw [hstorage]
-    have hnotMem : query ∉ slots := by simpa using hmem
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintSlots_other hnotMem).symm
+  ·
+      by_cases hmem : ∃ slot ∈ slots, query = IRStorageSlot.ofNat slot
+      · simp only [hmem, ↓reduceIte]
+        rcases hmem with ⟨slot, hslotMem, rfl⟩
+        have hresolved' :
+            findResolvedFieldAtSlotCopy fields (IRStorageSlot.ofNat slot).toNat = some f := by
+          simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using
+            (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) = some f from
+              by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved slot hslotMem)
+        rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved' hnotAddr hnotDyn]
+        have hcontains :
+              (slots.map SourceSemantics.wordNormalize).contains
+                (SourceSemantics.wordNormalize slot) = true := by
+            rw [List.contains_eq_mem]
+            exact decide_eq_true (List.mem_map.mpr ⟨slot, hslotMem, rfl⟩)
+        have hcontains' :
+              (slots.map SourceSemantics.wordNormalize).contains
+                (slot % Verity.Core.Uint256.modulus) = true := by
+            simpa [SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+              Verity.Core.UINT256_MODULUS, Verity.Core.Uint256.modulus] using hcontains
+        simp only [SourceSemantics.writeUintSlots, IRStorageSlot.toNat_ofNat_wordNormalize,
+            SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+            Verity.Core.UINT256_MODULUS, hcontains',
+            ↓reduceIte, Verity.Core.Uint256.val_ofNat]
+        exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (Nat.mod_eq_of_lt hvalue).symm
+      · simp only [hmem, ↓reduceIte]
+        rw [hstorage]
+        have hnotMem : query.toNat ∉ slots.map SourceSemantics.wordNormalize := by
+          intro hq
+          rcases List.mem_map.mp hq with ⟨slot, hslotMem, hslotEq⟩
+          apply hmem
+          exact ⟨slot, hslotMem, IRStorageSlot.eq_of_toNat_eq (by
+            simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using hslotEq.symm)⟩
+        exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+          (encodeStorageAt_writeUintSlots_other hnotMem).symm
 
 private theorem runtimeStateMatchesIR_writeUintKeyedMappingSlot
     {fields : List Field}
@@ -6399,16 +6707,22 @@ private theorem runtimeStateMatchesIR_writeUintKeyedMappingSlot
   refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   funext query
   simp only [Compiler.Proofs.abstractStoreMappingEntry]
-  by_cases hEq : query = Compiler.Proofs.solidityMappingSlot slot key
+  by_cases hEq : query = IRStorageSlot.ofNat (Compiler.Proofs.solidityMappingSlot slot key)
   · subst hEq
     simp only [↓reduceIte]
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
-      (fields := fields) (world := runtime.world) (slot := slot) (key := key) (value := value)
-      hresolved hdyn hvalue).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize,
+          Compiler.Proofs.abstractMappingSlot_eq_solidity,
+          SourceSemantics.wordNormalize_idem] using
+          (encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
+            (fields := fields) (world := runtime.world) (slot := slot) (key := key)
+            (value := value) hresolved hdyn hvalue).symm)
   · simp only [hEq, ↓reduceIte]
     rw [hstorage]
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintKeyedMappingSlots_singleton_other (fields := fields)
-      (world := runtime.world) (slot := slot) (key := key) (query := query) (value := value) hEq).symm
+      (world := runtime.world) (slot := slot) (key := key) (query := query.toNat) (value := value)
+      (by simpa [Compiler.Constants.evmModulus, EvmYul.UInt256.size] using IRStorageSlot.toNat_lt_size query)
+      (IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq)).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMappingChainSlot
     {fields : List Field}
@@ -6438,7 +6752,7 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingChainSlot
     ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   funext query
-  by_cases hEq : query = SourceSemantics.mappingSlotChain slot keys
+  by_cases hEq : query = IRStorageSlot.ofNat (SourceSemantics.mappingSlotChain slot keys)
   · subst hEq
     rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     have henc : SourceSemantics.encodeStorageAt fields runtime.world
@@ -6447,15 +6761,19 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingChainSlot
       rw [encodeStorageAt_eq_copy]
       simp only [encodeStorageAtCopy, hresolved, hdyn]
     simp only [hstorage, henc]
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_eq_written
-      (fields := fields) (world := runtime.world) (slot := slot) (keys := keys) (value := value)
-      hresolved hdyn hvalue).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize,
+          SourceSemantics.wordNormalize_idem] using
+          (encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_eq_written
+            (fields := fields) (world := runtime.world) (slot := slot) (keys := keys)
+            (value := value) hresolved hdyn hvalue).symm)
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     simp only [hEq, ↓reduceIte]
     rw [hstorage]
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_other
       (fields := fields) (world := runtime.world) (slot := slot) (keys := keys)
-      (query := query) (value := value) hEq).symm
+      (query := query.toNat) (value := value)
+      (IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq)).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMappingSlot
     {fields : List Field}
@@ -6491,16 +6809,22 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingSlot
   funext query
   rw [hbridge]
   simp only [Compiler.Proofs.abstractStoreMappingEntry]
-  by_cases hEq : query = Compiler.Proofs.solidityMappingSlot slot key
+  by_cases hEq : query = IRStorageSlot.ofNat (Compiler.Proofs.solidityMappingSlot slot key)
   · subst hEq
     simp only [↓reduceIte]
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
-      (fields := fields) (world := runtime.world) (slot := slot) (key := key) (value := value)
-      hresolved hdyn hvalue).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize,
+          Compiler.Proofs.abstractMappingSlot_eq_solidity,
+          SourceSemantics.wordNormalize_idem] using
+          (encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
+            (fields := fields) (world := runtime.world) (slot := slot) (key := key)
+            (value := value) hresolved hdyn hvalue).symm)
   · simp only [hEq, ↓reduceIte]
     rw [hstorage]
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintKeyedMappingSlots_singleton_other (fields := fields)
-      (world := runtime.world) (slot := slot) (key := key) (query := query) (value := value) hEq).symm
+      (world := runtime.world) (slot := slot) (key := key) (query := query.toNat) (value := value)
+      (by simpa [Compiler.Constants.evmModulus, EvmYul.UInt256.size] using IRStorageSlot.toNat_lt_size query)
+      (IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq)).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMappingWordSlot
     {fields : List Field}
@@ -6528,7 +6852,7 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingWordSlot
     ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   funext query
-  by_cases hEq : query = mappingWordTargetSlot slot key wordOffset
+  by_cases hEq : query = IRStorageSlot.ofNat (mappingWordTargetSlot slot key wordOffset)
   · subst hEq
     rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     have henc : SourceSemantics.encodeStorageAt fields runtime.world
@@ -6537,15 +6861,22 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingWordSlot
       rw [encodeStorageAt_eq_copy]
       simp only [encodeStorageAtCopy, hresolved, hdyn]
     simp only [hstorage, henc]
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_eq_written
-      (fields := fields) (world := runtime.world) (slot := slot) (key := key)
-      (wordOffset := wordOffset) (value := value) hresolved hdyn hvalue).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (by
+          simpa [IRStorageSlot.toNat_ofNat_wordNormalize,
+            mappingWordTargetSlot, SourceSemantics.wordNormalize,
+            SourceSemantics.wordNormalize_idem, Compiler.Constants.evmModulus,
+            Verity.Core.UINT256_MODULUS] using
+          (encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_eq_written
+            (fields := fields) (world := runtime.world) (slot := slot) (key := key)
+            (wordOffset := wordOffset) (value := value) hresolved hdyn hvalue).symm)
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     simp only [hEq, ↓reduceIte]
     rw [hstorage]
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_other
       (fields := fields) (world := runtime.world) (slot := slot) (key := key)
-      (wordOffset := wordOffset) (query := query) (value := value) hEq).symm
+        (wordOffset := wordOffset) (query := query.toNat) (value := value)
+        (by simpa [mappingWordTargetSlot] using
+          IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq)).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMappingPackedWordSlot
     {fields : List Field} {runtime : SourceSemantics.RuntimeState} {state : IRState}
@@ -6567,7 +6898,7 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingPackedWordSlot
             (mappingWordTargetSlot slot key wordOffset)
             (SourceSemantics.packedWordWrite
               (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
-                (state.storage (mappingWordTargetSlot slot key wordOffset)))
+                (state.storage (IRStorageSlot.ofNat (mappingWordTargetSlot slot key wordOffset))))
               value
               packed) } := by
   rcases hruntime with
@@ -6575,26 +6906,49 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingPackedWordSlot
   refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   funext query
   set tgt := mappingWordTargetSlot slot key wordOffset with htgt
-  by_cases hEq : query = tgt
+  by_cases hEq : query = IRStorageSlot.ofNat tgt
   · subst hEq
     rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     have henc : SourceSemantics.encodeStorageAt fields runtime.world tgt =
         (runtime.world.storage tgt).val := by
       rw [encodeStorageAt_eq_copy]; simp only [encodeStorageAtCopy, hresolved, hdyn]
-    simp only [hstorage, henc]
-    rw [show (Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-        (runtime.world.storage tgt).val).toNat = (runtime.world.storage tgt).val from
-      Nat.mod_eq_of_lt (runtime.world.storage tgt).isLt]
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
-      (encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_eq_written
-        (fields := fields) (world := runtime.world) (slot := slot) (key := key)
-        (wordOffset := wordOffset) (packed := packed) (value := value) hresolved hdyn).symm
+    have htgtNorm : SourceSemantics.wordNormalize tgt = tgt := by
+      rw [htgt]
+      exact SourceSemantics.wordNormalize_idem _
+    have htgtSlot : (IRStorageSlot.ofNat tgt).toNat = tgt := by
+      rw [IRStorageSlot.toNat_ofNat_wordNormalize, htgtNorm]
+    have htgtLt : tgt < Verity.Core.UINT256_MODULUS := by
+      have h := SourceSemantics.wordNormalize_lt_evmModulus tgt
+      rw [htgtNorm] at h
+      simpa [Compiler.Constants.evmModulus, Verity.Core.UINT256_MODULUS] using h
+    have htgtLtLit :
+        mappingWordTargetSlot slot key wordOffset <
+          115792089237316195423570985008687907853269984665640564039457584007913129639936 := by
+      simpa [htgt, Verity.Core.UINT256_MODULUS] using htgtLt
+    have hstorageLtLit :
+        (runtime.world.storage (mappingWordTargetSlot slot key wordOffset)).val <
+          115792089237316195423570985008687907853269984665640564039457584007913129639936 := by
+      simpa [Verity.Core.Uint256.modulus, Verity.Core.UINT256_MODULUS] using
+        (runtime.world.storage (mappingWordTargetSlot slot key wordOffset)).isLt
+    have hencNorm : SourceSemantics.encodeStorageAt fields runtime.world
+        (IRStorageSlot.ofNat tgt).toNat = (runtime.world.storage tgt).val := by
+      simpa [htgtSlot] using henc
+    simp only [hstorage, hencNorm]
+    simp [IRStorageWord.toNat_ofNat, EvmYul.UInt256.size,
+      Verity.Core.UINT256_MODULUS, Nat.mod_eq_of_lt (runtime.world.storage tgt).isLt]
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (by
+        simpa [htgt, Nat.mod_eq_of_lt htgtLtLit, Nat.mod_eq_of_lt hstorageLtLit] using
+        (encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_eq_written
+          (fields := fields) (world := runtime.world) (slot := slot) (key := key)
+          (wordOffset := wordOffset) (packed := packed) (value := value) hresolved hdyn).symm)
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     simp only [hEq, ↓reduceIte]; rw [hstorage]
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
       (encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_other
         (fields := fields) (world := runtime.world) (slot := slot) (key := key)
-        (wordOffset := wordOffset) (packed := packed) (query := query) (value := value) hEq).symm
+          (wordOffset := wordOffset) (packed := packed) (query := query.toNat) (value := value)
+          (by simpa [htgt, mappingWordTargetSlot] using
+            IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq)).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2Slot
     {fields : List Field}
@@ -6629,22 +6983,27 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2Slot
   funext query
   simp only [Compiler.Proofs.abstractStoreMappingEntry]
   by_cases hEq : query =
-      Compiler.Proofs.solidityMappingSlot
+      (IRStorageSlot.ofNat (Compiler.Proofs.solidityMappingSlot
         (Compiler.Proofs.abstractMappingSlot slot key1)
-        key2
+        key2))
   · subst hEq
     simp only [↓reduceIte]
     rw [Compiler.Proofs.abstractMappingSlot_eq_solidity] at hresolved hdyn
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_eq_written
-      (fields := fields) (world := runtime.world)
-      (slot := slot) (key1 := key1) (key2 := key2) (value := value)
-      hresolved hdyn hvalue).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (by
+          simpa [IRStorageSlot.toNat_ofNat_wordNormalize,
+            Compiler.Proofs.abstractMappingSlot_eq_solidity,
+            SourceSemantics.wordNormalize_idem] using
+            (encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_eq_written
+                (fields := fields) (world := runtime.world)
+                (slot := slot) (key1 := key1) (key2 := key2) (value := value)
+                hresolved hdyn hvalue).symm)
   · simp only [hEq, ↓reduceIte]
     rw [hstorage]
-    rw [Compiler.Proofs.abstractMappingSlot_eq_solidity] at hEq
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_other (fields := fields)
       (world := runtime.world) (slot := slot) (key1 := key1) (key2 := key2)
-      (query := query) (value := value) hEq).symm
+      (query := query.toNat) (value := value)
+      (by simpa [Compiler.Constants.evmModulus, EvmYul.UInt256.size] using IRStorageSlot.toNat_lt_size query)
+      (by simpa [IRStorageSlot.ofNat_toNat] using hEq)).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2WordSlot
     {fields : List Field}
@@ -6672,7 +7031,7 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2WordSlot
     ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   funext query
-  by_cases hEq : query = mapping2WordTargetSlot slot key1 key2 wordOffset
+  by_cases hEq : query = IRStorageSlot.ofNat (mapping2WordTargetSlot slot key1 key2 wordOffset)
   · subst hEq
     rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     have henc : SourceSemantics.encodeStorageAt fields runtime.world
@@ -6681,16 +7040,23 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2WordSlot
       rw [encodeStorageAt_eq_copy]
       simp only [encodeStorageAtCopy, hresolved, hdyn]
     simp only [hstorage, henc]
-    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_written
-      (fields := fields) (world := runtime.world)
-      (slot := slot) (key1 := key1) (key2 := key2) (wordOffset := wordOffset)
-      (value := value) hresolved hdyn hvalue).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (by
+          simpa [IRStorageSlot.toNat_ofNat_wordNormalize,
+            mapping2WordTargetSlot, SourceSemantics.wordNormalize,
+            SourceSemantics.wordNormalize_idem, Compiler.Constants.evmModulus,
+            Verity.Core.UINT256_MODULUS] using
+          (encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_written
+            (fields := fields) (world := runtime.world)
+            (slot := slot) (key1 := key1) (key2 := key2) (wordOffset := wordOffset)
+            (value := value) hresolved hdyn hvalue).symm)
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     simp only [hEq, ↓reduceIte]
     rw [hstorage]
     exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_other
       (fields := fields) (world := runtime.world) (slot := slot) (key1 := key1)
-      (key2 := key2) (wordOffset := wordOffset) (query := query) (value := value) hEq).symm
+        (key2 := key2) (wordOffset := wordOffset) (query := query.toNat) (value := value)
+        (by simpa [mapping2WordTargetSlot] using
+          IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat hEq)).symm
 
 private theorem bindingsExactlyMatchIRVarsOnScope_writeUintSlot
     {scope : List String}
@@ -8177,10 +8543,10 @@ private theorem execIRStmt_sstore_foldl_mappingSlot
         [keyIRs.foldl
           (fun slotExpr keyExpr => Compiler.Yul.YulExpr.call "mappingSlot" [slotExpr, keyExpr])
           (Compiler.Yul.YulExpr.lit baseSlot), valueExpr])) =
-      .continue { state with
-        storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage
-          (SourceSemantics.mappingSlotChain baseSlot keyVals) valueVal } := by
-  suffices ∀ (startExpr : Compiler.Yul.YulExpr) (startSlot : Nat)
+        .continue { state with
+          storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage
+            (SourceSemantics.mappingSlotChain baseSlot keyVals) valueVal } := by
+  suffices h : ∀ (startExpr : Compiler.Yul.YulExpr) (startSlot : Nat)
       (kIRs : List Compiler.Yul.YulExpr) (kVals : List Nat),
       List.Forall₂ (fun exprIR value => evalIRExpr state exprIR = some value) kIRs kVals →
       evalIRExpr state startExpr = some startSlot →
@@ -8193,7 +8559,7 @@ private theorem execIRStmt_sstore_foldl_mappingSlot
           storage := Compiler.Proofs.abstractStoreStorageOrMapping state.storage
             (kVals.foldl Compiler.Proofs.abstractMappingSlot startSlot) valueVal } by
     simpa [SourceSemantics.mappingSlotChain] using
-      this (Compiler.Yul.YulExpr.lit baseSlot) baseSlot keyIRs keyVals hkeys (by simp [evalIRExpr])
+      h (Compiler.Yul.YulExpr.lit baseSlot) baseSlot keyIRs keyVals hkeys (by simp [evalIRExpr])
   intro startExpr startSlot kIRs kVals hf hstart
   induction hf generalizing startExpr startSlot with
   | nil =>
@@ -8766,8 +9132,9 @@ private theorem compiledStmtStep_setMappingWord_singleSlot_of_slotSafety_preserv
             Compiler.Proofs.abstractStoreStorageOrMapping state.storage targetSlot valueNat =
               fun s =>
                 if s =
-                    (Compiler.Proofs.solidityMappingSlot slot keyNat + wordOffset) %
-                      Compiler.Constants.evmModulus then
+                    IRStorageSlot.ofNat
+                      ((Compiler.Proofs.solidityMappingSlot slot keyNat + wordOffset) %
+                        Compiler.Constants.evmModulus) then
                   Compiler.Proofs.IRGeneration.IRStorageWord.ofNat valueNat
                 else
                   state.storage s := by
@@ -9097,7 +9464,8 @@ private theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety_p
         hvalueSourceEval.symm
       rcases hslotSafety runtime keyNat hKeySrc with ⟨hresolvedNone, hdynNone⟩
       set targetSlot := mappingWordTargetSlot slot keyNat wordOffset
-      set oldWordNat := Compiler.Proofs.IRGeneration.IRStorageWord.toNat (state.storage targetSlot)
+      set oldWordNat := Compiler.Proofs.IRGeneration.IRStorageWord.toNat
+        (state.storage (IRStorageSlot.ofNat targetSlot))
       set storedWordNat := SourceSemantics.packedWordWrite oldWordNat valueNat packed
       have hMappingBaseEval :
           evalIRExpr state (YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]) =
@@ -9861,8 +10229,9 @@ private theorem compiledStmtStep_setStructMember_singleSlot_of_slotSafety_preser
             Compiler.Proofs.abstractStoreStorageOrMapping state.storage targetSlot valueNat =
               fun s =>
                 if s =
-                    (Compiler.Proofs.solidityMappingSlot slot keyNat + wordOffset) %
-                      Compiler.Constants.evmModulus then
+                    IRStorageSlot.ofNat
+                      ((Compiler.Proofs.solidityMappingSlot slot keyNat + wordOffset) %
+                        Compiler.Constants.evmModulus) then
                   Compiler.Proofs.IRGeneration.IRStorageWord.ofNat valueNat
                 else
                   state.storage s := by
@@ -10401,10 +10770,11 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
               Compiler.Proofs.abstractStoreStorageOrMapping state.storage targetSlot valueNat =
                 fun s =>
                   if s =
-                      (Verity.Core.Uint256.ofNat wordOffset +
-                        Verity.Core.Uint256.ofNat
-                          (Compiler.Proofs.solidityMappingSlot
-                            (Compiler.Proofs.solidityMappingSlot slot key1Nat) key2Nat)).val then
+                      IRStorageSlot.ofNat
+                        ((Verity.Core.Uint256.ofNat wordOffset +
+                          Verity.Core.Uint256.ofNat
+                            (Compiler.Proofs.solidityMappingSlot
+                              (Compiler.Proofs.solidityMappingSlot slot key1Nat) key2Nat)).val) then
                     Compiler.Proofs.IRGeneration.IRStorageWord.ofNat valueNat
                   else
                     state.storage s := by
@@ -10731,10 +11101,11 @@ private theorem compiledStmtStep_setStructMember2_singleSlot_of_slotSafety_prese
               Compiler.Proofs.abstractStoreStorageOrMapping state.storage targetSlot valueNat =
                 fun s =>
                   if s =
-                      (Verity.Core.Uint256.ofNat wordOffset +
-                        Verity.Core.Uint256.ofNat
-                          (Compiler.Proofs.solidityMappingSlot
-                            (Compiler.Proofs.solidityMappingSlot slot key1Nat) key2Nat)).val then
+                      IRStorageSlot.ofNat
+                        ((Verity.Core.Uint256.ofNat wordOffset +
+                          Verity.Core.Uint256.ofNat
+                            (Compiler.Proofs.solidityMappingSlot
+                              (Compiler.Proofs.solidityMappingSlot slot key1Nat) key2Nat)).val) then
                     Compiler.Proofs.IRGeneration.IRStorageWord.ofNat valueNat
                   else
                     state.storage s := by
@@ -11605,16 +11976,25 @@ private theorem compiledStmtStep_letStorageField
     rfl
   preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
     have hEvalSrc : SourceSemantics.evalExpr fields runtime (.storage fieldName) =
-        some (runtime.world.storage slot).val := by
+        some (runtime.world.storage (SourceSemantics.wordNormalize slot)).val := by
       show (match findFieldWithResolvedSlot fields fieldName with
-        | some (_, s) => some (runtime.world.storage s).val | none => none) = _
+        | some (_, s) => some (runtime.world.storage (SourceSemantics.wordNormalize s)).val
+        | none => none) = _
       rw [hfind]
     have hresolved := findResolvedFieldAtSlotCopy_of_findFieldWithResolvedSlot_singleton
       hnoConflict hfind
       (by simpa using findFieldWriteSlots_of_findFieldWithResolvedSlot hfind) (by rfl)
     have hIR := FunctionBody.evalIRExpr_sload_of_runtimeStateMatchesIR hruntime slot
-    rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved (by rfl) (by rfl)] at hIR
-    set v := (runtime.world.storage slot).val; set state' := state.setVar tmp v
+    have hresolved' :
+          findResolvedFieldAtSlotCopy fields (IRStorageSlot.ofNat slot).toNat =
+            some { name := fieldName, ty := FieldType.uint256 } := by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using
+          (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) =
+              some { name := fieldName, ty := FieldType.uint256 } from
+            by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
+    rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved' (by rfl) (by rfl)] at hIR
+    set v := (runtime.world.storage (SourceSemantics.wordNormalize slot)).val
+    set state' := state.setVar tmp v
     set runtime' := { runtime with bindings := SourceSemantics.bindValue runtime.bindings tmp v }
     have hNextScopeIncl : FunctionBody.scopeNamesIncluded
         (stmtNextScope scope (.letVar tmp (Expr.storage fieldName))) (tmp :: scope) := by
@@ -11628,13 +12008,20 @@ private theorem compiledStmtStep_letStorageField
         | none => SourceSemantics.StmtResult.revert) = _; rw [hEvalSrc]
     · have : [YulStmt.let_ tmp (YulExpr.call "sload" [YulExpr.lit slot])].length +
           extraFuel + 1 = Nat.succ (Nat.succ extraFuel) := by simp [List.length]; omega
-      rw [this]; simp [execIRStmts, execIRStmt, hIR, state']
-      rw [Nat.mod_eq_of_lt (runtime.world.storage slot).isLt]
+      rw [this]; simp [execIRStmts, execIRStmt, hIR, state', v,
+        SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+        Verity.Core.UINT256_MODULUS]
+      apply congrArg (state.setVar tmp)
+      exact Nat.mod_eq_of_lt (by
+        simpa [SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+          Verity.Core.UINT256_MODULUS] using
+          (runtime.world.storage (SourceSemantics.wordNormalize slot)).isLt)
     · simp only [stmtStepMatchesIRExec]
       exact ⟨FunctionBody.runtimeStateMatchesIR_setVar_bindValue hruntime tmp v,
         FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included
           (FunctionBody.bindingsExactlyMatchIRVarsOnScope_setVar_bindValue hexact) hNextScopeIncl,
-        FunctionBody.bindingsBounded_bindValue hbounded tmp v (runtime.world.storage slot).isLt,
+          FunctionBody.bindingsBounded_bindValue hbounded tmp v
+            (runtime.world.storage (SourceSemantics.wordNormalize slot)).isLt,
         FunctionBody.scopeNamesPresent_of_included
           (FunctionBody.scopeNamesPresent_cons_bindValue hscope) hNextScopeIncl⟩
 
@@ -11667,18 +12054,28 @@ private theorem compiledStmtStep_letStorageAddrField
     rfl
   preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
     have hEvalSrc : SourceSemantics.evalExpr fields runtime (.storageAddr fieldName) =
-        some (runtime.world.storageAddr slot).val := by
+        some (runtime.world.storageAddr (SourceSemantics.wordNormalize slot)).val := by
       show (match findFieldWithResolvedSlot fields fieldName with
-        | some (_, s) => some (runtime.world.storageAddr s).val | none => none) = _
+        | some (_, s) => some (runtime.world.storageAddr (SourceSemantics.wordNormalize s)).val
+        | none => none) = _
       rw [hfind]
     have hresolved := findResolvedFieldAtSlotCopy_of_findFieldWithResolvedSlot_singleton
       hnoConflict hfind
       (by simpa using findFieldWriteSlots_of_findFieldWithResolvedSlot hfind) (by rfl)
     have hIR := FunctionBody.evalIRExpr_sload_of_runtimeStateMatchesIR hruntime slot
-    rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved (by rfl) (by rfl)] at hIR
-    set v := (runtime.world.storageAddr slot).val; set state' := state.setVar tmp v
+    have hresolved' :
+          findResolvedFieldAtSlotCopy fields (IRStorageSlot.ofNat slot).toNat =
+            some { name := fieldName, ty := FieldType.address } := by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using
+          (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) =
+              some { name := fieldName, ty := FieldType.address } from
+            by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
+    rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved' (by rfl) (by rfl)] at hIR
+    set v := (runtime.world.storageAddr (SourceSemantics.wordNormalize slot)).val
+    set state' := state.setVar tmp v
     set runtime' := { runtime with bindings := SourceSemantics.bindValue runtime.bindings tmp v }
-    have hAddrLt : v < Verity.Core.UINT256_MODULUS := Nat.lt_trans (runtime.world.storageAddr slot).isLt (by decide)
+    have hAddrLt : v < Verity.Core.UINT256_MODULUS :=
+      Nat.lt_trans (runtime.world.storageAddr (SourceSemantics.wordNormalize slot)).isLt (by decide)
     have hNextScopeIncl : FunctionBody.scopeNamesIncluded
         (stmtNextScope scope (.letVar tmp (Expr.storageAddr fieldName))) (tmp :: scope) := by
       intro n hn; simp [stmtNextScope, collectStmtNames, collectExprNames] at hn
@@ -11691,8 +12088,12 @@ private theorem compiledStmtStep_letStorageAddrField
         | none => SourceSemantics.StmtResult.revert) = _; rw [hEvalSrc]
     · have : [YulStmt.let_ tmp (YulExpr.call "sload" [YulExpr.lit slot])].length +
           extraFuel + 1 = Nat.succ (Nat.succ extraFuel) := by simp [List.length]; omega
-      rw [this]; simp [execIRStmts, execIRStmt, hIR, state']
-      rw [Nat.mod_eq_of_lt hAddrLt]
+      rw [this]; simp [execIRStmts, execIRStmt, hIR, state', v,
+        SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+        Verity.Core.UINT256_MODULUS]
+      apply congrArg (state.setVar tmp)
+      exact Nat.mod_eq_of_lt (by
+        simpa [Verity.Core.UINT256_MODULUS] using hAddrLt)
     · simp only [stmtStepMatchesIRExec]
       exact ⟨FunctionBody.runtimeStateMatchesIR_setVar_bindValue hruntime tmp v,
         FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included
@@ -11732,16 +12133,25 @@ private theorem compiledStmtStep_assignStorageField
     rfl
   preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
     have hEvalSrc : SourceSemantics.evalExpr fields runtime (.storage fieldName) =
-        some (runtime.world.storage slot).val := by
+        some (runtime.world.storage (SourceSemantics.wordNormalize slot)).val := by
       show (match findFieldWithResolvedSlot fields fieldName with
-        | some (_, s) => some (runtime.world.storage s).val | none => none) = _
+        | some (_, s) => some (runtime.world.storage (SourceSemantics.wordNormalize s)).val
+        | none => none) = _
       rw [hfind]
     have hresolved := findResolvedFieldAtSlotCopy_of_findFieldWithResolvedSlot_singleton
       hnoConflict hfind
       (by simpa using findFieldWriteSlots_of_findFieldWithResolvedSlot hfind) (by rfl)
     have hIR := FunctionBody.evalIRExpr_sload_of_runtimeStateMatchesIR hruntime slot
-    rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved (by rfl) (by rfl)] at hIR
-    set v := (runtime.world.storage slot).val; set state' := state.setVar name v
+    have hresolved' :
+          findResolvedFieldAtSlotCopy fields (IRStorageSlot.ofNat slot).toNat =
+            some { name := fieldName, ty := FieldType.uint256 } := by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using
+          (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) =
+              some { name := fieldName, ty := FieldType.uint256 } from
+            by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
+    rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved' (by rfl) (by rfl)] at hIR
+    set v := (runtime.world.storage (SourceSemantics.wordNormalize slot)).val
+    set state' := state.setVar name v
     set runtime' := { runtime with bindings := SourceSemantics.bindValue runtime.bindings name v }
     have hNextScopeIncl : FunctionBody.scopeNamesIncluded
         (stmtNextScope scope (.assignVar name (Expr.storage fieldName))) (name :: scope) := by
@@ -11755,13 +12165,20 @@ private theorem compiledStmtStep_assignStorageField
         | none => SourceSemantics.StmtResult.revert) = _; rw [hEvalSrc]
     · have : [YulStmt.assign name (YulExpr.call "sload" [YulExpr.lit slot])].length +
           extraFuel + 1 = Nat.succ (Nat.succ extraFuel) := by simp [List.length]; omega
-      rw [this]; simp [execIRStmts, execIRStmt, hIR, state']
-      rw [Nat.mod_eq_of_lt (runtime.world.storage slot).isLt]
+      rw [this]; simp [execIRStmts, execIRStmt, hIR, state', v,
+        SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+        Verity.Core.UINT256_MODULUS]
+      apply congrArg (state.setVar name)
+      exact Nat.mod_eq_of_lt (by
+        simpa [SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+          Verity.Core.UINT256_MODULUS] using
+          (runtime.world.storage (SourceSemantics.wordNormalize slot)).isLt)
     · simp only [stmtStepMatchesIRExec]
       exact ⟨FunctionBody.runtimeStateMatchesIR_setVar_bindValue hruntime name v,
         FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included
           (FunctionBody.bindingsExactlyMatchIRVarsOnScope_setVar_bindValue hexact) hNextScopeIncl,
-        FunctionBody.bindingsBounded_bindValue hbounded name v (runtime.world.storage slot).isLt,
+          FunctionBody.bindingsBounded_bindValue hbounded name v
+            (runtime.world.storage (SourceSemantics.wordNormalize slot)).isLt,
         FunctionBody.scopeNamesPresent_of_included
           (FunctionBody.scopeNamesPresent_cons_bindValue hscope) hNextScopeIncl⟩
 
@@ -11794,18 +12211,28 @@ private theorem compiledStmtStep_assignStorageAddrField
     rfl
   preserves runtime state extraFuel hexact hscope hbounded hruntime hslack := by
     have hEvalSrc : SourceSemantics.evalExpr fields runtime (.storageAddr fieldName) =
-        some (runtime.world.storageAddr slot).val := by
+        some (runtime.world.storageAddr (SourceSemantics.wordNormalize slot)).val := by
       show (match findFieldWithResolvedSlot fields fieldName with
-        | some (_, s) => some (runtime.world.storageAddr s).val | none => none) = _
+        | some (_, s) => some (runtime.world.storageAddr (SourceSemantics.wordNormalize s)).val
+        | none => none) = _
       rw [hfind]
     have hresolved := findResolvedFieldAtSlotCopy_of_findFieldWithResolvedSlot_singleton
       hnoConflict hfind
       (by simpa using findFieldWriteSlots_of_findFieldWithResolvedSlot hfind) (by rfl)
     have hIR := FunctionBody.evalIRExpr_sload_of_runtimeStateMatchesIR hruntime slot
-    rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved (by rfl) (by rfl)] at hIR
-    set v := (runtime.world.storageAddr slot).val; set state' := state.setVar name v
+    have hresolved' :
+          findResolvedFieldAtSlotCopy fields (IRStorageSlot.ofNat slot).toNat =
+            some { name := fieldName, ty := FieldType.address } := by
+        simpa [IRStorageSlot.toNat_ofNat_wordNormalize] using
+          (show findResolvedFieldAtSlotCopy fields (SourceSemantics.wordNormalize slot) =
+              some { name := fieldName, ty := FieldType.address } from
+            by rw [findResolvedFieldAtSlotCopy_wordNormalize]; exact hresolved)
+    rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved' (by rfl) (by rfl)] at hIR
+    set v := (runtime.world.storageAddr (SourceSemantics.wordNormalize slot)).val
+    set state' := state.setVar name v
     set runtime' := { runtime with bindings := SourceSemantics.bindValue runtime.bindings name v }
-    have hAddrLt : v < Verity.Core.UINT256_MODULUS := Nat.lt_trans (runtime.world.storageAddr slot).isLt (by decide)
+    have hAddrLt : v < Verity.Core.UINT256_MODULUS :=
+      Nat.lt_trans (runtime.world.storageAddr (SourceSemantics.wordNormalize slot)).isLt (by decide)
     have hNextScopeIncl : FunctionBody.scopeNamesIncluded
         (stmtNextScope scope (.assignVar name (Expr.storageAddr fieldName))) (name :: scope) := by
       intro n hn; simp [stmtNextScope, collectStmtNames, collectExprNames] at hn
@@ -11818,8 +12245,12 @@ private theorem compiledStmtStep_assignStorageAddrField
         | none => SourceSemantics.StmtResult.revert) = _; rw [hEvalSrc]
     · have : [YulStmt.assign name (YulExpr.call "sload" [YulExpr.lit slot])].length +
           extraFuel + 1 = Nat.succ (Nat.succ extraFuel) := by simp [List.length]; omega
-      rw [this]; simp [execIRStmts, execIRStmt, hIR, state']
-      rw [Nat.mod_eq_of_lt hAddrLt]
+      rw [this]; simp [execIRStmts, execIRStmt, hIR, state', v,
+        SourceSemantics.wordNormalize, Compiler.Constants.evmModulus,
+        Verity.Core.UINT256_MODULUS]
+      apply congrArg (state.setVar name)
+      exact Nat.mod_eq_of_lt (by
+        simpa [Verity.Core.UINT256_MODULUS] using hAddrLt)
     · simp only [stmtStepMatchesIRExec]
       exact ⟨FunctionBody.runtimeStateMatchesIR_setVar_bindValue hruntime name v,
         FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included
@@ -17188,7 +17619,7 @@ theorem compiledStmtStepWithHelpersAndHelperIR_internalCallAssign
         FunctionBody.runtimeStateMatchesIR fields runtime state →
         stmtStepMatchesIRExecWithInternals fields
           (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
-          (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
+        (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
             (Stmt.internalCallAssign names calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
             [YulStmt.letMany names (YulExpr.call
@@ -17248,7 +17679,7 @@ theorem compiledStmtStepWithHelpersAndHelperIR_internalCall
         FunctionBody.runtimeStateMatchesIR fields runtime state →
         stmtStepMatchesIRExecWithInternals fields
           (stmtNextScope scope (Stmt.internalCall calleeName args))
-          (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
+        (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
             (Stmt.internalCall calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
             [YulStmt.expr (YulExpr.call
@@ -17385,7 +17816,7 @@ structure DirectInternalHelperCallHeadStepBridge
         FunctionBody.runtimeStateMatchesIR fields runtime state →
         stmtStepMatchesIRExecWithInternals fields
           (stmtNextScope scope (Stmt.internalCall calleeName args))
-          (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
+        (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
             (Stmt.internalCall calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
             [YulStmt.expr (YulExpr.call
@@ -17418,7 +17849,7 @@ structure DirectInternalHelperAssignHeadStepBridge
         FunctionBody.runtimeStateMatchesIR fields runtime state →
         stmtStepMatchesIRExecWithInternals fields
           (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
-          (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
+        (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
             (Stmt.internalCallAssign names calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
             [YulStmt.letMany names (YulExpr.call
@@ -17453,7 +17884,7 @@ structure DirectInternalHelperHeadStepBridgeCatalog
         FunctionBody.runtimeStateMatchesIR fields runtime state →
         stmtStepMatchesIRExecWithInternals fields
           (stmtNextScope scope (Stmt.internalCall calleeName args))
-          (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
+        (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
             (Stmt.internalCall calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
             [YulStmt.expr (YulExpr.call
@@ -17482,7 +17913,7 @@ structure DirectInternalHelperHeadStepBridgeCatalog
         FunctionBody.runtimeStateMatchesIR fields runtime state →
         stmtStepMatchesIRExecWithInternals fields
           (stmtNextScope scope (Stmt.internalCallAssign names calleeName args))
-          (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
+        (SourceSemantics.execStmtWithHelpers spec fields helperFuel runtime
             (Stmt.internalCallAssign names calleeName args))
           (execIRStmtsWithInternals runtimeContract (irFuel + 3) state
             [YulStmt.letMany names (YulExpr.call

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -92,7 +92,7 @@ structure IRState where
       touching this signature. Currently `IRStorageWord` is an `abbrev`
       for `Nat`, so this is definitionally `Nat → Nat` and existing
       callsites continue to typecheck. -/
-  storage : Nat → IRStorageWord
+  storage : IRStorageSlot → IRStorageWord
   /-- Transient storage slots (slot → value). -/
   transientStorage : Nat → Nat := fun _ => 0
   /-- Memory words (offset → value) -/
@@ -1132,7 +1132,7 @@ other non-transaction fields unchanged. -/
 structure IRResult where
   success : Bool
   returnValue : Option Nat
-  finalStorage : Nat → IRStorageWord
+  finalStorage : IRStorageSlot → IRStorageWord
   finalMappings : Nat → Nat → IRStorageWord
   events : List (List Nat)
 

--- a/Compiler/Proofs/IRGeneration/IRStorageWord.lean
+++ b/Compiler/Proofs/IRGeneration/IRStorageWord.lean
@@ -88,4 +88,56 @@ theorem toNat_lt_size (w : IRStorageWord) : w.toNat < UInt256.size := by
 
 end IRStorageWord
 
+/-- The carrier of an IR storage slot key.
+
+    EVM storage is keyed by 256-bit words. Keeping IR storage keyed by raw
+    `Nat` lets distinct IR slots alias when projected through EVMYulLean's
+    `UInt256` storage map. `IRStorageSlot` makes that modulo behavior part of
+    the IR model instead of a theorem-level precondition. -/
+@[reducible] def IRStorageSlot : Type := UInt256
+
+namespace IRStorageSlot
+
+/-- Inject a `Nat` slot into the bounded storage-key carrier by reducing modulo
+    `UInt256.size`. -/
+@[inline] def ofNat (n : Nat) : IRStorageSlot := UInt256.ofNat n
+
+/-- Project an `IRStorageSlot` back to `Nat`. -/
+@[inline] def toNat (slot : IRStorageSlot) : Nat := UInt256.toNat slot
+
+/-- Project an `IRStorageSlot` to the EVMYulLean `UInt256` representation. -/
+@[inline] def toUInt256 (slot : IRStorageSlot) : UInt256 := slot
+
+instance instOfNat (n : Nat) : OfNat IRStorageSlot n := ⟨ofNat n⟩
+
+instance : Inhabited IRStorageSlot := ⟨ofNat 0⟩
+
+@[simp] theorem toNat_ofNat (n : Nat) : (ofNat n).toNat = n % UInt256.size := rfl
+
+@[simp] theorem toUInt256_ofNat (n : Nat) : (ofNat n).toUInt256 = UInt256.ofNat n := rfl
+
+@[simp] theorem ofNat_toNat (slot : IRStorageSlot) : ofNat slot.toNat = slot := by
+  cases slot with
+  | mk v =>
+    cases v with
+    | mk val isLt =>
+      show UInt256.ofNat val = ⟨⟨val, isLt⟩⟩
+      apply congrArg UInt256.mk
+      apply Fin.ext
+      show val % UInt256.size = val
+      exact Nat.mod_eq_of_lt isLt
+
+theorem toNat_lt_size (slot : IRStorageSlot) : slot.toNat < UInt256.size := by
+  cases slot with
+  | mk v => exact v.isLt
+
+theorem eq_of_toNat_eq {a b : IRStorageSlot} (h : a.toNat = b.toNat) : a = b := by
+  rw [← ofNat_toNat a, ← ofNat_toNat b, h]
+
+theorem toNat_ne_of_ne {a b : IRStorageSlot} (h : a ≠ b) : a.toNat ≠ b.toNat := by
+  intro hnat
+  exact h (eq_of_toNat_eq hnat)
+
+end IRStorageSlot
+
 end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -18,6 +18,10 @@ namespace SourceSemantics
 def wordNormalize (n : Nat) : Nat :=
   ((n : Verity.Core.Uint256) : Nat)
 
+@[simp] theorem wordNormalize_eq_mod (n : Nat) :
+    wordNormalize n = n % Compiler.Constants.evmModulus := by
+  rfl
+
 def uint8Modulus : Nat := 2 ^ 8
 
 def addressModulus : Nat := 2 ^ 160
@@ -266,7 +270,8 @@ def findResolvedFieldAtSlot (fields : List Field) (slot : Nat) : Option Field :=
     | [] => none
     | field :: rest =>
         let resolvedSlot := field.slot.getD idx
-        if resolvedSlot = slot || field.aliasSlots.contains slot then
+        if wordNormalize resolvedSlot = wordNormalize slot ||
+            (field.aliasSlots.map wordNormalize).contains (wordNormalize slot) then
           some field
         else
           go rest (idx + 1)
@@ -277,7 +282,7 @@ def findDynamicArrayElementAtSlot
   let rec scanElements (baseSlot : Nat) : List Verity.Core.Uint256 → Nat → Option Nat
     | [], _ => none
     | value :: rest, idx =>
-        if Compiler.Proofs.solidityMappingSlot baseSlot idx = targetSlot then
+        if Compiler.Proofs.solidityMappingSlot baseSlot idx = wordNormalize targetSlot then
           some value.val
         else
           scanElements baseSlot rest (idx + 1)
@@ -324,9 +329,10 @@ def encodeStorage (spec : CompilationModel) (world : Verity.ContractState) :
 def writeUintSlots (world : Verity.ContractState) (slots : List Nat) (value : Nat) :
     Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
+  let targets := slots.map wordNormalize
   { world with
     storage := fun slot =>
-      if slots.contains slot then word else world.storage slot }
+      if targets.contains slot then word else world.storage slot }
 
 def writeStorageWordSlot (world : Verity.ContractState) (slot wordOffset value : Nat) :
     Verity.ContractState :=
@@ -353,9 +359,10 @@ def writeStorageWordSlots (world : Verity.ContractState) (slots : List Nat) (wor
 def writeAddressSlots (world : Verity.ContractState) (slots : List Nat) (value : Nat) :
     Verity.ContractState :=
   let addr := Verity.wordToAddress (value : Verity.Core.Uint256)
+  let targets := slots.map wordNormalize
   { world with
     storageAddr := fun slot =>
-      if slots.contains slot then addr else world.storageAddr slot }
+      if targets.contains slot then addr else world.storageAddr slot }
 
 def writeAddressKeyedMappingSlots
     (world : Verity.ContractState) (slots : List Nat) (key value : Nat) :
@@ -365,16 +372,18 @@ def writeAddressKeyedMappingSlots
   | slot :: _ =>
       let keyAddr := Verity.wordToAddress (key : Verity.Core.Uint256)
       let word : Verity.Core.Uint256 := value
-      let storageNat : Nat → Compiler.Proofs.IRGeneration.IRStorageWord :=
-        fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (world.storage s).val
+      let storageNat : Compiler.Proofs.IRGeneration.IRStorageSlot →
+          Compiler.Proofs.IRGeneration.IRStorageWord :=
+        fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (world.storage s.toNat).val
       let storage :=
         slots.foldl
           (fun current slot =>
             Compiler.Proofs.abstractStoreMappingEntry current slot key value)
-          storageNat
+        storageNat
       { world with
         storage := fun s =>
-          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat (storage s) : Verity.Core.Uint256)
+          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
+            (storage (Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat s)) : Verity.Core.Uint256)
         storageMap := fun baseSlot addr =>
           if baseSlot == slot && addr == keyAddr then
             word
@@ -388,7 +397,7 @@ def writeAddressKeyedMappingChainSlots
     (world : Verity.ContractState) (slots keys : List Nat) (value : Nat) :
     Verity.ContractState :=
   let word : Verity.Core.Uint256 := value
-  let targets := slots.map (fun slot => mappingSlotChain slot keys)
+  let targets := slots.map (fun slot => wordNormalize (mappingSlotChain slot keys))
   { world with
     storage := fun slot =>
       if targets.contains slot then word else world.storage slot }
@@ -433,16 +442,18 @@ def writeUintKeyedMappingSlots
   | slot :: _ =>
       let keyWord : Verity.Core.Uint256 := key
       let word : Verity.Core.Uint256 := value
-      let storageNat : Nat → Compiler.Proofs.IRGeneration.IRStorageWord :=
-        fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (world.storage s).val
+      let storageNat : Compiler.Proofs.IRGeneration.IRStorageSlot →
+          Compiler.Proofs.IRGeneration.IRStorageWord :=
+        fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (world.storage s.toNat).val
       let storage :=
         slots.foldl
           (fun current slot =>
             Compiler.Proofs.abstractStoreMappingEntry current slot key value)
-          storageNat
+        storageNat
       { world with
         storage := fun s =>
-          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat (storage s) : Verity.Core.Uint256)
+          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
+            (storage (Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat s)) : Verity.Core.Uint256)
         storageMapUint := fun baseSlot key' =>
           if baseSlot == slot && key' == keyWord then
             word
@@ -458,8 +469,9 @@ def writeAddressKeyedMapping2Slots
       let key1Addr := Verity.wordToAddress (key1 : Verity.Core.Uint256)
       let key2Addr := Verity.wordToAddress (key2 : Verity.Core.Uint256)
       let word : Verity.Core.Uint256 := value
-      let storageNat : Nat → Compiler.Proofs.IRGeneration.IRStorageWord :=
-        fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (world.storage s).val
+      let storageNat : Compiler.Proofs.IRGeneration.IRStorageSlot →
+          Compiler.Proofs.IRGeneration.IRStorageWord :=
+        fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (world.storage s.toNat).val
       let storage :=
         slots.foldl
           (fun current slot =>
@@ -468,10 +480,11 @@ def writeAddressKeyedMapping2Slots
               (Compiler.Proofs.abstractMappingSlot slot key1)
               key2
               value)
-          storageNat
+        storageNat
       { world with
         storage := fun s =>
-          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat (storage s) : Verity.Core.Uint256)
+          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
+            (storage (Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat s)) : Verity.Core.Uint256)
         storageMap2 := fun baseSlot addr1 addr2 =>
           if baseSlot == slot && addr1 == key1Addr && addr2 == key2Addr then
             word
@@ -563,14 +576,14 @@ private def ceilDivVal (lhs rhs : Verity.Core.Uint256) : Nat :=
 def evalExpr (fields : List Field) (state : RuntimeState) : Expr → Option Nat
   | .literal n => some (wordNormalize n)
   | .param name => some (lookupValue state.bindings name)
-  | .storage fieldName =>
-      match findFieldWithResolvedSlot fields fieldName with
-      | some (_, slot) => some (state.world.storage slot).val
-      | none => none
-  | .storageAddr fieldName =>
-      match findFieldWithResolvedSlot fields fieldName with
-      | some (_, slot) => some (state.world.storageAddr slot).val
-      | none => none
+    | .storage fieldName =>
+        match findFieldWithResolvedSlot fields fieldName with
+        | some (_, slot) => some (state.world.storage (wordNormalize slot)).val
+        | none => none
+    | .storageAddr fieldName =>
+        match findFieldWithResolvedSlot fields fieldName with
+        | some (_, slot) => some (state.world.storageAddr (wordNormalize slot)).val
+        | none => none
   | .storageArrayLength fieldName =>
       match findFieldWithResolvedSlot fields fieldName with
       | some ({ ty := .dynamicArray _, .. }, slot) => some (state.world.storageArray slot).length
@@ -897,19 +910,19 @@ private theorem evalExpr_storage
     (fields : List Field)
     (state : RuntimeState)
     (fieldName : String) :
-    evalExpr fields state (.storage fieldName) =
-      match findFieldWithResolvedSlot fields fieldName with
-      | some (_, slot) => some (state.world.storage slot).val
-      | none => none := rfl
+      evalExpr fields state (.storage fieldName) =
+        match findFieldWithResolvedSlot fields fieldName with
+        | some (_, slot) => some (state.world.storage (wordNormalize slot)).val
+        | none => none := rfl
 
 private theorem evalExpr_storageAddr
     (fields : List Field)
     (state : RuntimeState)
     (fieldName : String) :
-    evalExpr fields state (.storageAddr fieldName) =
-      match findFieldWithResolvedSlot fields fieldName with
-      | some (_, slot) => some (state.world.storageAddr slot).val
-      | none => none := rfl
+      evalExpr fields state (.storageAddr fieldName) =
+        match findFieldWithResolvedSlot fields fieldName with
+        | some (_, slot) => some (state.world.storageAddr (wordNormalize slot)).val
+        | none => none := rfl
 
 private theorem evalExpr_storageArrayLength
     (fields : List Field)
@@ -2377,14 +2390,14 @@ mutual
       (state : RuntimeState) : Expr → Option Nat
     | .literal n => some (wordNormalize n)
     | .param name => some (lookupValue state.bindings name)
-    | .storage fieldName =>
-        match findFieldWithResolvedSlot fields fieldName with
-        | some (_, slot) => some (state.world.storage slot).val
-        | none => none
-    | .storageAddr fieldName =>
-        match findFieldWithResolvedSlot fields fieldName with
-        | some (_, slot) => some (state.world.storageAddr slot).val
-        | none => none
+      | .storage fieldName =>
+          match findFieldWithResolvedSlot fields fieldName with
+          | some (_, slot) => some (state.world.storage (wordNormalize slot)).val
+          | none => none
+      | .storageAddr fieldName =>
+          match findFieldWithResolvedSlot fields fieldName with
+          | some (_, slot) => some (state.world.storageAddr (wordNormalize slot)).val
+          | none => none
     | .storageArrayLength fieldName =>
         match findFieldWithResolvedSlot fields fieldName with
         | some ({ ty := .dynamicArray _, .. }, slot) => some (state.world.storageArray slot).length

--- a/Compiler/Proofs/MappingSlot.lean
+++ b/Compiler/Proofs/MappingSlot.lean
@@ -5,7 +5,7 @@ import Compiler.Proofs.IRGeneration.IRStorageWord
 
 namespace Compiler.Proofs
 
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 
 /-!
 Mapping slot abstraction used by proof interpreters.
@@ -70,32 +70,35 @@ def abstractNestedMappingSlot (baseSlot key1 key2 : Nat) : Nat :=
   abstractMappingSlot (abstractMappingSlot baseSlot key1) key2
 
 /-- Derived mapping-table view from flat storage. -/
-def storageAsMappings (storage : Nat → IRStorageWord) : Nat → Nat → IRStorageWord :=
-  fun baseSlot key => storage (solidityMappingSlot baseSlot key)
+def storageAsMappings (storage : IRStorageSlot → IRStorageWord) : Nat → Nat → IRStorageWord :=
+  fun baseSlot key => storage (IRStorageSlot.ofNat (solidityMappingSlot baseSlot key))
 
 /-- Read a mapping entry directly from base slot and key. -/
 def abstractLoadMappingEntry
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (baseSlot key : Nat) : IRStorageWord :=
-  storage (solidityMappingSlot baseSlot key)
+  storage (IRStorageSlot.ofNat (solidityMappingSlot baseSlot key))
 
 /-- Write a mapping entry directly from base slot and key. -/
 def abstractStoreMappingEntry
-    (storage : Nat → IRStorageWord)
-    (baseSlot key value : Nat) : Nat → IRStorageWord :=
-  fun s => if s = solidityMappingSlot baseSlot key then IRStorageWord.ofNat value else storage s
+    (storage : IRStorageSlot → IRStorageWord)
+    (baseSlot key value : Nat) : IRStorageSlot → IRStorageWord :=
+  fun s => if s = IRStorageSlot.ofNat (solidityMappingSlot baseSlot key) then
+    IRStorageWord.ofNat value
+  else
+    storage s
 
 /-- Read through the active mapping-slot backend from flat storage. -/
 def abstractLoadStorageOrMapping
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (slot : Nat) : IRStorageWord :=
-  storage slot
+  storage (IRStorageSlot.ofNat slot)
 
 /-- Write through the active mapping-slot backend to flat storage. -/
 def abstractStoreStorageOrMapping
-    (storage : Nat → IRStorageWord)
-    (slot value : Nat) : Nat → IRStorageWord :=
-  fun s => if s = slot then IRStorageWord.ofNat value else storage s
+    (storage : IRStorageSlot → IRStorageWord)
+    (slot value : Nat) : IRStorageSlot → IRStorageWord :=
+  fun s => if s = IRStorageSlot.ofNat slot then IRStorageWord.ofNat value else storage s
 
 @[simp] theorem abstractMappingSlot_eq_solidity (baseSlot key : Nat) :
     abstractMappingSlot baseSlot key = solidityMappingSlot baseSlot key := rfl
@@ -118,26 +121,30 @@ def abstractStoreStorageOrMapping
   simp [abstractNestedMappingSlot]
 
 @[simp] theorem abstractLoadMappingEntry_eq
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (baseSlot key : Nat) :
-    abstractLoadMappingEntry storage baseSlot key = storage (solidityMappingSlot baseSlot key) := rfl
+    abstractLoadMappingEntry storage baseSlot key =
+      storage (IRStorageSlot.ofNat (solidityMappingSlot baseSlot key)) := rfl
 
 @[simp] theorem abstractStoreMappingEntry_eq
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (baseSlot key value : Nat) :
     abstractStoreMappingEntry storage baseSlot key value =
-      (fun s => if s = solidityMappingSlot baseSlot key then IRStorageWord.ofNat value else storage s) := rfl
+      (fun s => if s = IRStorageSlot.ofNat (solidityMappingSlot baseSlot key) then
+        IRStorageWord.ofNat value
+      else
+        storage s) := rfl
 
 @[simp] theorem abstractLoadStorageOrMapping_eq
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (slot : Nat) :
-    abstractLoadStorageOrMapping storage slot = storage slot := rfl
+    abstractLoadStorageOrMapping storage slot = storage (IRStorageSlot.ofNat slot) := rfl
 
 @[simp] theorem abstractStoreStorageOrMapping_eq
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (slot value : Nat) :
     abstractStoreStorageOrMapping storage slot value =
-      (fun s => if s = slot then IRStorageWord.ofNat value else storage s) := rfl
+      (fun s => if s = IRStorageSlot.ofNat slot then IRStorageWord.ofNat value else storage s) := rfl
 
 /-- Keccak256 output interpreted as a big-endian 256-bit natural is less than 2^256.
     This is mathematically true because keccak produces exactly 32 bytes, so

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean
@@ -10,7 +10,7 @@ import Mathlib.Data.Finmap
 namespace Compiler.Proofs.YulGeneration.Backends
 
 open Compiler.Yul
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 
 abbrev AdapterError := String
 
@@ -1045,7 +1045,7 @@ def evalPureBuiltinViaEvmYulLean
     `abstractLoadStorageOrMapping`, the shared Verity/Phase-2 storage-read
     helper whose EVMYulLean-state correspondence is witnessed by
     `storageLookup_projectStorage` in `EvmYulLeanStateBridge.lean` (projecting
-    the abstract `storage : Nat → IRStorageWord` into EVMYulLean's `Storage` recovers the
+    the abstract `storage : IRStorageSlot → IRStorageWord` into EVMYulLean's `Storage` recovers the
     same value). `mappingSlot` is bridged by routing through
     `abstractMappingSlot` — the same keccak-faithful Solidity mapping-slot
     derivation used by Verity's `evalBuiltinCallWithContext`; both backends
@@ -1053,7 +1053,7 @@ def evalPureBuiltinViaEvmYulLean
     context-dependent builtins (`caller`, `address`, `timestamp`, ...) are
     routed at the `evalBuiltinCallWithBackendContext` level. -/
 def evalBuiltinCallViaEvmYulLean
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (_sender : Nat)
     (selector : Nat)
     (calldata : List Nat)
@@ -1061,7 +1061,7 @@ def evalBuiltinCallViaEvmYulLean
     (argVals : List Nat) : Option Nat :=
   match func, argVals with
   | "calldataload", [offset] => some (Compiler.Proofs.YulGeneration.calldataloadWord selector calldata offset)
-  | "sload", [slot] => some (storage slot).toNat
+  | "sload", [slot] => some (storage (IRStorageSlot.ofNat slot)).toNat
   | "mappingSlot", [base, key] => some (Compiler.Proofs.abstractMappingSlot base key)
   | _, _ => evalPureBuiltinViaEvmYulLean func argVals
 

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean
@@ -6,7 +6,7 @@ import Mathlib.Data.Nat.Bitwise
 namespace Compiler.Proofs.YulGeneration.Backends
 
 open Compiler.Proofs.YulGeneration
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 
 private theorem word_lt_uint256_size (x : Nat) :
     x % EvmYul.UInt256.size < 2 ^ 256 := by
@@ -21,7 +21,7 @@ private theorem uint256_ofNat_mod_evmModulus (n : Nat) :
   simp only [Fin.ofNat, EvmYul.UInt256.size, evmModulus, Nat.mod_mod]
 
 private theorem verity_eval_add_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "add" [a, b] =
       some ((a + b) % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -34,7 +34,7 @@ private theorem bridge_eval_add_normalized (a b : Nat) :
   simp [Fin.val_add, Nat.add_mod]
 
 private theorem verity_eval_sub_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sub" [a, b] =
       some ((evmModulus + a % evmModulus - b % evmModulus) % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -49,7 +49,7 @@ private theorem bridge_eval_sub_normalized (a b : Nat) :
   simp [Fin.sub_def, Nat.add_mod]
 
 private theorem verity_eval_mul_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mul" [a, b] =
       some ((a * b) % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -62,7 +62,7 @@ private theorem bridge_eval_mul_normalized (a b : Nat) :
   simp [Fin.mul_def, Nat.mul_mod]
 
 private theorem verity_eval_div_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "div" [a, b] =
       (if b % evmModulus = 0 then some 0 else some ((a % evmModulus) / (b % evmModulus))) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -79,7 +79,7 @@ private theorem bridge_eval_div_normalized (a b : Nat) :
   · simp [hb]
 
 private theorem verity_eval_mod_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mod" [a, b] =
       (if b % evmModulus = 0 then some 0 else some ((a % evmModulus) % (b % evmModulus))) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -110,7 +110,7 @@ private theorem bridge_eval_mod_normalized (a b : Nat) :
     rfl
 
 private theorem verity_eval_eq_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "eq" [a, b] =
       some (if a % evmModulus = b % evmModulus then 1 else 0) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -121,7 +121,7 @@ private theorem bridge_eval_eq_normalized (a b : Nat) :
   rfl
 
 private theorem verity_eval_iszero_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "iszero" [a] =
       some (if a % evmModulus = 0 then 1 else 0) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -133,7 +133,7 @@ private theorem bridge_eval_iszero_normalized (a : Nat) :
 
 set_option maxHeartbeats 2000000 in
 private theorem verity_eval_lt_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "lt" [a, b] =
       some (if a % evmModulus < b % evmModulus then 1 else 0) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -145,7 +145,7 @@ private theorem bridge_eval_lt_normalized (a b : Nat) :
 
 set_option maxHeartbeats 2000000 in
 private theorem verity_eval_gt_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "gt" [a, b] =
       some (if a % evmModulus > b % evmModulus then 1 else 0) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -292,14 +292,14 @@ private theorem bridge_eval_shr_normalized (shift value : Nat) :
     simp [hs, EvmYul.UInt256.shiftRight, EvmYul.UInt256.toNat, hs']
 
 @[simp] theorem evalBuiltinCall_add_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "add" [a, b] =
       evalPureBuiltinViaEvmYulLean "add" [a, b] := by
   rw [verity_eval_add_normalized, bridge_eval_add_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCall_sub_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sub" [a, b] =
       evalPureBuiltinViaEvmYulLean "sub" [a, b] := by
   rw [verity_eval_sub_normalized, bridge_eval_sub_normalized]
@@ -311,21 +311,21 @@ private theorem bridge_eval_shr_normalized (shift value : Nat) :
   simp [EvmYul.UInt256.size, evmModulus, hsub]
 
 @[simp] theorem evalBuiltinCall_mul_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mul" [a, b] =
       evalPureBuiltinViaEvmYulLean "mul" [a, b] := by
   rw [verity_eval_mul_normalized, bridge_eval_mul_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCall_div_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "div" [a, b] =
       evalPureBuiltinViaEvmYulLean "div" [a, b] := by
   rw [verity_eval_div_normalized, bridge_eval_div_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCall_mod_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mod" [a, b] =
       evalPureBuiltinViaEvmYulLean "mod" [a, b] := by
   rw [verity_eval_mod_normalized, bridge_eval_mod_normalized]
@@ -334,7 +334,7 @@ private theorem bridge_eval_shr_normalized (shift value : Nat) :
 /-- Universal bridge theorem for `eq`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_eq_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "eq" [a, b] =
       evalPureBuiltinViaEvmYulLean "eq" [a, b] := by
   rw [verity_eval_eq_normalized, bridge_eval_eq_normalized]
@@ -343,7 +343,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `iszero`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_iszero_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "iszero" [a] =
       evalPureBuiltinViaEvmYulLean "iszero" [a] := by
   rw [verity_eval_iszero_normalized, bridge_eval_iszero_normalized]
@@ -352,7 +352,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `lt`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_lt_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "lt" [a, b] =
       evalPureBuiltinViaEvmYulLean "lt" [a, b] := by
   rw [verity_eval_lt_normalized, bridge_eval_lt_normalized]
@@ -361,7 +361,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `gt`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_gt_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "gt" [a, b] =
       evalPureBuiltinViaEvmYulLean "gt" [a, b] := by
   rw [verity_eval_gt_normalized, bridge_eval_gt_normalized]
@@ -370,7 +370,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `and`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_and_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "and" [a, b] =
       evalPureBuiltinViaEvmYulLean "and" [a, b] := by
   rw [show evalBuiltinCall storage sender selector calldata "and" [a, b] =
@@ -381,7 +381,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `or`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_or_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "or" [a, b] =
       evalPureBuiltinViaEvmYulLean "or" [a, b] := by
   rw [show evalBuiltinCall storage sender selector calldata "or" [a, b] =
@@ -392,7 +392,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `xor`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_xor_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "xor" [a, b] =
       evalPureBuiltinViaEvmYulLean "xor" [a, b] := by
   change some (Nat.bitwise bne (a % evmModulus) (b % evmModulus)) =
@@ -404,7 +404,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `not`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_not_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "not" [a] =
       evalPureBuiltinViaEvmYulLean "not" [a] := by
   change some (a % evmModulus ^^^ (evmModulus - 1)) =
@@ -415,7 +415,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `shl`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_shl_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "shl" [shift, value] =
       evalPureBuiltinViaEvmYulLean "shl" [shift, value] := by
   rw [show evalBuiltinCall storage sender selector calldata "shl" [shift, value] =
@@ -429,7 +429,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `shr`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_shr_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "shr" [shift, value] =
       evalPureBuiltinViaEvmYulLean "shr" [shift, value] := by
   rw [show evalBuiltinCall storage sender selector calldata "shr" [shift, value] =
@@ -441,105 +441,105 @@ EVMYulLean UInt256 semantics on all inputs. -/
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_add_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "add" [a, b] =
       evalBuiltinCall storage sender selector calldata "add" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_add_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_sub_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "sub" [a, b] =
       evalBuiltinCall storage sender selector calldata "sub" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_sub_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_mul_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "mul" [a, b] =
       evalBuiltinCall storage sender selector calldata "mul" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_mul_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_div_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "div" [a, b] =
       evalBuiltinCall storage sender selector calldata "div" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_div_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_mod_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "mod" [a, b] =
       evalBuiltinCall storage sender selector calldata "mod" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_mod_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_eq_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "eq" [a, b] =
       evalBuiltinCall storage sender selector calldata "eq" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_eq_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_iszero_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "iszero" [a] =
       evalBuiltinCall storage sender selector calldata "iszero" [a] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_iszero_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_lt_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "lt" [a, b] =
       evalBuiltinCall storage sender selector calldata "lt" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_lt_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_gt_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "gt" [a, b] =
       evalBuiltinCall storage sender selector calldata "gt" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_gt_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_and_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "and" [a, b] =
       evalBuiltinCall storage sender selector calldata "and" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_and_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_or_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "or" [a, b] =
       evalBuiltinCall storage sender selector calldata "or" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_or_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_xor_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "xor" [a, b] =
       evalBuiltinCall storage sender selector calldata "xor" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_xor_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_not_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "not" [a] =
       evalBuiltinCall storage sender selector calldata "not" [a] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_not_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_shl_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "shl" [shift, value] =
       evalBuiltinCall storage sender selector calldata "shl" [shift, value] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_shl_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_shr_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "shr" [shift, value] =
       evalBuiltinCall storage sender selector calldata "shr" [shift, value] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -552,7 +552,7 @@ The key proof obligation is showing that the intermediate result is already
 < UInt256.size when the modulus is nonzero, so the outer `% size` is a no-op. -/
 
 private theorem verity_eval_addmod_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCall storage sender selector calldata "addmod" [a, b, n] =
       (if n % evmModulus = 0 then some 0 else some (((a % evmModulus) + (b % evmModulus)) % (n % evmModulus))) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -611,7 +611,7 @@ private theorem bridge_eval_addmod_normalized (a b n : Nat) :
       (by unfold EvmYul.UInt256.size; simp))))
 
 private theorem verity_eval_mulmod_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCall storage sender selector calldata "mulmod" [a, b, n] =
       (if n % evmModulus = 0 then some 0 else some (((a % evmModulus) * (b % evmModulus)) % (n % evmModulus))) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -646,7 +646,7 @@ private theorem bridge_eval_mulmod_normalized (a b n : Nat) :
 /-- Universal bridge theorem for `addmod`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_addmod_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCall storage sender selector calldata "addmod" [a, b, n] =
       evalPureBuiltinViaEvmYulLean "addmod" [a, b, n] := by
   rw [verity_eval_addmod_normalized, bridge_eval_addmod_normalized]
@@ -655,21 +655,21 @@ EVMYulLean UInt256 semantics on all inputs. -/
 /-- Universal bridge theorem for `mulmod`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_mulmod_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCall storage sender selector calldata "mulmod" [a, b, n] =
       evalPureBuiltinViaEvmYulLean "mulmod" [a, b, n] := by
   rw [verity_eval_mulmod_normalized, bridge_eval_mulmod_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_addmod_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "addmod" [a, b, n] =
       evalBuiltinCall storage sender selector calldata "addmod" [a, b, n] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
     evalBuiltinCall_addmod_bridge]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_mulmod_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b n : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "mulmod" [a, b, n] =
       evalBuiltinCall storage sender selector calldata "mulmod" [a, b, n] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -691,7 +691,7 @@ private theorem nat_land_0xFF (n : Nat) : Nat.land n 255 = n % 256 := by
 
 set_option maxHeartbeats 4000000 in
 private theorem verity_eval_byte_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
     evalBuiltinCall storage sender selector calldata "byte" [i, x] =
       (if i % evmModulus > 31 then some 0
        else some ((x % evmModulus / 2 ^ ((31 - i % evmModulus) * 8)) % 256)) := by
@@ -761,14 +761,14 @@ private theorem bridge_eval_byte_normalized (i x : Nat) :
 /-- Universal bridge theorem for `byte`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_byte_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
     evalBuiltinCall storage sender selector calldata "byte" [i, x] =
       evalPureBuiltinViaEvmYulLean "byte" [i, x] := by
   rw [verity_eval_byte_normalized, bridge_eval_byte_normalized]
   simp [EvmYul.UInt256.size, evmModulus]
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_byte_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (i x : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "byte" [i, x] =
       evalBuiltinCall storage sender selector calldata "byte" [i, x] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -785,7 +785,7 @@ set_option maxHeartbeats 4000000 in
 /-- Helper: Verity's signed less-than on raw Nat inputs reduces to a comparison
 via `Int256.toInt`. This normalizes `evalBuiltinCallWithContext` for `slt`. -/
 private theorem verity_eval_slt_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "slt" [a, b] =
       some (if Verity.Core.Int256.toInt
               (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (a % evmModulus))) <
@@ -805,7 +805,7 @@ set_option maxHeartbeats 4000000 in
 /-- Helper: Verity's signed greater-than on raw Nat inputs reduces to a comparison
 via `Int256.toInt`. This normalizes `evalBuiltinCallWithContext` for `sgt`. -/
 private theorem verity_eval_sgt_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sgt" [a, b] =
       some (if Verity.Core.Int256.toInt
               (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (b % evmModulus))) <
@@ -893,7 +893,7 @@ private theorem slt_int256_eq_sltBool (a b : Nat) (ha : a < evmModulus) (hb : b 
 /-- Universal bridge theorem for `slt`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_slt_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "slt" [a, b] =
       evalPureBuiltinViaEvmYulLean "slt" [a, b] := by
   rw [verity_eval_slt_normalized, bridge_eval_slt_normalized]
@@ -916,7 +916,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
   exact slt_int256_eq_sltBool (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_slt_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "slt" [a, b] =
       evalBuiltinCall storage sender selector calldata "slt" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -954,7 +954,7 @@ private theorem sgt_int256_eq_sgtBool (a b : Nat) (ha : a < evmModulus) (hb : b 
 /-- Universal bridge theorem for `sgt`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_sgt_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sgt" [a, b] =
       evalPureBuiltinViaEvmYulLean "sgt" [a, b] := by
   rw [verity_eval_sgt_normalized, bridge_eval_sgt_normalized]
@@ -977,7 +977,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
   exact sgt_int256_eq_sgtBool (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_sgt_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "sgt" [a, b] =
       evalBuiltinCall storage sender selector calldata "sgt" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -994,7 +994,7 @@ The core equivalence requires showing both repeated-squaring loops compute
 the same result. This needs an induction proof matching the loop invariants. -/
 
 private theorem verity_eval_exp_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "exp" [a, b] =
       some (natModPow (a % evmModulus) (b % evmModulus) evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
@@ -1104,7 +1104,7 @@ private theorem exp_natModPow_eq_uint256Exp (a b : Nat)
 /-- Universal bridge theorem for `exp`: Verity builtin semantics agree with
 EVMYulLean UInt256 semantics on all inputs. -/
 @[simp] theorem evalBuiltinCall_exp_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "exp" [a, b] =
       evalPureBuiltinViaEvmYulLean "exp" [a, b] := by
   rw [verity_eval_exp_normalized, bridge_eval_exp_normalized]
@@ -1120,7 +1120,7 @@ EVMYulLean UInt256 semantics on all inputs. -/
   exact exp_natModPow_eq_uint256Exp (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_exp_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "exp" [a, b] =
       evalBuiltinCall storage sender selector calldata "exp" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -1134,7 +1134,7 @@ implement EVM SDIV: signed division with truncation toward zero, where
 `sdiv(MIN_INT256, -1) = MIN_INT256`. -/
 
 private theorem verity_eval_sdiv_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sdiv" [a, b] =
       some (Verity.Core.Int256.div
         (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (a % evmModulus)))
@@ -1365,7 +1365,7 @@ private theorem sdiv_int256_eq_uint256Sdiv (a b : Nat)
 
 /-- Universal bridge theorem for `sdiv`. -/
 @[simp] theorem evalBuiltinCall_sdiv_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sdiv" [a, b] =
       evalPureBuiltinViaEvmYulLean "sdiv" [a, b] := by
   rw [verity_eval_sdiv_normalized, bridge_eval_sdiv_normalized]
@@ -1386,7 +1386,7 @@ private theorem sdiv_int256_eq_uint256Sdiv (a b : Nat)
   exact sdiv_int256_eq_uint256Sdiv (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_sdiv_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "sdiv" [a, b] =
       evalBuiltinCall storage sender selector calldata "sdiv" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -1398,7 +1398,7 @@ The `smod` bridge connects Verity's `Int256.mod` (sign-magnitude remainder via I
 with EVMYulLean's `UInt256.smod` (sign/abs decomposition with `sgn`/`toSigned`). -/
 
 private theorem verity_eval_smod_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "smod" [a, b] =
       some (Verity.Core.Int256.mod
         (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (a % evmModulus)))
@@ -1912,7 +1912,7 @@ private theorem smod_int256_eq_uint256Smod (a b : Nat)
 
 /-- Universal bridge theorem for `smod`. -/
 @[simp] theorem evalBuiltinCall_smod_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "smod" [a, b] =
       evalPureBuiltinViaEvmYulLean "smod" [a, b] := by
   rw [verity_eval_smod_normalized, bridge_eval_smod_normalized]
@@ -1933,7 +1933,7 @@ private theorem smod_int256_eq_uint256Smod (a b : Nat)
   exact smod_int256_eq_uint256Smod (a % evmModulus) (b % evmModulus) ha hb
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_smod_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "smod" [a, b] =
       evalBuiltinCall storage sender selector calldata "smod" [a, b] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -1945,7 +1945,7 @@ The `sar` bridge connects Verity's `Int256.sar` (floor division by 2^shift via I
 with EVMYulLean's `UInt256.sar` (complement-shift-complement for negatives). -/
 
 private theorem verity_eval_sar_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "sar" [shift, value] =
       some (Verity.Core.Int256.sar
         (Verity.Core.Int256.ofUint256 (Verity.Core.Uint256.ofNat (shift % evmModulus)))
@@ -2287,7 +2287,7 @@ private theorem sar_int256_eq_uint256Sar (shift value : Nat)
 
 /-- Universal bridge theorem for `sar`. -/
 @[simp] theorem evalBuiltinCall_sar_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "sar" [shift, value] =
       evalPureBuiltinViaEvmYulLean "sar" [shift, value] := by
   rw [verity_eval_sar_normalized, bridge_eval_sar_normalized]
@@ -2308,7 +2308,7 @@ private theorem sar_int256_eq_uint256Sar (shift value : Nat)
   exact sar_int256_eq_uint256Sar (shift % evmModulus) (value % evmModulus) hs hv
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_sar_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "sar" [shift, value] =
       evalBuiltinCall storage sender selector calldata "sar" [shift, value] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -2321,7 +2321,7 @@ Nat arithmetic) with EVMYulLean's `UInt256.signextend` (shift-based bit test).
 Both implement EVM SIGNEXTEND: extending the sign bit at byte position `b`. -/
 
 private theorem verity_eval_signextend_normalized
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
     evalBuiltinCall storage sender selector calldata "signextend" [byteIdx, value] =
       some (Verity.Core.Uint256.signextend
         (Verity.Core.Uint256.ofNat (byteIdx % evmModulus))
@@ -2611,7 +2611,7 @@ private theorem signextend_uint256_eq (byteIdx value : Nat)
 
 /-- Universal bridge theorem for `signextend`. -/
 @[simp] theorem evalBuiltinCall_signextend_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
     evalBuiltinCall storage sender selector calldata "signextend" [byteIdx, value] =
       evalPureBuiltinViaEvmYulLean "signextend" [byteIdx, value] := by
   rw [verity_eval_signextend_normalized, bridge_eval_signextend_normalized]
@@ -2632,7 +2632,7 @@ private theorem signextend_uint256_eq (byteIdx value : Nat)
   exact signextend_uint256_eq (byteIdx % evmModulus) (value % evmModulus) hb hv
 
 @[simp] theorem evalBuiltinCallWithBackend_evmYulLean_signextend_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (byteIdx value : Nat) :
     evalBuiltinCallWithBackend .evmYulLean storage sender selector calldata "signextend" [byteIdx, value] =
       evalBuiltinCall storage sender selector calldata "signextend" [byteIdx, value] := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallViaEvmYulLean,
@@ -2734,7 +2734,7 @@ fallback covers all builtins. -/
 /-- `calldataload` is bridged at the full adapter boundary because it depends
     on the selector/calldata context rather than only on argument words. -/
 @[simp] theorem evalBuiltinCall_calldataload_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (offset : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (offset : Nat) :
     evalBuiltinCall storage sender selector calldata "calldataload" [offset] =
       evalBuiltinCallViaEvmYulLean storage sender selector calldata "calldataload" [offset] := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext, evalBuiltinCallViaEvmYulLean]
@@ -2745,7 +2745,7 @@ fallback covers all builtins. -/
     that helper is witnessed by `storageLookup_projectStorage` in
     `EvmYulLeanStateBridge.lean`. -/
 @[simp] theorem evalBuiltinCall_sload_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (slot : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (slot : Nat) :
     evalBuiltinCall storage sender selector calldata "sload" [slot] =
       evalBuiltinCallViaEvmYulLean storage sender selector calldata "sload" [slot] := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext, evalBuiltinCallViaEvmYulLean]
@@ -2757,7 +2757,7 @@ fallback covers all builtins. -/
     ultimately invoke the same kernel-computable `KeccakEngine.keccak256`,
     the two sides are definitionally equal. -/
 @[simp] theorem evalBuiltinCall_mappingSlot_bridge
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (base key : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (base key : Nat) :
     evalBuiltinCall storage sender selector calldata "mappingSlot" [base, key] =
       evalBuiltinCallViaEvmYulLean storage sender selector calldata "mappingSlot" [base, key] := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext, evalBuiltinCallViaEvmYulLean]
@@ -2798,7 +2798,7 @@ These are the key composition lemmas for Phase 4 (retargeting the theorem
 stack to EVMYulLean). -/
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_add_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "add" [a, b] =
@@ -2809,7 +2809,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sub_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sub" [a, b] =
@@ -2820,7 +2820,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_mul_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "mul" [a, b] =
@@ -2831,7 +2831,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_div_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "div" [a, b] =
@@ -2842,7 +2842,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_mod_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "mod" [a, b] =
@@ -2853,7 +2853,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_eq_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "eq" [a, b] =
@@ -2864,7 +2864,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_iszero_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "iszero" [a] =
@@ -2875,7 +2875,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_lt_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "lt" [a, b] =
@@ -2886,7 +2886,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_gt_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "gt" [a, b] =
@@ -2897,7 +2897,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_slt_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "slt" [a, b] =
@@ -2908,7 +2908,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sgt_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sgt" [a, b] =
@@ -2919,7 +2919,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_and_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "and" [a, b] =
@@ -2930,7 +2930,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_or_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "or" [a, b] =
@@ -2941,7 +2941,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_xor_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "xor" [a, b] =
@@ -2952,7 +2952,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_not_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "not" [a] =
@@ -2963,7 +2963,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_shl_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "shl" [a, b] =
@@ -2974,7 +2974,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_shr_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "shr" [a, b] =
@@ -2985,7 +2985,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_addmod_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b c : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "addmod" [a, b, c] =
@@ -2996,7 +2996,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_mulmod_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b c : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "mulmod" [a, b, c] =
@@ -3007,7 +3007,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_byte_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (i x : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "byte" [i, x] =
@@ -3018,7 +3018,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_exp_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "exp" [a, b] =
@@ -3029,7 +3029,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sdiv_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sdiv" [a, b] =
@@ -3040,7 +3040,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_smod_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (a b : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "smod" [a, b] =
@@ -3051,7 +3051,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sar_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sar" [shift, value] =
@@ -3062,7 +3062,7 @@ stack to EVMYulLean). -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_signextend_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (byteIdx value : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "signextend" [byteIdx, value] =
@@ -3090,7 +3090,7 @@ These lemmas define the exact Phase-3 boundary that later retargeting proofs
 can rewrite against. -/
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_sload_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (slot : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "sload" [slot] =
@@ -3099,7 +3099,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext, evalBuiltinCallViaEvmYulLean]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_caller_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "caller" [] =
@@ -3108,7 +3108,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_address_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "address" [] =
@@ -3117,7 +3117,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_callvalue_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "callvalue" [] =
@@ -3126,7 +3126,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_timestamp_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "timestamp" [] =
@@ -3135,7 +3135,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_number_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "number" [] =
@@ -3144,7 +3144,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_blobbasefee_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "blobbasefee" [] =
@@ -3153,7 +3153,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_chainid_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "chainid" [] =
@@ -3162,7 +3162,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_calldataload_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (offset : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "calldataload" [offset] =
@@ -3173,7 +3173,7 @@ can rewrite against. -/
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_calldatasize_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "calldatasize" [] =
@@ -3182,7 +3182,7 @@ can rewrite against. -/
   simp [evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackendContext_evmYulLean_mappingSlot_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (base key : Nat) :
     evalBuiltinCallWithBackendContext .evmYulLean storage sender msgValue thisAddress
       blockTimestamp blockNumber chainId blobBaseFee selector calldata "mappingSlot" [base, key] =
@@ -3215,7 +3215,7 @@ separately when the builtin is known to be in the bridged pure fragment. -/
     per-builtin bridge lemmas are applied after this routing rewrite when the
     builtin is known to lie in the bridged pure fragment. -/
 theorem evalBuiltinCallWithBackendContext_evmYulLean_pure_bridge
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (func : String) (argVals : List Nat)
     (hCaller : func ≠ "caller")
     (hAddress : func ≠ "address")

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeTest.lean
@@ -21,10 +21,10 @@ namespace Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeTest
 
 open Compiler.Proofs.YulGeneration
 open Compiler.Proofs.YulGeneration.Backends
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 
 -- Shared test parameters (state-independent for pure builtins)
-private def testStorage : Nat → IRStorageWord := fun _ => 0
+private def testStorage : IRStorageSlot → IRStorageWord := fun _ => 0
 private def testSender : Nat := 42
 private def testMsgValue : Nat := 99
 private def testThisAddress : Nat := 0xC0FFEE
@@ -165,55 +165,55 @@ example : verityEval "iszero" [Compiler.Constants.evmModulus] =
           bridgeEval "iszero" [Compiler.Constants.evmModulus] := by native_decide
 
 /-- Universal bridge theorem for `add` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "add" [a, b] =
       evalPureBuiltinViaEvmYulLean "add" [a, b] := by
   exact evalBuiltinCall_add_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `sub` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "sub" [a, b] =
       evalPureBuiltinViaEvmYulLean "sub" [a, b] := by
   exact evalBuiltinCall_sub_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `mul` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mul" [a, b] =
       evalPureBuiltinViaEvmYulLean "mul" [a, b] := by
   exact evalBuiltinCall_mul_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `div` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "div" [a, b] =
       evalPureBuiltinViaEvmYulLean "div" [a, b] := by
   exact evalBuiltinCall_div_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `mod` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "mod" [a, b] =
       evalPureBuiltinViaEvmYulLean "mod" [a, b] := by
   exact evalBuiltinCall_mod_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `eq` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "eq" [a, b] =
       evalPureBuiltinViaEvmYulLean "eq" [a, b] := by
   exact evalBuiltinCall_eq_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `iszero` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "iszero" [a] =
       evalPureBuiltinViaEvmYulLean "iszero" [a] := by
   exact evalBuiltinCall_iszero_bridge storage sender selector calldata a
 
 /-- Universal bridge theorem for `lt` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "lt" [a, b] =
       evalPureBuiltinViaEvmYulLean "lt" [a, b] := by
   exact evalBuiltinCall_lt_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `gt` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "gt" [a, b] =
       evalPureBuiltinViaEvmYulLean "gt" [a, b] := by
   exact evalBuiltinCall_gt_bridge storage sender selector calldata a b
@@ -250,19 +250,19 @@ example : verityEval "xor" [Compiler.Constants.evmModulus, 0] =
           bridgeEval "xor" [Compiler.Constants.evmModulus, 0] := by native_decide
 
 /-- Universal bridge theorem for `and` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "and" [a, b] =
       evalPureBuiltinViaEvmYulLean "and" [a, b] := by
   exact evalBuiltinCall_and_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `or` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "or" [a, b] =
       evalPureBuiltinViaEvmYulLean "or" [a, b] := by
   exact evalBuiltinCall_or_bridge storage sender selector calldata a b
 
 /-- Universal bridge theorem for `xor` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a b : Nat) :
     evalBuiltinCall storage sender selector calldata "xor" [a, b] =
       evalPureBuiltinViaEvmYulLean "xor" [a, b] := by
   exact evalBuiltinCall_xor_bridge storage sender selector calldata a b
@@ -275,7 +275,7 @@ example : verityEval "not" [Compiler.Constants.evmModulus] =
           bridgeEval "not" [Compiler.Constants.evmModulus] := by native_decide
 
 /-- Universal bridge theorem for `not` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (a : Nat) :
     evalBuiltinCall storage sender selector calldata "not" [a] =
       evalPureBuiltinViaEvmYulLean "not" [a] := by
   exact evalBuiltinCall_not_bridge storage sender selector calldata a
@@ -292,7 +292,7 @@ example : verityEval "shl" [Compiler.Constants.evmModulus - 1, 3] =
           bridgeEval "shl" [Compiler.Constants.evmModulus - 1, 3] := by native_decide
 
 /-- Universal bridge theorem for `shl` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "shl" [shift, value] =
       evalPureBuiltinViaEvmYulLean "shl" [shift, value] := by
   exact evalBuiltinCall_shl_bridge storage sender selector calldata shift value
@@ -309,7 +309,7 @@ example : verityEval "shr" [Compiler.Constants.evmModulus - 1, 12345] =
           bridgeEval "shr" [Compiler.Constants.evmModulus - 1, 12345] := by native_decide
 
 /-- Universal bridge theorem for `shr` (symbolic, not vector-based). -/
-example (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
+example (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) (shift value : Nat) :
     evalBuiltinCall storage sender selector calldata "shr" [shift, value] =
       evalPureBuiltinViaEvmYulLean "shr" [shift, value] := by
   exact evalBuiltinCall_shr_bridge storage sender selector calldata shift value

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeDispatchOracleTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeDispatchOracleTest.lean
@@ -33,14 +33,14 @@ private def nestedMultiWordMappingBaseSlot : Nat :=
 private def nestedMultiWordMappingMemberSlot : Nat :=
   nestedMultiWordMappingBaseSlot + 1
 
-private def seededStorage : Nat -> IRStorageWord := fun slot =>
-  if slot = 7 then IRStorageWord.ofNat 77 else
-  if slot = mappingReadSlot then IRStorageWord.ofNat 515 else
-  if slot = packedMappingSlot then IRStorageWord.ofNat 0x123456 else
-  if slot = multiWordMappingBaseSlot then IRStorageWord.ofNat 0xAAAA else
-  if slot = multiWordMappingMemberSlot then IRStorageWord.ofNat 0xBBBB else
-  if slot = nestedMultiWordMappingBaseSlot then IRStorageWord.ofNat 0xCCCC else
-  if slot = nestedMultiWordMappingMemberSlot then IRStorageWord.ofNat 0xDDDD else IRStorageWord.ofNat 0
+private def seededStorage : IRStorageSlot -> IRStorageWord := fun slot =>
+  if slot = IRStorageSlot.ofNat 7 then IRStorageWord.ofNat 77 else
+  if slot = IRStorageSlot.ofNat mappingReadSlot then IRStorageWord.ofNat 515 else
+  if slot = IRStorageSlot.ofNat packedMappingSlot then IRStorageWord.ofNat 0x123456 else
+  if slot = IRStorageSlot.ofNat multiWordMappingBaseSlot then IRStorageWord.ofNat 0xAAAA else
+  if slot = IRStorageSlot.ofNat multiWordMappingMemberSlot then IRStorageWord.ofNat 0xBBBB else
+  if slot = IRStorageSlot.ofNat nestedMultiWordMappingBaseSlot then IRStorageWord.ofNat 0xCCCC else
+  if slot = IRStorageSlot.ofNat nestedMultiWordMappingMemberSlot then IRStorageWord.ofNat 0xDDDD else IRStorageWord.ofNat 0
 
 private def sampleIRTx (selector : Nat) (args : List Nat := []) : IRTransaction :=
   { sender := 0xCAFE
@@ -324,7 +324,7 @@ private def memoryRevertDispatchSmokeContract : IRContract :=
 
 private def referenceRuntimeWithBackendFuel
     (fuel : Nat) (runtimeCode : List Compiler.Yul.YulStmt)
-    (tx : YulTransaction) (storage : Nat -> IRStorageWord) (events : List (List Nat)) :
+    (tx : YulTransaction) (storage : IRStorageSlot -> IRStorageWord) (events : List (List Nat)) :
     YulResult :=
   let initialState := YulState.initial tx storage events
   yulResultOfExecWithRollback initialState
@@ -336,7 +336,8 @@ private def resultsMatchOnSlots
     nativeResult.returnValue == referenceResult.returnValue &&
     nativeResult.events == referenceResult.events &&
     slots.all (fun slot =>
-      nativeResult.finalStorage slot == referenceResult.finalStorage slot)
+      nativeResult.finalStorage (IRStorageSlot.ofNat slot) ==
+        referenceResult.finalStorage (IRStorageSlot.ofNat slot))
 
 private def emittedDispatchMatchesReferenceWithExpected
     (contract : IRContract) (tx : IRTransaction)
@@ -358,8 +359,8 @@ private def emittedDispatchMatchesReferenceWithExpected
     nativeResult.returnValue == expectedReturn &&
     reference.returnValue == expectedReturn &&
     expectedSlots.all (fun (slot, value) =>
-      nativeResult.finalStorage slot == IRStorageWord.ofNat value &&
-        reference.finalStorage slot == IRStorageWord.ofNat value))
+      nativeResult.finalStorage (IRStorageSlot.ofNat slot) == IRStorageWord.ofNat value &&
+        reference.finalStorage (IRStorageSlot.ofNat slot) == IRStorageWord.ofNat value))
 
 private def emittedCompiledDispatchMatchesReferenceWithExpected
     (contract : Except String IRContract) (tx : IRTransaction)

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -11,7 +11,7 @@ open Compiler.Yul
 open Compiler.Proofs.YulGeneration
 open Compiler.Proofs.YulGeneration.Backends.StateBridge
 open Lean Elab Tactic Meta
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 
 /-!
 Executable native EVMYulLean runtime harness for #1737.
@@ -34,7 +34,7 @@ external-call semantics.
 def initialState
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.Yul.State :=
   let verityState := YulState.initial tx storage
@@ -415,7 +415,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_installsExecutionContract
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.code =
       contract ∧
@@ -426,7 +426,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_installsCurrentAccountContract
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     ((initialState contract tx storage observableSlots).sharedState.accountMap.find?
         (natToAddress tx.thisAddress)).map (fun account => account.code) =
@@ -438,7 +438,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_transactionEnvironment
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.source =
       natToAddress tx.sender ∧
@@ -460,7 +460,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_source
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.source =
       natToAddress tx.sender := by
@@ -470,7 +470,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_sender
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.sender =
       natToAddress tx.sender := by
@@ -480,7 +480,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_codeOwner
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.codeOwner =
       natToAddress tx.thisAddress := by
@@ -490,7 +490,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_weiValue
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.weiValue =
       natToUInt256 tx.msgValue := by
@@ -500,7 +500,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_blockTimestamp
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.header.timestamp =
       tx.blockTimestamp := by
@@ -510,7 +510,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_blockNumber
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.header.number =
       tx.blockNumber := by
@@ -520,7 +520,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_calldata
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.calldata =
       calldataToByteArray tx.functionSelector tx.args := by
@@ -530,7 +530,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_calldataSize
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.calldata.size =
       4 + tx.args.length * 32 := by
@@ -619,7 +619,7 @@ theorem readBytes_offset4_get?_of_lt_source
 @[simp] theorem initialState_calldataReadWord_selectorByte0
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (ByteArray.readBytes
         (initialState contract tx storage observableSlots).toState.executionEnv.calldata
@@ -643,7 +643,7 @@ theorem readBytes_offset4_get?_of_lt_source
 @[simp] theorem initialState_calldataReadWord_selectorByte1
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (ByteArray.readBytes
         (initialState contract tx storage observableSlots).toState.executionEnv.calldata
@@ -668,7 +668,7 @@ theorem readBytes_offset4_get?_of_lt_source
 @[simp] theorem initialState_calldataReadWord_selectorByte2
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (ByteArray.readBytes
         (initialState contract tx storage observableSlots).toState.executionEnv.calldata
@@ -693,7 +693,7 @@ theorem readBytes_offset4_get?_of_lt_source
 @[simp] theorem initialState_calldataReadWord_selectorByte3
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (ByteArray.readBytes
         (initialState contract tx storage observableSlots).toState.executionEnv.calldata
@@ -720,7 +720,7 @@ theorem readBytes_offset4_get?_of_lt_source
 theorem initialState_calldataReadWord_arg0Byte
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -799,7 +799,7 @@ private theorem list_reverse_eq_drop4_reverse_append_four
 theorem initialState_calldataReadWord_selectorPrefix
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     let bytes := ByteArray.readBytes
       (initialState contract tx storage observableSlots).toState.executionEnv.calldata 0 32
@@ -1263,7 +1263,7 @@ theorem uint256_toByteArray_size (value : EvmYul.UInt256) :
 theorem initialState_calldataReadWord_arg0Bytes
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -1308,7 +1308,7 @@ theorem initialState_calldataReadWord_arg0Bytes
 theorem initialState_calldataload4_arg0_value
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -1349,7 +1349,7 @@ theorem initialState_calldataload4_arg0_value
 theorem initialState_calldataload4_arg0_word
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -1371,7 +1371,7 @@ theorem initialState_calldataload4_arg0_word
 theorem initialState_selectorExpr_native_value
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.UInt256.toNat
       (EvmYul.UInt256.shiftRight
@@ -1410,7 +1410,7 @@ theorem initialState_selectorExpr_native_value
 theorem initialState_selectorExpr_native_value_of_readBytes_size
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (_hReadBytesSize :
       ∀ source : ByteArray, (ByteArray.readBytes source 0 32).size = 32) :
@@ -1426,7 +1426,7 @@ theorem initialState_selectorExpr_native_value_of_readBytes_size
 theorem initialState_selectorExpr_native_uint256
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.UInt256.shiftRight
         (EvmYul.State.calldataload
@@ -1605,7 +1605,7 @@ theorem primCall_calldataload4_initialState_arg0_ok
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -1629,7 +1629,7 @@ theorem primCall_calldataload4_initialState_arg0_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (arg : Nat)
@@ -1655,7 +1655,7 @@ theorem primCall_calldataload4_initialState_ofIR_arg0_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : Compiler.Proofs.IRGeneration.IRTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (arg : Nat)
@@ -1688,7 +1688,7 @@ theorem primCall_calldataload4_initialState_ofIR_arg0_ok_withStore
 theorem primCall_calldataload0_then_shr224_initialState_selector_ok
     (loadFuel shrFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat) :
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) :
     (do
       let (state', values) ←
         EvmYul.Yul.primCall (loadFuel + 1)
@@ -1949,7 +1949,7 @@ theorem eval_lowerExprNative_selectorExpr_ok
 theorem eval_lowerExprNative_selectorExpr_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.Yul.eval 10
         (Backends.lowerExprNative Compiler.Proofs.YulGeneration.selectorExpr)
@@ -2030,7 +2030,7 @@ private theorem uint256_isZero_ofNat_zero :
 theorem eval_lowerExprNative_iszero_lt_calldatasize_4_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     EvmYul.Yul.eval 10
@@ -2070,7 +2070,7 @@ theorem eval_lowerExprNative_callvalue_ok
 theorem eval_lowerExprNative_callvalue_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.Yul.eval 5
         (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
@@ -2288,7 +2288,7 @@ theorem exec_let_lowerExprNative_iszero_lt_calldatasize_4_ok
 theorem exec_let_lowerExprNative_iszero_lt_calldatasize_4_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (name : EvmYul.Identifier)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
@@ -2342,7 +2342,7 @@ theorem exec_let_lowerExprNative_iszero_lt_calldatasize_4_initialState_ok_fuel
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (name : EvmYul.Identifier)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
@@ -2404,7 +2404,7 @@ theorem eval_lowerExprNative_iszero_ident_one_ok_fuel
 theorem exec_let_lowerExprNative_selectorExpr_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (discrName : EvmYul.Identifier) :
     EvmYul.Yul.exec 11
@@ -2439,7 +2439,7 @@ theorem exec_let_lowerExprNative_selectorExpr_initialState_ok_fuel
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (discrName : EvmYul.Identifier) :
     EvmYul.Yul.exec (fuel + 11)
@@ -2480,7 +2480,7 @@ theorem exec_let_lowerExprNative_selectorExpr_initialState_store_ok_fuel
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (discrName : EvmYul.Identifier) :
@@ -2783,7 +2783,7 @@ def nativeSwitchPrefixStmts
 def nativeSwitchInitialOkState
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.Yul.State :=
   .Ok (initialState contract tx storage observableSlots).sharedState ∅
@@ -2791,7 +2791,7 @@ def nativeSwitchInitialOkState
 def nativeSwitchPrefixFinalState
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     EvmYul.Yul.State :=
@@ -2809,7 +2809,7 @@ state whose native switch temporaries are aligned to the interpreter oracle. -/
 theorem exec_nativeSwitchPrefix_selector_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     EvmYul.Yul.exec 12
@@ -2845,7 +2845,7 @@ theorem exec_nativeSwitchPrefix_selector_initialState_ok
 
 theorem exec_nativeSwitchPrefix_selector_initialState_ok_fuel
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     EvmYul.Yul.exec (fuel + 12)
       (.Block (nativeSwitchPrefixStmts discrName matchedName))
@@ -2888,7 +2888,7 @@ theorem exec_nativeSwitchPrefix_selector_initialState_ok_fuel
     bindings (e.g. the buildSwitch wrapper's `__has_selector := 1`). -/
 theorem exec_nativeSwitchPrefix_selector_initialState_store_ok_fuel
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (discrName matchedName : EvmYul.Identifier) :
     EvmYul.Yul.exec (fuel + 12)
@@ -3099,7 +3099,7 @@ theorem exec_if_lowerExprNative_iszero_ident_one_skip_fuel
     `If1`-skip lemma. -/
 private theorem nativeSwitchInitialOkState_insert_lookup_self
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (name : EvmYul.Identifier) (value : EvmYul.UInt256) :
     ((nativeSwitchInitialOkState contract tx storage observableSlots).insert
         name value)[name]! = value := by
@@ -3148,7 +3148,7 @@ theorem exec_block_singleton_eq
     `nativeSwitchInitialOkState_insert_lookup_self`. -/
 theorem exec_block_letSelector_if1Skip_initialState_fuel
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (selectorName : EvmYul.Identifier) (if1Body tail : List EvmYul.Yul.Ast.Stmt)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     EvmYul.Yul.exec (fuel + 12)
@@ -3189,7 +3189,7 @@ theorem exec_block_letSelector_if1Skip_initialState_fuel
     lemmas through `nativeSwitchInitialOkState_insert_lookup_self`. -/
 theorem exec_block_letSelector_if1Skip_if2Take_initialState_fuel
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (selectorName : EvmYul.Identifier)
     (if1Body if2Body : List EvmYul.Yul.Ast.Stmt)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
@@ -4090,7 +4090,7 @@ theorem nativeSwitchDiscrTempName_ne_matchedTempName
 theorem nativeSwitchPrefixFinalState_matched
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     (nativeSwitchPrefixFinalState contract tx storage observableSlots
@@ -4102,7 +4102,7 @@ theorem nativeSwitchPrefixFinalState_matched
 theorem nativeSwitchPrefixFinalState_discr
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier)
     (selector : Nat)
@@ -4123,7 +4123,7 @@ theorem nativeSwitchPrefixFinalState_discr
 theorem nativeSwitchPrefixFinalState_marked
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     ((nativeSwitchPrefixFinalState contract tx storage observableSlots discrName matchedName).insert matchedName (EvmYul.UInt256.ofNat 1))[matchedName]! =
@@ -4135,7 +4135,7 @@ theorem nativeSwitchPrefixFinalState_marked
 def nativeSwitchPrefixStateForId
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (switchId : Nat) :
     EvmYul.Yul.State :=
@@ -4146,7 +4146,7 @@ def nativeSwitchPrefixStateForId
 def nativeSwitchMarkedPrefixStateForId
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (switchId : Nat) :
     EvmYul.Yul.State :=
@@ -5441,7 +5441,7 @@ theorem exec_nativeSwitchPrefix_then_tail_fuel
     (tail : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier)
     (final : EvmYul.Yul.State)
@@ -5481,7 +5481,7 @@ theorem exec_nativeSwitchPrefix_then_tail_error_fuel
     (tail : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier)
     (err : EvmYul.Yul.Exception)
@@ -5519,7 +5519,7 @@ theorem exec_nativeSwitchPrefix_then_tail_error_fuel
 theorem exec_nativeSwitchTail_find_hit_preserved_fuel
     (fuel selector switchId tag : Nat)
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt)) (defaultBody body : List EvmYul.Yul.Ast.Stmt)
-    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) (final : EvmYul.Yul.State)
     (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
@@ -5570,7 +5570,7 @@ theorem exec_nativeSwitchTail_find_hit_error_fuel
     (defaultBody body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -5614,7 +5614,7 @@ theorem exec_nativeSwitchTail_find_none_with_default_nonempty_fuel
     (defaultBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (final : EvmYul.Yul.State)
     (hSelector :
@@ -5662,7 +5662,7 @@ theorem exec_nativeSwitchTail_find_none_without_default_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -5705,7 +5705,7 @@ theorem exec_nativeSwitchTail_find_none_with_revert_default_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -5747,7 +5747,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_hit_preserved_fuel
     (body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (final : EvmYul.Yul.State)
     (hSelector :
@@ -5788,7 +5788,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_hit_error_fuel
     (body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector :
@@ -5823,7 +5823,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_default_nonempty_fue
     (defaultBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (final : EvmYul.Yul.State)
     (hSelector :
@@ -5860,7 +5860,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -5893,7 +5893,7 @@ theorem exec_lowerNativeSwitchBlock_storePrefix_tail_error_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (defaultBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (err : EvmYul.Yul.Exception)
     (hTail :
@@ -5937,7 +5937,7 @@ theorem exec_lowerNativeSwitchBlock_storePrefix_tail_error_fuel
 /-- `matched := 0` lookup on the post-prefix state with arbitrary store. -/
 theorem nativeSwitchPrefixStoreState_matched_eq
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (discrName matchedName : EvmYul.Identifier)
     (discrValue : EvmYul.Literal) :
@@ -5951,7 +5951,7 @@ theorem nativeSwitchPrefixStoreState_matched_eq
 /-- `discr := selector` lookup on the post-prefix state with arbitrary store. -/
 theorem nativeSwitchPrefixStoreState_discr_eq
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (discrName matchedName : EvmYul.Identifier)
     (selector : Nat) (hne : discrName ≠ matchedName)
@@ -5978,7 +5978,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_store
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (hSelector :
@@ -6018,7 +6018,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_hit_error_store_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (defaultBody body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat) (store : EvmYul.Yul.VarStore)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat) (store : EvmYul.Yul.VarStore)
     (err : EvmYul.Yul.Exception)
     (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
@@ -6068,7 +6068,7 @@ theorem exec_block_lowerNativeSwitchBlock_revert_default_hasSelectorState_error
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -6111,7 +6111,7 @@ theorem exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_err
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (defaultBody body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
@@ -6158,7 +6158,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_without_default_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -6183,7 +6183,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_without_default_fuel
 @[simp] theorem initialState_unbridgedEnvironmentDefaults
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.header.baseFeePerGas =
       0 ∧
@@ -6200,9 +6200,9 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_without_default_fuel
     mkBlockHeader, EvmYul.State.chainId]
 
 /-- Project the account storage for the current contract back to Verity's
-    `Nat → IRStorageWord` storage view. -/
+    `IRStorageSlot → IRStorageWord` storage view. -/
 def projectStorageFromState (tx : YulTransaction) (state : EvmYul.Yul.State) :
-    Nat → IRStorageWord :=
+    IRStorageSlot → IRStorageWord :=
   extractStorage state.sharedState (natToAddress tx.thisAddress)
 
 /-- Projecting final native storage reads the current contract account storage
@@ -6217,7 +6217,7 @@ def projectStorageFromState (tx : YulTransaction) (state : EvmYul.Yul.State) :
       state.sharedState.accountMap.find? (natToAddress tx.thisAddress) =
         some account)
     (hSlot : account.storage.find? (natToUInt256 slot) = some value) :
-    projectStorageFromState tx state slot = value := by
+    projectStorageFromState tx state (IRStorageSlot.ofNat slot) = value := by
   simp [projectStorageFromState, extractStorage, hAccount, hSlot]
 
 /-- Projecting final native storage defaults to zero when the current contract
@@ -6231,7 +6231,7 @@ def projectStorageFromState (tx : YulTransaction) (state : EvmYul.Yul.State) :
       state.sharedState.accountMap.find? (natToAddress tx.thisAddress) =
         some account)
     (hSlot : account.storage.find? (natToUInt256 slot) = none) :
-    projectStorageFromState tx state slot = 0 := by
+    projectStorageFromState tx state (IRStorageSlot.ofNat slot) = 0 := by
   simp [projectStorageFromState, extractStorage, hAccount, hSlot]
 
 /-- Projecting final native storage defaults to zero when the current contract
@@ -6243,7 +6243,7 @@ def projectStorageFromState (tx : YulTransaction) (state : EvmYul.Yul.State) :
     (hAccount :
       state.sharedState.accountMap.find? (natToAddress tx.thisAddress) =
         none) :
-    projectStorageFromState tx state slot = 0 := by
+    projectStorageFromState tx state (IRStorageSlot.ofNat slot) = 0 := by
   simp [projectStorageFromState, extractStorage, hAccount]
 
 /-- Native initial-state storage materialization agrees with Verity storage on
@@ -6252,14 +6252,14 @@ def projectStorageFromState (tx : YulTransaction) (state : EvmYul.Yul.State) :
 theorem initialState_observableStorageSlot
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hSlot : slot ∈ observableSlots)
     (hRange : ∀ s ∈ observableSlots, s < EvmYul.UInt256.size) :
     projectStorageFromState tx
-      (initialState contract tx storage observableSlots) slot =
-      storage slot := by
+      (initialState contract tx storage observableSlots) (IRStorageSlot.ofNat slot) =
+      storage (IRStorageSlot.ofNat slot) := by
   simp only [projectStorageFromState, extractStorage, initialState,
     EvmYul.Yul.State.sharedState, YulState.initial, toSharedState]
   rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
@@ -6275,7 +6275,7 @@ theorem initialState_observableStorageSlot
 theorem initialState_sload_observableSlot_value
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hSlot : slot ∈ observableSlots)
@@ -6283,10 +6283,10 @@ theorem initialState_sload_observableSlot_value
     (EvmYul.State.sload
       (initialState contract tx storage observableSlots).toState
       (natToUInt256 slot)).2 =
-      storage slot := by
+      storage (IRStorageSlot.ofNat slot) := by
   have hFindStorage :
       (projectStorage storage observableSlots).find? (natToUInt256 slot) =
-        some (storage slot) := by
+        some (storage (IRStorageSlot.ofNat slot)) := by
     simpa [projectStorage, IRStorageWord.toUInt256] using
       foldl_insert_find storage observableSlots slot hSlot hRange
         (Batteries.RBMap.empty : EvmYul.Storage)
@@ -6295,7 +6295,7 @@ theorem initialState_sload_observableSlot_value
   rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
   rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
   change (Batteries.RBMap.find? (projectStorage storage observableSlots)
-      (natToUInt256 slot)).getD ⟨0⟩ = storage slot
+      (natToUInt256 slot)).getD ⟨0⟩ = storage (IRStorageSlot.ofNat slot)
   rw [hFindStorage]
   rfl
 
@@ -6305,7 +6305,7 @@ theorem initialState_sload_observableSlot_value
 theorem initialState_sload_omittedSlot_value
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hNotSlot : slot ∉ observableSlots)
@@ -6335,7 +6335,7 @@ theorem primCall_sload_initialState_observableSlot_ok
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hSlot : slot ∈ observableSlots)
@@ -6350,7 +6350,7 @@ theorem primCall_sload_initialState_observableSlot_ok
           .ok ((initialState contract tx storage observableSlots).setSharedState
               { (initialState contract tx storage observableSlots).toSharedState with
                 toState := state' },
-            [storage slot]) := by
+            [storage (IRStorageSlot.ofNat slot)]) := by
   rw [primCall_sload_ok]
   generalize hload :
       EvmYul.State.sload
@@ -6371,7 +6371,7 @@ theorem primCall_sload_initialState_omittedSlot_ok
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hNotSlot : slot ∉ observableSlots)
@@ -6410,7 +6410,7 @@ theorem primCall_sload_initialState_observableSlot_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (slot : Nat)
@@ -6428,7 +6428,7 @@ theorem primCall_sload_initialState_observableSlot_ok_withStore
               { (.Ok (initialState contract tx storage observableSlots).sharedState
                   store : EvmYul.Yul.State).toSharedState with
                 toState := state' }),
-            [storage slot]) := by
+            [storage (IRStorageSlot.ofNat slot)]) := by
   rw [primCall_sload_ok]
   generalize hload :
       EvmYul.State.sload
@@ -6453,7 +6453,7 @@ theorem primCall_sload_initialState_omittedSlot_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (slot : Nat)
@@ -6499,7 +6499,7 @@ theorem primCall_sstore_initialState_wordSlot_ok
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (slot value : Nat)
     (_hSlotRange : slot < EvmYul.UInt256.size) :
@@ -6520,7 +6520,7 @@ theorem primCall_sstore_initialState_wordSlot_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (slot value : Nat)
@@ -6546,7 +6546,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_ok
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -6742,14 +6742,14 @@ theorem primCall_mstore0_then_return32_ok_hReturn_size
 theorem initialState_omittedStorageSlot
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hNotSlot : slot ∉ observableSlots)
     (hRange : ∀ s ∈ observableSlots, s < EvmYul.UInt256.size)
     (hSlotRange : slot < EvmYul.UInt256.size) :
     projectStorageFromState tx
-      (initialState contract tx storage observableSlots) slot = 0 := by
+      (initialState contract tx storage observableSlots) (IRStorageSlot.ofNat slot) = 0 := by
   simp only [projectStorageFromState, extractStorage, initialState,
     EvmYul.Yul.State.sharedState, YulState.initial, toSharedState]
   rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
@@ -6760,7 +6760,7 @@ theorem initialState_omittedStorageSlot
   have hNone :
       (projectStorage storage observableSlots).find? (natToUInt256 slot) = none := by
     simpa [projectStorage] using h
-  rw [hNone]
+  simp [IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hNone]
 
 /-- Decode one 32-byte big-endian word from an EVMYulLean byte array. -/
 def byteArrayWord (bytes : ByteArray) (offset : Nat) : Nat :=
@@ -7097,7 +7097,7 @@ theorem contractDispatcherExecResult_block_dispatcher_eq_exec_block
     (body : List EvmYul.Yul.Ast.Stmt)
     (functions : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     contractDispatcherExecResult (Nat.succ (Nat.succ fuel))
         { dispatcher := .Block body, functions := functions }
@@ -7162,7 +7162,7 @@ theorem callDispatcherBlockResult_initialState_eq_contractDispatcherBlockResult
     (fuel' : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     callDispatcherBlockResult fuel' contract
         (initialState contract tx storage observableSlots) =
@@ -7206,7 +7206,7 @@ theorem callDispatcher_succ_eq_callDispatcherBlockResult
     back to the supplied initial storage function. -/
 def projectResult
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (result :
       Except EvmYul.Yul.Exception
@@ -7236,7 +7236,7 @@ def projectResult
 
 @[simp] theorem projectResult_ok
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7260,7 +7260,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7289,7 +7289,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_yulHalt
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -7305,7 +7305,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_events
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7315,7 +7315,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_success
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7325,7 +7325,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_returnValue
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7336,7 +7336,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7347,7 +7347,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_finalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal)
@@ -7359,13 +7359,13 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
         some account)
     (hSlot : account.storage.find? (natToUInt256 slot) = some value) :
     (projectResult tx initialStorage initialEvents
-      (.ok (state, values))).finalStorage slot = value := by
+      (.ok (state, values))).finalStorage (IRStorageSlot.ofNat slot) = value := by
   simp [projectResult, projectStorageFromState_accountStorageSlot,
     hAccount, hSlot]
 
 @[simp] theorem projectResult_ok_missingFinalStorageAccountSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal)
@@ -7374,12 +7374,12 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
       state.sharedState.accountMap.find? (natToAddress tx.thisAddress) =
         none) :
     (projectResult tx initialStorage initialEvents
-      (.ok (state, values))).finalStorage slot = 0 := by
+      (.ok (state, values))).finalStorage (IRStorageSlot.ofNat slot) = 0 := by
   simp [projectResult, projectStorageFromState_missingAccount, hAccount]
 
 @[simp] theorem projectResult_ok_missingFinalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal)
@@ -7390,7 +7390,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
         some account)
     (hSlot : account.storage.find? (natToUInt256 slot) = none) :
     (projectResult tx initialStorage initialEvents
-      (.ok (state, values))).finalStorage slot = 0 := by
+      (.ok (state, values))).finalStorage (IRStorageSlot.ofNat slot) = 0 := by
   simp [projectResult, projectStorageFromState_missingAccountStorageSlot,
     hAccount, hSlot]
 
@@ -7407,7 +7407,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (slot value : Nat)
@@ -7419,7 +7419,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot
           (initialState contract tx storage observableSlots)
           EvmYul.Operation.SSTORE [natToUInt256 slot, natToUInt256 value] =
         .ok (finalState, []) ∧
-      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage slot =
+      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage (IRStorageSlot.ofNat slot) =
         natToUInt256 value := by
   refine ⟨(initialState contract tx storage observableSlots).setState
     ((initialState contract tx storage observableSlots).toState.sstore
@@ -7451,7 +7451,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_of_erase
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (slot value : Nat)
@@ -7466,7 +7466,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_of_erase
           (initialState contract tx storage observableSlots)
           EvmYul.Operation.SSTORE [natToUInt256 slot, natToUInt256 value] =
         .ok (finalState, []) ∧
-      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage slot =
+      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage (IRStorageSlot.ofNat slot) =
         0 := by
   refine ⟨(initialState contract tx storage observableSlots).setState
     ((initialState contract tx storage observableSlots).toState.sstore
@@ -7485,7 +7485,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_of_erase
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, hErase]
+      Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
 /-- Native primitive execution of `sstore(slot, 0)` on a word-canonical
     initial runtime slot with no observable slots materialized. The zero-write
@@ -7495,7 +7495,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_emptyObser
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (slot value : Nat)
     (hSlotRange : slot < EvmYul.UInt256.size)
@@ -7506,7 +7506,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_emptyObser
           (initialState contract tx storage [])
           EvmYul.Operation.SSTORE [natToUInt256 slot, natToUInt256 value] =
         .ok (finalState, []) ∧
-      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage slot =
+      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage (IRStorageSlot.ofNat slot) =
         0 := by
   exact
     primCall_sstore_initialState_wordSlot_projectResult_slot_zero_of_erase
@@ -7522,7 +7522,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7535,7 +7535,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot
           (.Ok (initialState contract tx storage observableSlots).sharedState store)
           EvmYul.Operation.SSTORE [natToUInt256 slot, natToUInt256 value] =
         .ok (finalState, []) ∧
-      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage slot =
+      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage (IRStorageSlot.ofNat slot) =
         natToUInt256 value := by
   let initialWithStore : EvmYul.Yul.State :=
     .Ok (initialState contract tx storage observableSlots).sharedState store
@@ -7566,7 +7566,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7582,7 +7582,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_
           (.Ok (initialState contract tx storage observableSlots).sharedState store)
           EvmYul.Operation.SSTORE [natToUInt256 slot, natToUInt256 value] =
         .ok (finalState, []) ∧
-      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage slot =
+      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage (IRStorageSlot.ofNat slot) =
         0 := by
   let initialWithStore : EvmYul.Yul.State :=
     .Ok (initialState contract tx storage observableSlots).sharedState store
@@ -7604,15 +7604,15 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, hErase]
+      Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
 /-- Native primitive execution of `sstore(slot, 0)` from an arbitrary local
-    store when no observable storage slots were materialized. -/
+    store when no observable storage (IRStorageSlot.ofNat slot)s were materialized. -/
 theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_emptyObservable
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (store : EvmYul.Yul.VarStore)
     (slot value : Nat)
@@ -7624,7 +7624,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_
           (.Ok (initialState contract tx storage []).sharedState store)
           EvmYul.Operation.SSTORE [natToUInt256 slot, natToUInt256 value] =
         .ok (finalState, []) ∧
-      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage slot =
+      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage (IRStorageSlot.ofNat slot) =
         0 := by
   exact
     primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_of_erase
@@ -7640,7 +7640,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_ok
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -7675,7 +7675,7 @@ def primCall_calldataload4_then_sstore0_stop_initialState_arg0
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     Except EvmYul.Yul.Exception
       (EvmYul.Yul.State × List EvmYul.Yul.Ast.Literal) := do
@@ -7704,7 +7704,7 @@ def primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore) :
     Except EvmYul.Yul.Exception
@@ -7731,7 +7731,7 @@ def primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_eq
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -7774,7 +7774,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_eq
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_eq
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (arg : Nat)
@@ -7822,7 +7822,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_eq
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_projectResult_ok
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7860,7 +7860,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_projectResult_eq
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7899,7 +7899,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_ofIR_arg0_withStor
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : Compiler.Proofs.IRGeneration.IRTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7931,7 +7931,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_ofIR_arg0_withStor
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_projectResult_slot0
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7945,7 +7945,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
         loadFuel storeFuel stopFuel contract tx storage observableSlots store =
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
-        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage 0 =
+        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage (IRStorageSlot.ofNat 0) =
         natToUInt256 arg := by
   let initialWithStore : EvmYul.Yul.State :=
     .Ok (initialState contract tx storage observableSlots).sharedState store
@@ -7978,7 +7978,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7994,7 +7994,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
         loadFuel storeFuel stopFuel contract tx storage observableSlots store =
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
-        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage 0 =
+        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage (IRStorageSlot.ofNat 0) =
         0 := by
   let initialWithStore : EvmYul.Yul.State :=
     .Ok (initialState contract tx storage observableSlots).sharedState store
@@ -8019,7 +8019,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, hErase]
+      Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
 /-- Zero-write storage projection for the full generated `store(uint256)`
     selected body from an arbitrary local store when no observable slots were
@@ -8028,7 +8028,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (store : EvmYul.Yul.VarStore)
     (arg : Nat)
@@ -8041,7 +8041,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
         loadFuel storeFuel stopFuel contract tx storage [] store =
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
-        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage 0 =
+        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage (IRStorageSlot.ofNat 0) =
         0 := by
   exact
     primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_projectResult_slot0_zero_of_erase
@@ -8055,7 +8055,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult_ok
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8088,7 +8088,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult_slot0
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8101,7 +8101,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
         loadFuel storeFuel stopFuel contract tx storage observableSlots =
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
-        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage 0 =
+        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage (IRStorageSlot.ofNat 0) =
         natToUInt256 arg := by
   let finalState :=
     (initialState contract tx storage observableSlots).setState
@@ -8132,7 +8132,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8148,7 +8148,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
         loadFuel storeFuel stopFuel contract tx storage observableSlots =
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
-        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage 0 =
+        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage (IRStorageSlot.ofNat 0) =
         0 := by
   let finalState :=
     (initialState contract tx storage observableSlots).setState
@@ -8171,7 +8171,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, hErase]
+      Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
 /-- Zero-write storage projection for the full generated `store(uint256)` selected
     body through `STOP` when no observable slots were materialized. -/
@@ -8179,7 +8179,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (arg : Nat)
     (rest : List Nat)
@@ -8191,7 +8191,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
         loadFuel storeFuel stopFuel contract tx storage [] =
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
-        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage 0 =
+        (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage (IRStorageSlot.ofNat 0) =
         0 := by
   exact
     primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult_slot0_zero_of_erase
@@ -8206,7 +8206,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8226,7 +8226,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
               EvmYul.Operation.SSTORE [EvmYul.UInt256.ofNat 0, value]
         | _ => .error EvmYul.Yul.Exception.InvalidArguments) =
         .ok (finalState, []) ∧
-      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage 0 =
+      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage (IRStorageSlot.ofNat 0) =
         natToUInt256 arg := by
   refine ⟨(initialState contract tx storage observableSlots).setState
     ((initialState contract tx storage observableSlots).toState.sstore
@@ -8251,7 +8251,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8274,7 +8274,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
               EvmYul.Operation.SSTORE [EvmYul.UInt256.ofNat 0, value]
         | _ => .error EvmYul.Yul.Exception.InvalidArguments) =
         .ok (finalState, []) ∧
-      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage 0 =
+      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage (IRStorageSlot.ofNat 0) =
         0 := by
   refine ⟨(initialState contract tx storage observableSlots).setState
     ((initialState contract tx storage observableSlots).toState.sstore
@@ -8293,14 +8293,14 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, hErase]
+      Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
 /-- Zero `sstore` projection with empty observable-slot materialization. -/
 theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot0_zero_emptyObservable
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (arg : Nat)
     (rest : List Nat)
@@ -8319,7 +8319,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
               EvmYul.Operation.SSTORE [EvmYul.UInt256.ofNat 0, value]
         | _ => .error EvmYul.Yul.Exception.InvalidArguments) =
         .ok (finalState, []) ∧
-      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage 0 =
+      (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage (IRStorageSlot.ofNat 0) =
         0 := by
   exact
     primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot0_zero_of_erase
@@ -8328,7 +8328,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
 
 @[simp] theorem projectResult_yulHalt_events
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -8339,7 +8339,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
 
 @[simp] theorem projectResult_yulHalt_success
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -8349,7 +8349,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
 
 @[simp] theorem projectResult_yulHalt_returnValue
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -8365,7 +8365,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
 theorem primCall_mstore0_then_return32_emptyMemory_projectResult_returnValue
     (mstoreFuel returnFuel : Nat)
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (sharedState : EvmYul.SharedState .Yul)
     (store : EvmYul.Yul.VarStore)
@@ -8400,7 +8400,7 @@ theorem primCall_mstore0_then_return32_emptyMemory_projectResult_returnValue
 theorem primCall_mstore0_then_return32_emptyMemory_projectResult_eq
     (mstoreFuel returnFuel : Nat)
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (sharedState : EvmYul.SharedState .Yul)
     (store : EvmYul.Yul.VarStore)
@@ -8444,7 +8444,7 @@ def primCall_sload0_then_mstore0_return32_initialState
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat) :
     Except EvmYul.Yul.Exception
       (EvmYul.Yul.State × List EvmYul.Yul.Ast.Literal) := do
@@ -8474,7 +8474,7 @@ def primCall_sload0_then_mstore0_return32_initialState_withStore
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore) :
     Except EvmYul.Yul.Exception
@@ -8508,7 +8508,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_projectResult_returnV
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSlot : 0 ∈ observableSlots)
@@ -8552,7 +8552,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_omittedSlot_projectRe
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hNotSlot : 0 ∉ observableSlots)
@@ -8600,7 +8600,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_projectResult_returnV
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hRange : ∀ s ∈ observableSlots, s < EvmYul.UInt256.size) :
@@ -8638,7 +8638,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -8684,7 +8684,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_omittedSlot
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -8732,7 +8732,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -8775,7 +8775,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -8814,7 +8814,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_yulHalt_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -8825,7 +8825,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_yulHalt_finalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8837,14 +8837,14 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
         some account)
     (hSlot : account.storage.find? (natToUInt256 slot) = some slotValue) :
     (projectResult tx initialStorage initialEvents
-      (.error (.YulHalt state value))).finalStorage slot =
+      (.error (.YulHalt state value))).finalStorage (IRStorageSlot.ofNat slot) =
         slotValue := by
   simp [projectResult, projectStorageFromState_accountStorageSlot,
     hAccount, hSlot]
 
 @[simp] theorem projectResult_yulHalt_missingFinalStorageAccountSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8853,12 +8853,12 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
       state.sharedState.accountMap.find? (natToAddress tx.thisAddress) =
         none) :
     (projectResult tx initialStorage initialEvents
-      (.error (.YulHalt state value))).finalStorage slot = 0 := by
+      (.error (.YulHalt state value))).finalStorage (IRStorageSlot.ofNat slot) = 0 := by
   simp [projectResult, projectStorageFromState_missingAccount, hAccount]
 
 @[simp] theorem projectResult_yulHalt_missingFinalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8869,13 +8869,13 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
         some account)
     (hSlot : account.storage.find? (natToUInt256 slot) = none) :
     (projectResult tx initialStorage initialEvents
-      (.error (.YulHalt state value))).finalStorage slot = 0 := by
+      (.error (.YulHalt state value))).finalStorage (IRStorageSlot.ofNat slot) = 0 := by
   simp [projectResult, projectStorageFromState_missingAccountStorageSlot,
     hAccount, hSlot]
 
 @[simp] theorem projectResult_stop
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State) :
     projectResult tx initialStorage initialEvents
@@ -8890,7 +8890,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_32ByteReturn
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8908,7 +8908,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_non32ByteReturn
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8926,7 +8926,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat)) :
     projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert) =
@@ -8939,7 +8939,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_events
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat)) :
     (projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert)).events =
@@ -8948,7 +8948,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_success
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat)) :
     (projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert)).success = false := by
@@ -8956,7 +8956,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_returnValue
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat)) :
     (projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert)).returnValue = none := by
@@ -8964,7 +8964,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat)) :
     (projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert)).finalMappings =
@@ -8973,17 +8973,17 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_finalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (slot : Nat) :
     (projectResult tx initialStorage initialEvents
-      (.error EvmYul.Yul.Exception.Revert)).finalStorage slot =
-      initialStorage slot := by
+      (.error EvmYul.Yul.Exception.Revert)).finalStorage (IRStorageSlot.ofNat slot) =
+      initialStorage (IRStorageSlot.ofNat slot) := by
   rfl
 
 @[simp] theorem projectResult_hardError
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9009,7 +9009,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_success
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9030,7 +9030,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_returnValue
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9051,13 +9051,13 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_finalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (slot : Nat)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
-    (projectResult tx initialStorage initialEvents (.error err)).finalStorage slot =
-      initialStorage slot := by
+    (projectResult tx initialStorage initialEvents (.error err)).finalStorage (IRStorageSlot.ofNat slot) =
+      initialStorage (IRStorageSlot.ofNat slot) := by
   cases err with
   | YulHalt state value =>
       exact False.elim (hNotHalt state value rfl)
@@ -9074,7 +9074,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9096,7 +9096,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_events
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9126,7 +9126,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_proje
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelector :
@@ -9148,8 +9148,8 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_proje
         (.error EvmYul.Yul.Exception.Revert)).returnValue = none ∧
     (∀ slot,
       (projectResult tx storage initialEvents
-        (.error EvmYul.Yul.Exception.Revert)).finalStorage slot =
-          storage slot) := by
+        (.error EvmYul.Yul.Exception.Revert)).finalStorage (IRStorageSlot.ofNat slot) =
+          storage (IRStorageSlot.ofNat slot)) := by
   refine ⟨?_, ?_, ?_, ?_⟩
   · exact exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_fuel
       fuel selector switchId cases contract tx storage observableSlots
@@ -9182,7 +9182,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_find_none_with_revert
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelector :
@@ -9207,8 +9207,8 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_find_none_with_revert
         (.error EvmYul.Yul.Exception.Revert)).returnValue = none ∧
     (∀ slot,
       (projectResult tx storage initialEvents
-        (.error EvmYul.Yul.Exception.Revert)).finalStorage slot =
-          storage slot) := by
+        (.error EvmYul.Yul.Exception.Revert)).finalStorage (IRStorageSlot.ofNat slot) =
+          storage (IRStorageSlot.ofNat slot)) := by
   exact
     exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_projectResult
       fuel selector switchId
@@ -9229,7 +9229,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_find_none_with_revert
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelector :
@@ -9263,7 +9263,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_find_none_with_revert
   exact ⟨hExec, by simp⟩
 
 def simpleStorageRevertProjectedResult
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat)) : YulResult :=
   { success := false
     returnValue := none
@@ -9311,7 +9311,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_tx_find_none_with_rev
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelectorBound : tx.functionSelector < Compiler.Constants.selectorModulus)
@@ -9359,7 +9359,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_tx_miss_with_revert_d
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelectorBound : tx.functionSelector < Compiler.Constants.selectorModulus)
@@ -9398,7 +9398,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageConcrete_tx_miss_with_revert_de
     (fuel switchId : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelectorBound : tx.functionSelector < Compiler.Constants.selectorModulus)
@@ -9434,7 +9434,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_store_hit_error_fuel
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -9478,7 +9478,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_store_hit_error_store
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (err : EvmYul.Yul.Exception)
@@ -9540,7 +9540,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_store_hit_projectResu
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State)
@@ -9586,7 +9586,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageConcrete_store_hit_projectResul
     (fuel switchId : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State)
@@ -9636,7 +9636,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_retrieve_hit_error_fu
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector :
@@ -9674,7 +9674,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_retrieve_hit_error_fu
 
 def simpleStorageRetrieveHaltProjectedResult
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State) : YulResult :=
@@ -9696,7 +9696,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_retrieve_hit_projectR
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State)
@@ -9745,7 +9745,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageConcrete_retrieve_hit_projectRe
     (fuel switchId : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State)
@@ -9790,7 +9790,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageConcrete_retrieve_hit_projectRe
 
 @[simp] theorem projectResult_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → IRStorageWord)
+    (initialStorage : IRStorageSlot → IRStorageWord)
     (initialEvents : List (List Nat))
     (result :
       Except EvmYul.Yul.Exception
@@ -9811,7 +9811,7 @@ def interpretRuntimeNative
     (fuel : Nat)
     (runtimeCode : List YulStmt)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (events : List (List Nat) := []) :
     Except AdapterError YulResult := do
@@ -9827,7 +9827,7 @@ def interpretRuntimeNative
     (fuel : Nat)
     (runtimeCode : List YulStmt)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (events : List (List Nat))
     (err : AdapterError)
@@ -9841,7 +9841,7 @@ def interpretRuntimeNative
     (fuel : Nat)
     (runtimeCode : List YulStmt)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (events : List (List Nat))
     (contract : EvmYul.Yul.Ast.YulContract)
@@ -9859,7 +9859,7 @@ def interpretRuntimeNative
     (fuel : Nat)
     (runtimeCode : List YulStmt)
     (tx : YulTransaction)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (observableSlots : List Nat)
     (events : List (List Nat))
     (contract : EvmYul.Yul.Ast.YulContract)
@@ -9879,7 +9879,7 @@ path once the state/result bridge lemmas are proved. It intentionally returns
 closed for duplicate helper definitions or unsupported runtime shapes.
 
 The observable slot set is explicit because the public theorem compares only
-those final storage slots. Native execution materializes those slots plus
+those final storage (IRStorageSlot.ofNat slot)s. Native execution materializes those slots plus
 literal `sload` slots derived from the emitted runtime so storage reads remain
 faithful even when callers compare a smaller public projection.
 -/

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -6299,6 +6299,78 @@ theorem initialState_sload_observableSlot_value
   rw [hFindStorage]
   rfl
 
+/-- Native `sload` from an initially materialized slot returns the exact bounded
+    IR storage word. This is the range-free version used after IR storage keys
+    moved to `IRStorageSlot`: Nat aliases modulo 2^256 carry the same bounded
+    key and therefore the same projected value. -/
+theorem initialState_sload_materializedSlot_value
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (slots : List Nat)
+    (slot : Nat)
+    (hSlot : slot ∈ slots) :
+    (EvmYul.State.sload
+      (initialState contract tx storage slots).toState
+      (natToUInt256 slot)).2 =
+      storage (IRStorageSlot.ofNat slot) := by
+  have hFindStorage :
+      (projectStorage storage slots).find? (natToUInt256 slot) =
+        some (storage (IRStorageSlot.ofNat slot)) := by
+    simpa [projectStorage, IRStorageWord.toUInt256] using
+      foldl_insert_find_projected storage slots slot hSlot
+        (Batteries.RBMap.empty : EvmYul.Storage)
+  simp only [EvmYul.State.sload, EvmYul.State.lookupAccount,
+    EvmYul.Yul.State.toState, initialState, toSharedState, YulState.initial]
+  rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
+  rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
+  change (Batteries.RBMap.find? (projectStorage storage slots)
+      (natToUInt256 slot)).getD ⟨0⟩ = storage (IRStorageSlot.ofNat slot)
+  rw [hFindStorage]
+  rfl
+
+/-- Projected storage is unchanged by the generated retrieve core
+    `sload(0); mstore(0, _); return(0, 32)`. The only `sload` state effect is
+    recording an accessed storage key, and `mstore`/`return` update only the
+    machine-state fields used for returndata. -/
+theorem projectStorageFromState_retrieveHit_initialState_materialized
+    (contract : EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (slots : List Nat)
+    (store : EvmYul.Yul.VarStore)
+    (slot : Nat)
+    (hSlot : slot ∈ slots) :
+    let shared := (initialState contract tx storage slots).sharedState
+    let p := shared.sload (EvmYul.UInt256.ofNat 0)
+    let shared1 : EvmYul.SharedState .Yul := { shared with toState := p.1 }
+    let shared2 : EvmYul.SharedState .Yul :=
+      { shared1 with
+        toMachineState :=
+          shared1.toMachineState.mstore (EvmYul.UInt256.ofNat 0) p.2 }
+    let shared3 : EvmYul.SharedState .Yul :=
+      { shared2 with
+        toMachineState :=
+          shared2.toMachineState.evmReturn
+            (EvmYul.UInt256.ofNat 0) (EvmYul.UInt256.ofNat 32) }
+    projectStorageFromState tx (EvmYul.Yul.State.Ok shared3 store)
+        (IRStorageSlot.ofNat slot) =
+      storage (IRStorageSlot.ofNat slot) := by
+  intro shared p shared1 shared2 shared3
+  have hAccountMap :
+      shared3.accountMap =
+        (initialState contract tx storage slots).sharedState.accountMap := by
+    simp [shared3, shared2, shared1, p, shared, EvmYul.State.sload,
+      EvmYul.State.addAccessedStorageKey, EvmYul.Substate.addAccessedStorageKey]
+  simp only [projectStorageFromState, extractStorage,
+    EvmYul.Yul.State.sharedState, hAccountMap, initialState, YulState.initial,
+    toSharedState]
+  rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
+  rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
+  have h := storageLookup_projectStorage_projected storage slots slot hSlot
+  unfold storageLookup at h
+  exact h
+
 /-- Native `sload` from an initially omitted materialized slot returns the EVM
     zero word. The range hypotheses rule out modular aliasing between the omitted
     slot and any materialized storage key. -/

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -94,7 +94,10 @@ def materializedStorageSlots
     (runtimeCode : List YulStmt)
     (observableSlots : List Nat) :
     List Nat :=
-  yulStmtsLiteralStorageReadSlots runtimeCode ++ observableSlots
+  -- Slot zero is the common simple-storage getter slot and is harmless to
+  -- materialize twice; keeping it explicit avoids depending on the opaque
+  -- partial literal-read collector for baseline storage projection facts.
+  0 :: yulStmtsLiteralStorageReadSlots runtimeCode ++ observableSlots
 
 /-! ## Native Environment Support Boundary -/
 

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSmokeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSmokeTest.lean
@@ -4,7 +4,7 @@ import EvmYul.Yul.Interpreter
 namespace Compiler.Proofs.YulGeneration.Backends
 
 open Compiler.Yul
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 
 private def runNativeProgram (stmts : List YulStmt) : Option EvmYul.Yul.State :=
   match lowerStmtsNative stmts with
@@ -34,9 +34,9 @@ private def sampleTx : Compiler.Proofs.YulGeneration.YulTransaction :=
     functionSelector := 0x01020304
     args := [41] }
 
-private def zeroStorage : Nat → IRStorageWord := fun _ => IRStorageWord.ofNat 0
+private def zeroStorage : IRStorageSlot → IRStorageWord := fun _ => IRStorageWord.ofNat 0
 
-private def seededStorage : Nat → IRStorageWord := fun slot =>
+private def seededStorage : IRStorageSlot → IRStorageWord := fun slot =>
   if slot = 7 then IRStorageWord.ofNat 77 else IRStorageWord.ofNat 0
 
 private def wordByteArray (value : Nat) : ByteArray :=
@@ -54,7 +54,7 @@ private def stateWithLogEntries (entries : List EvmYul.LogEntry) : EvmYul.Yul.St
   .Ok { shared with substate := { shared.substate with logSeries := entries.toArray } } ∅
 
 private def stateWithStorageLogReturn
-    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
+    (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
     (entries : List EvmYul.LogEntry) (returnWord : Nat) : EvmYul.Yul.State :=
   let shared := StateBridge.toSharedState
     (Compiler.Proofs.YulGeneration.YulState.initial sampleTx storage) observableSlots
@@ -73,7 +73,8 @@ private def nativeStoresBuiltinWithTx
     .let_ "v" (.call builtin []),
     .expr (.call "sstore" [.lit slot, .ident "v"])
   ] tx zeroStorage [slot] with
-  | .ok result => result.success && result.finalStorage slot == IRStorageWord.ofNat expected
+  | .ok result =>
+      result.success && result.finalStorage (IRStorageSlot.ofNat slot) == IRStorageWord.ofNat expected
   | .error _ => false
 
 private def nativeStoresBuiltin (builtin : String) (slot expected : Nat) : Bool :=
@@ -151,7 +152,7 @@ private def nativeAllowsUserFunctionNamedChainid : Bool :=
 
 private def referenceRuntimeWithFuel
     (fuel : Nat) (stmts : List YulStmt) (tx : Compiler.Proofs.YulGeneration.YulTransaction)
-    (storage : Nat → IRStorageWord) (events : List (List Nat)) :
+    (storage : IRStorageSlot → IRStorageWord) (events : List (List Nat)) :
     Compiler.Proofs.YulGeneration.YulResult :=
   let initialState := Compiler.Proofs.YulGeneration.YulState.initial tx storage events
   match Compiler.Proofs.YulGeneration.execYulFuel fuel initialState (.stmts stmts) with
@@ -186,7 +187,9 @@ private def resultsMatchOnSlots
   nativeResult.success == referenceResult.success &&
     nativeResult.returnValue == referenceResult.returnValue &&
     nativeResult.events == referenceResult.events &&
-    slots.all (fun slot => nativeResult.finalStorage slot == referenceResult.finalStorage slot)
+    slots.all (fun slot =>
+      nativeResult.finalStorage (IRStorageSlot.ofNat slot) ==
+        referenceResult.finalStorage (IRStorageSlot.ofNat slot))
 
 private def nativeMatchesReferenceRuntime
     (stmts : List YulStmt) (observableSlots compareSlots : List Nat) : Bool :=
@@ -211,7 +214,7 @@ private def nativeCopiesSloadToSlot
   match Native.interpretRuntimeNative 128 [
     .expr (.call "sstore" [.lit 8, .call "sload" [.lit 7]])
   ] sampleTx seededStorage observableSlots with
-  | .ok result => result.success && result.finalStorage 8 == IRStorageWord.ofNat expected
+  | .ok result => result.success && result.finalStorage (IRStorageSlot.ofNat 8) == IRStorageWord.ofNat expected
   | .error _ => false
 
 private def nativeCopiesTransientLoadToStorage : Bool :=
@@ -219,7 +222,7 @@ private def nativeCopiesTransientLoadToStorage : Bool :=
     .expr (.call "tstore" [.lit 3, .lit 88]),
     .expr (.call "sstore" [.lit 9, .call "tload" [.lit 3]])
   ] sampleTx zeroStorage [9] with
-  | .ok result => result.success && result.finalStorage 9 == IRStorageWord.ofNat 88
+  | .ok result => result.success && result.finalStorage (IRStorageSlot.ofNat 9) == IRStorageWord.ofNat 88
   | .error _ => false
 
 private def nativeInitialStateInstallsContractAndStorage : Bool :=
@@ -282,12 +285,12 @@ private def nativeStopCommitsStorageAndPreservesEvents : Bool :=
   | .ok result =>
       result.success &&
         result.returnValue.isNone &&
-        result.finalStorage 7 == IRStorageWord.ofNat 99 &&
+        result.finalStorage (IRStorageSlot.ofNat 7) == IRStorageWord.ofNat 99 &&
         result.events == [[1, 2, 3]]
   | .error _ => false
 
 private def nativeReturnHaltProjectsStorageReturnAndEvents : Bool :=
-  let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
+  let finalStorage : IRStorageSlot → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
   let result :=
     Native.projectResult sampleTx seededStorage [[1, 2, 3]]
       (.error (.YulHalt
@@ -295,11 +298,11 @@ private def nativeReturnHaltProjectsStorageReturnAndEvents : Bool :=
         (EvmYul.UInt256.ofNat 1)))
   result.success &&
     result.returnValue == some 44 &&
-    result.finalStorage 7 == IRStorageWord.ofNat 99 &&
+    result.finalStorage (IRStorageSlot.ofNat 7) == IRStorageWord.ofNat 99 &&
     result.events == [[1, 2, 3], [5, 88]]
 
 private def nativeValueResultProjectsStorageReturnAndEvents : Bool :=
-  let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
+  let finalStorage : IRStorageSlot → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
   let result :=
     Native.projectResult sampleTx seededStorage [[1, 2, 3]]
       (.ok
@@ -307,7 +310,7 @@ private def nativeValueResultProjectsStorageReturnAndEvents : Bool :=
           [EvmYul.UInt256.ofNat 44]))
   result.success &&
     result.returnValue == some 44 &&
-    result.finalStorage 7 == IRStorageWord.ofNat 99 &&
+    result.finalStorage (IRStorageSlot.ofNat 7) == IRStorageWord.ofNat 99 &&
     result.events == [[1, 2, 3], [5, 88]]
 
 private def nativeHardErrorRollsBackStorageAndEvents : Bool :=
@@ -318,7 +321,7 @@ private def nativeHardErrorRollsBackStorageAndEvents : Bool :=
       (.error EvmYul.Yul.Exception.OutOfFuel)
   !result.success &&
     result.returnValue.isNone &&
-    result.finalStorage 7 == IRStorageWord.ofNat 5 &&
+    result.finalStorage (IRStorageSlot.ofNat 7) == IRStorageWord.ofNat 5 &&
     result.events == [[1, 2, 3]]
 
 private def nativeRevertErrorRollsBackStorageAndEvents : Bool :=
@@ -329,7 +332,7 @@ private def nativeRevertErrorRollsBackStorageAndEvents : Bool :=
       (.error EvmYul.Yul.Exception.Revert)
   !result.success &&
     result.returnValue.isNone &&
-    result.finalStorage 7 == IRStorageWord.ofNat 5 &&
+    result.finalStorage (IRStorageSlot.ofNat 7) == IRStorageWord.ofNat 5 &&
     result.events == [[1, 2, 3]]
 
 private def dispatchSmokeContract : Compiler.IRContract :=
@@ -834,7 +837,7 @@ example :
       ],
       .expr (.call "sstore" [.lit 7, .call "inc" [.lit 41]])
     ] sampleTx zeroStorage [7] with
-    | .ok result => result.success && result.finalStorage 7 == IRStorageWord.ofNat 42
+    | .ok result => result.success && result.finalStorage (IRStorageSlot.ofNat 7) == IRStorageWord.ofNat 42
     | .error _ => false) = true := by
   native_decide
 
@@ -842,7 +845,7 @@ example :
     (match Native.interpretRuntimeNative 128
       [.expr (.call "sstore" [.lit 7, .lit 99])]
       sampleTx zeroStorage [7] with
-    | .ok result => result.success && result.finalStorage 7 == IRStorageWord.ofNat 99
+    | .ok result => result.success && result.finalStorage (IRStorageSlot.ofNat 7) == IRStorageWord.ofNat 99
     | .error _ => false) = true := by
   native_decide
 
@@ -895,14 +898,14 @@ example :
   native_decide
 
 example :
-    (let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
+    (let finalStorage : IRStorageSlot → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
      let result :=
       Native.projectResult sampleTx seededStorage [[1, 2, 3]]
         (.ok
           (stateWithStorageLogReturn finalStorage [7] [sampleLogEntry [5] 88] 0,
             [EvmYul.UInt256.ofNat 44]))
      result.finalMappings) =
-    (let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
+    (let finalStorage : IRStorageSlot → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
      let result :=
       Native.projectResult sampleTx seededStorage [[1, 2, 3]]
         (.ok
@@ -912,14 +915,14 @@ example :
   rfl
 
 example :
-    (let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
+    (let finalStorage : IRStorageSlot → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
      let result :=
       Native.projectResult sampleTx seededStorage [[1, 2, 3]]
         (.error (.YulHalt
           (stateWithStorageLogReturn finalStorage [7] [sampleLogEntry [5] 88] 44)
           (EvmYul.UInt256.ofNat 1)))
      result.finalMappings) =
-    (let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
+    (let finalStorage : IRStorageSlot → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
      let result :=
       Native.projectResult sampleTx seededStorage [[1, 2, 3]]
         (.error (.YulHalt
@@ -1165,7 +1168,7 @@ example :
         [[1, 2, 3]]
         (.error EvmYul.Yul.Exception.Revert)
      !result.success &&
-       result.finalStorage 7 == IRStorageWord.ofNat 5 &&
+       result.finalStorage (IRStorageSlot.ofNat 7) == IRStorageWord.ofNat 5 &&
        result.events == [[1, 2, 3]]) = true := by
   native_decide
 

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanRetarget.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanRetarget.lean
@@ -328,7 +328,7 @@ private theorem backends_agree_calldatasize s se mv ta bt bn ci bb sl cd av :
   | _ :: _ => rfl
 
 -- Unary builtin: sload (state-dependent, routed through the same
--- `storage : Nat → IRStorageWord` lookup used by Verity's `evalBuiltinCallWithContext`)
+-- `storage : IRStorageSlot → IRStorageWord` lookup used by Verity's `evalBuiltinCallWithContext`)
 private theorem backends_agree_sload s se mv ta bt bn ci bb sl cd av :
     evalBuiltinCallWithBackendContext .verity s se mv ta bt bn ci bb sl cd "sload" av =
     evalBuiltinCallWithBackendContext .evmYulLean s se mv ta bt bn ci bb sl cd "sload" av := by
@@ -368,7 +368,7 @@ All bridged builtin dependencies are fully proven in `EvmYulLeanBridgeLemmas.lea
     This theorem is sorry-free, composing the fully proven per-builtin bridge
     lemmas in `EvmYulLeanBridgeLemmas.lean`. -/
 theorem backends_agree_on_bridged_builtins
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat)
     (func : String) (argVals : List Nat)
     (hBridged : func ∈ bridgedBuiltins) :
@@ -440,7 +440,7 @@ set_option maxHeartbeats 1000000 in
     program that evaluates `keccak256(...)` through this interpreter halts
     identically on both sides.  -/
 private theorem backends_agree_on_keccak256
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) (argVals : List Nat) :
     evalBuiltinCallWithBackendContext .verity storage sender msgValue thisAddress
@@ -2655,7 +2655,7 @@ noncomputable def execYulStmtsWithBackend
 noncomputable def interpretYulRuntimeWithBackendFuel
     (backend : BuiltinBackend) (fuel : Nat)
     (runtimeCode : List Compiler.Yul.YulStmt)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (events : List (List Nat) := []) :
     YulResult :=
   let initialState := YulState.initial tx storage events
@@ -2664,7 +2664,7 @@ noncomputable def interpretYulRuntimeWithBackendFuel
 
 noncomputable def interpretYulRuntimeWithBackend
     (backend : BuiltinBackend) (runtimeCode : List Compiler.Yul.YulStmt)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (events : List (List Nat) := []) :
     YulResult :=
   interpretYulRuntimeWithBackendFuel backend (sizeOf runtimeCode + 1)
@@ -2672,7 +2672,7 @@ noncomputable def interpretYulRuntimeWithBackend
 
 @[simp] theorem interpretYulRuntimeWithBackend_eq_fuel
     (backend : BuiltinBackend) (runtimeCode : List Compiler.Yul.YulStmt)
-    (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (events : List (List Nat) := []) :
     interpretYulRuntimeWithBackend backend runtimeCode tx storage events =
       interpretYulRuntimeWithBackendFuel backend (sizeOf runtimeCode + 1)
@@ -2681,7 +2681,7 @@ noncomputable def interpretYulRuntimeWithBackend
 
 theorem interpretYulRuntimeWithBackend_verity_eq
     (runtimeCode : List Compiler.Yul.YulStmt) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (events : List (List Nat) := []) :
+    (storage : IRStorageSlot → IRStorageWord) (events : List (List Nat) := []) :
     interpretYulRuntimeWithBackend .verity runtimeCode tx storage events =
     interpretYulRuntime runtimeCode tx storage events := by
   unfold interpretYulRuntimeWithBackend interpretYulRuntimeWithBackendFuel

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
@@ -684,6 +684,69 @@ theorem foldl_insert_find (storage : IRStorageSlot → IRStorageWord)
     | inr hmem =>
       exact ih hmem (fun s hs => hRange s (List.mem_cons_of_mem _ hs)) _
 
+/-- Equal projected EVM storage keys denote equal bounded IR storage slots. -/
+theorem IRStorageSlot_ofNat_eq_of_natToUInt256_eq {a b : Nat}
+    (h : natToUInt256 a = natToUInt256 b) :
+    IRStorageSlot.ofNat a = IRStorageSlot.ofNat b := by
+  simpa [natToUInt256, IRStorageSlot.ofNat] using h
+
+/-- Folding projected storage slots preserves an already-correct lookup for a
+    bounded target key. Any later Nat alias for the same EVM key writes the same
+    bounded IR slot value, so no Nat range/injectivity hypothesis is needed. -/
+theorem foldl_insert_preserves_find_projected_value
+    (storage : IRStorageSlot → IRStorageWord)
+    (slots : List Nat) (slot : Nat) (acc : EvmYul.Storage)
+    (hAcc :
+      acc.find? (natToUInt256 slot) =
+        some (IRStorageWord.toUInt256 (storage (IRStorageSlot.ofNat slot)))) :
+    (slots.foldl (fun m s =>
+        m.insert (natToUInt256 s)
+          (IRStorageWord.toUInt256 (storage (IRStorageSlot.ofNat s)))) acc).find?
+      (natToUInt256 slot) =
+        some (IRStorageWord.toUInt256 (storage (IRStorageSlot.ofNat slot))) := by
+  induction slots generalizing acc with
+  | nil => exact hAcc
+  | cons hd tl ih =>
+      simp only [List.foldl_cons]
+      by_cases hcmp : compare (natToUInt256 slot) (natToUInt256 hd) = Ordering.eq
+      · have hkey : natToUInt256 slot = natToUInt256 hd :=
+          UInt256_eq_of_compare_eq hcmp
+        have hslot : IRStorageSlot.ofNat hd = IRStorageSlot.ofNat slot :=
+          (IRStorageSlot_ofNat_eq_of_natToUInt256_eq hkey.symm)
+        apply ih
+        rw [Batteries.RBMap.find?_insert_of_eq _ hcmp]
+        simp [hslot]
+      · apply ih
+        rw [Batteries.RBMap.find?_insert_of_ne _ hcmp]
+        exact hAcc
+
+/-- Helper: after folding a suffix of Nat slots into an accumulator, if `slot`
+    appears in that suffix, then the accumulated projected map contains the
+    bounded value for `slot`.
+
+    Unlike `foldl_insert_find`, this form intentionally has no Nat range
+    hypothesis. Distinct Nat slots that alias modulo 2^256 map to the same
+    `IRStorageSlot`, so a later aliased insert writes the same value. -/
+theorem foldl_insert_find_projected (storage : IRStorageSlot → IRStorageWord)
+    (slots : List Nat) (slot : Nat) (hSlot : slot ∈ slots)
+    (acc : EvmYul.Storage) :
+    (slots.foldl (fun m s =>
+        m.insert (natToUInt256 s)
+          (IRStorageWord.toUInt256 (storage (IRStorageSlot.ofNat s)))) acc).find?
+      (natToUInt256 slot) =
+        some (IRStorageWord.toUInt256 (storage (IRStorageSlot.ofNat slot))) := by
+  induction slots generalizing acc with
+  | nil => exact absurd hSlot List.not_mem_nil
+  | cons hd tl ih =>
+      simp only [List.foldl_cons]
+      cases List.mem_cons.mp hSlot with
+      | inl heq =>
+          subst heq
+          apply foldl_insert_preserves_find_projected_value
+          rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
+      | inr hmem =>
+          exact ih hmem _
+
 /-- Storage lookup commutes: reading a slot from the projected storage
     yields the same value as reading it from Verity's storage function.
 
@@ -693,11 +756,21 @@ theorem foldl_insert_find (storage : IRStorageSlot → IRStorageWord)
     last-write-wins semantics of `foldl` would make the theorem false. -/
 theorem storageLookup_projectStorage (storage : IRStorageSlot → IRStorageWord)
     (slots : List Nat) (slot : Nat) (hSlot : slot ∈ slots)
-    (hRange : ∀ s ∈ slots, s < UInt256.size) :
+    (_hRange : ∀ s ∈ slots, s < UInt256.size) :
     storageLookup (projectStorage storage slots) (natToUInt256 slot) =
       storage (IRStorageSlot.ofNat slot) := by
   simp only [storageLookup, projectStorage]
-  rw [foldl_insert_find storage slots slot hSlot hRange]
+  rw [foldl_insert_find_projected storage slots slot hSlot]
+  rfl
+
+/-- Range-free storage lookup for projected bounded IR storage. -/
+theorem storageLookup_projectStorage_projected
+    (storage : IRStorageSlot → IRStorageWord)
+    (slots : List Nat) (slot : Nat) (hSlot : slot ∈ slots) :
+    storageLookup (projectStorage storage slots) (natToUInt256 slot) =
+      storage (IRStorageSlot.ofNat slot) := by
+  simp only [storageLookup, projectStorage]
+  rw [foldl_insert_find_projected storage slots slot hSlot]
   rfl
 
 /-- Nat→UInt256→Nat round-trip for values in range.

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
@@ -39,7 +39,7 @@ import Batteries.Data.RBMap.Lemmas
 namespace Compiler.Proofs.YulGeneration.Backends.StateBridge
 
 open Compiler.Proofs.YulGeneration
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 open EvmYul
 
 /-! ## Nat ↔ UInt256 Conversions -/
@@ -105,14 +105,12 @@ def storageWrite (s : EvmYul.Storage) (slot val : UInt256) : EvmYul.Storage :=
 
 /-- Project a finite set of Verity storage slots into an EVMYulLean Storage map.
 
-**Range precondition**: Callers must ensure all slots satisfy `slot < UInt256.size`
-(equivalently `slot < 2^256`). Without this, distinct `Nat` slots differing by
-multiples of `2^256` alias to the same RBMap key via `natToUInt256`. The
-`storageLookup_projectStorage` theorem enforces this via its `hRange` hypothesis. -/
-def projectStorage (storage : Nat → IRStorageWord) (slots : List Nat) : EvmYul.Storage :=
+Nat slot inputs are normalized through `IRStorageSlot.ofNat`, matching the
+EVMYulLean `UInt256` key used in the projected map. -/
+def projectStorage (storage : IRStorageSlot → IRStorageWord) (slots : List Nat) : EvmYul.Storage :=
   slots.foldl (init := Batteries.RBMap.empty) fun acc slot =>
     let key := natToUInt256 slot
-    let val := IRStorageWord.toUInt256 (storage slot)
+    let val := IRStorageWord.toUInt256 (storage (IRStorageSlot.ofNat slot))
     acc.insert key val
 
 /-! ## Execution Environment Bridge
@@ -458,15 +456,14 @@ def toSharedState (state : YulState) (observableSlots : List Nat) :
 /-- Extract observable storage from an EVMYulLean state for the contract
     at the given address. Returns the Verity-style storage function.
 
-**Range note**: `natToUInt256` reduces `slot` modulo `2^256`, so queries
-at `slot >= 2^256` alias onto low-bit keys. Bridge equivalence proofs
-should carry an in-range hypothesis (`slot < UInt256.size`). -/
+The bounded IR slot is already the EVM storage key, so extraction is lossless
+with respect to the IR storage domain. -/
 def extractStorage (sharedState : SharedState .Yul) (addr : AccountAddress) :
-    Nat → IRStorageWord :=
+    IRStorageSlot → IRStorageWord :=
   fun slot =>
     match sharedState.accountMap.find? addr with
     | some account =>
-      match account.storage.find? (natToUInt256 slot) with
+      match account.storage.find? (IRStorageSlot.toUInt256 slot) with
       | some val => val
       | none => 0
     | none => 0
@@ -640,12 +637,12 @@ theorem compare_natToUInt256_ne {a b : Nat}
 
 /-- Helper: folding inserts over a list of slots that does NOT contain `slot`
     preserves whatever `find?` value the accumulator had for `natToUInt256 slot`. -/
-theorem foldl_insert_find_not_mem (storage : Nat → IRStorageWord)
+theorem foldl_insert_find_not_mem (storage : IRStorageSlot → IRStorageWord)
     (slots : List Nat) (slot : Nat) (hNotMem : slot ∉ slots)
     (hRange : ∀ s ∈ slots, s < UInt256.size)
     (hSlotRange : slot < UInt256.size)
     (acc : EvmYul.Storage) :
-    (slots.foldl (fun m s => m.insert (natToUInt256 s) (IRStorageWord.toUInt256 (storage s))) acc).find?
+    (slots.foldl (fun m s => m.insert (natToUInt256 s) (IRStorageWord.toUInt256 (storage (IRStorageSlot.ofNat s)))) acc).find?
       (natToUInt256 slot) = acc.find? (natToUInt256 slot) := by
   induction slots generalizing acc with
   | nil => rfl
@@ -663,12 +660,12 @@ theorem foldl_insert_find_not_mem (storage : Nat → IRStorageWord)
 
     This generalizes `storageLookup_projectStorage` to work with any
     accumulator (not just `empty`), which is needed for the induction. -/
-theorem foldl_insert_find (storage : Nat → IRStorageWord)
+theorem foldl_insert_find (storage : IRStorageSlot → IRStorageWord)
     (slots : List Nat) (slot : Nat) (hSlot : slot ∈ slots)
     (hRange : ∀ s ∈ slots, s < UInt256.size)
     (acc : EvmYul.Storage) :
-    (slots.foldl (fun m s => m.insert (natToUInt256 s) (IRStorageWord.toUInt256 (storage s))) acc).find?
-      (natToUInt256 slot) = some (IRStorageWord.toUInt256 (storage slot)) := by
+    (slots.foldl (fun m s => m.insert (natToUInt256 s) (IRStorageWord.toUInt256 (storage (IRStorageSlot.ofNat s)))) acc).find?
+      (natToUInt256 slot) = some (IRStorageWord.toUInt256 (storage (IRStorageSlot.ofNat slot))) := by
   induction slots generalizing acc with
   | nil => exact absurd hSlot List.not_mem_nil
   | cons hd tl ih =>
@@ -694,11 +691,11 @@ theorem foldl_insert_find (storage : Nat → IRStorageWord)
     slot list (EVM storage slots are always < 2^256). Without it, two
     distinct Nat slots could collide under modular reduction and the
     last-write-wins semantics of `foldl` would make the theorem false. -/
-theorem storageLookup_projectStorage (storage : Nat → IRStorageWord)
+theorem storageLookup_projectStorage (storage : IRStorageSlot → IRStorageWord)
     (slots : List Nat) (slot : Nat) (hSlot : slot ∈ slots)
     (hRange : ∀ s ∈ slots, s < UInt256.size) :
     storageLookup (projectStorage storage slots) (natToUInt256 slot) =
-      storage slot := by
+      storage (IRStorageSlot.ofNat slot) := by
   simp only [storageLookup, projectStorage]
   rw [foldl_insert_find storage slots slot hSlot hRange]
   rfl

--- a/Compiler/Proofs/YulGeneration/Equivalence.lean
+++ b/Compiler/Proofs/YulGeneration/Equivalence.lean
@@ -48,7 +48,8 @@ def resultsMatchOn (slots : List Nat) (mappingKeys : List (Nat × Nat))
     (ir : IRResult) (yul : YulResult) : Bool :=
   ir.success == yul.success &&
   ir.returnValue == yul.returnValue &&
-  slots.all (fun slot => ir.finalStorage slot == yul.finalStorage slot) &&
+  slots.all (fun slot =>
+    ir.finalStorage (IRStorageSlot.ofNat slot) == yul.finalStorage (IRStorageSlot.ofNat slot)) &&
   mappingKeys.all (fun (base, key) => ir.finalMappings base key == yul.finalMappings base key) &&
   ir.events == yul.events
 

--- a/Compiler/Proofs/YulGeneration/Preservation.lean
+++ b/Compiler/Proofs/YulGeneration/Preservation.lean
@@ -27,7 +27,7 @@ See `TRUST_ASSUMPTIONS.md` for the full trust-boundary description.
   rfl
 
 @[simp] private theorem interpretYulRuntime_eq_yulResultOfExecWithRollback_initial
-    (runtimeCode : List YulStmt) (tx : YulTransaction) (storage : Nat → IRStorageWord)
+    (runtimeCode : List YulStmt) (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (events : List (List Nat)) :
     interpretYulRuntime runtimeCode tx storage events =
       yulResultOfExecWithRollback (YulState.initial tx storage events)

--- a/Compiler/Proofs/YulGeneration/ReferenceOracle/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/ReferenceOracle/Builtins.lean
@@ -16,7 +16,7 @@ current retargeting path; this file is not part of that trust boundary.
 -/
 
 open Compiler.Proofs
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 export Compiler.Constants (evmModulus selectorModulus selectorShift)
 
 /-- Auxiliary loop for modular exponentiation via repeated squaring.
@@ -36,7 +36,7 @@ def natModPow (base exp modulus : Nat) : Nat :=
   else modPowAux modulus (base % modulus) exp 1
 
 def evalBuiltinCallWithContext
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (sender : Nat)
     (msgValue : Nat)
     (thisAddress : Nat)
@@ -257,7 +257,7 @@ abbrev defaultBuiltinBackend : BuiltinBackend := .verity
 
 def evalBuiltinCallWithBackendContext
     (backend : BuiltinBackend)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (sender : Nat)
     (msgValue : Nat)
     (thisAddress : Nat)
@@ -312,7 +312,7 @@ def evalBuiltinCallWithBackendContext
 
 def evalBuiltinCallWithBackend
     (backend : BuiltinBackend)
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (sender : Nat)
     (selector : Nat)
     (calldata : List Nat)
@@ -321,7 +321,7 @@ def evalBuiltinCallWithBackend
   evalBuiltinCallWithBackendContext backend storage sender 0 0 0 0 0 0 selector calldata func argVals
 
 def evalBuiltinCall
-    (storage : Nat → IRStorageWord)
+    (storage : IRStorageSlot → IRStorageWord)
     (sender : Nat)
     (selector : Nat)
     (calldata : List Nat)
@@ -330,60 +330,60 @@ def evalBuiltinCall
   evalBuiltinCallWithContext storage sender 0 0 0 0 0 0 selector calldata func argVals
 
 @[simp] theorem evalBuiltinCall_callvalue_nil
-    (storage : Nat → IRStorageWord) (sender thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender 0 thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "callvalue" [] =
       some 0 := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_callvalue_context
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "callvalue" [] =
       some (msgValue % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_calldatasize_nil
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) :
     evalBuiltinCall storage sender selector calldata "calldatasize" [] =
       some ((4 + calldata.length * 32) % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_caller_nil
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (calldata : List Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (calldata : List Nat) :
     evalBuiltinCall storage sender selector calldata "caller" [] = some sender := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_address_nil
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "address" [] =
       some (thisAddress % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_timestamp_nil
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "timestamp" [] =
       some (blockTimestamp % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_number_nil
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "number" [] =
       some (blockNumber % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_chainid_nil
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "chainid" [] =
       some (chainId % evmModulus) := by
   simp [evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCall_blobbasefee_nil
-    (storage : Nat → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
+    (storage : IRStorageSlot → IRStorageWord) (sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector : Nat)
     (calldata : List Nat) :
     evalBuiltinCallWithContext storage sender msgValue thisAddress blockTimestamp blockNumber chainId blobBaseFee selector calldata "blobbasefee" [] =
       some (blobBaseFee % evmModulus) := by
@@ -395,12 +395,12 @@ def evalBuiltinCall
   simp [calldataloadWord]
 
 @[simp] theorem evalBuiltinCall_calldataload_offset4_single
-    (storage : Nat → IRStorageWord) (sender selector value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector value : Nat) :
     evalBuiltinCall storage sender selector [value] "calldataload" [4] = some (value % evmModulus) := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext, calldataloadWord]
 
 @[simp] theorem evalBuiltinCallWithBackend_calldataload_offset4_single
-    (storage : Nat → IRStorageWord) (sender selector value : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector value : Nat) :
     evalBuiltinCallWithBackend
         defaultBuiltinBackend
         storage
@@ -414,13 +414,13 @@ def evalBuiltinCall
     calldataloadWord]
 
 @[simp] theorem evalBuiltinCall_sload_single
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (slot : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (slot : Nat) :
     evalBuiltinCall storage sender selector [] "sload" [slot] =
       some (Compiler.Proofs.abstractLoadStorageOrMapping storage slot).toNat := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackend_sload_single
-    (storage : Nat → IRStorageWord) (sender selector : Nat) (slot : Nat) :
+    (storage : IRStorageSlot → IRStorageWord) (sender selector : Nat) (slot : Nat) :
     evalBuiltinCallWithBackend
         defaultBuiltinBackend
         storage

--- a/Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
+++ b/Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
@@ -73,7 +73,7 @@ structure YulTransaction where
     (YulTransaction.ofIR tx).args = tx.args := rfl
 
 /-- Initial state for Yul execution. -/
-def YulState.initial (tx : YulTransaction) (storage : Nat → IRStorageWord)
+def YulState.initial (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
     (events : List (List Nat) := []) : YulState :=
   { vars := []
     storage := storage
@@ -342,13 +342,13 @@ noncomputable def execYulStmts (state : YulState) (stmts : List YulStmt) : YulEx
 structure YulResult where
   success : Bool
   returnValue : Option Nat
-  finalStorage : Nat → IRStorageWord
+  finalStorage : IRStorageSlot → IRStorageWord
   finalMappings : Nat → Nat → IRStorageWord
   events : List (List Nat)
 
 /-- Execute a Yul runtime program with selector-aware calldata -/
 noncomputable def interpretYulRuntime (runtimeCode : List YulStmt) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (events : List (List Nat) := []) : YulResult :=
+    (storage : IRStorageSlot → IRStorageWord) (events : List (List Nat) := []) : YulResult :=
   let initialState := YulState.initial tx storage events
   match execYulStmts initialState runtimeCode with
   | .continue s =>
@@ -378,7 +378,7 @@ noncomputable def interpretYulRuntime (runtimeCode : List YulStmt) (tx : YulTran
 
 /-- Interpret a Yul object by executing its runtime code. -/
 noncomputable def interpretYulObject (obj : YulObject) (tx : YulTransaction)
-    (storage : Nat → IRStorageWord) (events : List (List Nat) := []) : YulResult :=
+    (storage : IRStorageSlot → IRStorageWord) (events : List (List Nat) := []) : YulResult :=
   interpretYulRuntime obj.runtimeCode tx storage events
 
 end Compiler.Proofs.YulGeneration

--- a/Compiler/Proofs/YulGeneration/ReferenceOracle/State.lean
+++ b/Compiler/Proofs/YulGeneration/ReferenceOracle/State.lean
@@ -2,13 +2,13 @@ import Compiler.Proofs.IRGeneration.IRStorageWord
 
 namespace Compiler.Proofs.YulGeneration
 
-open Compiler.Proofs.IRGeneration (IRStorageWord)
+open Compiler.Proofs.IRGeneration (IRStorageWord IRStorageSlot)
 
 /-! Shared state structures for the reference-oracle Yul runtime. -/
 
 structure YulState where
   vars : List (String × Nat)
-  storage : Nat → IRStorageWord
+  storage : IRStorageSlot → IRStorageWord
   transientStorage : Nat → Nat := fun _ => 0
   memory : Nat → Nat
   calldata : List Nat

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -124,9 +124,9 @@ private def mkRandomTx (extFns : List FunctionSpec) (selectors : List Nat)
     let (args, seed3) := genArgs fn.params.length seed2
     ({ sender := sender, functionSelector := selector, args := args }, seed3)
 
-private def seededStorage (seed : Nat) (slotIdx : Nat) : Nat :=
-  let mix := seed + slotIdx * 0x9e3779b97f4a7c15 + 0xbf58476d1ce4e5b9
-  mix % (2 ^ 256)
+private def seededStorage (seed : Nat) (slotIdx : IRStorageSlot) : IRStorageWord :=
+  let mix := seed + slotIdx.toNat * 0x9e3779b97f4a7c15 + 0xbf58476d1ce4e5b9
+  IRStorageWord.ofNat mix
 
 private def observedSlotsForTx (spec : CompilationModel) (_tx : IRTransaction) : List Nat :=
   (canonicalFieldSlots spec ++ writeSlots spec).eraseDups

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -161,9 +161,9 @@ private def fuzzStorageEntries : List Nat → FuzzRng → FuzzRng × List (Nat �
       let (rng, tail) := fuzzStorageEntries rest rng
       (rng, (slotIdx, value) :: tail)
 
-private def storageOfEntries (entries : List (Nat × Nat)) : Nat → IRStorageWord :=
+private def storageOfEntries (entries : List (Nat × Nat)) : IRStorageSlot → IRStorageWord :=
   fun slotIdx =>
-    match entries.find? (fun entry => entry.1 == slotIdx) with
+    match entries.find? (fun entry => IRStorageSlot.ofNat entry.1 == slotIdx) with
     | some (_, value) => IRStorageWord.ofNat value
     | none => IRStorageWord.ofNat 0
 
@@ -185,7 +185,8 @@ private def sampledResultsMatch
   ir.success == yul.success &&
   ir.returnValue == yul.returnValue &&
   ir.events == yul.events &&
-  slots.all (fun slotIdx => ir.finalStorage slotIdx == yul.finalStorage slotIdx) &&
+  slots.all (fun slotIdx =>
+    ir.finalStorage (IRStorageSlot.ofNat slotIdx) == yul.finalStorage (IRStorageSlot.ofNat slotIdx)) &&
   bases.all (fun base => keys.all (fun key => ir.finalMappings base key == yul.finalMappings base key))
 
 private def roundTripTrialsPerFunction : Nat := 1

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -762,6 +762,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail_callvalue_strip_error
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail2_lt_strip_error
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail3_closed
+#print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBody_halt
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageBuildSwitchSourceCases_lowered_concrete
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_selectorMiss_revert
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_storeHit_error_via_reduction
@@ -776,6 +777,10 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail2
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail3
+#print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherFuel_ge_25
+#print axioms Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_retrieveHit
+#print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
+#print axioms Compiler.Proofs.EndToEnd.projectResult_retrieveHit_eq
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeCallDispatcherBridge_of_per_case
 #print axioms Compiler.Proofs.EndToEnd.simpleStorage_endToEnd_evmYulLean
 #print axioms Compiler.Proofs.EndToEnd.simpleStorage_endToEnd_native_evmYulLean_of_callDispatcher_bridge
@@ -3526,4 +3531,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3350 theorems/lemmas (2419 public, 931 private, 0 sorry'd)
+-- Total: 3355 theorems/lemmas (2424 public, 931 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3155,6 +3155,8 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState_missingAccount
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.initialState_observableStorageSlot
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.initialState_sload_observableSlot_value
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.initialState_sload_materializedSlot_value
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState_retrieveHit_initialState_materialized
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.initialState_sload_omittedSlot_value
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.primCall_sload_initialState_observableSlot_ok
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.primCall_sload_initialState_omittedSlot_ok
@@ -3510,7 +3512,11 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.compare_natToUInt256_ne
 #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.foldl_insert_find_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.foldl_insert_find
+#print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.IRStorageSlot_ofNat_eq_of_natToUInt256_eq
+#print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.foldl_insert_preserves_find_projected_value
+#print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.foldl_insert_find_projected
 #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.storageLookup_projectStorage
+#print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.storageLookup_projectStorage_projected
 #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.uint256_roundtrip
 
 -- Compiler/Proofs/YulGeneration/Equivalence.lean
@@ -3551,4 +3557,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3375 theorems/lemmas (2431 public, 944 private, 0 sorry'd)
+-- Total: 3381 theorems/lemmas (2437 public, 944 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1460,16 +1460,29 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- #print axioms Compiler.Proofs.IRGeneration.encodeStorageAt_writeUintSlots_other  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.encodeStorageAt_writeUintKeyedMappingSlots_singleton_other  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_other  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.toNat_ofNat_wordNormalize  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.toNat_ofNat_wordNormalize_arg  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat_wordNormalize  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.wordNormalize_lt_evmModulus  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.toNat_ofNat_of_lt  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.ne_toNat_wordNormalize_of_ne_ofNat  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.ne_toNat_of_ne_ofNat_of_lt  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.uint256_add_val_eq_mod  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.mappingWordTargetSlot_eq_uint256_add  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.mapping2WordTargetSlot_eq_uint256_add  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_other  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_other  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.wordNormalize_idem  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.findResolvedFieldAtSlotCopyFrom_wordNormalize  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.findResolvedFieldAtSlotCopy_wordNormalize  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.findResolvedFieldAtSlot_go_eq_copy  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.findResolvedFieldAtSlotCopy_eq  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.findDynamicArrayElementAtSlot_scanElements_eq_copy  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.findDynamicArrayElementAtSlot_go_eq_copy  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.findDynamicArrayElementAtSlotCopy_eq  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.findDynamicArrayElementAtSlotCopy_scanElements_wordNormalize  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.findDynamicArrayElementAtSlotCopy_go_wordNormalize  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.findDynamicArrayElementAtSlotCopy_wordNormalize  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.encodeStorageAt_eq_copy  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.fieldWriteEntriesAt_base_mem  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.exists_mem_zipIdx_of_mem  -- private
@@ -1892,6 +1905,12 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.IRGeneration.IRStorageWord.toNat_ofNat
 #print axioms Compiler.Proofs.IRGeneration.IRStorageWord.ofNat_toNat
 #print axioms Compiler.Proofs.IRGeneration.IRStorageWord.toNat_lt_size
+#print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.toNat_ofNat
+#print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.toUInt256_ofNat
+#print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.ofNat_toNat
+#print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.toNat_lt_size
+#print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.eq_of_toNat_eq
+#print axioms Compiler.Proofs.IRGeneration.IRStorageSlot.toNat_ne_of_ne
 
 -- Compiler/Proofs/IRGeneration/ParamLoading.lean
 #print axioms Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
@@ -1921,6 +1940,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.IRGeneration.ParamLoading.exec_genParamLoads_supported_then
 
 -- Compiler/Proofs/IRGeneration/SourceSemantics.lean
+#print axioms Compiler.Proofs.IRGeneration.SourceSemantics.wordNormalize_eq_mod
 #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.exists_splitEventArgsByParams_of_length
 #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.exists_eventFromResolvedArgs?_of_supported_length
 #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.exists_writeUnindexedEventScratch_of_length
@@ -3531,4 +3551,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3355 theorems/lemmas (2424 public, 931 private, 0 sorry'd)
+-- Total: 3375 theorems/lemmas (2431 public, 944 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -781,6 +781,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_retrieveHit
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
 #print axioms Compiler.Proofs.EndToEnd.projectResult_retrieveHit_eq
+#print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeRetrieveHitBridge_proved
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeCallDispatcherBridge_of_per_case
 #print axioms Compiler.Proofs.EndToEnd.simpleStorage_endToEnd_evmYulLean
 #print axioms Compiler.Proofs.EndToEnd.simpleStorage_endToEnd_native_evmYulLean_of_callDispatcher_bridge
@@ -3557,4 +3558,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3381 theorems/lemmas (2437 public, 944 private, 0 sorry'd)
+-- Total: 3382 theorems/lemmas (2438 public, 944 private, 0 sorry'd)

--- a/docs/IR_STORAGE_PHASE2_PLAN.md
+++ b/docs/IR_STORAGE_PHASE2_PLAN.md
@@ -1,0 +1,77 @@
+# IR Storage Refactor — Phase 2 Plan
+
+Phase 2 of [`IR_STORAGE_UINT256_REFACTOR.md`](IR_STORAGE_UINT256_REFACTOR.md):
+discharge `simpleStorageNativeRetrieveHitBridge` once Phase 1 lands the
+`UInt256`-bounded IR storage carrier, then drop the `hRetrieveHit` premise from
+`simpleStorage_endToEnd_native_evmYulLean`.
+
+This file is the working scaffold for the Phase 2 PR. It is plan-only so the
+PR opens against a green build.
+
+## Prerequisite
+
+Phase 1 (#1754) must land first. Phase 2 is a no-op without the bounded carrier
+because the storage-modulo gap is what blocks the bridge.
+
+## Why this becomes provable after Phase 1
+
+After Phase 1, every value flowing through `IRState.storage` is `UInt256`-bounded
+by construction. That eliminates the two structural blockers documented in the
+parent transition note:
+
+1. **Storage-value gap on the projected `finalStorage`.** Native projection
+   applies `% UInt256.size`; the IR oracle reads raw `Nat`. Once the IR carrier
+   is `UInt256`, the modulo becomes the identity on every observable slot —
+   the two sides agree definitionally up to the `IRStorageWord.toNat ∘ ofNat`
+   round-trip lemma exposed by Phase 0.
+2. **Return-value gap from `mstore` byte buffer.** The retrieve-hit return is
+   built by `mstore` of a `UInt256` and re-extracted by `projectHaltReturn` from
+   `state.sharedState.H_return`. With the IR oracle's pre-`mstore` value already
+   `UInt256`-bounded, the `mstore` step is no longer lossy: the same 32 bytes
+   land in the buffer on both sides.
+
+## Phase 2 deliverables
+
+1. Lemma `simpleStorageNativeRetrieveHitBridge_proved` — analogous to the
+   already-discharged `simpleStorageNativeSelectorMissBridge_proved`.
+2. Replace the explicit `hRetrieveHit` premise on
+   `simpleStorage_endToEnd_native_evmYulLean` with the proved lemma.
+3. `PrintAxioms` for the public theorem no longer lists the retrieve-hit
+   bridge.
+4. `Contracts/SimpleStorage/Proofs/` unchanged.
+
+## Proof obligation outline
+
+The current bridge statement (see `Compiler/Proofs/EndToEnd.lean`) reduces, after
+the carrier flip, to:
+- The native dispatcher's hit-case body executes the `sload` against
+  `SharedState.storage`, returns its `UInt256` payload, `mstore`s it to memory
+  at the canonical return offset, and halts with `H_return` covering those 32
+  bytes.
+- The IR oracle's hit-case path computes the same `UInt256` value via
+  `IRStorageWord.toUInt256 ∘ IRState.storage`.
+- After Phase 1, both sides reduce to the same `UInt256` and therefore to the
+  same projected `Nat`. The bridge closes by `rfl` modulo the round-trip
+  lemmas already exported from `IRStorageWord.lean`.
+
+## Risks
+
+- The native side's `mstore`/`H_return` chain still requires byte-level
+  alignment lemmas at the `projectHaltReturn` boundary. Those lemmas exist
+  for the selector-miss case; the retrieve-hit reuse must match offset and
+  length conventions exactly.
+- If Phase 1 leaves any spec theorem reading raw `Nat` from storage at the
+  spec boundary, the retrieve-hit lemma will need a `toNat`-shape adapter.
+
+## Exit criteria
+
+- `simpleStorageNativeRetrieveHitBridge_proved` lands and is invoked at the
+  call site of the former `hRetrieveHit` premise.
+- `simpleStorage_endToEnd_native_evmYulLean` no longer carries `hRetrieveHit`.
+- `PrintAxioms` reflects the drop.
+- `lake build` and `make check` clean.
+
+## Status
+
+Plan-only. Implementation depends on Phase 1 (#1754) landing first. The
+`hStoreHit` premise remains and is handled by Phase 3.

--- a/scripts/check_mapping_slot_boundary.py
+++ b/scripts/check_mapping_slot_boundary.py
@@ -59,10 +59,12 @@ KECCAK_ROUTING_RE = re.compile(
 )
 KECCAK_LOAD_ENTRY_ROUTING_RE = re.compile(
     r"(?:def\s+abstractLoadMappingEntry[\s\S]*?:=\s*(?:let\s+_.*?\n\s*)?storage\s+\(solidityMappingSlot\s+baseSlot\s+key\))"
+    r"|(?:def\s+abstractLoadMappingEntry[\s\S]*?:=\s*(?:let\s+_.*?\n\s*)?storage\s+\(IRStorageSlot\.ofNat\s+\(solidityMappingSlot\s+baseSlot\s+key\)\))"
     r"|(?:def\s+abstractLoadMappingEntry[\s\S]*?\|\s*\.keccak\s*=>\s*storage\s+\(solidityMappingSlot\s+baseSlot\s+key\))"
 )
 KECCAK_STORE_ENTRY_ROUTING_RE = re.compile(
     r"(?:def\s+abstractStoreMappingEntry[\s\S]*?:=\s*fun\s+s\s*=>\s*if\s+s\s*=\s*solidityMappingSlot\s+baseSlot\s+key)"
+    r"|(?:def\s+abstractStoreMappingEntry[\s\S]*?:=\s*fun\s+s\s*=>\s*if\s+s\s*=\s*IRStorageSlot\.ofNat\s+\(solidityMappingSlot\s+baseSlot\s+key\))"
     r"|(?:def\s+abstractStoreMappingEntry[\s\S]*?\|\s*\.keccak\s*=>[\s\S]*?s\s*=\s*solidityMappingSlot\s+baseSlot\s+key)"
 )
 

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -320,6 +320,12 @@ ALLOWLIST: set[str] = {
     # the chained `setMachineState` overrides to extract the 32-byte
     # `H_return` window before computing `projectHaltReturn`.
     "projectResult_retrieveHit_eq",
+    # Phase 2 retrieve-hit bridge closure: composes the closed-form IR result,
+    # native dispatcher halt endpoint, projected-storage preservation, and
+    # EVMYulLean Layer-3 result agreement under the public theorem hypotheses.
+    # Splitting would create several single-use helpers whose proofs are mostly
+    # repeated hypothesis plumbing around the same concrete retrieve path.
+    "simpleStorageNativeRetrieveHitBridge_proved",
     # Safe-body public EVMYulLean wrapper derives the raw BridgedStmts function
     # hypotheses from compile output, static parameter closure, and
     # BridgedSafeStmts witnesses before delegating to the function-bridge

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -278,6 +278,26 @@ ALLOWLIST: set[str] = {
     # while delegating to the lowered native theorem; the long span is the public
     # hypothesis surface, not a large proof script.
     "simpleStorage_endToEnd_native_evmYulLean",
+    # Phase 2 retrieve-hit prerequisites: closed-form interpretIR reduction
+    # over the retrieve body's two-statement form (`mstore(0, sload(0));
+    # return(0, 32)`); the proof must walk the EDSL execIRStmts/execIRStmt
+    # state machine through the call/expr/builtin layers and discharge a
+    # fuel-bound side condition. Cannot be split without exposing internal
+    # IR-evaluation helpers.
+    "interpretIR_simpleStorage_retrieveHit",
+    # Phase 2 retrieve-hit prerequisites: dispatcher-exec halt-form chain.
+    # Composes the body-level closed form with the existing tail3 reduction
+    # endpoint after opening the source-lowered existential and pinning the
+    # switch case shape. The 155-line span is the union of fuel-reshape,
+    # existential-opening, body-state plumbing, and `_via_reduction`'s
+    # decomposition obligation; each piece is mechanical but inseparable.
+    "simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel",
+    # Phase 2 retrieve-hit prerequisites: closed-form `projectResult`
+    # evaluation on the YulHalt halt produced by the lowered retrieve body.
+    # The proof must thread `mstore0_then_return32_*` harness lemmas across
+    # the chained `setMachineState` overrides to extract the 32-byte
+    # `H_return` window before computing `projectHaltReturn`.
+    "projectResult_retrieveHit_eq",
     # Safe-body public EVMYulLean wrapper derives the raw BridgedStmts function
     # hypotheses from compile output, static parameter closure, and
     # BridgedSafeStmts witnesses before delegating to the function-bridge

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -147,7 +147,29 @@ ALLOWLIST: set[str] = {
     # --- Mapping slot and field resolution proofs ---
     "findResolvedFieldAtSlotCopyFrom_of_member",
     "firstFieldWriteSlotConflictCopyFrom_some_of_seen_slot_member",
+    # IRStorageSlot migration: these storage write/state-match proofs grew
+    # because each case now carries both the old source Nat slot reasoning and
+    # the bounded IRStorageSlot normalization bridge. Splitting them further
+    # would duplicate the same `wordNormalize`/`IRStorageSlot.ofNat` plumbing
+    # across one-off local helpers.
+    "runtimeStateMatchesIR_writeUintSlots",
+    "runtimeStateMatchesIR_writeAddressSlot",
+    "runtimeStateMatchesIR_writeAddressKeyedMappingChainSlot",
+    "runtimeStateMatchesIR_writeAddressKeyedMappingSlot",
+    "runtimeStateMatchesIR_writeAddressKeyedMappingWordSlot",
+    "runtimeStateMatchesIR_writeAddressKeyedMappingPackedWordSlot",
+    "runtimeStateMatchesIR_writeAddressKeyedMapping2Slot",
+    "runtimeStateMatchesIR_writeAddressKeyedMapping2WordSlot",
     "encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_eq_written",
+    "encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_eq_written",
+    "encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_written",
+    # Source storage-read steps need to bridge `sload(lit slot)` through
+    # `wordNormalize slot` and then repackage the updated binding/state
+    # invariants. These are four parallel cases for uint/address let/assign.
+    "compiledStmtStep_letStorageField",
+    "compiledStmtStep_letStorageAddrField",
+    "compiledStmtStep_assignStorageField",
+    "compiledStmtStep_assignStorageAddrField",
     # --- Compat scratch lemmas ---
     "compatScratch_not_internalImmutable",
     "compatScratch_startsWith_reserved",


### PR DESCRIPTION
## Summary
- Adds `docs/IR_STORAGE_PHASE2_PLAN.md` — the Phase 2 working scaffold (proof outline, exit criteria).
- **No Lean code changes yet.** The `simpleStorageNativeRetrieveHitBridge_proved` lemma and the drop of the `hRetrieveHit` premise from `simpleStorage_endToEnd_native_evmYulLean` land in subsequent commits on this branch once Phase 1 (#1754) is merged.

## Stacking
Stacked on #1754 (Phase 1 carrier flip), which is itself stacked on #1753 (Phase 0 typed-alias surface). Base of this PR: `codex/ir-storage-phase1-carrier-flip`. Will be retargeted as parents merge.

## Phase 2 scope
See [`docs/IR_STORAGE_PHASE2_PLAN.md`](../blob/codex/ir-storage-phase2-retrieve-hit-discharge/docs/IR_STORAGE_PHASE2_PLAN.md). High-level:
1. Prove `simpleStorageNativeRetrieveHitBridge_proved`, mirroring the already-discharged selector-miss bridge.
2. Replace the explicit `hRetrieveHit` premise on `simpleStorage_endToEnd_native_evmYulLean` with the proved lemma.
3. `PrintAxioms` no longer lists the retrieve-hit bridge.

## Why
Phase 1's `UInt256`-bounded IR storage carrier eliminates the storage-modulo gap and the lossy-`mstore` gap that #1743 documented. With both gaps closed, the retrieve-hit bridge reduces by `rfl` modulo the `IRStorageWord` round-trip lemmas exported from #1753.

## Test plan
- [ ] `lake build` clean.
- [ ] `make check` clean.
- [ ] `simpleStorage_endToEnd_native_evmYulLean` has no `hRetrieveHit` premise.
- [ ] `hStoreHit` premise still present (handled by Phase 3).
- [ ] `Contracts/SimpleStorage/Proofs/` unchanged.

## Status
**Draft.** Plan-only; depends on Phase 1 (#1754).

Refs #1743. Refs #1753. Refs #1754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the IR interpreter/storage key type from `Nat` to `IRStorageSlot` (mod-`2^256`), requiring widespread proof updates and new modulo-normalization logic that could invalidate assumptions if any callsites were missed.
> 
> **Overview**
> **Keys IR storage by `IRStorageSlot` (UInt256) instead of raw `Nat`**, pushing EVM modulo-`2^256` slot behavior into the IR model. This threads through `IRState.storage`/`IRResult.finalStorage`, updates layout/write-slot validation to normalize slots modulo `evmModulus`, and adjusts many IR-generation/induction lemmas to use `IRStorageSlot.ofNat`/`.toNat` and `wordNormalize`.
> 
> **Discharges the SimpleStorage native `retrieve()` hit-case bridge** by adding closed-form execution/projection lemmas for the lowered retrieve body and wiring `simpleStorage_endToEnd_native_evmYulLean` to use `simpleStorageNativeRetrieveHitBridge_proved` instead of taking `hRetrieveHit` as a premise. Also updates `ArithmeticProfile` and native-result comparison predicates to reflect the new storage key type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b8eb00bd9c5657ca19073659810f9925618027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->