### PR TITLE
proofs: discharge store-hit bridge (Phase 3) [stacked on #1755]

### DIFF
--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -3837,6 +3837,61 @@ theorem simpleStorageNativeDispatcherFuel_ge_25 :
   unfold simpleStorageNativeDispatcherFuel
   decide
 
+theorem simpleStorageNativeDispatcherFuel_ge_21 :
+    simpleStorageNativeDispatcherFuel ≥ 21 := by
+  exact Nat.le_trans (by decide) simpleStorageNativeDispatcherFuel_ge_25
+
+/-- Native dispatcher exec at exactly `simpleStorageNativeDispatcherFuel`
+reduces to `.error Revert` for the selector-miss class. -/
+theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_atFuel
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (hSelectorRange : tx.functionSelector % Compiler.Constants.selectorModulus
+        < EvmYul.UInt256.size)
+    (hSelMissStore : tx.functionSelector % Compiler.Constants.selectorModulus
+        ≠ 0x6057361d)
+    (hSelMissRetrieve : tx.functionSelector % Compiler.Constants.selectorModulus
+        ≠ 0x2e64cec1)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
+    Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+        simpleStorageNativeDispatcherFuel
+        Compiler.SimpleStorageNativeWitness.nativeContract
+        (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+          observableSlots) =
+      .error EvmYul.Yul.Exception.Revert := by
+  have hReshape : simpleStorageNativeDispatcherFuel =
+      (simpleStorageNativeDispatcherFuel - 21) + 21 :=
+    (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_21).symm
+  rw [hReshape]
+  exact simpleStorageNativeContract_dispatcherExec_selectorMiss_revert
+    (simpleStorageNativeDispatcherFuel - 21)
+    (tx.functionSelector % Compiler.Constants.selectorModulus)
+    tx storage observableSlots
+    rfl hSelectorRange hSelMissStore hSelMissRetrieve hNoWrap
+
+/-- Closed-form `interpretIR` reduction for the SimpleStorage selector-miss
+class. Given the two raw selector mismatches (`≠ 0x6057361d` and
+`≠ 0x2e64cec1`), `interpretIR` falls into the `find?`-`none` branch and returns
+the trivial reverted shape with storage and events untouched. -/
+theorem interpretIR_simpleStorage_selectorMiss
+    (tx : IRTransaction) (initialState : IRState)
+    (hSelMissStore : tx.functionSelector ≠ 0x6057361d)
+    (hSelMissRetrieve : tx.functionSelector ≠ 0x2e64cec1) :
+    interpretIR simpleStorageIRContract tx initialState =
+      { success := false
+        returnValue := none
+        finalStorage := initialState.storage
+        finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
+        events := initialState.events } := by
+  unfold interpretIR
+  simp only [simpleStorageIRContract, List.find?]
+  have hstore : (0x6057361d == tx.functionSelector) = false := by
+    simp [BEq.beq, hSelMissStore.symm]
+  have hretrieve : (0x2e64cec1 == tx.functionSelector) = false := by
+    simp [BEq.beq, hSelMissRetrieve.symm]
+  simp [hstore, hretrieve]
+
 /-- Closed-form `interpretIR` reduction for the SimpleStorage retrieve-hit
 class. Given the raw selector match (`= 0x2e64cec1`), `interpretIR` enters the
 `retrieve` body which is read-only on storage: it loads slot 0 via `sload`,
@@ -4391,6 +4446,103 @@ theorem simpleStorageNativeRetrieveHitBridge_proved
   · exact hProject
   · exact hAgree
 
+/-- Selector-miss native dispatcher bridge discharged against the existing
+public entry preconditions. The native selector-miss path reverts, so
+`projectResult` preserves the parameter-passed initial storage directly. -/
+theorem simpleStorageNativeSelectorMissBridge_proved
+    (tx : IRTransaction) (initialState : IRState) (observableSlots : List Nat)
+    (hselector : tx.functionSelector < selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < evmModulus)
+    (hvars : initialState.vars = [])
+    (hmemory : initialState.memory = fun _ => 0)
+    (htransient : initialState.transientStorage = fun _ => 0)
+    (hreturn : initialState.returnValue = none)
+    (hdispatchGuardSafe : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      HasSelectorDeadBridge fn.body)
+    (hparamErase : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      paramLoadErasure fn tx (initialState.withTx tx)) :
+    simpleStorageNativeSelectorMissBridge tx initialState observableSlots := by
+  intro hSelMissRetrieve hSelMissStore
+  have hSelEq : tx.functionSelector % selectorModulus = tx.functionSelector :=
+    Nat.mod_eq_of_lt hselector
+  have hSelMissTxStore : tx.functionSelector ≠ 0x6057361d := by
+    rw [← hSelEq]
+    exact hSelMissStore
+  have hSelMissTxRetrieve : tx.functionSelector ≠ 0x2e64cec1 := by
+    rw [← hSelEq]
+    exact hSelMissRetrieve
+  have hLayer3 :
+      Compiler.Proofs.YulGeneration.resultsMatch
+        (interpretIR simpleStorageIRContract tx initialState)
+        (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackend
+          .evmYulLean (Compiler.emitYul simpleStorageIRContract).runtimeCode
+          (YulTransaction.ofIR tx) initialState.storage initialState.events) :=
+    layer3_contract_preserves_semantics_evmYulLean simpleStorageIRContract tx initialState
+      hselector hNoWrap hvars hmemory htransient hreturn hparamErase
+      hdispatchGuardSafe hNoHasSelector hHasSelectorDead
+      (by intro fn hmem; simp [simpleStorageIRContract] at hmem ⊢; rcases hmem with rfl | rfl <;> rfl)
+      (by intro s hs; simp [simpleStorageIRContract] at hs) rfl rfl
+      simpleStorage_functions_bridged
+  have hIR := interpretIR_simpleStorage_selectorMiss tx initialState
+    hSelMissTxStore hSelMissTxRetrieve
+  rw [hIR] at hLayer3
+  have hSizeEq :
+      sizeOf (Compiler.emitYul simpleStorageIRContract).runtimeCode =
+        simpleStorageNativeDispatcherFuel := by
+    rw [simpleStorage_runtimeCode_eq_single_dispatcher]
+    rfl
+  rcases hLayer3 with ⟨hsuccess, hreturnValue, hstorage, _hmappings, hevents⟩
+  refine nativeDispatcherExecAgreesWithInterpreterPositive_of_exec_error_project_eq_agree
+    (err := EvmYul.Yul.Exception.Revert)
+    (nativeYul :=
+      { success := false
+        returnValue := none
+        finalStorage := initialState.storage
+        finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
+        events := initialState.events })
+    ?_ ?_ ?_
+  · apply simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_atFuel
+    · have hMod :
+          (YulTransaction.ofIR tx).functionSelector
+            % Compiler.Constants.selectorModulus
+            < Compiler.Constants.selectorModulus :=
+        Nat.mod_lt _ (by decide)
+      exact Nat.lt_trans hMod (by decide)
+    · change (YulTransaction.ofIR tx).functionSelector % selectorModulus ≠ _
+      change tx.functionSelector % selectorModulus ≠ _
+      exact hSelMissStore
+    · change (YulTransaction.ofIR tx).functionSelector % selectorModulus ≠ _
+      change tx.functionSelector % selectorModulus ≠ _
+      exact hSelMissRetrieve
+    · change 4 + (YulTransaction.ofIR tx).args.length * 32 < EvmYul.UInt256.size
+      change 4 + tx.args.length * 32 < EvmYul.UInt256.size
+      simpa [evmModulus, EvmYul.UInt256.size] using hNoWrap
+  · rfl
+  · show yulResultsAgreeOn observableSlots _
+      (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackendFuel
+        .evmYulLean simpleStorageNativeDispatcherFuel.succ
+        (Compiler.emitYul simpleStorageIRContract).runtimeCode
+        (YulTransaction.ofIR tx) initialState.storage initialState.events)
+    have hFuelGoal :
+        (simpleStorageNativeDispatcherFuel.succ : Nat) =
+          sizeOf (Compiler.emitYul simpleStorageIRContract).runtimeCode + 1 := by
+      rw [hSizeEq]
+    rw [hFuelGoal]
+    show yulResultsAgreeOn observableSlots _
+      (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackend
+        .evmYulLean (Compiler.emitYul simpleStorageIRContract).runtimeCode
+        (YulTransaction.ofIR tx) initialState.storage initialState.events)
+    refine ⟨?_, ?_, ?_, ?_⟩
+    · exact hsuccess
+    · exact hreturnValue
+    · intro slot _
+      exact hstorage (IRStorageSlot.ofNat slot)
+    · exact hevents
+
 /-- Recover the monolithic `simpleStorageNativeCallDispatcherBridge` from the
 three per-case sub-bridges by case analysis on
 `tx.functionSelector % selectorModulus`. -/
@@ -4503,13 +4655,12 @@ theorem simpleStorage_endToEnd_native_evmYulLean_of_callDispatcher_bridge
 witness supplied per-selector-case.
 
 This theorem targets native EVMYulLean execution, but it does not pretend the
-remaining selected-body native dispatcher proof is complete. Callers must
-supply three per-case sub-bridges (retrieve hit, store hit, selector miss)
-covering the three selector classes the lowered switch branches on. The
-sub-bridges are recombined into the monolithic
-`simpleStorageNativeCallDispatcherBridge` via
-`simpleStorageNativeCallDispatcherBridge_of_per_case` before delegating to the
-underlying `_of_callDispatcher_bridge` wrapper.
+  remaining selected-body native dispatcher proof is complete. Callers must
+  supply the remaining store-hit sub-bridge; retrieve hit and selector miss
+  are discharged below. The per-case bridges are recombined into the monolithic
+  `simpleStorageNativeCallDispatcherBridge` via
+  `simpleStorageNativeCallDispatcherBridge_of_per_case` before delegating to the
+  underlying `_of_callDispatcher_bridge` wrapper.
 
 Each sub-bridge is strictly weaker than the monolithic bridge: it gets to
 assume the selector class as a precondition, so its discharger does not need
@@ -4533,15 +4684,13 @@ theorem simpleStorage_endToEnd_native_evmYulLean
       yulStmtsNoRef "__has_selector" fn.body)
     (hHasSelectorDead : ∀ fn, fn ∈ simpleStorageIRContract.functions →
       HasSelectorDeadBridge fn.body)
-    (hparamErase : ∀ fn, fn ∈ simpleStorageIRContract.functions →
-      paramLoadErasure fn tx (initialState.withTx tx))
-    (hStoreHit :
-      simpleStorageNativeStoreHitBridge tx initialState observableSlots)
-    (hSelectorMiss :
-      simpleStorageNativeSelectorMissBridge tx initialState observableSlots)
-    (hEnv :
-      Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
-        (Compiler.emitYul simpleStorageIRContract).runtimeCode
+      (hparamErase : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+        paramLoadErasure fn tx (initialState.withTx tx))
+      (hStoreHit :
+        simpleStorageNativeStoreHitBridge tx initialState observableSlots)
+      (hEnv :
+        Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
+          (Compiler.emitYul simpleStorageIRContract).runtimeCode
         (YulTransaction.ofIR tx) = .ok ()) :
     nativeResultsMatchOn observableSlots
       (interpretIR simpleStorageIRContract tx initialState)
@@ -4560,9 +4709,13 @@ theorem simpleStorage_endToEnd_native_evmYulLean
               tx initialState observableSlots
               (simpleStorageNativeRetrieveHitBridge_proved tx initialState
                 observableSlots hselector hNoWrap hvars hmemory htransient
-                hreturn hdispatchGuardSafe hNoHasSelector hHasSelectorDead
-                hparamErase)
-              hStoreHit hSelectorMiss))))
+                  hreturn hdispatchGuardSafe hNoHasSelector hHasSelectorDead
+                  hparamErase)
+                hStoreHit
+                (simpleStorageNativeSelectorMissBridge_proved tx initialState
+                  observableSlots hselector hNoWrap hvars hmemory htransient
+                  hreturn hdispatchGuardSafe hNoHasSelector hHasSelectorDead
+                  hparamErase)))))
 
 /-! ## Universal Pure Arithmetic Bridge
 

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -3040,6 +3040,16 @@ def simpleStorageLoweredStoreCaseBodyTail2 : List EvmYul.Yul.Ast.Stmt :=
      (.call "sstore" [.lit 0, .ident "value"])),
    .ExprStmtCall (Backends.lowerExprNative (.call "stop" []))]
 
+/-- 3-statement calldatasize-stripped tail of
+`simpleStorageLoweredStoreCaseBodyTail2`, with the argument-length revert guard
+removed after proving the transaction supplies the setter argument. -/
+def simpleStorageLoweredStoreCaseBodyTail3 : List EvmYul.Yul.Ast.Stmt :=
+  [.Let ["value"] (some (Backends.lowerExprNative
+     (.call "calldataload" [.lit 4]))),
+   .ExprStmtCall (Backends.lowerExprNative
+     (.call "sstore" [.lit 0, .ident "value"])),
+   .ExprStmtCall (Backends.lowerExprNative (.call "stop" []))]
+
 /-- 3-statement callvalue-stripped tail of `simpleStorageLoweredRetrieveCaseBody`. -/
 def simpleStorageLoweredRetrieveCaseBodyTail2 : List EvmYul.Yul.Ast.Stmt :=
   [.If (Backends.lowerExprNative
@@ -3161,6 +3171,143 @@ theorem exec_block_simpleStorageLoweredRetrieveCaseBodyTail2_lt_strip_error
     codeOverride (.Ok shared store) = .ok (.Ok shared store)
   exact Backends.Native.exec_if_lowerExprNative_lt_calldatasize_skip_ge_fuel
     fuel _ codeOverride shared store 4 hSize (by decide) hGe
+
+/-- Store-case dual of
+`exec_block_simpleStorageLoweredRetrieveCaseBodyTail2_lt_strip_error`, with
+the ABI argument guard threshold `36 = 4 + 32`. -/
+theorem exec_block_simpleStorageLoweredStoreCaseBodyTail2_lt_strip_error
+    (fuel : Nat) (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (shared : EvmYul.SharedState .Yul) (store : EvmYul.Yul.VarStore)
+    (err : EvmYul.Yul.Exception)
+    (hSize : shared.executionEnv.calldata.size < EvmYul.UInt256.size)
+    (hGe : 36 ≤ shared.executionEnv.calldata.size)
+    (hTail3 :
+      EvmYul.Yul.exec (fuel + 10)
+        (.Block simpleStorageLoweredStoreCaseBodyTail3)
+        codeOverride (.Ok shared store) = .error err) :
+    EvmYul.Yul.exec (fuel + 11)
+      (.Block simpleStorageLoweredStoreCaseBodyTail2)
+      codeOverride (.Ok shared store) = .error err := by
+  show EvmYul.Yul.exec (Nat.succ (fuel + 10))
+    (.Block ((simpleStorageLoweredStoreCaseBodyTail2).head! ::
+      simpleStorageLoweredStoreCaseBodyTail3))
+    codeOverride (.Ok shared store) = .error err
+  refine Backends.Native.exec_block_cons_tail_error (fuel + 10) _
+    simpleStorageLoweredStoreCaseBodyTail3 codeOverride
+    (.Ok shared store) (.Ok shared store) err ?_ hTail3
+  show EvmYul.Yul.exec (fuel + 10)
+    (.If (Backends.lowerExprNative
+            (Yul.YulExpr.call "lt"
+              [Yul.YulExpr.call "calldatasize" [],
+               Yul.YulExpr.lit 36]))
+      [.ExprStmtCall (Backends.lowerExprNative
+        (.call "revert" [.lit 0, .lit 0]))])
+    codeOverride (.Ok shared store) = .ok (.Ok shared store)
+  exact Backends.Native.exec_if_lowerExprNative_lt_calldatasize_skip_ge_fuel
+    (fuel + 1) _ codeOverride shared store 36 hSize (by decide) hGe
+
+/-- Closed-form native exec of the store hit-case 3-statement payload
+    `let value := calldataload(4); sstore(0, value); stop` after the
+    callvalue and argument-length guards have been stripped. -/
+theorem exec_block_simpleStorageLoweredStoreCaseBodyTail3_halt
+    (fuel : Nat) (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat) (store : EvmYul.Yul.VarStore)
+    (arg : Nat) (rest : List Nat) (hArgs : tx.args = arg :: rest) :
+    let initialWithStore : EvmYul.Yul.State :=
+      .Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState store
+    let withValue := initialWithStore.insert "value"
+      (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
+    let finalState := withValue.setState
+      (withValue.toState.sstore (EvmYul.UInt256.ofNat 0)
+        (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg))
+    EvmYul.Yul.exec (fuel + 10)
+        (.Block simpleStorageLoweredStoreCaseBodyTail3)
+        codeOverride initialWithStore =
+      .error (EvmYul.Yul.Exception.YulHalt finalState ⟨0⟩) := by
+  intro initialWithStore withValue finalState
+  have hWord :
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState.calldataload (EvmYul.UInt256.ofNat 4) =
+        Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg := by
+    simpa [EvmYul.Yul.State.toState] using
+      Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataload4_arg0_word
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage observableSlots
+        arg rest hArgs
+  simp [simpleStorageLoweredStoreCaseBodyTail3, Backends.lowerExprNative,
+    Backends.lookupRuntimePrimOp, EvmYul.Yul.exec, EvmYul.Yul.eval,
+    EvmYul.Yul.evalArgs, EvmYul.Yul.evalTail, EvmYul.Yul.execPrimCall,
+    EvmYul.Yul.reverse', EvmYul.Yul.cons', EvmYul.Yul.multifill',
+    EvmYul.Yul.State.multifill, initialWithStore, withValue, finalState,
+    hWord, EvmYul.Yul.State.insert, GetElem?.getElem!, decidableGetElem?,
+    GetElem.getElem, EvmYul.Yul.State.store, EvmYul.Yul.State.lookup!]
+  have hPerm :
+      (EvmYul.Yul.State.Ok
+        (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+          observableSlots).sharedState
+        (Finmap.insert "value"
+          (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
+          store)).executionEnv.perm = true := by
+    rfl
+  rw [show fuel + 7 = (fuel + 6) + 1 by omega]
+  rw [Compiler.Proofs.YulGeneration.Backends.Native.primCall_sstore_ok
+    (fuel + 6) _ _ _ hPerm]
+  rfl
+
+/-- Composed body-level closed form for the SimpleStorage store hit-case when
+the calldata contains the setter argument. -/
+theorem exec_block_simpleStorageLoweredStoreCaseBody_halt
+    (fuel : Nat) (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat) (store : EvmYul.Yul.VarStore)
+    (arg : Nat) (rest : List Nat) (hArgs : tx.args = arg :: rest)
+    (hWei :
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState.executionEnv.weiValue =
+      (⟨0⟩ : EvmYul.Literal))
+    (hSize :
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState.executionEnv.calldata.size <
+      EvmYul.UInt256.size)
+    (hGe :
+      36 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState.executionEnv.calldata.size) :
+    let initialWithStore : EvmYul.Yul.State :=
+      .Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState store
+    let withValue := initialWithStore.insert "value"
+      (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
+    let finalState := withValue.setState
+      (withValue.toState.sstore (EvmYul.UInt256.ofNat 0)
+        (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg))
+    EvmYul.Yul.exec (fuel + 13) (.Block simpleStorageLoweredStoreCaseBody)
+        codeOverride initialWithStore =
+      .error (EvmYul.Yul.Exception.YulHalt finalState ⟨0⟩) := by
+  intro initialWithStore withValue finalState
+  have hTail3 := exec_block_simpleStorageLoweredStoreCaseBodyTail3_halt
+    fuel codeOverride tx storage observableSlots store arg rest hArgs
+  have hTail2 := exec_block_simpleStorageLoweredStoreCaseBodyTail2_lt_strip_error
+    fuel codeOverride
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState
+      store _ hSize hGe hTail3
+  have hTail := exec_block_simpleStorageLoweredStoreCaseBodyTail_callvalue_strip_error
+    (fuel + 4) codeOverride
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState
+      store _ hWei hTail2
+  exact exec_block_simpleStorageLoweredStoreCaseBody_head_strip_error
+    (fuel + 11) codeOverride initialWithStore _ hTail
 
 /-- Closed-form native exec of the retrieve hit-case 2-statement payload
     `mstore(0, sload(0)) ; return(0, 32)`. EVMYulLean models `RETURN` as a
@@ -3952,6 +4099,77 @@ theorem interpretIR_simpleStorage_retrieveHit
   -- Goal: `match execIRStmts (sizeOf body + 1) state' body with ... = ...`.
   rw [hbody _ _ hsize]
 
+/-- Closed-form `interpretIR` reduction for the SimpleStorage store-hit class
+when the ABI argument is present. The IR setter writes the first calldata word
+to bounded storage slot zero and stops successfully. -/
+theorem interpretIR_simpleStorage_storeHit_arg
+    (tx : IRTransaction) (initialState : IRState)
+    (arg : Nat) (rest : List Nat)
+    (hSel : tx.functionSelector = 0x6057361d)
+    (hArgs : tx.args = arg :: rest) :
+      interpretIR simpleStorageIRContract tx initialState =
+        { success := true
+          returnValue := none
+          finalStorage :=
+            Compiler.Proofs.abstractStoreStorageOrMapping initialState.storage 0
+              (arg % evmModulus)
+          finalMappings :=
+            Compiler.Proofs.storageAsMappings
+              (Compiler.Proofs.abstractStoreStorageOrMapping initialState.storage 0
+                (arg % evmModulus))
+          events := initialState.events } := by
+  have hstore : (0x6057361d == tx.functionSelector) = true := by
+    simp [BEq.beq, hSel]
+  have hbody : ∀ (n : Nat) (s : IRState), 3 ≤ n →
+      execIRStmts (n + 1) s
+        [Yul.YulStmt.let_ "value" (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
+         Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+            [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
+         Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])] =
+          .stop
+            { s.setVar "value" (Compiler.Proofs.YulGeneration.calldataloadWord
+                s.selector s.calldata 4) with
+              storage := Compiler.Proofs.abstractStoreStorageOrMapping
+                s.storage 0 (Compiler.Proofs.YulGeneration.calldataloadWord
+                  s.selector s.calldata 4) } := by
+    intro n s hn
+    obtain ⟨k, rfl⟩ : ∃ k, n = k + 3 := ⟨n - 3, by omega⟩
+    simp +decide [execIRStmts, execIRStmt, evalIRExpr, IRState.getVar,
+      IRState.setVar]
+  have hsize : 3 ≤ sizeOf
+      ([Yul.YulStmt.let_ "value" (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
+        Yul.YulStmt.expr (Yul.YulExpr.call "sstore"
+          [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
+        Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])] : List Yul.YulStmt) := by
+    decide
+  unfold interpretIR
+  simp only [simpleStorageIRContract, List.find?, hstore, List.length_cons,
+    List.length_nil, Nat.reduceAdd]
+  unfold execIRFunction
+  simp only [hArgs, List.zip_cons_cons, List.zip_nil_left, List.foldl_cons,
+    List.foldl_nil]
+  rw [hbody _ _ hsize]
+  simp [IRState.setVar, Compiler.Proofs.abstractStoreStorageOrMapping_eq,
+    Compiler.Proofs.YulGeneration.calldataloadWord, evmModulus]
+
+/-- Closed-form `interpretIR` reduction for the SimpleStorage store-hit class
+when calldata is too short for the single setter argument. The dispatcher
+selects the function, but the IR arity guard fails before executing the body. -/
+theorem interpretIR_simpleStorage_storeHit_short
+    (tx : IRTransaction) (initialState : IRState)
+    (hSel : tx.functionSelector = 0x6057361d)
+    (hShort : tx.args = []) :
+      interpretIR simpleStorageIRContract tx initialState =
+        { success := false
+          returnValue := none
+          finalStorage := initialState.storage
+          finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
+          events := initialState.events } := by
+  have hstore : (0x6057361d == tx.functionSelector) = true := by
+    simp [BEq.beq, hSel]
+  unfold interpretIR
+  simp [simpleStorageIRContract, hstore, hShort]
+
 /-- Native dispatcher exec at exactly `simpleStorageNativeDispatcherFuel`
 reduces to `.error (YulHalt (.Ok shared3 _) ⟨1⟩)` for the retrieve-hit class,
 where `shared3` is the closed-form shared state after the
@@ -4116,6 +4334,148 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
         List (Nat × List EvmYul.Yul.Ast.Stmt)).length = 2 := rfl
   rw [hLen, show (g + 4) + 2 + 19 = g + 25 from by omega] at h
   exact h
+
+/-- Native dispatcher exec at exactly `simpleStorageNativeDispatcherFuel`
+reduces to the `STOP` halt for the store-hit class when calldata supplies the
+setter argument. -/
+theorem simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (arg : Nat) (rest : List Nat) (hArgs : tx.args = arg :: rest)
+    (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hMsgValue : tx.msgValue % EvmYul.UInt256.size = 0) :
+    ∃ store_body haltState,
+      Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+          simpleStorageNativeDispatcherFuel
+          Compiler.SimpleStorageNativeWitness.nativeContract
+          (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+            Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+            observableSlots) =
+        .error (EvmYul.Yul.Exception.YulHalt haltState ⟨0⟩) ∧
+      haltState =
+        let initialWithStore : EvmYul.Yul.State :=
+          .Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+            Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+            observableSlots).sharedState store_body
+        let withValue := initialWithStore.insert "value"
+          (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
+        withValue.setState
+          (withValue.toState.sstore (EvmYul.UInt256.ofNat 0)
+            (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)) := by
+  set g := simpleStorageNativeDispatcherFuel - 25 with hg_def
+  have hReshape : simpleStorageNativeDispatcherFuel = g + 25 :=
+    (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_25).symm
+  rw [hReshape]
+  obtain ⟨reservedNames, n0, cases', midN, hExec, hLowerCases⟩ :=
+    simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
+      (g + 11) tx storage observableSlots hNoWrap
+  obtain ⟨storeBody', retrieveBody', hCases⟩ :=
+    simpleStorageBuildSwitchSourceCases_lowered_shape reservedNames _ midN
+      cases' hLowerCases
+  subst hCases
+  obtain ⟨hStoreBody, hRetrieveBody⟩ :=
+    simpleStorageLoweredHitCasesShape_concrete hLowerCases
+  subst hStoreBody
+  subst hRetrieveBody
+  set switchId := Backends.freshNativeSwitchId reservedNames n0 with hSw
+  let store_body : EvmYul.Yul.VarStore :=
+    ((((∅ : EvmYul.Yul.VarStore).insert "__has_selector"
+            (EvmYul.UInt256.ofNat 1)).insert
+          (Backends.nativeSwitchDiscrTempName switchId)
+          (EvmYul.UInt256.ofNat
+            (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+        (Backends.nativeSwitchMatchedTempName switchId)
+        (EvmYul.UInt256.ofNat 0)).insert
+      (Backends.nativeSwitchMatchedTempName switchId)
+      (EvmYul.UInt256.ofNat 1)
+  let initialWithStore : EvmYul.Yul.State :=
+    .Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+      Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+      observableSlots).sharedState store_body
+  let withValue := initialWithStore.insert "value"
+    (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
+  let finalState := withValue.setState
+    (withValue.toState.sstore (EvmYul.UInt256.ofNat 0)
+      (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg))
+  refine ⟨store_body, finalState, ?_, ?_⟩
+  · have hWei :
+        (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+          observableSlots).sharedState.executionEnv.weiValue =
+        (⟨0⟩ : EvmYul.Literal) := by
+      rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue]
+      apply congrArg EvmYul.UInt256.mk
+      apply Fin.ext
+      simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256,
+        EvmYul.UInt256.ofNat, Fin.ofNat] using hMsgValue
+    have hSize :
+        (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+          observableSlots).sharedState.executionEnv.calldata.size <
+        EvmYul.UInt256.size := by
+      rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+      exact hNoWrap
+    have hGe :
+        36 ≤ (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+          observableSlots).sharedState.executionEnv.calldata.size := by
+      rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+      rw [hArgs]
+      simp
+      omega
+    have hBodyHalt :=
+      exec_block_simpleStorageLoweredStoreCaseBody_halt g
+        (some Compiler.SimpleStorageNativeWitness.nativeContract)
+        tx storage observableSlots store_body arg rest hArgs hWei hSize hGe
+    have hReduction := hExec
+    rw [show (g + 11 + 14 : Nat) = (g + 4) + 2 + 19 from by omega,
+        show (g + 11 + 8 : Nat) = (g + 4) + 2 + 13 from by omega,
+        show (2 : Nat) = ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
+          (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
+          List (Nat × List EvmYul.Yul.Ast.Stmt)).length from rfl] at hReduction
+    have hBodyExec : ∀ pre suffix,
+        ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
+          (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
+          List (Nat × List EvmYul.Yul.Ast.Stmt)) =
+          pre ++ (0x6057361d, simpleStorageLoweredStoreCaseBody) :: suffix →
+        EvmYul.Yul.exec (((g + 4) + 1) + suffix.length + 7)
+          (.Block simpleStorageLoweredStoreCaseBody)
+          (some Compiler.SimpleStorageNativeWitness.nativeContract)
+          (simpleStorageDispatcherHitBodyInputState switchId tx storage
+            observableSlots) =
+          .error (EvmYul.Yul.Exception.YulHalt finalState ⟨0⟩) := by
+      rintro pre suffix hDecomp
+      cases pre with
+      | nil =>
+        simp only [List.nil_append, List.cons.injEq] at hDecomp
+        obtain ⟨_, hSuf⟩ := hDecomp
+        subst hSuf
+        simpa [simpleStorageDispatcherHitBodyInputState, initialWithStore,
+          withValue, finalState] using hBodyHalt
+      | cons _ restPre =>
+        exfalso
+        simp only [List.cons_append, List.cons.injEq] at hDecomp
+        obtain ⟨_, hRest⟩ := hDecomp
+        cases restPre with
+        | nil =>
+          simp only [List.nil_append, List.cons.injEq, Prod.mk.injEq] at hRest
+          exact absurd hRest.1.1 (by decide)
+        | cons _ _ => simp at hRest
+    have h := simpleStorageNativeContract_dispatcherExec_storeHit_error_via_reduction
+      (g + 4) switchId
+      [(0x6057361d, simpleStorageLoweredStoreCaseBody),
+       (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)]
+      simpleStorageLoweredStoreCaseBody simpleStorageLoweredRetrieveCaseBody
+      tx storage observableSlots
+      (EvmYul.Yul.Exception.YulHalt finalState ⟨0⟩)
+      hSelector rfl hBodyExec hReduction
+    have hLen :
+        ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
+          (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
+          List (Nat × List EvmYul.Yul.Ast.Stmt)).length = 2 := rfl
+    rw [hLen, show (g + 4) + 2 + 19 = g + 25 from by omega] at h
+    exact h
+  · rfl
 
 /-- Closed-form evaluation of `projectResult` on the retrieve-hit halt error
 produced by the lowered SimpleStorage retrieve body. The halt state is built

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -3206,6 +3206,41 @@ theorem exec_block_simpleStorageLoweredStoreCaseBodyTail2_lt_strip_error
   exact Backends.Native.exec_if_lowerExprNative_lt_calldatasize_skip_ge_fuel
     (fuel + 1) _ codeOverride shared store 36 hSize (by decide) hGe
 
+/-- Store-case argument-length guard fires when calldata contains only the
+selector. This is the short-calldata counterpart to
+`exec_block_simpleStorageLoweredStoreCaseBodyTail2_lt_strip_error`. -/
+theorem exec_block_simpleStorageLoweredStoreCaseBodyTail2_short_revert
+    (fuel : Nat) (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (shared : EvmYul.SharedState .Yul) (store : EvmYul.Yul.VarStore)
+    (hSizeEq : shared.executionEnv.calldata.size = 4) :
+    EvmYul.Yul.exec (fuel + 11)
+      (.Block simpleStorageLoweredStoreCaseBodyTail2)
+      codeOverride (.Ok shared store) =
+      .error EvmYul.Yul.Exception.Revert := by
+  show EvmYul.Yul.exec (Nat.succ (fuel + 10))
+    (.Block ((simpleStorageLoweredStoreCaseBodyTail2).head! ::
+      simpleStorageLoweredStoreCaseBodyTail3))
+    codeOverride (.Ok shared store) = .error EvmYul.Yul.Exception.Revert
+  refine Backends.Native.exec_block_cons_error (fuel + 10) _
+    simpleStorageLoweredStoreCaseBodyTail3 codeOverride
+    (.Ok shared store) EvmYul.Yul.Exception.Revert ?_
+  refine Backends.Native.exec_if_eval_nonzero_error (fuel + 9) _ _
+    codeOverride (.Ok shared store) (.Ok shared store)
+    (EvmYul.UInt256.ofNat 1) EvmYul.Yul.Exception.Revert ?_ ?_ ?_
+  · rw [Backends.Native.eval_lowerExprNative_lt_calldatasize_ok_fuel]
+    simp [hSizeEq, EvmYul.UInt256.lt, EvmYul.UInt256.ofNat, Fin.ofNat,
+      EvmYul.UInt256.size]
+    decide
+  · change (EvmYul.UInt256.ofNat 1 : EvmYul.UInt256) ≠ ⟨0⟩
+    decide
+  · simpa [Backends.Native.nativeRevertZeroZeroStmt, Backends.lowerExprNative,
+      Backends.lookupRuntimePrimOp] using
+      (Backends.Native.exec_block_cons_error (fuel + 8)
+      Backends.Native.nativeRevertZeroZeroStmt [] codeOverride
+      (.Ok shared store) EvmYul.Yul.Exception.Revert
+      (Backends.Native.exec_revert_zero_zero_error (fuel + 2)
+        (.Ok shared store) codeOverride))
+
 /-- Closed-form native exec of the store hit-case 3-statement payload
     `let value := calldataload(4); sstore(0, value); stop` after the
     callvalue and argument-length guards have been stripped. -/
@@ -4477,6 +4512,314 @@ theorem simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel
     exact h
   · rfl
 
+/-- Native dispatcher exec at exactly `simpleStorageNativeDispatcherFuel`
+reverts for the store-hit class when calldata contains no setter argument. -/
+theorem simpleStorageNativeContract_dispatcherExec_storeHit_short_revert_atFuel
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord) (observableSlots : List Nat)
+    (hArgs : tx.args = [])
+    (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
+    (hMsgValue : tx.msgValue % EvmYul.UInt256.size = 0) :
+    Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
+        simpleStorageNativeDispatcherFuel
+        Compiler.SimpleStorageNativeWitness.nativeContract
+        (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+          Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+          observableSlots) =
+      .error EvmYul.Yul.Exception.Revert := by
+  set g := simpleStorageNativeDispatcherFuel - 25 with hg_def
+  have hReshape : simpleStorageNativeDispatcherFuel = g + 25 :=
+    (Nat.sub_add_cancel simpleStorageNativeDispatcherFuel_ge_25).symm
+  rw [hReshape]
+  obtain ⟨reservedNames, n0, cases', midN, hExec, hLowerCases⟩ :=
+    simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
+      (g + 11) tx storage observableSlots hNoWrap
+  obtain ⟨storeBody', retrieveBody', hCases⟩ :=
+    simpleStorageBuildSwitchSourceCases_lowered_shape reservedNames _ midN
+      cases' hLowerCases
+  subst hCases
+  obtain ⟨hStoreBody, hRetrieveBody⟩ :=
+    simpleStorageLoweredHitCasesShape_concrete hLowerCases
+  subst hStoreBody
+  subst hRetrieveBody
+  set switchId := Backends.freshNativeSwitchId reservedNames n0 with hSw
+  let store_body : EvmYul.Yul.VarStore :=
+    ((((∅ : EvmYul.Yul.VarStore).insert "__has_selector"
+            (EvmYul.UInt256.ofNat 1)).insert
+          (Backends.nativeSwitchDiscrTempName switchId)
+          (EvmYul.UInt256.ofNat
+            (tx.functionSelector % Compiler.Constants.selectorModulus))).insert
+        (Backends.nativeSwitchMatchedTempName switchId)
+        (EvmYul.UInt256.ofNat 0)).insert
+      (Backends.nativeSwitchMatchedTempName switchId)
+      (EvmYul.UInt256.ofNat 1)
+  have hWei :
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState.executionEnv.weiValue =
+      (⟨0⟩ : EvmYul.Literal) := by
+    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_weiValue]
+    apply congrArg EvmYul.UInt256.mk
+    apply Fin.ext
+    simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256,
+      EvmYul.UInt256.ofNat, Fin.ofNat] using hMsgValue
+  have hSizeEq :
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState.executionEnv.calldata.size = 4 := by
+    rw [Compiler.Proofs.YulGeneration.Backends.Native.initialState_calldataSize]
+    simp [hArgs]
+  have hTail2 :=
+    exec_block_simpleStorageLoweredStoreCaseBodyTail2_short_revert
+      g (some Compiler.SimpleStorageNativeWitness.nativeContract)
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState
+      store_body hSizeEq
+  have hTail :=
+    exec_block_simpleStorageLoweredStoreCaseBodyTail_callvalue_strip_error
+      (g + 4) (some Compiler.SimpleStorageNativeWitness.nativeContract)
+      (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        observableSlots).sharedState
+      store_body _ hWei hTail2
+  have hBodyRevert :
+      EvmYul.Yul.exec (g + 13) (.Block simpleStorageLoweredStoreCaseBody)
+        (some Compiler.SimpleStorageNativeWitness.nativeContract)
+        (simpleStorageDispatcherHitBodyInputState switchId tx storage
+          observableSlots) =
+        .error EvmYul.Yul.Exception.Revert := by
+    exact exec_block_simpleStorageLoweredStoreCaseBody_head_strip_error
+      (g + 11) _ _ _ hTail
+  have hReduction := hExec
+  rw [show (g + 11 + 14 : Nat) = (g + 4) + 2 + 19 from by omega,
+      show (g + 11 + 8 : Nat) = (g + 4) + 2 + 13 from by omega,
+      show (2 : Nat) = ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
+        (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
+        List (Nat × List EvmYul.Yul.Ast.Stmt)).length from rfl] at hReduction
+  have hBodyExec : ∀ pre suffix,
+      ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
+        (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
+        List (Nat × List EvmYul.Yul.Ast.Stmt)) =
+        pre ++ (0x6057361d, simpleStorageLoweredStoreCaseBody) :: suffix →
+      EvmYul.Yul.exec (((g + 4) + 1) + suffix.length + 7)
+        (.Block simpleStorageLoweredStoreCaseBody)
+        (some Compiler.SimpleStorageNativeWitness.nativeContract)
+        (simpleStorageDispatcherHitBodyInputState switchId tx storage
+          observableSlots) =
+        .error EvmYul.Yul.Exception.Revert := by
+    rintro pre suffix hDecomp
+    cases pre with
+    | nil =>
+      simp only [List.nil_append, List.cons.injEq] at hDecomp
+      obtain ⟨_, hSuf⟩ := hDecomp
+      subst hSuf
+      simpa [simpleStorageDispatcherHitBodyInputState, store_body] using hBodyRevert
+    | cons _ restPre =>
+      exfalso
+      simp only [List.cons_append, List.cons.injEq] at hDecomp
+      obtain ⟨_, hRest⟩ := hDecomp
+      cases restPre with
+      | nil =>
+        simp only [List.nil_append, List.cons.injEq, Prod.mk.injEq] at hRest
+        exact absurd hRest.1.1 (by decide)
+      | cons _ _ => simp at hRest
+  have h := simpleStorageNativeContract_dispatcherExec_storeHit_error_via_reduction
+    (g + 4) switchId
+    [(0x6057361d, simpleStorageLoweredStoreCaseBody),
+     (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)]
+    simpleStorageLoweredStoreCaseBody simpleStorageLoweredRetrieveCaseBody
+    tx storage observableSlots EvmYul.Yul.Exception.Revert
+    hSelector rfl hBodyExec hReduction
+  have hLen :
+      ([(0x6057361d, simpleStorageLoweredStoreCaseBody),
+        (0x2e64cec1, simpleStorageLoweredRetrieveCaseBody)] :
+        List (Nat × List EvmYul.Yul.Ast.Stmt)).length = 2 := rfl
+  rw [hLen, show (g + 4) + 2 + 19 = g + 25 from by omega] at h
+  exact h
+
+/-- Projected native storage after the generated `store(uint256)` body agrees
+with the IR setter update on every materialized slot. The native zero-write
+case erases slot zero from the finite EVM map; projected lookup still agrees
+with IR storage because missing native storage reads as the zero word. -/
+theorem projectStorageFromState_storeHit_initialState_materialized
+    (tx : YulTransaction) (storage : IRStorageSlot → IRStorageWord)
+    (slots : List Nat) (store : EvmYul.Yul.VarStore)
+    (arg slot : Nat)
+    (hSlot : slot ∈ slots) :
+    let initialWithStore : EvmYul.Yul.State :=
+      .Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
+        Compiler.SimpleStorageNativeWitness.nativeContract tx storage
+        slots).sharedState store
+    let withValue := initialWithStore.insert "value"
+      (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg)
+    let finalState := withValue.setState
+      (withValue.toState.sstore (EvmYul.UInt256.ofNat 0)
+        (Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256 arg))
+    Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState tx
+        finalState (IRStorageSlot.ofNat slot) =
+      (Compiler.Proofs.abstractStoreStorageOrMapping storage 0 arg)
+        (IRStorageSlot.ofNat slot) := by
+  intro initialWithStore withValue finalState
+  simp only [Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.extractStorage,
+    finalState, withValue, initialWithStore,
+    EvmYul.Yul.State.sharedState, EvmYul.Yul.State.setState,
+    EvmYul.Yul.State.toState, EvmYul.Yul.State.insert,
+    EvmYul.State.sstore, EvmYul.State.lookupAccount,
+    EvmYul.State.setAccount, EvmYul.State.addAccessedStorageKey,
+    EvmYul.Account.updateStorage,
+    Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
+    YulState.initial,
+    Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256]
+  simp only [Option.option,
+    Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
+  by_cases hValueZero :
+      (EvmYul.UInt256.ofNat arg == (Inhabited.default : EvmYul.UInt256)) = true
+  · rw [hValueZero]
+    simp only [ite_true, IRStorageSlot.toUInt256, IRStorageSlot.ofNat]
+    have hArgZeroUInt :
+        EvmYul.UInt256.ofNat arg = (⟨0⟩ : EvmYul.UInt256) := by
+      cases hArg : EvmYul.UInt256.ofNat arg with
+      | mk v =>
+          rw [hArg] at hValueZero
+          change (v == (0 : Fin EvmYul.UInt256.size)) = true at hValueZero
+          have hv : v = (0 : Fin EvmYul.UInt256.size) :=
+            of_decide_eq_true hValueZero
+          subst hv
+          rfl
+    have hArgZero : IRStorageWord.ofNat arg = (0 : IRStorageWord) := by
+      simpa [Compiler.Proofs.IRGeneration.IRStorageWord.ofNat] using hArgZeroUInt
+    by_cases hKey :
+        compare (EvmYul.UInt256.ofNat slot) (EvmYul.UInt256.ofNat 0) =
+          Ordering.eq
+    · have hSlotEq :
+          IRStorageSlot.ofNat slot = IRStorageSlot.ofNat 0 := by
+        have hUInt :
+            EvmYul.UInt256.ofNat slot = EvmYul.UInt256.ofNat 0 :=
+          Compiler.Proofs.YulGeneration.Backends.StateBridge.UInt256_eq_of_compare_eq
+            hKey
+        simpa [IRStorageSlot.ofNat] using hUInt
+      have hUInt :
+          EvmYul.UInt256.ofNat slot = EvmYul.UInt256.ofNat 0 := by
+        simpa [IRStorageSlot.ofNat] using hSlotEq
+      have hErase :
+          (Batteries.RBMap.erase
+            (Compiler.Proofs.YulGeneration.Backends.StateBridge.projectStorage
+              storage slots)
+            (EvmYul.UInt256.ofNat 0)).find? (EvmYul.UInt256.ofNat slot) =
+            none := by
+        simpa [hUInt] using
+          (Batteries.RBMap.find?_erase_self
+            (Compiler.Proofs.YulGeneration.Backends.StateBridge.projectStorage
+              storage slots)
+            (EvmYul.UInt256.ofNat 0))
+      rw [hErase, hUInt]
+      simp only [Compiler.Proofs.abstractStoreStorageOrMapping,
+        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat, IRStorageSlot.ofNat]
+      simp only [if_true]
+      rw [hArgZeroUInt]
+      rfl
+    · have hErase :
+          (Batteries.RBMap.erase
+            (Compiler.Proofs.YulGeneration.Backends.StateBridge.projectStorage
+              storage slots)
+            (EvmYul.UInt256.ofNat 0)).find? (EvmYul.UInt256.ofNat slot) =
+          (Compiler.Proofs.YulGeneration.Backends.StateBridge.projectStorage
+              storage slots).find? (EvmYul.UInt256.ofNat slot) := by
+        exact Batteries.RBMap.find?_erase_of_ne _ hKey
+      have hLookup :=
+        Compiler.Proofs.YulGeneration.Backends.StateBridge.storageLookup_projectStorage_projected
+          storage slots slot hSlot
+      have hLookup' :
+          (match
+            (Compiler.Proofs.YulGeneration.Backends.StateBridge.projectStorage
+              storage slots).find? (EvmYul.UInt256.ofNat slot) with
+          | some val => val
+          | none => (⟨0⟩ : EvmYul.UInt256)) =
+            storage (IRStorageSlot.ofNat slot) := by
+        simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.storageLookup,
+          Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256]
+          using hLookup
+      rw [hErase]
+      have hSlotNe :
+          IRStorageSlot.ofNat slot ≠ IRStorageSlot.ofNat 0 := by
+        intro hEq
+        apply hKey
+        have hUIntEq :
+            EvmYul.UInt256.ofNat slot = EvmYul.UInt256.ofNat 0 := by
+          simpa [IRStorageSlot.ofNat] using hEq
+        rw [hUIntEq]
+        exact Std.ReflCmp.compare_self
+      have hSlotNe' :
+          EvmYul.UInt256.ofNat slot ≠ IRStorageSlot.ofNat 0 := by
+        simpa [IRStorageSlot.ofNat] using hSlotNe
+      have hSlotNeUInt :
+          EvmYul.UInt256.ofNat slot ≠ EvmYul.UInt256.ofNat 0 := by
+        intro hEq
+        exact hSlotNe' (by simpa [IRStorageSlot.ofNat] using hEq)
+      simpa [Compiler.Proofs.abstractStoreStorageOrMapping, IRStorageSlot.ofNat,
+        hSlotNeUInt] using hLookup'
+  · have hValueNonzero :
+        (EvmYul.UInt256.ofNat arg == (Inhabited.default : EvmYul.UInt256)) =
+          false := by
+      cases h :
+          (EvmYul.UInt256.ofNat arg == (Inhabited.default : EvmYul.UInt256)) <;>
+        simp [h] at hValueZero ⊢
+    rw [hValueNonzero]
+    simp only [Bool.false_eq_true, ite_false, IRStorageSlot.toUInt256,
+      IRStorageSlot.ofNat]
+    by_cases hKey :
+        compare (EvmYul.UInt256.ofNat slot) (EvmYul.UInt256.ofNat 0) =
+          Ordering.eq
+    · have hSlotEq :
+          IRStorageSlot.ofNat slot = IRStorageSlot.ofNat 0 := by
+        have hUInt :
+            EvmYul.UInt256.ofNat slot = EvmYul.UInt256.ofNat 0 :=
+          Compiler.Proofs.YulGeneration.Backends.StateBridge.UInt256_eq_of_compare_eq
+            hKey
+        simpa [IRStorageSlot.ofNat] using hUInt
+      have hUInt :
+          EvmYul.UInt256.ofNat slot = EvmYul.UInt256.ofNat 0 := by
+        simpa [IRStorageSlot.ofNat] using hSlotEq
+      rw [Batteries.RBMap.find?_insert_of_eq _ hKey]
+      rw [hUInt]
+      simp [Compiler.Proofs.abstractStoreStorageOrMapping,
+        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat, IRStorageSlot.ofNat]
+    · rw [Batteries.RBMap.find?_insert_of_ne _ hKey]
+      have hLookup :=
+        Compiler.Proofs.YulGeneration.Backends.StateBridge.storageLookup_projectStorage_projected
+          storage slots slot hSlot
+      have hLookup' :
+          (match
+            (Compiler.Proofs.YulGeneration.Backends.StateBridge.projectStorage
+              storage slots).find? (EvmYul.UInt256.ofNat slot) with
+          | some val => val
+          | none => (⟨0⟩ : EvmYul.UInt256)) =
+            storage (IRStorageSlot.ofNat slot) := by
+        simpa [Compiler.Proofs.YulGeneration.Backends.StateBridge.storageLookup,
+          Compiler.Proofs.YulGeneration.Backends.StateBridge.natToUInt256]
+          using hLookup
+      have hSlotNe :
+          IRStorageSlot.ofNat slot ≠ IRStorageSlot.ofNat 0 := by
+        intro hEq
+        apply hKey
+        have hUIntEq :
+            EvmYul.UInt256.ofNat slot = EvmYul.UInt256.ofNat 0 := by
+          simpa [IRStorageSlot.ofNat] using hEq
+        rw [hUIntEq]
+        exact Std.ReflCmp.compare_self
+      have hSlotNe' :
+          EvmYul.UInt256.ofNat slot ≠ IRStorageSlot.ofNat 0 := by
+        simpa [IRStorageSlot.ofNat] using hSlotNe
+      have hSlotNeUInt :
+          EvmYul.UInt256.ofNat slot ≠ EvmYul.UInt256.ofNat 0 := by
+        intro hEq
+        exact hSlotNe' (by simpa [IRStorageSlot.ofNat] using hEq)
+      simpa [Compiler.Proofs.abstractStoreStorageOrMapping, IRStorageSlot.ofNat,
+        hSlotNeUInt] using hLookup'
+
 /-- Closed-form evaluation of `projectResult` on the retrieve-hit halt error
 produced by the lowered SimpleStorage retrieve body. The halt state is built
 by chaining `sload(0)` (toState override), `mstore(0, _)` (toMachineState
@@ -4806,6 +5149,230 @@ theorem simpleStorageNativeRetrieveHitBridge_proved
   · exact hProject
   · exact hAgree
 
+/-- Store-hit native dispatcher bridge discharged against the existing public
+entry preconditions. The proof splits on whether the setter calldata argument
+is present: short calldata follows the native `revert(0,0)` argument guard,
+while present calldata executes the generated `sstore(0, calldataload(4));
+stop` body and compares projected storage on materialized observable slots. -/
+theorem simpleStorageNativeStoreHitBridge_proved
+    (tx : IRTransaction) (initialState : IRState) (observableSlots : List Nat)
+    (hselector : tx.functionSelector < selectorModulus)
+    (hNoWrap : 4 + tx.args.length * 32 < evmModulus)
+    (hvars : initialState.vars = [])
+    (hmemory : initialState.memory = fun _ => 0)
+    (htransient : initialState.transientStorage = fun _ => 0)
+    (hreturn : initialState.returnValue = none)
+    (hdispatchGuardSafe : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      HasSelectorDeadBridge fn.body)
+    (hparamErase : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      paramLoadErasure fn tx (initialState.withTx tx)) :
+    simpleStorageNativeStoreHitBridge tx initialState observableSlots := by
+  intro hStore
+  have hSelectorEq : tx.functionSelector = 0x6057361d := by
+    have hmod := Nat.mod_eq_of_lt hselector
+    rw [hmod] at hStore
+    exact hStore
+  have hMsgValue : tx.msgValue % EvmYul.UInt256.size = 0 := by
+    let storeFn : IRFunction :=
+      { name := "store"
+        selector := 0x6057361d
+        params := [{ name := "value", ty := IRType.uint256 }]
+        ret := IRType.unit
+        body := [
+          Yul.YulStmt.let_ "value" (Yul.YulExpr.call "calldataload" [Yul.YulExpr.lit 4]),
+          Yul.YulStmt.expr (Yul.YulExpr.call "sstore" [Yul.YulExpr.lit 0, Yul.YulExpr.ident "value"]),
+          Yul.YulStmt.expr (Yul.YulExpr.call "stop" [])
+        ] }
+    have hmem : storeFn ∈ simpleStorageIRContract.functions := by
+      simp [storeFn, simpleStorageIRContract]
+    have hguards := hdispatchGuardSafe storeFn hmem
+    have hzero : tx.msgValue % evmModulus = 0 := by
+      rcases hguards with ⟨hValue, _⟩
+      rcases hValue with hPayable | hZero
+      · simp [storeFn] at hPayable
+      · exact hZero
+    simpa [evmModulus, EvmYul.UInt256.size] using hzero
+  have hLayer :
+      Compiler.Proofs.YulGeneration.resultsMatch
+        (interpretIR simpleStorageIRContract tx initialState)
+        (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackend
+          .evmYulLean (Compiler.emitYul simpleStorageIRContract).runtimeCode
+          (YulTransaction.ofIR tx) initialState.storage initialState.events) :=
+    layer3_contract_preserves_semantics_evmYulLean simpleStorageIRContract tx initialState
+      hselector hNoWrap hvars hmemory htransient hreturn hparamErase
+      hdispatchGuardSafe hNoHasSelector hHasSelectorDead
+      (by intro fn hmem; simp [simpleStorageIRContract] at hmem ⊢; rcases hmem with rfl | rfl <;> rfl)
+      (by intro s hs; simp [simpleStorageIRContract] at hs) rfl rfl
+      simpleStorage_functions_bridged
+  let yulTx := YulTransaction.ofIR tx
+  let slots :=
+    Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots
+      (Compiler.runtimeCode simpleStorageIRContract) observableSlots
+  cases hArgs : tx.args with
+  | nil =>
+      have hIR := interpretIR_simpleStorage_storeHit_short tx initialState
+        hSelectorEq hArgs
+      have hLayerFuel :
+          Compiler.Proofs.YulGeneration.resultsMatch
+            { success := false
+              returnValue := none
+              finalStorage := initialState.storage
+              finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
+              events := initialState.events }
+            (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackendFuel
+              .evmYulLean (Nat.succ simpleStorageNativeDispatcherFuel)
+              (Compiler.emitYul simpleStorageIRContract).runtimeCode
+              (YulTransaction.ofIR tx) initialState.storage initialState.events) := by
+        simpa [hIR, Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackend,
+          simpleStorageNativeDispatcherFuel, simpleStorage_runtimeCode_eq_single_dispatcher]
+          using hLayer
+      rcases hLayerFuel with ⟨hsuccess, hreturnValue, hstorage, _hmappings, hevents⟩
+      refine nativeDispatcherExecAgreesWithInterpreterPositive_of_exec_error_project_eq_agree
+        (err := EvmYul.Yul.Exception.Revert)
+        (nativeYul :=
+          { success := false
+            returnValue := none
+            finalStorage := initialState.storage
+            finalMappings := Compiler.Proofs.storageAsMappings initialState.storage
+            events := initialState.events })
+        ?_ ?_ ?_
+      · simpa [simpleStorage_runtimeCode_eq_single_dispatcher, yulTx, slots] using
+          (simpleStorageNativeContract_dispatcherExec_storeHit_short_revert_atFuel
+            yulTx initialState.storage slots
+            (by simpa [yulTx, YulTransaction.ofIR] using hArgs)
+            (by
+              simp [yulTx]
+              exact hStore.symm)
+            (by simpa [yulTx, YulTransaction.ofIR, evmModulus] using hNoWrap)
+            (by simpa [yulTx, YulTransaction.ofIR] using hMsgValue))
+      · rfl
+      · refine ⟨?_, ?_, ?_, ?_⟩
+        · exact hsuccess
+        · exact hreturnValue
+        · intro slot _
+          exact hstorage (IRStorageSlot.ofNat slot)
+        · exact hevents
+  | cons arg rest =>
+      have hIR := interpretIR_simpleStorage_storeHit_arg tx initialState arg rest
+        hSelectorEq hArgs
+      have hLayerFuel :
+          Compiler.Proofs.YulGeneration.resultsMatch
+            { success := true
+              returnValue := none
+              finalStorage :=
+                Compiler.Proofs.abstractStoreStorageOrMapping initialState.storage 0
+                  (arg % evmModulus)
+              finalMappings :=
+                Compiler.Proofs.storageAsMappings
+                  (Compiler.Proofs.abstractStoreStorageOrMapping initialState.storage 0
+                    (arg % evmModulus))
+              events := initialState.events }
+            (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackendFuel
+              .evmYulLean (Nat.succ simpleStorageNativeDispatcherFuel)
+              (Compiler.emitYul simpleStorageIRContract).runtimeCode
+              (YulTransaction.ofIR tx) initialState.storage initialState.events) := by
+        simpa [hIR, Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackend,
+          simpleStorageNativeDispatcherFuel, simpleStorage_runtimeCode_eq_single_dispatcher]
+          using hLayer
+      obtain ⟨store, haltState, hExec, hHaltState⟩ :=
+        simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel
+          yulTx initialState.storage slots arg rest
+          (by simpa [yulTx, YulTransaction.ofIR] using hArgs)
+          (by
+            simp [yulTx]
+            exact hStore.symm)
+          (by simpa [yulTx, YulTransaction.ofIR, evmModulus] using hNoWrap)
+          (by simpa [yulTx, YulTransaction.ofIR] using hMsgValue)
+      have hProject :
+          Compiler.Proofs.YulGeneration.Backends.Native.projectResult
+            (YulTransaction.ofIR tx) initialState.storage initialState.events
+            (.error (EvmYul.Yul.Exception.YulHalt haltState ⟨0⟩)) =
+          { success := true,
+            returnValue := none,
+            finalStorage :=
+              Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+                (YulTransaction.ofIR tx) haltState,
+            finalMappings :=
+              Compiler.Proofs.storageAsMappings
+                (Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+                  (YulTransaction.ofIR tx) haltState),
+            events :=
+              initialState.events ++
+                Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
+                  haltState } := by
+        simp
+      have hLogs :
+          Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
+            haltState = [] := by
+        subst hHaltState
+        simp only [Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState,
+          Compiler.Proofs.YulGeneration.Backends.Native.initialState,
+          Compiler.Proofs.YulGeneration.Backends.StateBridge.toSharedState,
+          YulState.initial, EvmYul.Yul.State.sharedState,
+          EvmYul.Yul.State.setState, EvmYul.Yul.State.toState,
+          EvmYul.Yul.State.insert, EvmYul.State.sstore,
+          EvmYul.State.setAccount, EvmYul.State.lookupAccount,
+          EvmYul.State.addAccessedStorageKey,
+          EvmYul.Account.updateStorage,
+          EvmYul.Substate.addAccessedStorageKey, Option.option]
+        split <;> rfl
+      have hAgree :
+          yulResultsAgreeOn observableSlots
+            { success := true,
+              returnValue := none,
+              finalStorage :=
+                Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+                  (YulTransaction.ofIR tx) haltState,
+              finalMappings :=
+                Compiler.Proofs.storageAsMappings
+                  (Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+                    (YulTransaction.ofIR tx) haltState),
+              events :=
+                initialState.events ++
+                  Compiler.Proofs.YulGeneration.Backends.Native.projectLogsFromState
+                    haltState }
+            (Compiler.Proofs.YulGeneration.Backends.interpretYulRuntimeWithBackendFuel
+              .evmYulLean (Nat.succ simpleStorageNativeDispatcherFuel)
+              (Compiler.emitYul simpleStorageIRContract).runtimeCode
+              (YulTransaction.ofIR tx) initialState.storage initialState.events) := by
+        rcases hLayerFuel with ⟨hsuccess, hreturnValue, hstorage, _hmappings, hevents⟩
+        refine ⟨?_, ?_, ?_, ?_⟩
+        · exact hsuccess
+        · exact hreturnValue
+        · intro slot hslot
+          have hslot' : slot ∈ slots := by
+            simp [slots, Compiler.Proofs.YulGeneration.Backends.Native.materializedStorageSlots,
+              hslot]
+          have hNative :=
+            projectStorageFromState_storeHit_initialState_materialized
+              yulTx initialState.storage slots store arg slot hslot'
+          have hNative' :
+              Compiler.Proofs.YulGeneration.Backends.Native.projectStorageFromState
+                  (YulTransaction.ofIR tx) haltState (IRStorageSlot.ofNat slot) =
+                (Compiler.Proofs.abstractStoreStorageOrMapping initialState.storage 0
+                  (arg % evmModulus)) (IRStorageSlot.ofNat slot) := by
+            subst hHaltState
+            rw [hNative]
+            have hArgMod :
+                EvmYul.UInt256.ofNat arg =
+                  EvmYul.UInt256.ofNat (arg % evmModulus) := by
+              unfold EvmYul.UInt256.ofNat
+              simp [Id.run, Fin.ofNat, evmModulus, EvmYul.UInt256.size]
+            simp [Compiler.Proofs.abstractStoreStorageOrMapping,
+              Compiler.Proofs.IRGeneration.IRStorageWord.ofNat, hArgMod]
+          exact hNative'.trans (hstorage (IRStorageSlot.ofNat slot))
+        · rw [hLogs, List.append_nil]
+          exact hevents
+      apply nativeDispatcherExecAgreesWithInterpreterPositive_of_exec_yulHalt_project_eq_agree
+        (haltState := haltState) (haltValue := ⟨0⟩)
+      · simpa [simpleStorage_runtimeCode_eq_single_dispatcher, yulTx, slots] using hExec
+      · exact hProject
+      · exact hAgree
+
 /-- Selector-miss native dispatcher bridge discharged against the existing
 public entry preconditions. The native selector-miss path reverts, so
 `projectResult` preserves the parameter-passed initial storage directly. -/
@@ -5012,24 +5579,7 @@ theorem simpleStorage_endToEnd_native_evmYulLean_of_callDispatcher_bridge
     hNativeCallDispatcher
 
 /-- Native SimpleStorage end-to-end theorem with the concrete native dispatcher
-witness supplied per-selector-case.
-
-This theorem targets native EVMYulLean execution, but it does not pretend the
-  remaining selected-body native dispatcher proof is complete. Callers must
-  supply the remaining store-hit sub-bridge; retrieve hit and selector miss
-  are discharged below. The per-case bridges are recombined into the monolithic
-  `simpleStorageNativeCallDispatcherBridge` via
-  `simpleStorageNativeCallDispatcherBridge_of_per_case` before delegating to the
-  underlying `_of_callDispatcher_bridge` wrapper.
-
-Each sub-bridge is strictly weaker than the monolithic bridge: it gets to
-assume the selector class as a precondition, so its discharger does not need
-to do the case analysis on `tx.functionSelector % selectorModulus`. The
-retrieve-hit case is the closest to unconditional discharge — its lowered
-2-statement body `mstore(0, sload(0)); return(0, 32)` already reduces to a
-closed-form `YulHalt` state via `exec_block_simpleStorageLoweredRetrieveCase
-BodyTail3_closed`, leaving only the observable-storage agreement step
-between the projected halt and the EVMYulLean interpreter result. -/
+bridge fully discharged for retrieve hit, store hit, and selector miss. -/
 theorem simpleStorage_endToEnd_native_evmYulLean
     (tx : IRTransaction) (initialState : IRState) (observableSlots : List Nat)
     (hselector : tx.functionSelector < selectorModulus)
@@ -5044,11 +5594,9 @@ theorem simpleStorage_endToEnd_native_evmYulLean
       yulStmtsNoRef "__has_selector" fn.body)
     (hHasSelectorDead : ∀ fn, fn ∈ simpleStorageIRContract.functions →
       HasSelectorDeadBridge fn.body)
-      (hparamErase : ∀ fn, fn ∈ simpleStorageIRContract.functions →
-        paramLoadErasure fn tx (initialState.withTx tx))
-      (hStoreHit :
-        simpleStorageNativeStoreHitBridge tx initialState observableSlots)
-      (hEnv :
+    (hparamErase : ∀ fn, fn ∈ simpleStorageIRContract.functions →
+      paramLoadErasure fn tx (initialState.withTx tx))
+    (hEnv :
         Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
           (Compiler.emitYul simpleStorageIRContract).runtimeCode
         (YulTransaction.ofIR tx) = .ok ()) :
@@ -5071,7 +5619,10 @@ theorem simpleStorage_endToEnd_native_evmYulLean
                 observableSlots hselector hNoWrap hvars hmemory htransient
                   hreturn hdispatchGuardSafe hNoHasSelector hHasSelectorDead
                   hparamErase)
-                hStoreHit
+                (simpleStorageNativeStoreHitBridge_proved tx initialState
+                  observableSlots hselector hNoWrap hvars hmemory htransient
+                  hreturn hdispatchGuardSafe hNoHasSelector hHasSelectorDead
+                  hparamErase)
                 (simpleStorageNativeSelectorMissBridge_proved tx initialState
                   observableSlots hselector hNoWrap hvars hmemory htransient
                   hreturn hdispatchGuardSafe hNoHasSelector hHasSelectorDead

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -7532,10 +7532,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_of_erase
     (slot value : Nat)
     (hSlotRange : slot < EvmYul.UInt256.size)
     (hValueZero :
-      (natToUInt256 value == (⟨0⟩ : EvmYul.UInt256)) = true)
-    (hErase :
-      (Batteries.RBMap.erase (projectStorage storage observableSlots)
-        (natToUInt256 slot)).find? (natToUInt256 slot) = none) :
+      (natToUInt256 value == (⟨0⟩ : EvmYul.UInt256)) = true) :
     ∃ finalState,
       EvmYul.Yul.primCall (fuel + 1)
           (initialState contract tx storage observableSlots)
@@ -7559,6 +7556,10 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_of_erase
           true := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
+    have hErase :
+        (Batteries.RBMap.erase (projectStorage storage observableSlots)
+          (natToUInt256 slot)).find? (natToUInt256 slot) = none :=
+      Batteries.RBMap.find?_erase_self _ _
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
       Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
@@ -7586,7 +7587,6 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_emptyObser
   exact
     primCall_sstore_initialState_wordSlot_projectResult_slot_zero_of_erase
       fuel contract tx storage initialEvents [] slot value hSlotRange hValueZero
-      (by rfl)
 
 /-- Native primitive execution of `sstore(slot, value)` from an initial runtime
     shared state and arbitrary local-variable store, lifted through Verity's
@@ -7648,10 +7648,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_
     (slot value : Nat)
     (hSlotRange : slot < EvmYul.UInt256.size)
     (hValueZero :
-      (natToUInt256 value == (⟨0⟩ : EvmYul.UInt256)) = true)
-    (hErase :
-      (Batteries.RBMap.erase (projectStorage storage observableSlots)
-        (natToUInt256 slot)).find? (natToUInt256 slot) = none) :
+      (natToUInt256 value == (⟨0⟩ : EvmYul.UInt256)) = true) :
     ∃ finalState,
       EvmYul.Yul.primCall (fuel + 1)
           (.Ok (initialState contract tx storage observableSlots).sharedState store)
@@ -7678,6 +7675,10 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_
           true := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
+    have hErase :
+        (Batteries.RBMap.erase (projectStorage storage observableSlots)
+          (natToUInt256 slot)).find? (natToUInt256 slot) = none :=
+      Batteries.RBMap.find?_erase_self _ _
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
       Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
@@ -7704,7 +7705,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_
   exact
     primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_of_erase
       fuel contract tx storage initialEvents [] store slot value hSlotRange
-      hValueZero (by rfl)
+      hValueZero
 
 /-- Native primitive execution of the generated `store(uint256)` core, lifted
     through Verity's projected native result boundary for call success and
@@ -8061,9 +8062,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
     (rest : List Nat)
     (hArgs : tx.args = arg :: rest)
     (hValueZero :
-      (natToUInt256 arg == (⟨0⟩ : EvmYul.UInt256)) = true)
-    (hErase :
-      (Batteries.RBMap.erase (projectStorage storage observableSlots) (EvmYul.UInt256.ofNat 0)).find? (EvmYul.UInt256.ofNat 0) = none) :
+      (natToUInt256 arg == (⟨0⟩ : EvmYul.UInt256)) = true) :
     ∃ haltState haltValue,
       primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore
         loadFuel storeFuel stopFuel contract tx storage observableSlots store =
@@ -8093,6 +8092,10 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
           true := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
+    have hErase :
+        (Batteries.RBMap.erase (projectStorage storage observableSlots)
+          (EvmYul.UInt256.ofNat 0)).find? (EvmYul.UInt256.ofNat 0) = none :=
+      Batteries.RBMap.find?_erase_self _ _
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
       Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
@@ -8121,7 +8124,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
   exact
     primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_projectResult_slot0_zero_of_erase
       loadFuel storeFuel stopFuel contract tx storage initialEvents [] store arg
-      rest hArgs hValueZero (by rfl)
+      rest hArgs hValueZero
 
 /-- Native primitive execution of the full generated `store(uint256)` selected
     body tail: `calldataload(4); sstore(0, arg0); stop`. The terminating
@@ -8214,10 +8217,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
     (rest : List Nat)
     (hArgs : tx.args = arg :: rest)
     (hValueZero :
-      (natToUInt256 arg == (⟨0⟩ : EvmYul.UInt256)) = true)
-    (hErase :
-      (Batteries.RBMap.erase (projectStorage storage observableSlots)
-        (EvmYul.UInt256.ofNat 0)).find? (EvmYul.UInt256.ofNat 0) = none) :
+      (natToUInt256 arg == (⟨0⟩ : EvmYul.UInt256)) = true) :
     ∃ haltState haltValue,
       primCall_calldataload4_then_sstore0_stop_initialState_arg0
         loadFuel storeFuel stopFuel contract tx storage observableSlots =
@@ -8245,6 +8245,10 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
           true := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
+    have hErase :
+        (Batteries.RBMap.erase (projectStorage storage observableSlots)
+          (EvmYul.UInt256.ofNat 0)).find? (EvmYul.UInt256.ofNat 0) = none :=
+      Batteries.RBMap.find?_erase_self _ _
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
       Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
@@ -8271,7 +8275,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
   exact
     primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult_slot0_zero_of_erase
       loadFuel storeFuel stopFuel contract tx storage initialEvents [] arg rest
-      hArgs hValueZero (by rfl)
+      hArgs hValueZero
 
 /-- Native primitive execution of the generated `store(uint256)` core, lifted
     through Verity's projected native result boundary for a nonzero slot-zero
@@ -8333,10 +8337,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
     (rest : List Nat)
     (hArgs : tx.args = arg :: rest)
     (hValueZero :
-      (natToUInt256 arg == (⟨0⟩ : EvmYul.UInt256)) = true)
-    (hErase :
-      (Batteries.RBMap.erase (projectStorage storage observableSlots)
-        (EvmYul.UInt256.ofNat 0)).find? (EvmYul.UInt256.ofNat 0) = none) :
+      (natToUInt256 arg == (⟨0⟩ : EvmYul.UInt256)) = true) :
     ∃ finalState,
       (do
         let (state', values) ←
@@ -8367,6 +8368,10 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
           true := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueZero
     rw [hBranch]
+    have hErase :
+        (Batteries.RBMap.erase (projectStorage storage observableSlots)
+          (EvmYul.UInt256.ofNat 0)).find? (EvmYul.UInt256.ofNat 0) = none :=
+      Batteries.RBMap.find?_erase_self _ _
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
       Std.ReflCmp.compare_self, IRStorageSlot.toUInt256, IRStorageSlot.ofNat, hErase]
 
@@ -8399,7 +8404,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
   exact
     primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot0_zero_of_erase
       loadFuel storeFuel contract tx storage initialEvents [] arg rest hArgs
-      hValueZero (by rfl)
+      hValueZero
 
 @[simp] theorem projectResult_yulHalt_events
     (tx : YulTransaction)

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
@@ -134,6 +134,171 @@ theorem find?_erase_self {cmp : α → α → Ordering} [Std.TransCmp cmp]
   rw [findP?_erase_none]
   rfl
 
+theorem append_toList (l r : RBNode α) :
+    (l.append r).toList = l.toList ++ r.toList := by
+  induction l, r using RBNode.append.induct <;>
+    simp [RBNode.append, *]
+  · rename_i la lx lb rc ry rd ra rx rb h ih
+    have ih' := ih
+    rw [h] at ih'
+    simp at ih'
+    calc
+      ra.toList ++ rx :: (rb.toList ++ ry :: rd.toList)
+          = (ra.toList ++ rx :: rb.toList) ++ ry :: rd.toList := by
+              simp [List.append_assoc]
+      _ = (lb.toList ++ rc.toList) ++ ry :: rd.toList := by
+              rw [ih']
+      _ = lb.toList ++ (rc.toList ++ ry :: rd.toList) := by
+              simp [List.append_assoc]
+  · rename_i la lx lb rc ry rd ra rx rb h ih
+    have ih' := ih
+    rw [h] at ih'
+    simp at ih'
+    calc
+      ra.toList ++ rx :: (rb.toList ++ ry :: rd.toList)
+          = (ra.toList ++ rx :: rb.toList) ++ ry :: rd.toList := by
+              simp [List.append_assoc]
+      _ = (lb.toList ++ rc.toList) ++ ry :: rd.toList := by
+              rw [ih']
+      _ = lb.toList ++ (rc.toList ++ ry :: rd.toList) := by
+              simp [List.append_assoc]
+
+theorem mem_del_of_mem_ne {cut : α → Ordering}
+    {t : RBNode α} {x : α} (hx : x ∈ t) (hcut : cut x ≠ Ordering.eq) :
+    x ∈ t.del cut := by
+  induction t with
+  | nil => cases hx
+  | node c a y b iha ihb =>
+      simp only [RBNode.del]
+      split
+      · rename_i hy
+        rcases hx with rfl | hx | hx
+        · cases hblack : a.isBlack <;>
+            rw [← mem_toList] <;>
+            simp
+        · cases hblack : a.isBlack <;>
+            rw [← mem_toList] <;>
+            simp [iha hx]
+        · cases hblack : a.isBlack <;>
+            rw [← mem_toList] <;>
+            simp
+          · exact Or.inr (Or.inr hx)
+          · exact Or.inr (Or.inr hx)
+      · rename_i hy
+        rcases hx with rfl | hx | hx
+        · cases hblack : b.isBlack <;>
+            rw [← mem_toList] <;>
+            simp
+        · cases hblack : b.isBlack <;>
+            rw [← mem_toList] <;>
+            simp
+          · exact Or.inl hx
+          · exact Or.inl hx
+        · cases hblack : b.isBlack <;>
+            rw [← mem_toList] <;>
+            simp [ihb hx]
+      · rename_i hy
+        rcases hx with rfl | hx | hx
+        · exact absurd hy hcut
+        · rw [← mem_toList]
+          simp [append_toList]
+          exact Or.inl hx
+        · rw [← mem_toList]
+          simp [append_toList]
+          exact Or.inr hx
+
+theorem mem_of_mem_del {cut : α → Ordering}
+    {t : RBNode α} {x : α} (hx : x ∈ t.del cut) :
+    x ∈ t := by
+  induction t with
+  | nil => cases hx
+  | node c a y b iha ihb =>
+      simp only [RBNode.del] at hx
+      split at hx
+      · rename_i hy
+        cases hblack : a.isBlack
+        · rw [← mem_toList] at hx
+          simp only [hblack] at hx
+          simp at hx
+          rcases hx with hx | rfl | hx
+          · exact Or.inr (Or.inl (iha hx))
+          · exact Or.inl rfl
+          · exact Or.inr (Or.inr hx)
+        · rw [← mem_toList] at hx
+          simp only [hblack] at hx
+          simp at hx
+          rcases hx with hx | rfl | hx
+          · exact Or.inr (Or.inl (iha hx))
+          · exact Or.inl rfl
+          · exact Or.inr (Or.inr hx)
+      · rename_i hy
+        cases hblack : b.isBlack
+        · rw [← mem_toList] at hx
+          simp only [hblack] at hx
+          simp at hx
+          rcases hx with hx | rfl | hx
+          · exact Or.inr (Or.inl hx)
+          · exact Or.inl rfl
+          · exact Or.inr (Or.inr (ihb hx))
+        · rw [← mem_toList] at hx
+          simp only [hblack] at hx
+          simp at hx
+          rcases hx with hx | rfl | hx
+          · exact Or.inr (Or.inl hx)
+          · exact Or.inl rfl
+          · exact Or.inr (Or.inr (ihb hx))
+      · rw [← mem_toList] at hx
+        simp [append_toList] at hx ⊢
+        rcases hx with hx | hx
+        · exact Or.inr (Or.inl hx)
+        · exact Or.inr (Or.inr hx)
+
+theorem mem_erase_of_mem_ne {cut : α → Ordering}
+    {t : RBNode α} {x : α} (hx : x ∈ t) (hcut : cut x ≠ Ordering.eq) :
+    x ∈ t.erase cut := by
+  unfold erase
+  rw [← mem_toList]
+  simpa using mem_del_of_mem_ne (cut := cut) hx hcut
+
+theorem mem_of_mem_erase {cut : α → Ordering}
+    {t : RBNode α} {x : α} (hx : x ∈ t.erase cut) :
+    x ∈ t := by
+  unfold erase at hx
+  rw [← mem_toList] at hx
+  exact mem_of_mem_del (cut := cut) (by simpa using hx)
+
+theorem find?_erase_of_ne {cmp : α → α → Ordering}
+    {cut eraseCut : α → Ordering} [Std.TransCmp cmp] [IsStrictCut cmp cut]
+    (t : RBNode α) (ht : t.Ordered cmp)
+    (hNe : ∀ x, cut x = Ordering.eq → eraseCut x ≠ Ordering.eq) :
+    (t.erase eraseCut).find? cut = t.find? cut := by
+  have htErase : (t.erase eraseCut).Ordered cmp :=
+    Ordered.erase (cut := eraseCut) ht
+  cases hFind : t.find? cut with
+  | none =>
+      by_contra hneq
+      have hsome : ∃ x, (t.erase eraseCut).find? cut = some x := by
+        cases h : (t.erase eraseCut).find? cut with
+        | none =>
+            exfalso
+            exact hneq h
+        | some x => exact ⟨x, rfl⟩
+      rcases hsome with ⟨x, hx⟩
+      have hxMem : x ∈ t :=
+        mem_of_mem_erase (cut := eraseCut)
+          (find?_some_mem hx)
+      have hxEq : cut x = Ordering.eq := find?_some_eq_eq hx
+      have hxOld : t.find? cut = some x :=
+        (Ordered.find?_some ht).2 ⟨hxMem, hxEq⟩
+      rw [hFind] at hxOld
+      cases hxOld
+  | some x =>
+      have hxMem : x ∈ t := find?_some_mem hFind
+      have hxEq : cut x = Ordering.eq := find?_some_eq_eq hFind
+      exact (Ordered.find?_some htErase).2
+        ⟨mem_erase_of_mem_ne (cut := eraseCut) hxMem
+          (hNe x hxEq), hxEq⟩
+
 end RBNode
 
 namespace RBMap
@@ -142,6 +307,21 @@ theorem find?_erase_self {cmp : α → α → Ordering} [Std.TransCmp cmp]
     (m : RBMap α β cmp) (k : α) :
     (m.erase k).find? k = none :=
   RBNode.find?_erase_self m k
+
+theorem find?_erase_of_ne {cmp : α → α → Ordering} [Std.TransCmp cmp]
+    (m : RBMap α β cmp) {k k' : α} (hNe : cmp k' k ≠ Ordering.eq) :
+    (m.erase k).find? k' = m.find? k' := by
+  unfold RBMap.find? RBMap.findEntry? RBMap.erase RBSet.erase RBSet.findP?
+  rw [RBNode.find?_erase_of_ne (cmp := Ordering.byKey Prod.fst cmp)
+    (cut := fun y : α × β => cmp k' y.1)
+    (eraseCut := fun y : α × β => cmp k y.1) m.1 m.2.out.1]
+  intro y hy
+  intro hErase
+  have hKey : cmp k' k = Ordering.eq := by
+    have h1 : cmp k' y.1 = Ordering.eq := hy
+    have h2 : cmp k y.1 = Ordering.eq := hErase
+    exact Std.TransCmp.eq_trans h1 (Std.OrientedCmp.eq_comm.1 h2)
+  exact hNe hKey
 
 end RBMap
 end Batteries

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
@@ -127,13 +127,6 @@ theorem findP?_erase_none {cmp : α → α → Ordering} {cut : α → Ordering}
   rw [find?_eq_none_of_all_ne]
   exact erase_all_cut_ne (cmp := cmp) (cut := cut) s.2.out.1
 
-theorem find?_erase_self {cmp : α → α → Ordering} [Std.TransCmp cmp]
-    (m : RBMap α β cmp) (k : α) :
-    (m.erase k).find? k = none := by
-  unfold RBMap.find? RBMap.findEntry? RBMap.erase
-  rw [findP?_erase_none]
-  rfl
-
 theorem append_toList (l r : RBNode α) :
     (l.append r).toList = l.toList ++ r.toList := by
   induction l, r using RBNode.append.induct <;>
@@ -305,8 +298,10 @@ namespace RBMap
 
 theorem find?_erase_self {cmp : α → α → Ordering} [Std.TransCmp cmp]
     (m : RBMap α β cmp) (k : α) :
-    (m.erase k).find? k = none :=
-  RBNode.find?_erase_self m k
+    (m.erase k).find? k = none := by
+  unfold RBMap.find? RBMap.findEntry? RBMap.erase
+  rw [RBNode.findP?_erase_none]
+  rfl
 
 theorem find?_erase_of_ne {cmp : α → α → Ordering} [Std.TransCmp cmp]
     (m : RBMap α β cmp) {k k' : α} (hNe : cmp k' k ≠ Ordering.eq) :

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
@@ -36,6 +36,116 @@ import EvmYul.Maps.StorageMap
 import Batteries.Data.ByteArray
 import Batteries.Data.RBMap.Lemmas
 
+namespace Batteries
+namespace RBNode
+
+open RBColor
+
+theorem All.setBlack' {p : α → Prop} {t : RBNode α}
+    (h : t.All p) : t.setBlack.All p := by
+  cases t <;> simp [setBlack]
+  exact h
+
+theorem find?_eq_none_of_all_ne {cut : α → Ordering} {t : RBNode α}
+    (h : t.All (fun x => cut x ≠ Ordering.eq)) :
+    t.find? cut = none := by
+  induction t with
+  | nil => rfl
+  | node _ l x r ihl ihr =>
+      rw [find?]
+      split <;> rename_i hc
+      · exact ihl h.2.1
+      · exact ihr h.2.2
+      · exact False.elim (h.1 hc)
+
+theorem del_all_cut_ne {cmp : α → α → Ordering} {cut : α → Ordering}
+    [Std.TransCmp cmp] [IsStrictCut cmp cut] :
+    ∀ {t : RBNode α}, t.Ordered cmp →
+      (t.del cut).All (fun x => cut x ≠ Ordering.eq)
+  | nil, _ => by simp [del]
+  | node _ a y b, ht => by
+      rcases ht with ⟨hay, hyb, ha, hb⟩
+      rw [del]
+      split <;> rename_i hcut
+      · have haAll := del_all_cut_ne (cmp := cmp) (cut := cut) ha
+        have hy : cut y ≠ Ordering.eq := by simp [hcut]
+        have hbAll : b.All (fun x => cut x ≠ Ordering.eq) := by
+          apply hyb.imp
+          intro x hyx hxeq
+          have hlt : cut x = Ordering.lt := IsCut.lt_trans hyx.1 hcut
+          cases hlt.symm.trans hxeq
+        cases a with
+        | nil =>
+            simp [isBlack]
+            exact ⟨hy, haAll, hbAll⟩
+        | node c _ _ _ =>
+            cases c <;> simp [isBlack]
+            · exact ⟨hy, haAll, hbAll⟩
+            · exact All.balLeft haAll hy hbAll
+      · have hbAll := del_all_cut_ne (cmp := cmp) (cut := cut) hb
+        have hy : cut y ≠ Ordering.eq := by simp [hcut]
+        have haAll : a.All (fun x => cut x ≠ Ordering.eq) := by
+          apply hay.imp
+          intro x hxy hxeq
+          have hgt : cut x = Ordering.gt := IsCut.gt_trans hxy.1 hcut
+          cases hgt.symm.trans hxeq
+        cases b with
+        | nil =>
+            simp [isBlack]
+            exact ⟨hy, haAll, hbAll⟩
+        | node c _ _ _ =>
+            cases c <;> simp [isBlack]
+            · exact ⟨hy, haAll, hbAll⟩
+            · exact All.balRight haAll hy hbAll
+      · have haAll : a.All (fun x => cut x ≠ Ordering.eq) := by
+          apply hay.imp
+          intro x hxy hxeq
+          have hx : cmp x y = cut y := IsStrictCut.exact hxeq
+          rw [hcut] at hx
+          cases hxy.1.symm.trans hx
+        have hbAll : b.All (fun x => cut x ≠ Ordering.eq) := by
+          apply hyb.imp
+          intro x hyx hxeq
+          have hx : cmp x y = cut y := IsStrictCut.exact hxeq
+          rw [hcut] at hx
+          have hxygt : cmp x y = Ordering.gt :=
+            Std.OrientedCmp.gt_iff_lt.2 hyx.1
+          cases hxygt.symm.trans hx
+        exact All.append haAll hbAll
+
+theorem erase_all_cut_ne {cmp : α → α → Ordering} {cut : α → Ordering}
+    [Std.TransCmp cmp] [IsStrictCut cmp cut] {t : RBNode α}
+    (ht : t.Ordered cmp) :
+    (t.erase cut).All (fun x => cut x ≠ Ordering.eq) := by
+  unfold erase
+  exact All.setBlack' (del_all_cut_ne (cmp := cmp) (cut := cut) ht)
+
+theorem findP?_erase_none {cmp : α → α → Ordering} {cut : α → Ordering}
+    [Std.TransCmp cmp] [IsStrictCut cmp cut] (s : RBSet α cmp) :
+    (s.erase cut).findP? cut = none := by
+  unfold RBSet.erase RBSet.findP?
+  rw [find?_eq_none_of_all_ne]
+  exact erase_all_cut_ne (cmp := cmp) (cut := cut) s.2.out.1
+
+theorem find?_erase_self {cmp : α → α → Ordering} [Std.TransCmp cmp]
+    (m : RBMap α β cmp) (k : α) :
+    (m.erase k).find? k = none := by
+  unfold RBMap.find? RBMap.findEntry? RBMap.erase
+  rw [findP?_erase_none]
+  rfl
+
+end RBNode
+
+namespace RBMap
+
+theorem find?_erase_self {cmp : α → α → Ordering} [Std.TransCmp cmp]
+    (m : RBMap α β cmp) (k : α) :
+    (m.erase k).find? k = none :=
+  RBNode.find?_erase_self m k
+
+end RBMap
+end Batteries
+
 namespace Compiler.Proofs.YulGeneration.Backends.StateBridge
 
 open Compiler.Proofs.YulGeneration

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3507,7 +3507,6 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Batteries.RBNode.del_all_cut_ne
 #print axioms Batteries.RBNode.erase_all_cut_ne
 #print axioms Batteries.RBNode.findP?_erase_none
-#print axioms Batteries.RBNode.find?_erase_self
 #print axioms Batteries.RBNode.append_toList
 #print axioms Batteries.RBNode.mem_del_of_mem_ne
 #print axioms Batteries.RBNode.mem_of_mem_del
@@ -3586,4 +3585,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3410 theorems/lemmas (2466 public, 944 private, 0 sorry'd)
+-- Total: 3409 theorems/lemmas (2465 public, 944 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3504,7 +3504,14 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Batteries.RBNode.erase_all_cut_ne
 #print axioms Batteries.RBNode.findP?_erase_none
 #print axioms Batteries.RBNode.find?_erase_self
+#print axioms Batteries.RBNode.append_toList
+#print axioms Batteries.RBNode.mem_del_of_mem_ne
+#print axioms Batteries.RBNode.mem_of_mem_del
+#print axioms Batteries.RBNode.mem_erase_of_mem_ne
+#print axioms Batteries.RBNode.mem_of_mem_erase
+#print axioms Batteries.RBNode.find?_erase_of_ne
 #print axioms Batteries.RBMap.find?_erase_self
+#print axioms Batteries.RBMap.find?_erase_of_ne
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_selectorBytes_size  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_wordBytes_size  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_fold_size  -- private
@@ -3575,4 +3582,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3399 theorems/lemmas (2455 public, 944 private, 0 sorry'd)
+-- Total: 3406 theorems/lemmas (2462 public, 944 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -762,6 +762,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail_callvalue_strip_error
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail2_lt_strip_error
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBodyTail2_lt_strip_error
+#print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBodyTail2_short_revert
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBodyTail3_halt
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBody_halt
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail3_closed
@@ -789,8 +790,11 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_storeHit_short
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel
+#print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_storeHit_short_revert_atFuel
+#print axioms Compiler.Proofs.EndToEnd.projectStorageFromState_storeHit_initialState_materialized
 #print axioms Compiler.Proofs.EndToEnd.projectResult_retrieveHit_eq
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeRetrieveHitBridge_proved
+#print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeStoreHitBridge_proved
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeSelectorMissBridge_proved
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeCallDispatcherBridge_of_per_case
 #print axioms Compiler.Proofs.EndToEnd.simpleStorage_endToEnd_evmYulLean
@@ -3582,4 +3586,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3406 theorems/lemmas (2462 public, 944 private, 0 sorry'd)
+-- Total: 3410 theorems/lemmas (2466 public, 944 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3498,6 +3498,13 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.compileExprList_bridgedSource
 
 -- Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
+#print axioms Batteries.RBNode.All.setBlack'
+#print axioms Batteries.RBNode.find?_eq_none_of_all_ne
+#print axioms Batteries.RBNode.del_all_cut_ne
+#print axioms Batteries.RBNode.erase_all_cut_ne
+#print axioms Batteries.RBNode.findP?_erase_none
+#print axioms Batteries.RBNode.find?_erase_self
+#print axioms Batteries.RBMap.find?_erase_self
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_selectorBytes_size  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_wordBytes_size  -- private
 -- #print axioms Compiler.Proofs.YulGeneration.Backends.StateBridge.calldataToByteArray_fold_size  -- private
@@ -3568,4 +3575,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3392 theorems/lemmas (2448 public, 944 private, 0 sorry'd)
+-- Total: 3399 theorems/lemmas (2455 public, 944 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -778,10 +778,14 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail2
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail3
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherFuel_ge_25
+#print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeDispatcherFuel_ge_21
+#print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_atFuel
+#print axioms Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_selectorMiss
 #print axioms Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_retrieveHit
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
 #print axioms Compiler.Proofs.EndToEnd.projectResult_retrieveHit_eq
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeRetrieveHitBridge_proved
+#print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeSelectorMissBridge_proved
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeCallDispatcherBridge_of_per_case
 #print axioms Compiler.Proofs.EndToEnd.simpleStorage_endToEnd_evmYulLean
 #print axioms Compiler.Proofs.EndToEnd.simpleStorage_endToEnd_native_evmYulLean_of_callDispatcher_bridge
@@ -3558,4 +3562,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3382 theorems/lemmas (2438 public, 944 private, 0 sorry'd)
+-- Total: 3386 theorems/lemmas (2442 public, 944 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -761,6 +761,9 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBodyTail_callvalue_strip_error
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail_callvalue_strip_error
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail2_lt_strip_error
+#print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBodyTail2_lt_strip_error
+#print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBodyTail3_halt
+#print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredStoreCaseBody_halt
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBodyTail3_closed
 #print axioms Compiler.Proofs.EndToEnd.exec_block_simpleStorageLoweredRetrieveCaseBody_halt
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageBuildSwitchSourceCases_lowered_concrete
@@ -782,7 +785,10 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_atFuel
 #print axioms Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_selectorMiss
 #print axioms Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_retrieveHit
+#print axioms Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_storeHit_arg
+#print axioms Compiler.Proofs.EndToEnd.interpretIR_simpleStorage_storeHit_short
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_retrieveHit_halt_atFuel
+#print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel
 #print axioms Compiler.Proofs.EndToEnd.projectResult_retrieveHit_eq
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeRetrieveHitBridge_proved
 #print axioms Compiler.Proofs.EndToEnd.simpleStorageNativeSelectorMissBridge_proved
@@ -3562,4 +3568,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3386 theorems/lemmas (2442 public, 944 private, 0 sorry'd)
+-- Total: 3392 theorems/lemmas (2448 public, 944 private, 0 sorry'd)

--- a/docs/IR_STORAGE_PHASE3_PLAN.md
+++ b/docs/IR_STORAGE_PHASE3_PLAN.md
@@ -1,0 +1,84 @@
+# IR Storage Refactor — Phase 3 Plan
+
+Phase 3 of [`IR_STORAGE_UINT256_REFACTOR.md`](IR_STORAGE_UINT256_REFACTOR.md):
+discharge `simpleStorageNativeStoreHitBridge` and drop the `hStoreHit` premise
+from `simpleStorage_endToEnd_native_evmYulLean`. After Phase 3, the public
+SimpleStorage native theorem has zero remaining bridge premises.
+
+This file is the working scaffold for the Phase 3 PR. It is plan-only so the
+PR opens against a green build.
+
+## Prerequisites
+
+- Phase 1 (#1754) — `UInt256`-bounded IR storage carrier.
+- Phase 2 (#1755) — retrieve-hit bridge proved and `hRetrieveHit` removed.
+
+## Why this becomes provable after Phase 1
+
+The store-hit case has two distinct read paths and one write path:
+
+1. **The sstore-written slot.** Calldata round-trip is unconditionally bounded
+   to 32 bytes by the lowered dispatcher, so the WRITTEN value was already
+   `UInt256`-bounded; no Phase 1 dependency for that arm.
+2. **Re-read of any other materialized observable slot.** This is the same
+   gap as Phase 2 — Phase 1's carrier flip closes it.
+3. **Storage-state agreement after the write.** The native side mutates
+   `SharedState.storage` at slot index `s`; the IR oracle mutates
+   `IRState.storage` at the same index. Once both carriers are `UInt256`,
+   the post-state functional extensionality argument over slots reduces
+   identically on both sides.
+
+## Phase 3 deliverables
+
+1. Lemma `simpleStorageNativeStoreHitBridge_proved` — mirrors the Phase 2
+   retrieve-hit lemma, with the additional sstore mutation argument.
+2. Replace the explicit `hStoreHit` premise on
+   `simpleStorage_endToEnd_native_evmYulLean` with the proved lemma.
+3. `PrintAxioms` for the public theorem reports no remaining bridge premises
+   beyond the trusted EVMYulLean builtin axioms.
+4. `simpleStorageNativeCallDispatcherBridge_of_per_case` is the only
+   surviving dispatcher surface and is fully closed.
+5. `Contracts/SimpleStorage/Proofs/` unchanged.
+
+## Proof obligation outline
+
+After Phases 1 and 2, the store-hit bridge reduces to:
+
+- The native dispatcher's hit-case body executes `sstore(slot, calldata-word)`
+  on `SharedState.storage`, then halts. `H_return` is empty for the store
+  case.
+- The IR oracle's hit-case path applies the same functional update to
+  `IRState.storage`.
+- After Phase 1, both carriers are `UInt256`; the functional update agrees on
+  every slot index by `Function.update`-style reasoning.
+- The empty `H_return` matches trivially.
+
+## Risks
+
+- The `Function.update`-style equality proof requires decidable equality on
+  the slot index. `Nat` provides it; the bounded carrier does not change the
+  index type, only the value type — so this should remain mechanical.
+- Any spec theorem that explicitly observes `IRState.storage` after a write
+  may need a `Function.update_eq` rewrite at the spec boundary. Phase 1's
+  audit log should already enumerate these sites.
+
+## Exit criteria
+
+- `simpleStorageNativeStoreHitBridge_proved` lands and is invoked at the
+  call site of the former `hStoreHit` premise.
+- `simpleStorage_endToEnd_native_evmYulLean` has zero remaining bridge
+  premises.
+- `PrintAxioms` reflects the drop.
+- `lake build` and `make check` clean.
+
+## After Phase 3
+
+Phase 4 — generalize the per-case bridge surface to a dispatcher-shape-driven
+generic so a second contract (e.g. Counter) lifts to the native theorem
+without per-contract bridge code. That is intentionally out of scope for this
+PR.
+
+## Status
+
+Plan-only. Implementation depends on Phases 1 (#1754) and 2 (#1755) landing
+first.

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -218,6 +218,14 @@ ALLOWLIST: set[str] = {
     "exec_block_simpleStorageLoweredStoreCaseBody_halt",
     "interpretIR_simpleStorage_storeHit_arg",
     "simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel",
+    # Phase 3 short-calldata store-hit endpoint: same generated dispatcher
+    # plumbing as the halt endpoint, but the selected body takes the ABI
+    # argument-length revert branch before reaching the store payload.
+    "simpleStorageNativeContract_dispatcherExec_storeHit_short_revert_atFuel",
+    # Phase 3 store-hit storage projection: zero sstore erases the EVM RBMap
+    # key, while the IR stores a bounded zero word. The proof must split zero
+    # and nonzero writes plus same-key/other-key projected lookups.
+    "projectStorageFromState_storeHit_initialState_materialized",
     # RBMap erase-self deletion follows the Batteries red-black tree delete
     # algorithm through the three ordered-tree branches. The cases are
     # mechanical and shared by the native zero-sstore projection helpers.
@@ -346,6 +354,10 @@ ALLOWLIST: set[str] = {
     # under the public theorem hypotheses. Splitting would create single-use
     # helpers that only forward the same selector-miss facts and fuel reshape.
     "simpleStorageNativeSelectorMissBridge_proved",
+    # Phase 3 store-hit bridge closure: composes short-calldata revert and
+    # successful sstore/stop paths against Layer-3 EVMYulLean agreement, using
+    # the bounded-slot storage projection helper above.
+    "simpleStorageNativeStoreHitBridge_proved",
     # Safe-body public EVMYulLean wrapper derives the raw BridgedStmts function
     # hypotheses from compile output, static parameter closure, and
     # BridgedSafeStmts witnesses before delegating to the function-bridge

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -218,6 +218,13 @@ ALLOWLIST: set[str] = {
     "exec_block_simpleStorageLoweredStoreCaseBody_halt",
     "interpretIR_simpleStorage_storeHit_arg",
     "simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel",
+    # RBMap erase-self deletion follows the Batteries red-black tree delete
+    # algorithm through the three ordered-tree branches. The cases are
+    # mechanical and shared by the native zero-sstore projection helpers.
+    "del_all_cut_ne",
+    # Native zero-sstore projection composes calldata, sstore, stop, and the
+    # RBMap erase-self lookup fact in one generated store-body endpoint.
+    "primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_projectResult_slot0_zero_of_erase",
     # --- Helper-aware theorem stack (Issue #1630 / PR #1633 / PR #1639) ---
     "supported_function_body_correct_from_exact_state_generic_with_helpers",
     "supported_function_body_correct_from_exact_state_generic_with_helpers_goal",

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -326,6 +326,11 @@ ALLOWLIST: set[str] = {
     # Splitting would create several single-use helpers whose proofs are mostly
     # repeated hypothesis plumbing around the same concrete retrieve path.
     "simpleStorageNativeRetrieveHitBridge_proved",
+    # Phase 3 selector-miss bridge closure: composes the closed-form
+    # selector-miss IR result, native revert endpoint, and Layer-3 agreement
+    # under the public theorem hypotheses. Splitting would create single-use
+    # helpers that only forward the same selector-miss facts and fuel reshape.
+    "simpleStorageNativeSelectorMissBridge_proved",
     # Safe-body public EVMYulLean wrapper derives the raw BridgedStmts function
     # hypotheses from compile output, static parameter closure, and
     # BridgedSafeStmts witnesses before delegating to the function-bridge

--- a/scripts/check_proof_length.py
+++ b/scripts/check_proof_length.py
@@ -210,6 +210,14 @@ ALLOWLIST: set[str] = {
     "compile_preserves_semantics_except_mapping_writes_stmtSafety",
     "initialIRStateForTx_matches_runtime",
     "resultsMatch_of_execResultsAligned",
+    # --- SimpleStorage native EVMYulLean dispatcher closed forms ---
+    # These are concrete generated-code reductions for the store(uint256)
+    # selected path. The long proofs are linear fuel/body-shape plumbing over
+    # generated Yul and are kept local to the Phase 3 bridge discharge.
+    "exec_block_simpleStorageLoweredStoreCaseBodyTail3_halt",
+    "exec_block_simpleStorageLoweredStoreCaseBody_halt",
+    "interpretIR_simpleStorage_storeHit_arg",
+    "simpleStorageNativeContract_dispatcherExec_storeHit_halt_atFuel",
     # --- Helper-aware theorem stack (Issue #1630 / PR #1633 / PR #1639) ---
     "supported_function_body_correct_from_exact_state_generic_with_helpers",
     "supported_function_body_correct_from_exact_state_generic_with_helpers_goal",


### PR DESCRIPTION
## Summary
- Adds `docs/IR_STORAGE_PHASE3_PLAN.md` — the Phase 3 working scaffold (proof outline, exit criteria).
- **No Lean code changes yet.** The `simpleStorageNativeStoreHitBridge_proved` lemma and the drop of the `hStoreHit` premise from `simpleStorage_endToEnd_native_evmYulLean` land in subsequent commits on this branch once Phases 1 (#1754) and 2 (#1755) are merged.

## Stacking
Stacked on #1755 (Phase 2 retrieve-hit discharge), which is stacked on #1754 (Phase 1 carrier flip), which is stacked on #1753 (Phase 0 typed-alias surface). Base: `codex/ir-storage-phase2-retrieve-hit-discharge`. Will be retargeted as parents merge.

## Phase 3 scope
See [`docs/IR_STORAGE_PHASE3_PLAN.md`](../blob/codex/ir-storage-phase3-store-hit-discharge/docs/IR_STORAGE_PHASE3_PLAN.md). High-level:
1. Prove `simpleStorageNativeStoreHitBridge_proved`.
2. Replace the explicit `hStoreHit` premise on `simpleStorage_endToEnd_native_evmYulLean` with the proved lemma.
3. `PrintAxioms` reports zero remaining bridge premises on the public theorem.

## Why
After Phases 1 and 2, the store-hit case reduces to a `Function.update`-style equality on the post-write `IRState.storage` plus the same retrieve-hit reasoning for any re-read observable slot. The calldata round-trip arm was already 32-byte bounded.

## Test plan
- [ ] `lake build` clean.
- [ ] `make check` clean.
- [ ] `simpleStorage_endToEnd_native_evmYulLean` has neither `hRetrieveHit` nor `hStoreHit` premise.
- [ ] `PrintAxioms` for the public theorem reports zero remaining bridge axioms beyond the trusted EVMYulLean builtins.
- [ ] `Contracts/SimpleStorage/Proofs/` unchanged.

## Status
**Draft.** Plan-only; depends on Phases 1 (#1754) and 2 (#1755).

After Phase 3 lands, Phase 4 (generic dispatcher-shape bridge for second contract) follows in a separate PR — out of scope here.

Refs #1743. Refs #1753. Refs #1754. Refs #1755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds substantial new Lean proof machinery and refactors storage-erasure lemmas around `RBMap.erase`, which could affect downstream proof obligations and build time, but it does not change runtime compiler behavior.
> 
> **Overview**
> Fully discharges the remaining SimpleStorage native EVMYulLean end-to-end proof obligations by adding closed-form execution/interpretation theorems for the `store(uint256)` hit-case (including short-calldata revert) and the selector-miss revert case, and wiring these into `simpleStorage_endToEnd_native_evmYulLean` so it no longer requires external per-case bridge premises.
> 
> Refactors the native harness’s zero-`sstore` projection proofs to compute the RBMap erase lookup internally (dropping explicit `hErase` assumptions), supported by new `Batteries.RBNode`/`RBMap` lemmas in `EvmYulLeanStateBridge.lean` about `erase`/`del` membership and `find?` behavior.
> 
> Updates `PrintAxioms`, adds a Phase 3 plan doc, and extends `check_proof_length.py` allowlists for the new long, generated-code proof blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d8a0b932107a6d7d781c40d51ea2e0f19fab59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->