### PR TITLE
proofs: IR storage carrier flip (Phase 1)

### DIFF
--- a/Compiler/Proofs/ArithmeticProfile.lean
+++ b/Compiler/Proofs/ArithmeticProfile.lean
@@ -15,6 +15,7 @@
 -/
 
 import Compiler.Constants
+import Compiler.Proofs.IRGeneration.IRStorageWord
 import Compiler.Proofs.YulGeneration.ReferenceOracle.Builtins
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanAdapter
 import Compiler.Proofs.YulGeneration.Backends.EvmYulLeanBridgeLemmas
@@ -24,6 +25,7 @@ import EvmYul.UInt256
 namespace Compiler.Proofs.ArithmeticProfile
 
 open Compiler.Constants (evmModulus)
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 open Compiler.Proofs.YulGeneration (evalBuiltinCall)
 open Compiler.Proofs.YulGeneration.Backends (evalPureBuiltinViaEvmYulLean)
 
@@ -43,7 +45,7 @@ theorem evmyullean_size_eq_verity_modulus :
 -- ============================================================================
 
 -- Dummy state parameters (arithmetic builtins are state-independent).
-private def s : Nat → Nat := fun _ => 0
+private def s : Nat → IRStorageWord := fun _ => 0
 private def sender : Nat := 0
 private def sel : Nat := 0
 private def cd : List Nat := []

--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -705,7 +705,7 @@ private def paramLoadErasure (fn : IRFunction) (tx : IRTransaction) (state : IRS
 /-- Result wrapping equivalence: `interpretYulRuntime` produces the same `YulResult`
 as `yulResultOfExecWithRollback` when the rollback storage matches. -/
 theorem interpretYulRuntime_eq_yulResultOfExec
-    (stmts : List Yul.YulStmt) (tx : YulTransaction) (stor : Nat → Nat)
+    (stmts : List Yul.YulStmt) (tx : YulTransaction) (stor : Nat → IRStorageWord)
     (events : List (List Nat)) :
     interpretYulRuntime stmts tx stor events =
       yulResultOfExecWithRollback (YulState.initial tx stor events)
@@ -1632,7 +1632,7 @@ harness's per-selector body lemmas already speak about, in preparation for
 discharging the bridge from those lemmas. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_innerBlock_exec
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat) :
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
         (Nat.succ (Nat.succ (Nat.succ peeledFuel)))
         Compiler.SimpleStorageNativeWitness.nativeContract
@@ -1976,7 +1976,7 @@ spine using the pinned named witnesses. This combines
 existential let/if/if shape with a concrete equation in named witnesses. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_named_let_if_if_block_exec
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat) :
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat) :
     Compiler.Proofs.YulGeneration.Backends.Native.contractDispatcherExecResult
         (Nat.succ (Nat.succ (Nat.succ peeledFuel)))
         Compiler.SimpleStorageNativeWitness.nativeContract
@@ -2534,7 +2534,7 @@ through later case-dispatch peels using
 `exec_lowerNativeSwitchBlock_simpleStorageConcrete_*` lemmas. -/
 theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativeSwitchBlock_exec
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (switchId : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -2579,7 +2579,7 @@ where the lowered default body of the inner switch is pinned to
 in place of the unpinned existential variant. -/
 theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativeSwitchBlock_revert_default_exec
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (switchId : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
@@ -2626,7 +2626,7 @@ Built by switching the underlying `if2Body` decomposition to its sourceLowered
 companion. -/
 theorem exec_block_simpleStorageNativeDispatcherInnerStmts_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
@@ -2676,7 +2676,7 @@ a singleton lowered-switch block at fuel `peeledFuel + 8` on
 `(initialOk).insert "__has_selector" 1`. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_exec
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (switchId : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
@@ -2719,7 +2719,7 @@ store-parametric `exec_lowerNativeSwitchBlock_selector_find_none_with_revert_def
 endpoint. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (switchId : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)),
@@ -2763,7 +2763,7 @@ into the lowered `cases'.find?` results required by the `_via_reduction`
 endpoint. -/
 theorem simpleStorageNativeContract_dispatcherExec_eq_lowerNativeSwitchBlock_revert_default_exec_sourceLowered
     (peeledFuel : Nat)
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     ∃ (reservedNames : List String) (n0 : Nat)
       (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt)) (midN : Nat),
@@ -2813,7 +2813,7 @@ the direct selector-miss discharge composing into
 theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert_via_reduction
     (fuel selector switchId : Nat)
     (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hSelectorRange : selector < EvmYul.UInt256.size)
@@ -3258,7 +3258,7 @@ remaining selector-miss obligation in the SimpleStorage native dispatcher
 bridge to a purely source-level statement. -/
 theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert
     (fuel selector : Nat)
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hSelectorRange : selector < EvmYul.UInt256.size)
@@ -3307,7 +3307,7 @@ theorem simpleStorageNativeContract_dispatcherExec_selectorMiss_revert
 flag set: the input state shape consumed by the selected body inside the
 lowered native switch's hit branch. -/
 def simpleStorageDispatcherHitBodyInputState
-    (switchId : Nat) (tx : YulTransaction) (storage : Nat → Nat)
+    (switchId : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) : EvmYul.Yul.State :=
   ((((.Ok (Compiler.Proofs.YulGeneration.Backends.Native.initialState
             Compiler.SimpleStorageNativeWitness.nativeContract
@@ -3331,7 +3331,7 @@ theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_via_reduction
     (fuel switchId : Nat)
     (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (storeBody' retrieveBody' : List EvmYul.Yul.Ast.Stmt)
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector :
       0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -3386,7 +3386,7 @@ def simpleStorageLoweredHitCasesShape
     .ok ([(0x6057361d, storeBody'), (0x2e64cec1, retrieveBody')], midN)
 
 theorem simpleStorageNativeContract_dispatcherExec_storeHit_error
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3456,7 +3456,7 @@ only has to discharge the body-exec obligation on the *fixed* lowered body
 parametric premise. This strictly weakens the hit-case obligation that the
 dispatcher bridge proof has to supply. -/
 theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concrete
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3481,7 +3481,7 @@ theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concrete
   exact hBody reservedNames n0
 
 theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concrete_tail
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3512,7 +3512,7 @@ the 5-statement `simpleStorageLoweredStoreCaseBodyTail` at fuel `+8`. Strictly
 shrinks the dispatcher hit-case body-exec obligation under the natural Solidity
 assumption that non-payable functions are called with `msg.value = 0`. -/
 theorem simpleStorageNativeContract_dispatcherExec_storeHit_error_concrete_tail2
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3553,7 +3553,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_via_reducti
     (fuel switchId : Nat)
     (cases' : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (storeBody' retrieveBody' : List EvmYul.Yul.Ast.Stmt)
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector :
       0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -3600,7 +3600,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_via_reducti
   · simpa [simpleStorageDispatcherHitBodyInputState] using hBody
 
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3649,7 +3649,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error
       | cons _ _ => simp at hRest
 
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3674,7 +3674,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete
   exact hBody reservedNames n0
 
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3699,7 +3699,7 @@ theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_ta
 
 /-- Retrieve-case dual of `_storeHit_error_concrete_tail2`. -/
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail2
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)
@@ -3744,7 +3744,7 @@ the callvalue and lt-calldatasize guards via the strip lemmas. The
 calldata-size assumptions are derived automatically from `hNoWrap` and
 `initialState_calldataSize`. -/
 theorem simpleStorageNativeContract_dispatcherExec_retrieveHit_error_concrete_tail3
-    (fuel : Nat) (tx : YulTransaction) (storage : Nat → Nat)
+    (fuel : Nat) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) (err : EvmYul.Yul.Exception)
     (hSelector : 0x2e64cec1 = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size)

--- a/Compiler/Proofs/IRGeneration/Function.lean
+++ b/Compiler/Proofs/IRGeneration/Function.lean
@@ -425,9 +425,10 @@ theorem interpretFunction_eq_execResultToIRResult_of_body
           selector := tx.functionSelector }
         fn.body = sourceResult)
     (hrollbackStorage :
-      rollback.storage =
-        SourceSemantics.encodeStorage model
-          (SourceSemantics.withTransactionContext initialWorld tx))
+      rollback.storage = fun s =>
+        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+          (SourceSemantics.encodeStorage model
+            (SourceSemantics.withTransactionContext initialWorld tx) s))
     (hrollbackEvents :
       rollback.events =
         SourceSemantics.encodeEvents
@@ -475,9 +476,10 @@ theorem interpretFunctionWithHelpers_eq_execResultToIRResultWithInternals_of_bod
           selector := tx.functionSelector }
         fn.body = sourceResult)
     (hrollbackStorage :
-      rollback.storage =
-        SourceSemantics.encodeStorage model
-          (SourceSemantics.withTransactionContext initialWorld tx))
+      rollback.storage = fun s =>
+        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+          (SourceSemantics.encodeStorage model
+            (SourceSemantics.withTransactionContext initialWorld tx) s))
     (hrollbackEvents :
       rollback.events =
         SourceSemantics.encodeEvents
@@ -1215,11 +1217,13 @@ theorem compileFunctionSpec_correct_of_body
     rw [hcompile] at hcompiled
     injection hcompiled with hirFn
   have hrollbackStorage :
-      initialState.storage =
-        SourceSemantics.encodeStorage model
-          (SourceSemantics.withTransactionContext initialWorld tx) := by
-    simpa [initialState, FunctionBody.initialIRStateForTx] using
-      (FunctionBody.encodeStorage_withTransactionContext model initialWorld tx).symm
+      initialState.storage = fun s =>
+        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+          (SourceSemantics.encodeStorage model
+            (SourceSemantics.withTransactionContext initialWorld tx) s) := by
+    funext s
+    simp [initialState, FunctionBody.initialIRStateForTx,
+      FunctionBody.encodeStorage_withTransactionContext]
   have hrollbackEvents :
       initialState.events =
         SourceSemantics.encodeEvents
@@ -1302,11 +1306,13 @@ theorem compileFunctionSpec_correct_of_body_normalized_extraFuel
     rw [hcompile'] at hcompiled
     injection hcompiled with hirFn
   have hrollbackStorage :
-      initialState.storage =
-        SourceSemantics.encodeStorage model
-          (SourceSemantics.withTransactionContext initialWorld tx) := by
-    simpa [initialState, FunctionBody.initialIRStateForTx] using
-      (FunctionBody.encodeStorage_withTransactionContext model initialWorld tx).symm
+      initialState.storage = fun s =>
+        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+          (SourceSemantics.encodeStorage model
+            (SourceSemantics.withTransactionContext initialWorld tx) s) := by
+    funext s
+    simp [initialState, FunctionBody.initialIRStateForTx,
+      FunctionBody.encodeStorage_withTransactionContext]
   have hrollbackEvents :
       initialState.events =
         SourceSemantics.encodeEvents
@@ -1785,11 +1791,13 @@ theorem supported_function_correct_with_helper_proofs_body_goal
     rw [hcompile] at hcompiled
     injection hcompiled
   have hrollbackStorage :
-      initialState.storage =
-        SourceSemantics.encodeStorage model
-          (SourceSemantics.withTransactionContext initialWorld tx) := by
-    simpa [initialState, FunctionBody.initialIRStateForTx] using
-      (FunctionBody.encodeStorage_withTransactionContext model initialWorld tx).symm
+      initialState.storage = fun s =>
+        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+          (SourceSemantics.encodeStorage model
+            (SourceSemantics.withTransactionContext initialWorld tx) s) := by
+    funext s
+    simp [initialState, FunctionBody.initialIRStateForTx,
+      FunctionBody.encodeStorage_withTransactionContext]
   have hrollbackEvents :
       initialState.events =
         SourceSemantics.encodeEvents
@@ -2511,11 +2519,13 @@ theorem supported_constructor_body_correct_with_body_interface
       exact hEq.symm
     subst bodyIR
     have hrollbackStorage :
-        initialState.storage =
-          SourceSemantics.encodeStorage model
-            (SourceSemantics.withTransactionContext initialWorld tx) := by
-      simpa [initialState, FunctionBody.initialIRStateForTx, SourceSemantics.encodeStorage] using
-        (FunctionBody.encodeStorage_withTransactionContext model initialWorld tx).symm
+        initialState.storage = fun s =>
+          Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+            (SourceSemantics.encodeStorage model
+              (SourceSemantics.withTransactionContext initialWorld tx) s) := by
+      funext s
+      simp [initialState, FunctionBody.initialIRStateForTx,
+        FunctionBody.encodeStorage_withTransactionContext]
     have hrollbackEvents :
         initialState.events =
           SourceSemantics.encodeEvents

--- a/Compiler/Proofs/IRGeneration/FunctionBody.lean
+++ b/Compiler/Proofs/IRGeneration/FunctionBody.lean
@@ -100,7 +100,8 @@ def runtimeStateMatchesIR
     (fields : List Field)
     (runtime : SourceSemantics.RuntimeState)
     (state : IRState) : Prop :=
-  state.storage = SourceSemantics.encodeStorageAt fields runtime.world ∧
+  state.storage = (fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+    (SourceSemantics.encodeStorageAt fields runtime.world s)) ∧
   state.transientStorage = (fun slot => (runtime.world.transientStorage slot).val) ∧
   state.sender = runtime.world.sender.val ∧
   state.msgValue = runtime.world.msgValue.val ∧
@@ -124,7 +125,8 @@ def constructorRuntimeStateMatchesIR
     (fields : List Field)
     (runtime : SourceSemantics.RuntimeState)
     (state : IRState) : Prop :=
-  state.storage = SourceSemantics.encodeStorageAt fields runtime.world ∧
+  state.storage = (fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+    (SourceSemantics.encodeStorageAt fields runtime.world s)) ∧
   state.transientStorage = (fun slot => (runtime.world.transientStorage slot).val) ∧
   state.sender = runtime.world.sender.val ∧
   state.msgValue = runtime.world.msgValue.val ∧
@@ -145,7 +147,8 @@ def initialIRStateForTx
     (tx : IRTransaction)
     (initialWorld : Verity.ContractState) : IRState :=
   { vars := []
-    storage := SourceSemantics.encodeStorage spec initialWorld
+    storage := fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+      (SourceSemantics.encodeStorage spec initialWorld s)
     transientStorage := fun slot => (initialWorld.transientStorage slot).val
     memory := fun o => (initialWorld.memory o).val
     calldata := tx.args
@@ -1227,7 +1230,8 @@ theorem evalIRExpr_sload_of_runtimeStateMatchesIR
     (hmatch : runtimeStateMatchesIR fields runtime state)
     (slot : Nat) :
     evalIRExpr state (YulExpr.call "sload" [YulExpr.lit slot]) =
-      some (SourceSemantics.encodeStorageAt fields runtime.world slot) := by
+      some (SourceSemantics.encodeStorageAt fields runtime.world slot
+        % EvmYul.UInt256.size) := by
   rcases hmatch with ⟨hstorage, _, _, _, _, _, _, _, _, _, _⟩
   simp [evalIRExpr, evalIRCall, evalIRExprs,
     Compiler.Proofs.YulGeneration.evalBuiltinCallWithBackendContext,
@@ -7213,7 +7217,7 @@ theorem runtimeStateMatchesIR_setBothMemory
   refine ⟨?_, htrans, hsender, hmsgVal, hthis, hts, hbn, hcid, hblob, hsel, hcd, hcds, ?_, hret, hevt⟩
   · rw [hstor]
     funext slot
-    exact SourceSemantics.encodeStorageAt_congr rfl rfl rfl
+    exact congrArg _ (SourceSemantics.encodeStorageAt_congr rfl rfl rfl)
   · -- memory
     funext o
     by_cases ho : o = offset
@@ -7255,7 +7259,7 @@ theorem runtimeStateMatchesIR_updateMemoryEvents
     hcd, hcds, hmemory, hret, hevents⟩
   rw [hstor]
   funext slot
-  exact SourceSemantics.encodeStorageAt_congr rfl rfl rfl
+  exact congrArg _ (SourceSemantics.encodeStorageAt_congr rfl rfl rfl)
 
 theorem runtimeStateMatchesIR_setTransientStorage
     {fields : List Field}
@@ -7280,7 +7284,7 @@ theorem runtimeStateMatchesIR_setTransientStorage
   · -- storage: encodeStorageAt doesn't depend on transientStorage
     rw [hstor]
     funext slot
-    exact SourceSemantics.encodeStorageAt_congr rfl rfl rfl
+    exact congrArg _ (SourceSemantics.encodeStorageAt_congr rfl rfl rfl)
   · -- transientStorage
     funext o
     by_cases ho : o = offset
@@ -7385,7 +7389,8 @@ def sourceResultMatchesIRResult
     (ir : IRResult) : Prop :=
   source.success = ir.success ∧
   source.returnValue = ir.returnValue ∧
-  source.finalStorage = ir.finalStorage ∧
+  (fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (source.finalStorage s)) =
+    ir.finalStorage ∧
   source.events = ir.events
 
 /-- Helper: `eval_compileExpr_core` implies both `evalIRExpr` and source `evalExpr`
@@ -14761,7 +14766,8 @@ theorem stmtResultToSourceResult_matches_irExecResult
     (sourceResult : SourceSemantics.StmtResult)
     (irResult : IRExecResult)
     (hrollbackStorage :
-      rollback.storage = SourceSemantics.encodeStorage spec initialWorld)
+      rollback.storage = fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+        (SourceSemantics.encodeStorage spec initialWorld s))
     (hrollbackEvents :
       rollback.events = SourceSemantics.encodeEvents initialWorld.events)
     (hfields : fields = SourceSemantics.effectiveFields spec)

--- a/Compiler/Proofs/IRGeneration/GenericInduction.lean
+++ b/Compiler/Proofs/IRGeneration/GenericInduction.lean
@@ -5277,7 +5277,8 @@ private theorem encodeStorageAt_writeUintKeyedMappingSlots_singleton_other
   · simp only [SourceSemantics.writeUintKeyedMappingSlots, List.foldl_cons, List.foldl_nil]
     simp [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot] at hneq ⊢
     simp [hneq]
-    exact Verity.Core.Uint256.ext (Nat.mod_eq_of_lt (world.storage query).isLt)
+    apply Verity.Core.Uint256.ext
+    simp [Verity.Core.Uint256.modulus, Nat.mod_eq_of_lt (world.storage query).isLt]
   · simp [SourceSemantics.writeUintKeyedMappingSlots]
   · simp [SourceSemantics.writeUintKeyedMappingSlots]
 
@@ -5956,8 +5957,12 @@ private theorem encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
   simp only [hdyn']
   simp only [SourceSemantics.writeUintKeyedMappingSlots, List.foldl_cons, List.foldl_nil]
   simp only [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot]
-  simp only [ite_true, Verity.Core.Uint256.val_ofNat]
-  exact Nat.mod_eq_of_lt hvalue
+  simp only [ite_true, Verity.Core.Uint256.val_ofNat,
+    Compiler.Proofs.IRGeneration.IRStorageWord.toNat_ofNat,
+    SourceSemantics.UInt256_size_eq_UINT256_MODULUS]
+  have hvalue' : value < Verity.Core.UINT256_MODULUS := hvalue
+  show value % Verity.Core.UINT256_MODULUS % Verity.Core.UINT256_MODULUS = value
+  rw [Nat.mod_eq_of_lt hvalue', Nat.mod_eq_of_lt hvalue']
 
 private theorem encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_eq_written
     {fields : List Field}
@@ -6100,7 +6105,8 @@ private theorem encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_other
   · simp only [SourceSemantics.writeAddressKeyedMapping2Slots, List.foldl_cons, List.foldl_nil]
     simp [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot] at hneq ⊢
     simp [hneq]
-    exact Verity.Core.Uint256.ext (Nat.mod_eq_of_lt (world.storage query).isLt)
+    apply Verity.Core.Uint256.ext
+    simp [Verity.Core.Uint256.modulus, Nat.mod_eq_of_lt (world.storage query).isLt]
   · simp [SourceSemantics.writeAddressKeyedMapping2Slots]
   · simp [SourceSemantics.writeAddressKeyedMapping2Slots]
 
@@ -6145,8 +6151,12 @@ private theorem encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_eq_writ
   simp only [hdyn']
   simp only [SourceSemantics.writeAddressKeyedMapping2Slots, List.foldl_cons, List.foldl_nil]
   simp only [Compiler.Proofs.abstractStoreMappingEntry, Compiler.Proofs.abstractMappingSlot]
-  simp only [ite_true, Verity.Core.Uint256.val_ofNat]
-  exact Nat.mod_eq_of_lt hvalue
+  simp only [ite_true, Verity.Core.Uint256.val_ofNat,
+    Compiler.Proofs.IRGeneration.IRStorageWord.toNat_ofNat,
+    SourceSemantics.UInt256_size_eq_UINT256_MODULUS]
+  have hvalue' : value < Verity.Core.UINT256_MODULUS := hvalue
+  show value % Verity.Core.UINT256_MODULUS % Verity.Core.UINT256_MODULUS = value
+  rw [Nat.mod_eq_of_lt hvalue', Nat.mod_eq_of_lt hvalue']
 
 private theorem encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_other
     {fields : List Field}
@@ -6232,7 +6242,9 @@ private theorem encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_
   exact hvalue
 
 private def abstractStoreStorageOrMappingMany
-    (storage : Nat → Nat) (slots : List Nat) (value : Nat) : Nat → Nat :=
+    (storage : Nat → Compiler.Proofs.IRGeneration.IRStorageWord)
+    (slots : List Nat) (value : Nat) :
+    Nat → Compiler.Proofs.IRGeneration.IRStorageWord :=
   match slots with
   | [] => storage
   | slot :: rest =>
@@ -6242,11 +6254,13 @@ private def abstractStoreStorageOrMappingMany
         value
 
 private theorem abstractStoreStorageOrMappingMany_eq
-    {storage : Nat → Nat}
+    {storage : Nat → Compiler.Proofs.IRGeneration.IRStorageWord}
     {slots : List Nat}
     {value query : Nat} :
     abstractStoreStorageOrMappingMany storage slots value query =
-      if slots.contains query then value else storage query := by
+      if slots.contains query then
+        Compiler.Proofs.IRGeneration.IRStorageWord.ofNat value
+      else storage query := by
   induction slots generalizing storage with
   | nil =>
       simp [abstractStoreStorageOrMappingMany]
@@ -6254,7 +6268,8 @@ private theorem abstractStoreStorageOrMappingMany_eq
       by_cases hEq : query = slot
       · subst hEq
         simpa [abstractStoreStorageOrMappingMany, Compiler.Proofs.abstractStoreStorageOrMapping_eq] using
-          (ih (storage := fun s => if s = query then value else storage s))
+          (ih (storage := fun s => if s = query then
+            Compiler.Proofs.IRGeneration.IRStorageWord.ofNat value else storage s))
       · simp [abstractStoreStorageOrMappingMany, ih,
           Compiler.Proofs.abstractStoreStorageOrMapping_eq, hEq]
 
@@ -6282,11 +6297,13 @@ private theorem runtimeStateMatchesIR_writeUintSlot
     rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved hnotAddr hnotDyn]
     simp [SourceSemantics.writeUintSlots, Verity.Core.Uint256.val_ofNat]
-    exact (Nat.mod_eq_of_lt hvalue).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+      (Nat.mod_eq_of_lt hvalue).symm
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     simp only [hEq, ↓reduceIte]
     rw [hstorage]
-    exact (encodeStorageAt_writeUintSlots_singleton_other hEq).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+      (encodeStorageAt_writeUintSlots_singleton_other hEq).symm
 
 private theorem runtimeStateMatchesIR_writeAddressSlot
     {fields : List Field}
@@ -6315,12 +6332,14 @@ private theorem runtimeStateMatchesIR_writeAddressSlot
     simp [SourceSemantics.writeAddressSlots, Verity.wordToAddress, Verity.Core.Address.ofNat,
           Verity.Core.Uint256.val_ofNat, Verity.Core.Address.modulus, Compiler.Constants.addressMask]
     rw [Nat.mod_eq_of_lt hvalue]
+    refine congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat ?_
     simpa [Compiler.Constants.addressMask, Verity.Core.Address.modulus] using
       (Nat.and_two_pow_sub_one_eq_mod (n := 160) value)
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     simp only [hEq, ↓reduceIte]
     rw [hstorage]
     symm
+    refine congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat ?_
     apply SourceSemantics.encodeStorageAt_congr
     · simp [SourceSemantics.writeAddressSlots]
     · simp [SourceSemantics.writeAddressSlots, hEq]
@@ -6352,11 +6371,11 @@ private theorem runtimeStateMatchesIR_writeUintSlots
     have hq : query ∈ slots := by simpa using hmem
     rw [encodeStorageAt_eq_storage_of_resolvedSlot (hresolved query hq) hnotAddr hnotDyn]
     simp only [SourceSemantics.writeUintSlots, hmem, ↓reduceIte, Verity.Core.Uint256.val_ofNat]
-    exact (Nat.mod_eq_of_lt hvalue).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (Nat.mod_eq_of_lt hvalue).symm
   · simp only [hmem, ↓reduceIte]
     rw [hstorage]
     have hnotMem : query ∉ slots := by simpa using hmem
-    exact (encodeStorageAt_writeUintSlots_other hnotMem).symm
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintSlots_other hnotMem).symm
 
 private theorem runtimeStateMatchesIR_writeUintKeyedMappingSlot
     {fields : List Field}
@@ -6383,12 +6402,12 @@ private theorem runtimeStateMatchesIR_writeUintKeyedMappingSlot
   by_cases hEq : query = Compiler.Proofs.solidityMappingSlot slot key
   · subst hEq
     simp only [↓reduceIte]
-    exact (encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
       (fields := fields) (world := runtime.world) (slot := slot) (key := key) (value := value)
       hresolved hdyn hvalue).symm
   · simp only [hEq, ↓reduceIte]
     rw [hstorage]
-    exact (encodeStorageAt_writeUintKeyedMappingSlots_singleton_other (fields := fields)
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintKeyedMappingSlots_singleton_other (fields := fields)
       (world := runtime.world) (slot := slot) (key := key) (query := query) (value := value) hEq).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMappingChainSlot
@@ -6428,13 +6447,13 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingChainSlot
       rw [encodeStorageAt_eq_copy]
       simp only [encodeStorageAtCopy, hresolved, hdyn]
     simp only [hstorage, henc]
-    exact (encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_eq_written
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_eq_written
       (fields := fields) (world := runtime.world) (slot := slot) (keys := keys) (value := value)
       hresolved hdyn hvalue).symm
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     simp only [hEq, ↓reduceIte]
     rw [hstorage]
-    exact (encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_other
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMappingChainSlots_singleton_other
       (fields := fields) (world := runtime.world) (slot := slot) (keys := keys)
       (query := query) (value := value) hEq).symm
 
@@ -6475,12 +6494,12 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingSlot
   by_cases hEq : query = Compiler.Proofs.solidityMappingSlot slot key
   · subst hEq
     simp only [↓reduceIte]
-    exact (encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintKeyedMappingSlots_singleton_eq_written
       (fields := fields) (world := runtime.world) (slot := slot) (key := key) (value := value)
       hresolved hdyn hvalue).symm
   · simp only [hEq, ↓reduceIte]
     rw [hstorage]
-    exact (encodeStorageAt_writeUintKeyedMappingSlots_singleton_other (fields := fields)
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeUintKeyedMappingSlots_singleton_other (fields := fields)
       (world := runtime.world) (slot := slot) (key := key) (query := query) (value := value) hEq).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMappingWordSlot
@@ -6518,22 +6537,19 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingWordSlot
       rw [encodeStorageAt_eq_copy]
       simp only [encodeStorageAtCopy, hresolved, hdyn]
     simp only [hstorage, henc]
-    exact (encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_eq_written
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_eq_written
       (fields := fields) (world := runtime.world) (slot := slot) (key := key)
       (wordOffset := wordOffset) (value := value) hresolved hdyn hvalue).symm
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     simp only [hEq, ↓reduceIte]
     rw [hstorage]
-    exact (encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_other
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMappingWordSlots_singleton_other
       (fields := fields) (world := runtime.world) (slot := slot) (key := key)
       (wordOffset := wordOffset) (query := query) (value := value) hEq).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMappingPackedWordSlot
-    {fields : List Field}
-    {runtime : SourceSemantics.RuntimeState}
-    {state : IRState}
-    {slot key wordOffset value : Nat}
-    {packed : PackedBits}
+    {fields : List Field} {runtime : SourceSemantics.RuntimeState} {state : IRState}
+    {slot key wordOffset value : Nat} {packed : PackedBits}
     (hruntime : FunctionBody.runtimeStateMatchesIR fields runtime state)
     (hresolved :
       findResolvedFieldAtSlotCopy fields
@@ -6550,33 +6566,35 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMappingPackedWordSlot
             state.storage
             (mappingWordTargetSlot slot key wordOffset)
             (SourceSemantics.packedWordWrite
-              (state.storage (mappingWordTargetSlot slot key wordOffset))
+              (Compiler.Proofs.IRGeneration.IRStorageWord.toNat
+                (state.storage (mappingWordTargetSlot slot key wordOffset)))
               value
               packed) } := by
   rcases hruntime with
     ⟨hstorage, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   refine ⟨?_, htransient, hsender, hmsgValue, hthis, htimestamp, hblock, hchain, hret, hevents⟩
   funext query
-  by_cases hEq : query = mappingWordTargetSlot slot key wordOffset
+  set tgt := mappingWordTargetSlot slot key wordOffset with htgt
+  by_cases hEq : query = tgt
   · subst hEq
     rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
-    -- After simp [hstorage], the packedWordWrite arg becomes encodeStorageAt fields runtime.world slot
-    -- but _eq_written expects (runtime.world.storage slot).val. Show they're equal.
-    have henc : SourceSemantics.encodeStorageAt fields runtime.world
-        (mappingWordTargetSlot slot key wordOffset) =
-        (runtime.world.storage (mappingWordTargetSlot slot key wordOffset)).val := by
-      rw [encodeStorageAt_eq_copy]
-      simp only [encodeStorageAtCopy, hresolved, hdyn]
+    have henc : SourceSemantics.encodeStorageAt fields runtime.world tgt =
+        (runtime.world.storage tgt).val := by
+      rw [encodeStorageAt_eq_copy]; simp only [encodeStorageAtCopy, hresolved, hdyn]
     simp only [hstorage, henc]
-    exact (encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_eq_written
-      (fields := fields) (world := runtime.world) (slot := slot) (key := key)
-      (wordOffset := wordOffset) (packed := packed) (value := value) hresolved hdyn).symm
+    rw [show (Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+        (runtime.world.storage tgt).val).toNat = (runtime.world.storage tgt).val from
+      Nat.mod_eq_of_lt (runtime.world.storage tgt).isLt]
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+      (encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_eq_written
+        (fields := fields) (world := runtime.world) (slot := slot) (key := key)
+        (wordOffset := wordOffset) (packed := packed) (value := value) hresolved hdyn).symm
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
-    simp only [hEq, ↓reduceIte]
-    rw [hstorage]
-    exact (encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_other
-      (fields := fields) (world := runtime.world) (slot := slot) (key := key)
-      (wordOffset := wordOffset) (packed := packed) (query := query) (value := value) hEq).symm
+    simp only [hEq, ↓reduceIte]; rw [hstorage]
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat
+      (encodeStorageAt_writeAddressKeyedMappingPackedWordSlots_singleton_other
+        (fields := fields) (world := runtime.world) (slot := slot) (key := key)
+        (wordOffset := wordOffset) (packed := packed) (query := query) (value := value) hEq).symm
 
 private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2Slot
     {fields : List Field}
@@ -6617,14 +6635,14 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2Slot
   · subst hEq
     simp only [↓reduceIte]
     rw [Compiler.Proofs.abstractMappingSlot_eq_solidity] at hresolved hdyn
-    exact (encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_eq_written
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_eq_written
       (fields := fields) (world := runtime.world)
       (slot := slot) (key1 := key1) (key2 := key2) (value := value)
       hresolved hdyn hvalue).symm
   · simp only [hEq, ↓reduceIte]
     rw [hstorage]
     rw [Compiler.Proofs.abstractMappingSlot_eq_solidity] at hEq
-    exact (encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_other (fields := fields)
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMapping2Slots_singleton_other (fields := fields)
       (world := runtime.world) (slot := slot) (key1 := key1) (key2 := key2)
       (query := query) (value := value) hEq).symm
 
@@ -6663,14 +6681,14 @@ private theorem runtimeStateMatchesIR_writeAddressKeyedMapping2WordSlot
       rw [encodeStorageAt_eq_copy]
       simp only [encodeStorageAtCopy, hresolved, hdyn]
     simp only [hstorage, henc]
-    exact (encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_written
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_eq_written
       (fields := fields) (world := runtime.world)
       (slot := slot) (key1 := key1) (key2 := key2) (wordOffset := wordOffset)
       (value := value) hresolved hdyn hvalue).symm
   · rw [Compiler.Proofs.abstractStoreStorageOrMapping_eq]
     simp only [hEq, ↓reduceIte]
     rw [hstorage]
-    exact (encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_other
+    exact congrArg Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (encodeStorageAt_writeAddressKeyedMapping2WordSlots_singleton_other
       (fields := fields) (world := runtime.world) (slot := slot) (key1 := key1)
       (key2 := key2) (wordOffset := wordOffset) (query := query) (value := value) hEq).symm
 
@@ -8750,7 +8768,7 @@ private theorem compiledStmtStep_setMappingWord_singleSlot_of_slotSafety_preserv
                 if s =
                     (Compiler.Proofs.solidityMappingSlot slot keyNat + wordOffset) %
                       Compiler.Constants.evmModulus then
-                  valueNat
+                  Compiler.Proofs.IRGeneration.IRStorageWord.ofNat valueNat
                 else
                   state.storage s := by
           funext s
@@ -9079,7 +9097,7 @@ private theorem compiledStmtStep_setMappingPackedWord_singleSlot_of_slotSafety_p
         hvalueSourceEval.symm
       rcases hslotSafety runtime keyNat hKeySrc with ⟨hresolvedNone, hdynNone⟩
       set targetSlot := mappingWordTargetSlot slot keyNat wordOffset
-      set oldWordNat := state.storage targetSlot
+      set oldWordNat := Compiler.Proofs.IRGeneration.IRStorageWord.toNat (state.storage targetSlot)
       set storedWordNat := SourceSemantics.packedWordWrite oldWordNat valueNat packed
       have hMappingBaseEval :
           evalIRExpr state (YulExpr.call "mappingSlot" [YulExpr.lit slot, keyIR]) =
@@ -9845,7 +9863,7 @@ private theorem compiledStmtStep_setStructMember_singleSlot_of_slotSafety_preser
                 if s =
                     (Compiler.Proofs.solidityMappingSlot slot keyNat + wordOffset) %
                       Compiler.Constants.evmModulus then
-                  valueNat
+                  Compiler.Proofs.IRGeneration.IRStorageWord.ofNat valueNat
                 else
                   state.storage s := by
           funext s
@@ -10387,7 +10405,7 @@ private theorem compiledStmtStep_setMapping2Word_singleSlot_of_slotSafety_preser
                         Verity.Core.Uint256.ofNat
                           (Compiler.Proofs.solidityMappingSlot
                             (Compiler.Proofs.solidityMappingSlot slot key1Nat) key2Nat)).val then
-                    valueNat
+                    Compiler.Proofs.IRGeneration.IRStorageWord.ofNat valueNat
                   else
                     state.storage s := by
             funext s
@@ -10717,7 +10735,7 @@ private theorem compiledStmtStep_setStructMember2_singleSlot_of_slotSafety_prese
                         Verity.Core.Uint256.ofNat
                           (Compiler.Proofs.solidityMappingSlot
                             (Compiler.Proofs.solidityMappingSlot slot key1Nat) key2Nat)).val then
-                    valueNat
+                    Compiler.Proofs.IRGeneration.IRStorageWord.ofNat valueNat
                   else
                     state.storage s := by
             funext s
@@ -11597,8 +11615,7 @@ private theorem compiledStmtStep_letStorageField
     have hIR := FunctionBody.evalIRExpr_sload_of_runtimeStateMatchesIR hruntime slot
     rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved (by rfl) (by rfl)] at hIR
     set v := (runtime.world.storage slot).val; set state' := state.setVar tmp v
-    set runtime' := { runtime with
-      bindings := SourceSemantics.bindValue runtime.bindings tmp v }
+    set runtime' := { runtime with bindings := SourceSemantics.bindValue runtime.bindings tmp v }
     have hNextScopeIncl : FunctionBody.scopeNamesIncluded
         (stmtNextScope scope (.letVar tmp (Expr.storage fieldName))) (tmp :: scope) := by
       intro n hn; simp [stmtNextScope, collectStmtNames, collectExprNames] at hn
@@ -11612,6 +11629,7 @@ private theorem compiledStmtStep_letStorageField
     · have : [YulStmt.let_ tmp (YulExpr.call "sload" [YulExpr.lit slot])].length +
           extraFuel + 1 = Nat.succ (Nat.succ extraFuel) := by simp [List.length]; omega
       rw [this]; simp [execIRStmts, execIRStmt, hIR, state']
+      rw [Nat.mod_eq_of_lt (runtime.world.storage slot).isLt]
     · simp only [stmtStepMatchesIRExec]
       exact ⟨FunctionBody.runtimeStateMatchesIR_setVar_bindValue hruntime tmp v,
         FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included
@@ -11636,10 +11654,7 @@ private theorem stmtListGenericCore_singleton_letStorageField
 
 set_option maxHeartbeats 800000 in
 private theorem compiledStmtStep_letStorageAddrField
-    {fields : List Field}
-    {scope : List String}
-    {tmp fieldName : String}
-    {slot : Nat}
+    {fields : List Field} {scope : List String} {tmp fieldName : String} {slot : Nat}
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.address }, slot))
@@ -11663,6 +11678,7 @@ private theorem compiledStmtStep_letStorageAddrField
     rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved (by rfl) (by rfl)] at hIR
     set v := (runtime.world.storageAddr slot).val; set state' := state.setVar tmp v
     set runtime' := { runtime with bindings := SourceSemantics.bindValue runtime.bindings tmp v }
+    have hAddrLt : v < Verity.Core.UINT256_MODULUS := Nat.lt_trans (runtime.world.storageAddr slot).isLt (by decide)
     have hNextScopeIncl : FunctionBody.scopeNamesIncluded
         (stmtNextScope scope (.letVar tmp (Expr.storageAddr fieldName))) (tmp :: scope) := by
       intro n hn; simp [stmtNextScope, collectStmtNames, collectExprNames] at hn
@@ -11676,12 +11692,12 @@ private theorem compiledStmtStep_letStorageAddrField
     · have : [YulStmt.let_ tmp (YulExpr.call "sload" [YulExpr.lit slot])].length +
           extraFuel + 1 = Nat.succ (Nat.succ extraFuel) := by simp [List.length]; omega
       rw [this]; simp [execIRStmts, execIRStmt, hIR, state']
+      rw [Nat.mod_eq_of_lt hAddrLt]
     · simp only [stmtStepMatchesIRExec]
       exact ⟨FunctionBody.runtimeStateMatchesIR_setVar_bindValue hruntime tmp v,
         FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included
           (FunctionBody.bindingsExactlyMatchIRVarsOnScope_setVar_bindValue hexact) hNextScopeIncl,
-        FunctionBody.bindingsBounded_bindValue hbounded tmp v
-          (Nat.lt_trans (runtime.world.storageAddr slot).isLt (by decide)),
+        FunctionBody.bindingsBounded_bindValue hbounded tmp v hAddrLt,
         FunctionBody.scopeNamesPresent_of_included
           (FunctionBody.scopeNamesPresent_cons_bindValue hscope) hNextScopeIncl⟩
 
@@ -11726,8 +11742,7 @@ private theorem compiledStmtStep_assignStorageField
     have hIR := FunctionBody.evalIRExpr_sload_of_runtimeStateMatchesIR hruntime slot
     rw [encodeStorageAt_eq_storage_of_resolvedSlot hresolved (by rfl) (by rfl)] at hIR
     set v := (runtime.world.storage slot).val; set state' := state.setVar name v
-    set runtime' := { runtime with
-      bindings := SourceSemantics.bindValue runtime.bindings name v }
+    set runtime' := { runtime with bindings := SourceSemantics.bindValue runtime.bindings name v }
     have hNextScopeIncl : FunctionBody.scopeNamesIncluded
         (stmtNextScope scope (.assignVar name (Expr.storage fieldName))) (name :: scope) := by
       intro n hn; simp [stmtNextScope, collectStmtNames, collectExprNames] at hn
@@ -11741,6 +11756,7 @@ private theorem compiledStmtStep_assignStorageField
     · have : [YulStmt.assign name (YulExpr.call "sload" [YulExpr.lit slot])].length +
           extraFuel + 1 = Nat.succ (Nat.succ extraFuel) := by simp [List.length]; omega
       rw [this]; simp [execIRStmts, execIRStmt, hIR, state']
+      rw [Nat.mod_eq_of_lt (runtime.world.storage slot).isLt]
     · simp only [stmtStepMatchesIRExec]
       exact ⟨FunctionBody.runtimeStateMatchesIR_setVar_bindValue hruntime name v,
         FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included
@@ -11765,10 +11781,7 @@ private theorem stmtListGenericCore_singleton_assignStorageField
 
 set_option maxHeartbeats 800000 in
 private theorem compiledStmtStep_assignStorageAddrField
-    {fields : List Field}
-    {scope : List String}
-    {name fieldName : String}
-    {slot : Nat}
+    {fields : List Field} {scope : List String} {name fieldName : String} {slot : Nat}
     (hnoConflict : firstFieldWriteSlotConflict fields = none)
     (hfind : findFieldWithResolvedSlot fields fieldName =
       some ({ name := fieldName, ty := FieldType.address }, slot))
@@ -11792,6 +11805,7 @@ private theorem compiledStmtStep_assignStorageAddrField
     rw [encodeStorageAt_eq_storageAddr_of_resolvedSlot hresolved (by rfl) (by rfl)] at hIR
     set v := (runtime.world.storageAddr slot).val; set state' := state.setVar name v
     set runtime' := { runtime with bindings := SourceSemantics.bindValue runtime.bindings name v }
+    have hAddrLt : v < Verity.Core.UINT256_MODULUS := Nat.lt_trans (runtime.world.storageAddr slot).isLt (by decide)
     have hNextScopeIncl : FunctionBody.scopeNamesIncluded
         (stmtNextScope scope (.assignVar name (Expr.storageAddr fieldName))) (name :: scope) := by
       intro n hn; simp [stmtNextScope, collectStmtNames, collectExprNames] at hn
@@ -11805,12 +11819,12 @@ private theorem compiledStmtStep_assignStorageAddrField
     · have : [YulStmt.assign name (YulExpr.call "sload" [YulExpr.lit slot])].length +
           extraFuel + 1 = Nat.succ (Nat.succ extraFuel) := by simp [List.length]; omega
       rw [this]; simp [execIRStmts, execIRStmt, hIR, state']
+      rw [Nat.mod_eq_of_lt hAddrLt]
     · simp only [stmtStepMatchesIRExec]
       exact ⟨FunctionBody.runtimeStateMatchesIR_setVar_bindValue hruntime name v,
         FunctionBody.bindingsExactlyMatchIRVarsOnScope_of_included
           (FunctionBody.bindingsExactlyMatchIRVarsOnScope_setVar_bindValue hexact) hNextScopeIncl,
-        FunctionBody.bindingsBounded_bindValue hbounded name v
-          (Nat.lt_trans (runtime.world.storageAddr slot).isLt (by decide)),
+        FunctionBody.bindingsBounded_bindValue hbounded name v hAddrLt,
         FunctionBody.scopeNamesPresent_of_included
           (FunctionBody.scopeNamesPresent_cons_bindValue hscope) hNextScopeIncl⟩
 

--- a/Compiler/Proofs/IRGeneration/IRInterpreter.lean
+++ b/Compiler/Proofs/IRGeneration/IRInterpreter.lean
@@ -1132,8 +1132,8 @@ other non-transaction fields unchanged. -/
 structure IRResult where
   success : Bool
   returnValue : Option Nat
-  finalStorage : Nat → Nat
-  finalMappings : Nat → Nat → Nat
+  finalStorage : Nat → IRStorageWord
+  finalMappings : Nat → Nat → IRStorageWord
   events : List (List Nat)
 
 /-- Execute an IR function with given arguments.
@@ -4441,5 +4441,6 @@ example :
     result.success = true ∧ result.finalStorage 0 = 99 := by
   simp [interpretIR, execIRFunction, execIRStmts, execIRStmt, evalIRExpr,
     shortCalldataRegressionContract, IRState.initial, IRState.setVar, IRState.getVar]
+  rfl
 
 end Compiler.Proofs.IRGeneration

--- a/Compiler/Proofs/IRGeneration/IRStorageWord.lean
+++ b/Compiler/Proofs/IRGeneration/IRStorageWord.lean
@@ -35,44 +35,56 @@ open EvmYul
 
 /-- The carrier of a single IR storage slot value.
 
-    Phase 0: `IRStorageWord := Nat`. This is the current behavior of
-    `IRState.storage`, exposed through a typed alias so Phase 1 can swap
-    the representation without touching callsites.
-
-    Phase 1 will redefine this as a `UInt256`-backed bounded type.
+    Phase 1: `IRStorageWord := UInt256`. The carrier is a `UInt256`
+    bounded by `UInt256.size = 2^256` by construction, exposed through
+    a `@[reducible] def` so existing callsites that referred to
+    `IRStorageWord` as a function codomain continue to elaborate.
 
     Treat this as opaque from callers: always go through `ofNat` /
-    `toNat` / `toUInt256` rather than relying on the alias being `Nat`. -/
-abbrev IRStorageWord : Type := Nat
+    `toNat` / `toUInt256` rather than relying on the carrier being any
+    particular numeric type. -/
+@[reducible] def IRStorageWord : Type := UInt256
 
 namespace IRStorageWord
 
-/-- Inject a `Nat` value into `IRStorageWord`.
+/-- Inject a `Nat` value into `IRStorageWord` by reducing modulo
+    `UInt256.size`. -/
+@[inline] def ofNat (n : Nat) : IRStorageWord := UInt256.ofNat n
 
-    Phase 0: identity. Phase 1: `% UInt256.size`. -/
-@[inline] def ofNat (n : Nat) : IRStorageWord := n
-
-/-- Project an `IRStorageWord` back to `Nat`.
-
-    Phase 0: identity. Phase 1: `UInt256.toNat`. -/
-@[inline] def toNat (w : IRStorageWord) : Nat := w
+/-- Project an `IRStorageWord` back to `Nat`. The result is bounded by
+    `UInt256.size` (see `toNat_lt_size`). -/
+@[inline] def toNat (w : IRStorageWord) : Nat := UInt256.toNat w
 
 /-- Project an `IRStorageWord` to the EVMYulLean `UInt256` representation.
 
-    This is the projection used by the native state bridge. Phase 0
-    truncates the underlying `Nat` by `% UInt256.size` exactly as
-    `UInt256.ofNat` does today; Phase 1 will make this projection lossless
-    by construction. -/
-@[inline] def toUInt256 (w : IRStorageWord) : UInt256 := UInt256.ofNat w
+    Lossless: with the Phase 1 carrier this is the identity. -/
+@[inline] def toUInt256 (w : IRStorageWord) : UInt256 := w
 
-/-! ## Round-trip lemmas
+/-- `OfNat` instance so storage initial values like `fun _ => 0`
+    elaborate as `IRStorageWord`. -/
+instance instOfNat (n : Nat) : OfNat IRStorageWord n := ⟨ofNat n⟩
 
-    These hold in Phase 0 by definitional equality and are stated up
-    front so Phase 1's flip can preserve them as the migration contract. -/
+instance : Inhabited IRStorageWord := ⟨ofNat 0⟩
 
-@[simp] theorem toNat_ofNat (n : Nat) : (ofNat n).toNat = n := rfl
+/-! ## Round-trip lemmas -/
 
-@[simp] theorem ofNat_toNat (w : IRStorageWord) : ofNat w.toNat = w := rfl
+@[simp] theorem toNat_ofNat (n : Nat) : (ofNat n).toNat = n % UInt256.size := rfl
+
+@[simp] theorem ofNat_toNat (w : IRStorageWord) : ofNat w.toNat = w := by
+  cases w with
+  | mk v =>
+    cases v with
+    | mk val isLt =>
+      show UInt256.ofNat val = ⟨⟨val, isLt⟩⟩
+      apply congrArg UInt256.mk
+      apply Fin.ext
+      show val % UInt256.size = val
+      exact Nat.mod_eq_of_lt isLt
+
+/-- Every `IRStorageWord` value is bounded by `UInt256.size`. -/
+theorem toNat_lt_size (w : IRStorageWord) : w.toNat < UInt256.size := by
+  cases w with
+  | mk v => exact v.isLt
 
 end IRStorageWord
 

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -294,6 +294,15 @@ def findDynamicArrayElementAtSlot
         | _ => go rest (idx + 1)
   go fields 0
 
+/-- Bridge lemma: the EvmYulLean `UInt256.size` and the verity-core
+`UINT256_MODULUS` literal are the same `Nat` (`2^256`). Used to discharge
+`% UInt256.size` modulo wraps that arise from `IRStorageWord.toNat`
+projection of values originally bounded by `Verity.Core.Uint256.isLt`. -/
+@[simp] theorem UInt256_size_eq_UINT256_MODULUS :
+    EvmYul.UInt256.size = Verity.Core.UINT256_MODULUS := by
+  unfold EvmYul.UInt256.size Verity.Core.UINT256_MODULUS
+  rfl
+
 def encodeStorageAt (fields : List Field) (world : Verity.ContractState) (slot : Nat) : Nat :=
   match findResolvedFieldAtSlot fields slot with
   | some field =>
@@ -308,7 +317,8 @@ def encodeStorageAt (fields : List Field) (world : Verity.ContractState) (slot :
       | some value => value
       | none => (world.storage slot).val
 
-def encodeStorage (spec : CompilationModel) (world : Verity.ContractState) : Nat → Nat :=
+def encodeStorage (spec : CompilationModel) (world : Verity.ContractState) :
+    Nat → Nat :=
   encodeStorageAt (effectiveFields spec) world
 
 def writeUintSlots (world : Verity.ContractState) (slots : List Nat) (value : Nat) :
@@ -355,14 +365,16 @@ def writeAddressKeyedMappingSlots
   | slot :: _ =>
       let keyAddr := Verity.wordToAddress (key : Verity.Core.Uint256)
       let word : Verity.Core.Uint256 := value
-      let storageNat : Nat → Nat := fun s => (world.storage s).val
+      let storageNat : Nat → Compiler.Proofs.IRGeneration.IRStorageWord :=
+        fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (world.storage s).val
       let storage :=
         slots.foldl
           (fun current slot =>
             Compiler.Proofs.abstractStoreMappingEntry current slot key value)
           storageNat
       { world with
-        storage := fun s => (storage s : Verity.Core.Uint256)
+        storage := fun s =>
+          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat (storage s) : Verity.Core.Uint256)
         storageMap := fun baseSlot addr =>
           if baseSlot == slot && addr == keyAddr then
             word
@@ -421,14 +433,16 @@ def writeUintKeyedMappingSlots
   | slot :: _ =>
       let keyWord : Verity.Core.Uint256 := key
       let word : Verity.Core.Uint256 := value
-      let storageNat : Nat → Nat := fun s => (world.storage s).val
+      let storageNat : Nat → Compiler.Proofs.IRGeneration.IRStorageWord :=
+        fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (world.storage s).val
       let storage :=
         slots.foldl
           (fun current slot =>
             Compiler.Proofs.abstractStoreMappingEntry current slot key value)
           storageNat
       { world with
-        storage := fun s => (storage s : Verity.Core.Uint256)
+        storage := fun s =>
+          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat (storage s) : Verity.Core.Uint256)
         storageMapUint := fun baseSlot key' =>
           if baseSlot == slot && key' == keyWord then
             word
@@ -444,7 +458,8 @@ def writeAddressKeyedMapping2Slots
       let key1Addr := Verity.wordToAddress (key1 : Verity.Core.Uint256)
       let key2Addr := Verity.wordToAddress (key2 : Verity.Core.Uint256)
       let word : Verity.Core.Uint256 := value
-      let storageNat : Nat → Nat := fun s => (world.storage s).val
+      let storageNat : Nat → Compiler.Proofs.IRGeneration.IRStorageWord :=
+        fun s => Compiler.Proofs.IRGeneration.IRStorageWord.ofNat (world.storage s).val
       let storage :=
         slots.foldl
           (fun current slot =>
@@ -455,7 +470,8 @@ def writeAddressKeyedMapping2Slots
               value)
           storageNat
       { world with
-        storage := fun s => (storage s : Verity.Core.Uint256)
+        storage := fun s =>
+          (Compiler.Proofs.IRGeneration.IRStorageWord.toNat (storage s) : Verity.Core.Uint256)
         storageMap2 := fun baseSlot addr1 addr2 =>
           if baseSlot == slot && addr1 == key1Addr && addr2 == key2Addr then
             word

--- a/Compiler/Proofs/MappingSlot.lean
+++ b/Compiler/Proofs/MappingSlot.lean
@@ -83,7 +83,7 @@ def abstractLoadMappingEntry
 def abstractStoreMappingEntry
     (storage : Nat → IRStorageWord)
     (baseSlot key value : Nat) : Nat → IRStorageWord :=
-  fun s => if s = solidityMappingSlot baseSlot key then value else storage s
+  fun s => if s = solidityMappingSlot baseSlot key then IRStorageWord.ofNat value else storage s
 
 /-- Read through the active mapping-slot backend from flat storage. -/
 def abstractLoadStorageOrMapping
@@ -95,7 +95,7 @@ def abstractLoadStorageOrMapping
 def abstractStoreStorageOrMapping
     (storage : Nat → IRStorageWord)
     (slot value : Nat) : Nat → IRStorageWord :=
-  fun s => if s = slot then value else storage s
+  fun s => if s = slot then IRStorageWord.ofNat value else storage s
 
 @[simp] theorem abstractMappingSlot_eq_solidity (baseSlot key : Nat) :
     abstractMappingSlot baseSlot key = solidityMappingSlot baseSlot key := rfl
@@ -126,7 +126,7 @@ def abstractStoreStorageOrMapping
     (storage : Nat → IRStorageWord)
     (baseSlot key value : Nat) :
     abstractStoreMappingEntry storage baseSlot key value =
-      (fun s => if s = solidityMappingSlot baseSlot key then value else storage s) := rfl
+      (fun s => if s = solidityMappingSlot baseSlot key then IRStorageWord.ofNat value else storage s) := rfl
 
 @[simp] theorem abstractLoadStorageOrMapping_eq
     (storage : Nat → IRStorageWord)
@@ -137,7 +137,7 @@ def abstractStoreStorageOrMapping
     (storage : Nat → IRStorageWord)
     (slot value : Nat) :
     abstractStoreStorageOrMapping storage slot value =
-      (fun s => if s = slot then value else storage s) := rfl
+      (fun s => if s = slot then IRStorageWord.ofNat value else storage s) := rfl
 
 /-- Keccak256 output interpreted as a big-endian 256-bit natural is less than 2^256.
     This is mathematically true because keccak produces exactly 32 bytes, so

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean
@@ -1061,7 +1061,7 @@ def evalBuiltinCallViaEvmYulLean
     (argVals : List Nat) : Option Nat :=
   match func, argVals with
   | "calldataload", [offset] => some (Compiler.Proofs.YulGeneration.calldataloadWord selector calldata offset)
-  | "sload", [slot] => some (storage slot)
+  | "sload", [slot] => some (storage slot).toNat
   | "mappingSlot", [base, key] => some (Compiler.Proofs.abstractMappingSlot base key)
   | _, _ => evalPureBuiltinViaEvmYulLean func argVals
 

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeDispatchOracleTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeDispatchOracleTest.lean
@@ -33,14 +33,14 @@ private def nestedMultiWordMappingBaseSlot : Nat :=
 private def nestedMultiWordMappingMemberSlot : Nat :=
   nestedMultiWordMappingBaseSlot + 1
 
-private def seededStorage : Nat -> Nat := fun slot =>
-  if slot = 7 then 77 else
-  if slot = mappingReadSlot then 515 else
-  if slot = packedMappingSlot then 0x123456 else
-  if slot = multiWordMappingBaseSlot then 0xAAAA else
-  if slot = multiWordMappingMemberSlot then 0xBBBB else
-  if slot = nestedMultiWordMappingBaseSlot then 0xCCCC else
-  if slot = nestedMultiWordMappingMemberSlot then 0xDDDD else 0
+private def seededStorage : Nat -> IRStorageWord := fun slot =>
+  if slot = 7 then IRStorageWord.ofNat 77 else
+  if slot = mappingReadSlot then IRStorageWord.ofNat 515 else
+  if slot = packedMappingSlot then IRStorageWord.ofNat 0x123456 else
+  if slot = multiWordMappingBaseSlot then IRStorageWord.ofNat 0xAAAA else
+  if slot = multiWordMappingMemberSlot then IRStorageWord.ofNat 0xBBBB else
+  if slot = nestedMultiWordMappingBaseSlot then IRStorageWord.ofNat 0xCCCC else
+  if slot = nestedMultiWordMappingMemberSlot then IRStorageWord.ofNat 0xDDDD else IRStorageWord.ofNat 0
 
 private def sampleIRTx (selector : Nat) (args : List Nat := []) : IRTransaction :=
   { sender := 0xCAFE
@@ -324,7 +324,7 @@ private def memoryRevertDispatchSmokeContract : IRContract :=
 
 private def referenceRuntimeWithBackendFuel
     (fuel : Nat) (runtimeCode : List Compiler.Yul.YulStmt)
-    (tx : YulTransaction) (storage : Nat -> Nat) (events : List (List Nat)) :
+    (tx : YulTransaction) (storage : Nat -> IRStorageWord) (events : List (List Nat)) :
     YulResult :=
   let initialState := YulState.initial tx storage events
   yulResultOfExecWithRollback initialState
@@ -358,8 +358,8 @@ private def emittedDispatchMatchesReferenceWithExpected
     nativeResult.returnValue == expectedReturn &&
     reference.returnValue == expectedReturn &&
     expectedSlots.all (fun (slot, value) =>
-      nativeResult.finalStorage slot == value &&
-        reference.finalStorage slot == value))
+      nativeResult.finalStorage slot == IRStorageWord.ofNat value &&
+        reference.finalStorage slot == IRStorageWord.ofNat value))
 
 private def emittedCompiledDispatchMatchesReferenceWithExpected
     (contract : Except String IRContract) (tx : IRTransaction)

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -415,7 +415,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_installsExecutionContract
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.code =
       contract ∧
@@ -426,7 +426,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_installsCurrentAccountContract
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     ((initialState contract tx storage observableSlots).sharedState.accountMap.find?
         (natToAddress tx.thisAddress)).map (fun account => account.code) =
@@ -438,7 +438,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_transactionEnvironment
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.source =
       natToAddress tx.sender ∧
@@ -460,7 +460,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_source
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.source =
       natToAddress tx.sender := by
@@ -470,7 +470,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_sender
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.sender =
       natToAddress tx.sender := by
@@ -480,7 +480,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_codeOwner
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.codeOwner =
       natToAddress tx.thisAddress := by
@@ -490,7 +490,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_weiValue
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.weiValue =
       natToUInt256 tx.msgValue := by
@@ -500,7 +500,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_blockTimestamp
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.header.timestamp =
       tx.blockTimestamp := by
@@ -510,7 +510,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_blockNumber
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.header.number =
       tx.blockNumber := by
@@ -520,7 +520,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_calldata
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.calldata =
       calldataToByteArray tx.functionSelector tx.args := by
@@ -530,7 +530,7 @@ def validateNativeRuntimeEnvironment
 @[simp] theorem initialState_calldataSize
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.calldata.size =
       4 + tx.args.length * 32 := by
@@ -619,7 +619,7 @@ theorem readBytes_offset4_get?_of_lt_source
 @[simp] theorem initialState_calldataReadWord_selectorByte0
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (ByteArray.readBytes
         (initialState contract tx storage observableSlots).toState.executionEnv.calldata
@@ -643,7 +643,7 @@ theorem readBytes_offset4_get?_of_lt_source
 @[simp] theorem initialState_calldataReadWord_selectorByte1
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (ByteArray.readBytes
         (initialState contract tx storage observableSlots).toState.executionEnv.calldata
@@ -668,7 +668,7 @@ theorem readBytes_offset4_get?_of_lt_source
 @[simp] theorem initialState_calldataReadWord_selectorByte2
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (ByteArray.readBytes
         (initialState contract tx storage observableSlots).toState.executionEnv.calldata
@@ -693,7 +693,7 @@ theorem readBytes_offset4_get?_of_lt_source
 @[simp] theorem initialState_calldataReadWord_selectorByte3
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (ByteArray.readBytes
         (initialState contract tx storage observableSlots).toState.executionEnv.calldata
@@ -720,7 +720,7 @@ theorem readBytes_offset4_get?_of_lt_source
 theorem initialState_calldataReadWord_arg0Byte
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -799,7 +799,7 @@ private theorem list_reverse_eq_drop4_reverse_append_four
 theorem initialState_calldataReadWord_selectorPrefix
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     let bytes := ByteArray.readBytes
       (initialState contract tx storage observableSlots).toState.executionEnv.calldata 0 32
@@ -1263,7 +1263,7 @@ theorem uint256_toByteArray_size (value : EvmYul.UInt256) :
 theorem initialState_calldataReadWord_arg0Bytes
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -1308,7 +1308,7 @@ theorem initialState_calldataReadWord_arg0Bytes
 theorem initialState_calldataload4_arg0_value
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -1349,7 +1349,7 @@ theorem initialState_calldataload4_arg0_value
 theorem initialState_calldataload4_arg0_word
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -1371,7 +1371,7 @@ theorem initialState_calldataload4_arg0_word
 theorem initialState_selectorExpr_native_value
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.UInt256.toNat
       (EvmYul.UInt256.shiftRight
@@ -1410,7 +1410,7 @@ theorem initialState_selectorExpr_native_value
 theorem initialState_selectorExpr_native_value_of_readBytes_size
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (_hReadBytesSize :
       ∀ source : ByteArray, (ByteArray.readBytes source 0 32).size = 32) :
@@ -1426,7 +1426,7 @@ theorem initialState_selectorExpr_native_value_of_readBytes_size
 theorem initialState_selectorExpr_native_uint256
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.UInt256.shiftRight
         (EvmYul.State.calldataload
@@ -1605,7 +1605,7 @@ theorem primCall_calldataload4_initialState_arg0_ok
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -1629,7 +1629,7 @@ theorem primCall_calldataload4_initialState_arg0_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (arg : Nat)
@@ -1655,7 +1655,7 @@ theorem primCall_calldataload4_initialState_ofIR_arg0_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : Compiler.Proofs.IRGeneration.IRTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (arg : Nat)
@@ -1688,7 +1688,7 @@ theorem primCall_calldataload4_initialState_ofIR_arg0_ok_withStore
 theorem primCall_calldataload0_then_shr224_initialState_selector_ok
     (loadFuel shrFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → Nat) (observableSlots : List Nat) :
+    (tx : YulTransaction) (storage : Nat → IRStorageWord) (observableSlots : List Nat) :
     (do
       let (state', values) ←
         EvmYul.Yul.primCall (loadFuel + 1)
@@ -1949,7 +1949,7 @@ theorem eval_lowerExprNative_selectorExpr_ok
 theorem eval_lowerExprNative_selectorExpr_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.Yul.eval 10
         (Backends.lowerExprNative Compiler.Proofs.YulGeneration.selectorExpr)
@@ -2030,7 +2030,7 @@ private theorem uint256_isZero_ofNat_zero :
 theorem eval_lowerExprNative_iszero_lt_calldatasize_4_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     EvmYul.Yul.eval 10
@@ -2070,7 +2070,7 @@ theorem eval_lowerExprNative_callvalue_ok
 theorem eval_lowerExprNative_callvalue_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.Yul.eval 5
         (Backends.lowerExprNative (Yul.YulExpr.call "callvalue" []))
@@ -2288,7 +2288,7 @@ theorem exec_let_lowerExprNative_iszero_lt_calldatasize_4_ok
 theorem exec_let_lowerExprNative_iszero_lt_calldatasize_4_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (name : EvmYul.Identifier)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
@@ -2342,7 +2342,7 @@ theorem exec_let_lowerExprNative_iszero_lt_calldatasize_4_initialState_ok_fuel
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (name : EvmYul.Identifier)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
@@ -2404,7 +2404,7 @@ theorem eval_lowerExprNative_iszero_ident_one_ok_fuel
 theorem exec_let_lowerExprNative_selectorExpr_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (discrName : EvmYul.Identifier) :
     EvmYul.Yul.exec 11
@@ -2439,7 +2439,7 @@ theorem exec_let_lowerExprNative_selectorExpr_initialState_ok_fuel
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (discrName : EvmYul.Identifier) :
     EvmYul.Yul.exec (fuel + 11)
@@ -2480,7 +2480,7 @@ theorem exec_let_lowerExprNative_selectorExpr_initialState_store_ok_fuel
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (discrName : EvmYul.Identifier) :
@@ -2783,7 +2783,7 @@ def nativeSwitchPrefixStmts
 def nativeSwitchInitialOkState
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     EvmYul.Yul.State :=
   .Ok (initialState contract tx storage observableSlots).sharedState ∅
@@ -2791,7 +2791,7 @@ def nativeSwitchInitialOkState
 def nativeSwitchPrefixFinalState
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     EvmYul.Yul.State :=
@@ -2809,7 +2809,7 @@ state whose native switch temporaries are aligned to the interpreter oracle. -/
 theorem exec_nativeSwitchPrefix_selector_initialState_ok
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     EvmYul.Yul.exec 12
@@ -2845,7 +2845,7 @@ theorem exec_nativeSwitchPrefix_selector_initialState_ok
 
 theorem exec_nativeSwitchPrefix_selector_initialState_ok_fuel
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     EvmYul.Yul.exec (fuel + 12)
       (.Block (nativeSwitchPrefixStmts discrName matchedName))
@@ -2888,7 +2888,7 @@ theorem exec_nativeSwitchPrefix_selector_initialState_ok_fuel
     bindings (e.g. the buildSwitch wrapper's `__has_selector := 1`). -/
 theorem exec_nativeSwitchPrefix_selector_initialState_store_ok_fuel
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (discrName matchedName : EvmYul.Identifier) :
     EvmYul.Yul.exec (fuel + 12)
@@ -3099,7 +3099,7 @@ theorem exec_if_lowerExprNative_iszero_ident_one_skip_fuel
     `If1`-skip lemma. -/
 private theorem nativeSwitchInitialOkState_insert_lookup_self
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (name : EvmYul.Identifier) (value : EvmYul.UInt256) :
     ((nativeSwitchInitialOkState contract tx storage observableSlots).insert
         name value)[name]! = value := by
@@ -3148,7 +3148,7 @@ theorem exec_block_singleton_eq
     `nativeSwitchInitialOkState_insert_lookup_self`. -/
 theorem exec_block_letSelector_if1Skip_initialState_fuel
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (selectorName : EvmYul.Identifier) (if1Body tail : List EvmYul.Yul.Ast.Stmt)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
     EvmYul.Yul.exec (fuel + 12)
@@ -3189,7 +3189,7 @@ theorem exec_block_letSelector_if1Skip_initialState_fuel
     lemmas through `nativeSwitchInitialOkState_insert_lookup_self`. -/
 theorem exec_block_letSelector_if1Skip_if2Take_initialState_fuel
     (fuel : Nat) (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (selectorName : EvmYul.Identifier)
     (if1Body if2Body : List EvmYul.Yul.Ast.Stmt)
     (hNoWrap : 4 + tx.args.length * 32 < EvmYul.UInt256.size) :
@@ -4090,7 +4090,7 @@ theorem nativeSwitchDiscrTempName_ne_matchedTempName
 theorem nativeSwitchPrefixFinalState_matched
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     (nativeSwitchPrefixFinalState contract tx storage observableSlots
@@ -4102,7 +4102,7 @@ theorem nativeSwitchPrefixFinalState_matched
 theorem nativeSwitchPrefixFinalState_discr
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier)
     (selector : Nat)
@@ -4123,7 +4123,7 @@ theorem nativeSwitchPrefixFinalState_discr
 theorem nativeSwitchPrefixFinalState_marked
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier) :
     ((nativeSwitchPrefixFinalState contract tx storage observableSlots discrName matchedName).insert matchedName (EvmYul.UInt256.ofNat 1))[matchedName]! =
@@ -4135,7 +4135,7 @@ theorem nativeSwitchPrefixFinalState_marked
 def nativeSwitchPrefixStateForId
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (switchId : Nat) :
     EvmYul.Yul.State :=
@@ -4146,7 +4146,7 @@ def nativeSwitchPrefixStateForId
 def nativeSwitchMarkedPrefixStateForId
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (switchId : Nat) :
     EvmYul.Yul.State :=
@@ -5441,7 +5441,7 @@ theorem exec_nativeSwitchPrefix_then_tail_fuel
     (tail : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier)
     (final : EvmYul.Yul.State)
@@ -5481,7 +5481,7 @@ theorem exec_nativeSwitchPrefix_then_tail_error_fuel
     (tail : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (discrName matchedName : EvmYul.Identifier)
     (err : EvmYul.Yul.Exception)
@@ -5519,7 +5519,7 @@ theorem exec_nativeSwitchPrefix_then_tail_error_fuel
 theorem exec_nativeSwitchTail_find_hit_preserved_fuel
     (fuel selector switchId tag : Nat)
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt)) (defaultBody body : List EvmYul.Yul.Ast.Stmt)
-    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction) (storage : Nat → Nat)
+    (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) (final : EvmYul.Yul.State)
     (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
@@ -5570,7 +5570,7 @@ theorem exec_nativeSwitchTail_find_hit_error_fuel
     (defaultBody body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -5614,7 +5614,7 @@ theorem exec_nativeSwitchTail_find_none_with_default_nonempty_fuel
     (defaultBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (final : EvmYul.Yul.State)
     (hSelector :
@@ -5662,7 +5662,7 @@ theorem exec_nativeSwitchTail_find_none_without_default_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -5705,7 +5705,7 @@ theorem exec_nativeSwitchTail_find_none_with_revert_default_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -5747,7 +5747,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_hit_preserved_fuel
     (body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (final : EvmYul.Yul.State)
     (hSelector :
@@ -5788,7 +5788,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_hit_error_fuel
     (body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector :
@@ -5823,7 +5823,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_default_nonempty_fue
     (defaultBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (final : EvmYul.Yul.State)
     (hSelector :
@@ -5860,7 +5860,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -5893,7 +5893,7 @@ theorem exec_lowerNativeSwitchBlock_storePrefix_tail_error_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (defaultBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (err : EvmYul.Yul.Exception)
     (hTail :
@@ -5937,7 +5937,7 @@ theorem exec_lowerNativeSwitchBlock_storePrefix_tail_error_fuel
 /-- `matched := 0` lookup on the post-prefix state with arbitrary store. -/
 theorem nativeSwitchPrefixStoreState_matched_eq
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (discrName matchedName : EvmYul.Identifier)
     (discrValue : EvmYul.Literal) :
@@ -5951,7 +5951,7 @@ theorem nativeSwitchPrefixStoreState_matched_eq
 /-- `discr := selector` lookup on the post-prefix state with arbitrary store. -/
 theorem nativeSwitchPrefixStoreState_discr_eq
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (discrName matchedName : EvmYul.Identifier)
     (selector : Nat) (hne : discrName ≠ matchedName)
@@ -5978,7 +5978,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_store
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (hSelector :
@@ -6018,7 +6018,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_hit_error_store_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (defaultBody body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat) (store : EvmYul.Yul.VarStore)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat) (store : EvmYul.Yul.VarStore)
     (err : EvmYul.Yul.Exception)
     (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
@@ -6068,7 +6068,7 @@ theorem exec_block_lowerNativeSwitchBlock_revert_default_hasSelectorState_error
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -6111,7 +6111,7 @@ theorem exec_block_lowerNativeSwitchBlock_selector_find_hit_hasSelectorState_err
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (defaultBody body : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract) (tx : YulTransaction)
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : selector = tx.functionSelector % Compiler.Constants.selectorModulus)
     (hFind : cases.find? (fun entry => entry.1 == selector) = some (tag, body))
@@ -6158,7 +6158,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_without_default_fuel
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (hSelector :
       selector = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -6183,7 +6183,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_without_default_fuel
 @[simp] theorem initialState_unbridgedEnvironmentDefaults
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     (initialState contract tx storage observableSlots).sharedState.executionEnv.header.baseFeePerGas =
       0 ∧
@@ -6217,7 +6217,7 @@ def projectStorageFromState (tx : YulTransaction) (state : EvmYul.Yul.State) :
       state.sharedState.accountMap.find? (natToAddress tx.thisAddress) =
         some account)
     (hSlot : account.storage.find? (natToUInt256 slot) = some value) :
-    projectStorageFromState tx state slot = uint256ToNat value := by
+    projectStorageFromState tx state slot = value := by
   simp [projectStorageFromState, extractStorage, hAccount, hSlot]
 
 /-- Projecting final native storage defaults to zero when the current contract
@@ -6252,25 +6252,21 @@ def projectStorageFromState (tx : YulTransaction) (state : EvmYul.Yul.State) :
 theorem initialState_observableStorageSlot
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hSlot : slot ∈ observableSlots)
     (hRange : ∀ s ∈ observableSlots, s < EvmYul.UInt256.size) :
     projectStorageFromState tx
       (initialState contract tx storage observableSlots) slot =
-      storage slot % EvmYul.UInt256.size := by
+      storage slot := by
   simp only [projectStorageFromState, extractStorage, initialState,
     EvmYul.Yul.State.sharedState, YulState.initial, toSharedState]
   rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
   rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
-  simp only at *
   have h := storageLookup_projectStorage storage observableSlots slot hSlot hRange
   unfold storageLookup at h
-  generalize hfind : Batteries.RBMap.find? (projectStorage storage observableSlots)
-      (natToUInt256 slot) = found at h ⊢
-  cases found <;>
-    simpa [uint256ToNat, EvmYul.UInt256.toNat] using h
+  exact h
 
 /-- Native `sload` from an initially materialized observable slot returns the
     exact EVM word projected from Verity storage. The range hypothesis keeps
@@ -6279,7 +6275,7 @@ theorem initialState_observableStorageSlot
 theorem initialState_sload_observableSlot_value
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hSlot : slot ∈ observableSlots)
@@ -6287,11 +6283,11 @@ theorem initialState_sload_observableSlot_value
     (EvmYul.State.sload
       (initialState contract tx storage observableSlots).toState
       (natToUInt256 slot)).2 =
-      natToUInt256 (storage slot) := by
+      storage slot := by
   have hFindStorage :
       (projectStorage storage observableSlots).find? (natToUInt256 slot) =
-        some (natToUInt256 (storage slot)) := by
-    simpa [projectStorage] using
+        some (storage slot) := by
+    simpa [projectStorage, IRStorageWord.toUInt256] using
       foldl_insert_find storage observableSlots slot hSlot hRange
         (Batteries.RBMap.empty : EvmYul.Storage)
   simp only [EvmYul.State.sload, EvmYul.State.lookupAccount,
@@ -6299,7 +6295,7 @@ theorem initialState_sload_observableSlot_value
   rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
   rw [Batteries.RBMap.find?_insert_of_eq _ Std.ReflCmp.compare_self]
   change (Batteries.RBMap.find? (projectStorage storage observableSlots)
-      (natToUInt256 slot)).getD ⟨0⟩ = natToUInt256 (storage slot)
+      (natToUInt256 slot)).getD ⟨0⟩ = storage slot
   rw [hFindStorage]
   rfl
 
@@ -6309,7 +6305,7 @@ theorem initialState_sload_observableSlot_value
 theorem initialState_sload_omittedSlot_value
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hNotSlot : slot ∉ observableSlots)
@@ -6339,7 +6335,7 @@ theorem primCall_sload_initialState_observableSlot_ok
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hSlot : slot ∈ observableSlots)
@@ -6354,7 +6350,7 @@ theorem primCall_sload_initialState_observableSlot_ok
           .ok ((initialState contract tx storage observableSlots).setSharedState
               { (initialState contract tx storage observableSlots).toSharedState with
                 toState := state' },
-            [natToUInt256 (storage slot)]) := by
+            [storage slot]) := by
   rw [primCall_sload_ok]
   generalize hload :
       EvmYul.State.sload
@@ -6375,7 +6371,7 @@ theorem primCall_sload_initialState_omittedSlot_ok
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hNotSlot : slot ∉ observableSlots)
@@ -6414,7 +6410,7 @@ theorem primCall_sload_initialState_observableSlot_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (slot : Nat)
@@ -6432,7 +6428,7 @@ theorem primCall_sload_initialState_observableSlot_ok_withStore
               { (.Ok (initialState contract tx storage observableSlots).sharedState
                   store : EvmYul.Yul.State).toSharedState with
                 toState := state' }),
-            [natToUInt256 (storage slot)]) := by
+            [storage slot]) := by
   rw [primCall_sload_ok]
   generalize hload :
       EvmYul.State.sload
@@ -6457,7 +6453,7 @@ theorem primCall_sload_initialState_omittedSlot_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (slot : Nat)
@@ -6503,7 +6499,7 @@ theorem primCall_sstore_initialState_wordSlot_ok
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (slot value : Nat)
     (_hSlotRange : slot < EvmYul.UInt256.size) :
@@ -6524,7 +6520,7 @@ theorem primCall_sstore_initialState_wordSlot_ok_withStore
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (slot value : Nat)
@@ -6550,7 +6546,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_ok
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -6746,7 +6742,7 @@ theorem primCall_mstore0_then_return32_ok_hReturn_size
 theorem initialState_omittedStorageSlot
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (slot : Nat)
     (hNotSlot : slot ∉ observableSlots)
@@ -7101,7 +7097,7 @@ theorem contractDispatcherExecResult_block_dispatcher_eq_exec_block
     (body : List EvmYul.Yul.Ast.Stmt)
     (functions : Compiler.Proofs.YulGeneration.Backends.NativeFunctionMap)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     contractDispatcherExecResult (Nat.succ (Nat.succ fuel))
         { dispatcher := .Block body, functions := functions }
@@ -7166,7 +7162,7 @@ theorem callDispatcherBlockResult_initialState_eq_contractDispatcherBlockResult
     (fuel' : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     callDispatcherBlockResult fuel' contract
         (initialState contract tx storage observableSlots) =
@@ -7240,7 +7236,7 @@ def projectResult
 
 @[simp] theorem projectResult_ok
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7264,7 +7260,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7293,7 +7289,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_yulHalt
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -7309,7 +7305,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_events
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7319,7 +7315,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_success
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7329,7 +7325,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_returnValue
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7340,7 +7336,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal) :
@@ -7351,7 +7347,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_finalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal)
@@ -7363,13 +7359,13 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
         some account)
     (hSlot : account.storage.find? (natToUInt256 slot) = some value) :
     (projectResult tx initialStorage initialEvents
-      (.ok (state, values))).finalStorage slot = uint256ToNat value := by
+      (.ok (state, values))).finalStorage slot = value := by
   simp [projectResult, projectStorageFromState_accountStorageSlot,
     hAccount, hSlot]
 
 @[simp] theorem projectResult_ok_missingFinalStorageAccountSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal)
@@ -7383,7 +7379,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_eq
 
 @[simp] theorem projectResult_ok_missingFinalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (values : List EvmYul.Yul.Ast.Literal)
@@ -7411,7 +7407,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (slot value : Nat)
@@ -7424,7 +7420,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot
           EvmYul.Operation.SSTORE [natToUInt256 slot, natToUInt256 value] =
         .ok (finalState, []) ∧
       (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage slot =
-        value % EvmYul.UInt256.size := by
+        natToUInt256 value := by
   refine ⟨(initialState contract tx storage observableSlots).setState
     ((initialState contract tx storage observableSlots).toState.sstore
       (natToUInt256 slot) (natToUInt256 value)), ?_, ?_⟩
@@ -7434,17 +7430,14 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot
       initialState, EvmYul.Yul.State.sharedState, EvmYul.Yul.State.setState,
       EvmYul.Yul.State.toState, EvmYul.State.sstore, EvmYul.State.lookupAccount,
       EvmYul.State.setAccount, EvmYul.State.addAccessedStorageKey,
-      EvmYul.Account.updateStorage, YulState.initial, toSharedState,
-      natToUInt256, uint256ToNat, EvmYul.UInt256.toNat]
+      EvmYul.Account.updateStorage, YulState.initial, toSharedState]
     have hBranch :
         (EvmYul.UInt256.ofNat value == (Inhabited.default : EvmYul.UInt256)) =
           false := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueNonzero
     rw [hBranch]
-    have hSlotEq : EvmYul.UInt256.ofNat slot = natToUInt256 slot := rfl
-    simp [Option.option, hSlotEq, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, EvmYul.UInt256.size]
-    rfl
+    simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
+      Std.ReflCmp.compare_self]
 
 /-- Native primitive execution of `sstore(slot, 0)` on a word-canonical
     initial runtime slot, lifted through Verity's projected native result
@@ -7458,7 +7451,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_of_erase
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (slot value : Nat)
@@ -7502,7 +7495,7 @@ theorem primCall_sstore_initialState_wordSlot_projectResult_slot_zero_emptyObser
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (slot value : Nat)
     (hSlotRange : slot < EvmYul.UInt256.size)
@@ -7529,7 +7522,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7543,7 +7536,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot
           EvmYul.Operation.SSTORE [natToUInt256 slot, natToUInt256 value] =
         .ok (finalState, []) ∧
       (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage slot =
-        value % EvmYul.UInt256.size := by
+        natToUInt256 value := by
   let initialWithStore : EvmYul.Yul.State :=
     .Ok (initialState contract tx storage observableSlots).sharedState store
   refine ⟨initialWithStore.setState
@@ -7556,17 +7549,14 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot
       initialState, EvmYul.Yul.State.sharedState, EvmYul.Yul.State.setState,
       EvmYul.Yul.State.toState, EvmYul.State.sstore, EvmYul.State.lookupAccount,
       EvmYul.State.setAccount, EvmYul.State.addAccessedStorageKey,
-      EvmYul.Account.updateStorage, YulState.initial, toSharedState,
-      natToUInt256, uint256ToNat, EvmYul.UInt256.toNat]
+      EvmYul.Account.updateStorage, YulState.initial, toSharedState]
     have hBranch :
         (EvmYul.UInt256.ofNat value == (Inhabited.default : EvmYul.UInt256)) =
           false := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueNonzero
     rw [hBranch]
-    have hSlotEq : EvmYul.UInt256.ofNat slot = natToUInt256 slot := rfl
-    simp [Option.option, hSlotEq, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, EvmYul.UInt256.size]
-    rfl
+    simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
+      Std.ReflCmp.compare_self]
 
 /-- Native primitive execution of `sstore(slot, 0)` from an initial runtime
     shared state and arbitrary local-variable store, lifted through Verity's
@@ -7576,7 +7566,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7622,7 +7612,7 @@ theorem primCall_sstore_initialState_wordSlot_withStore_projectResult_slot_zero_
     (fuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (store : EvmYul.Yul.VarStore)
     (slot value : Nat)
@@ -7650,7 +7640,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_ok
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -7685,7 +7675,7 @@ def primCall_calldataload4_then_sstore0_stop_initialState_arg0
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     Except EvmYul.Yul.Exception
       (EvmYul.Yul.State × List EvmYul.Yul.Ast.Literal) := do
@@ -7714,7 +7704,7 @@ def primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore) :
     Except EvmYul.Yul.Exception
@@ -7741,7 +7731,7 @@ def primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_eq
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (arg : Nat)
     (rest : List Nat)
@@ -7784,7 +7774,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_eq
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_eq
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (arg : Nat)
@@ -7832,7 +7822,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_eq
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_projectResult_ok
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7870,7 +7860,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_projectResult_eq
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7909,7 +7899,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_ofIR_arg0_withStor
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : Compiler.Proofs.IRGeneration.IRTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7941,7 +7931,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_ofIR_arg0_withStor
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_projectResult_slot0
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -7956,7 +7946,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
         (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage 0 =
-        arg % EvmYul.UInt256.size := by
+        natToUInt256 arg := by
   let initialWithStore : EvmYul.Yul.State :=
     .Ok (initialState contract tx storage observableSlots).sharedState store
   let finalState :=
@@ -7972,16 +7962,14 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
       initialState, EvmYul.Yul.State.sharedState, EvmYul.Yul.State.setState,
       EvmYul.Yul.State.toState, EvmYul.State.sstore, EvmYul.State.lookupAccount,
       EvmYul.State.setAccount, EvmYul.State.addAccessedStorageKey,
-      EvmYul.Account.updateStorage, YulState.initial, toSharedState,
-      natToUInt256, uint256ToNat, EvmYul.UInt256.toNat]
+      EvmYul.Account.updateStorage, YulState.initial, toSharedState]
     have hBranch :
         (EvmYul.UInt256.ofNat arg == (Inhabited.default : EvmYul.UInt256)) =
           false := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueNonzero
     rw [hBranch]
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, EvmYul.UInt256.size]
-    rfl
+      Std.ReflCmp.compare_self]
 
 /-- Zero-write storage projection for the full generated `store(uint256)`
     selected body from an arbitrary local store, through the terminating
@@ -7990,7 +7978,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -8040,7 +8028,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (store : EvmYul.Yul.VarStore)
     (arg : Nat)
@@ -8067,7 +8055,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_withStore_pro
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult_ok
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8100,7 +8088,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
 theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult_slot0
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
-    (tx : YulTransaction) (storage : Nat → Nat)
+    (tx : YulTransaction) (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8114,7 +8102,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
         (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).finalStorage 0 =
-        arg % EvmYul.UInt256.size := by
+        natToUInt256 arg := by
   let finalState :=
     (initialState contract tx storage observableSlots).setState
       ((initialState contract tx storage observableSlots).toState.sstore
@@ -8128,16 +8116,14 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
       initialState, EvmYul.Yul.State.sharedState, EvmYul.Yul.State.setState,
       EvmYul.Yul.State.toState, EvmYul.State.sstore, EvmYul.State.lookupAccount,
       EvmYul.State.setAccount, EvmYul.State.addAccessedStorageKey,
-      EvmYul.Account.updateStorage, YulState.initial, toSharedState,
-      natToUInt256, uint256ToNat, EvmYul.UInt256.toNat]
+      EvmYul.Account.updateStorage, YulState.initial, toSharedState]
     have hBranch :
         (EvmYul.UInt256.ofNat arg == (Inhabited.default : EvmYul.UInt256)) =
           false := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueNonzero
     rw [hBranch]
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, EvmYul.UInt256.size]
-    rfl
+      Std.ReflCmp.compare_self]
 
 /-- Zero-write storage projection for the full generated `store(uint256)` selected
     body through the terminating `STOP`, with the remaining RBMap erasure fact
@@ -8146,7 +8132,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8193,7 +8179,7 @@ theorem primCall_calldataload4_then_sstore0_stop_initialState_arg0_projectResult
     (loadFuel storeFuel stopFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (arg : Nat)
     (rest : List Nat)
@@ -8220,7 +8206,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8241,7 +8227,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
         | _ => .error EvmYul.Yul.Exception.InvalidArguments) =
         .ok (finalState, []) ∧
       (projectResult tx storage initialEvents (.ok (finalState, []))).finalStorage 0 =
-        arg % EvmYul.UInt256.size := by
+        natToUInt256 arg := by
   refine ⟨(initialState contract tx storage observableSlots).setState
     ((initialState contract tx storage observableSlots).toState.sstore
       (EvmYul.UInt256.ofNat 0) (natToUInt256 arg)), ?_, ?_⟩
@@ -8251,23 +8237,21 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
       initialState, EvmYul.Yul.State.sharedState, EvmYul.Yul.State.setState,
       EvmYul.Yul.State.toState, EvmYul.State.sstore, EvmYul.State.lookupAccount,
       EvmYul.State.setAccount, EvmYul.State.addAccessedStorageKey,
-      EvmYul.Account.updateStorage, YulState.initial, toSharedState,
-      natToUInt256, uint256ToNat, EvmYul.UInt256.toNat]
+      EvmYul.Account.updateStorage, YulState.initial, toSharedState]
     have hBranch :
         (EvmYul.UInt256.ofNat arg == (Inhabited.default : EvmYul.UInt256)) =
           false := by
       simpa [natToUInt256, EvmYul.UInt256.instInhabited] using hValueNonzero
     rw [hBranch]
     simp [Option.option, Batteries.RBMap.find?_insert_of_eq _
-      Std.ReflCmp.compare_self, EvmYul.UInt256.size]
-    rfl
+      Std.ReflCmp.compare_self]
 
 /-- Zero `sstore` projection, with the remaining RBMap erasure fact isolated. -/
 theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot0_zero_of_erase
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (arg : Nat)
@@ -8316,7 +8300,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
     (loadFuel storeFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (arg : Nat)
     (rest : List Nat)
@@ -8344,7 +8328,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
 
 @[simp] theorem projectResult_yulHalt_events
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -8355,7 +8339,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
 
 @[simp] theorem projectResult_yulHalt_success
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -8365,7 +8349,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
 
 @[simp] theorem projectResult_yulHalt_returnValue
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -8381,7 +8365,7 @@ theorem primCall_calldataload4_then_sstore0_initialState_arg0_projectResult_slot
 theorem primCall_mstore0_then_return32_emptyMemory_projectResult_returnValue
     (mstoreFuel returnFuel : Nat)
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (sharedState : EvmYul.SharedState .Yul)
     (store : EvmYul.Yul.VarStore)
@@ -8416,7 +8400,7 @@ theorem primCall_mstore0_then_return32_emptyMemory_projectResult_returnValue
 theorem primCall_mstore0_then_return32_emptyMemory_projectResult_eq
     (mstoreFuel returnFuel : Nat)
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (sharedState : EvmYul.SharedState .Yul)
     (store : EvmYul.Yul.VarStore)
@@ -8460,7 +8444,7 @@ def primCall_sload0_then_mstore0_return32_initialState
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat) :
     Except EvmYul.Yul.Exception
       (EvmYul.Yul.State × List EvmYul.Yul.Ast.Literal) := do
@@ -8490,7 +8474,7 @@ def primCall_sload0_then_mstore0_return32_initialState_withStore
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore) :
     Except EvmYul.Yul.Exception
@@ -8524,7 +8508,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_projectResult_returnV
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSlot : 0 ∈ observableSlots)
@@ -8535,7 +8519,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_projectResult_returnV
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
         (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).returnValue =
-        some (storage 0 % EvmYul.UInt256.size) := by
+        some (uint256ToNat (storage 0)) := by
   unfold primCall_sload0_then_mstore0_return32_initialState
   rw [primCall_sload_initialState_observableSlot_ok sloadFuel contract tx storage
     observableSlots 0 hSlot hRange]
@@ -8554,7 +8538,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_projectResult_returnV
       rcases
         primCall_mstore0_then_return32_emptyMemory_projectResult_returnValue
           mstoreFuel returnFuel tx storage initialEvents sharedAfterLoad ∅
-          (natToUInt256 (storage 0)) hMemory with
+          (storage 0) hMemory with
         ⟨haltState, haltValue, hExec, hReturn⟩
       refine ⟨haltState, haltValue, ?_, ?_⟩
       · simpa [sharedAfterLoad] using hExec
@@ -8568,7 +8552,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_omittedSlot_projectRe
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hNotSlot : 0 ∉ observableSlots)
@@ -8616,7 +8600,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_projectResult_returnV
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hRange : ∀ s ∈ observableSlots, s < EvmYul.UInt256.size) :
@@ -8627,7 +8611,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_projectResult_returnV
       (projectResult tx storage initialEvents
         (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).returnValue =
         if 0 ∈ observableSlots then
-          some (storage 0 % EvmYul.UInt256.size)
+          some (uint256ToNat (storage 0))
         else
           some 0 := by
   by_cases hSlot : 0 ∈ observableSlots
@@ -8654,7 +8638,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -8667,7 +8651,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
         .error (EvmYul.Yul.Exception.YulHalt haltState haltValue) ∧
       (projectResult tx storage initialEvents
         (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).returnValue =
-        some (storage 0 % EvmYul.UInt256.size) := by
+        some (uint256ToNat (storage 0)) := by
   unfold primCall_sload0_then_mstore0_return32_initialState_withStore
   rw [primCall_sload_initialState_observableSlot_ok_withStore sloadFuel
     contract tx storage observableSlots store 0 hSlot hRange]
@@ -8688,7 +8672,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
       rcases
         primCall_mstore0_then_return32_emptyMemory_projectResult_returnValue
           mstoreFuel returnFuel tx storage initialEvents sharedAfterLoad store
-          (natToUInt256 (storage 0)) hMemory with
+          (storage 0) hMemory with
         ⟨haltState, haltValue, hExec, hReturn⟩
       refine ⟨haltState, haltValue, ?_, ?_⟩
       · simpa [sharedAfterLoad, initialWithStore] using hExec
@@ -8700,7 +8684,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_omittedSlot
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -8748,7 +8732,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -8761,7 +8745,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
       (projectResult tx storage initialEvents
         (.error (EvmYul.Yul.Exception.YulHalt haltState haltValue))).returnValue =
         if 0 ∈ observableSlots then
-          some (storage 0 % EvmYul.UInt256.size)
+          some (uint256ToNat (storage 0))
         else
           some 0 := by
   by_cases hSlot : 0 ∈ observableSlots
@@ -8791,7 +8775,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
     (sloadFuel mstoreFuel returnFuel : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
@@ -8806,7 +8790,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
         { success := true
           returnValue :=
             if 0 ∈ observableSlots then
-              some (storage 0 % EvmYul.UInt256.size)
+              some (uint256ToNat (storage 0))
             else
               some 0
           finalStorage := projectStorageFromState tx haltState
@@ -8822,7 +8806,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
   have hProjectReturn :
       projectHaltReturn haltState haltValue =
         if 0 ∈ observableSlots then
-          some (storage 0 % EvmYul.UInt256.size)
+          some (uint256ToNat (storage 0))
         else
           some 0 := by
     simpa [projectResult] using hReturn
@@ -8830,7 +8814,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_yulHalt_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal) :
@@ -8841,7 +8825,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_yulHalt_finalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8854,13 +8838,13 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
     (hSlot : account.storage.find? (natToUInt256 slot) = some slotValue) :
     (projectResult tx initialStorage initialEvents
       (.error (.YulHalt state value))).finalStorage slot =
-        uint256ToNat slotValue := by
+        slotValue := by
   simp [projectResult, projectStorageFromState_accountStorageSlot,
     hAccount, hSlot]
 
 @[simp] theorem projectResult_yulHalt_missingFinalStorageAccountSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8874,7 +8858,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_yulHalt_missingFinalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8891,7 +8875,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_stop
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State) :
     projectResult tx initialStorage initialEvents
@@ -8906,7 +8890,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_32ByteReturn
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8924,7 +8908,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_non32ByteReturn
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (state : EvmYul.Yul.State)
     (value : EvmYul.Yul.Ast.Literal)
@@ -8942,7 +8926,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat)) :
     projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert) =
@@ -8955,7 +8939,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_events
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat)) :
     (projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert)).events =
@@ -8964,7 +8948,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_success
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat)) :
     (projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert)).success = false := by
@@ -8972,7 +8956,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_returnValue
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat)) :
     (projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert)).returnValue = none := by
@@ -8980,7 +8964,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat)) :
     (projectResult tx initialStorage initialEvents
       (.error EvmYul.Yul.Exception.Revert)).finalMappings =
@@ -8989,7 +8973,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_revert_finalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (slot : Nat) :
     (projectResult tx initialStorage initialEvents
@@ -8999,7 +8983,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9025,7 +9009,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_success
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9046,7 +9030,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_returnValue
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9067,7 +9051,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_finalStorageSlot
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (slot : Nat)
@@ -9090,7 +9074,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9112,7 +9096,7 @@ theorem primCall_sload0_then_mstore0_return32_initialState_withStore_projectResu
 
 @[simp] theorem projectResult_hardError_events
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (err : EvmYul.Yul.Exception)
     (hNotHalt : ∀ state value, err ≠ EvmYul.Yul.Exception.YulHalt state value) :
@@ -9142,7 +9126,7 @@ theorem exec_lowerNativeSwitchBlock_selector_find_none_with_revert_default_proje
     (cases : List (Nat × List EvmYul.Yul.Ast.Stmt))
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelector :
@@ -9198,7 +9182,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_find_none_with_revert
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelector :
@@ -9245,7 +9229,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_find_none_with_revert
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelector :
@@ -9279,7 +9263,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_find_none_with_revert
   exact ⟨hExec, by simp⟩
 
 def simpleStorageRevertProjectedResult
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat)) : YulResult :=
   { success := false
     returnValue := none
@@ -9327,7 +9311,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_tx_find_none_with_rev
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelectorBound : tx.functionSelector < Compiler.Constants.selectorModulus)
@@ -9375,7 +9359,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_tx_miss_with_revert_d
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelectorBound : tx.functionSelector < Compiler.Constants.selectorModulus)
@@ -9414,7 +9398,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageConcrete_tx_miss_with_revert_de
     (fuel switchId : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (hSelectorBound : tx.functionSelector < Compiler.Constants.selectorModulus)
@@ -9450,7 +9434,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_store_hit_error_fuel
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector : 0x6057361d = tx.functionSelector % Compiler.Constants.selectorModulus)
@@ -9494,7 +9478,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_store_hit_error_store
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (store : EvmYul.Yul.VarStore)
     (err : EvmYul.Yul.Exception)
@@ -9556,7 +9540,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_store_hit_projectResu
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State)
@@ -9602,7 +9586,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageConcrete_store_hit_projectResul
     (fuel switchId : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State)
@@ -9652,7 +9636,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_retrieve_hit_error_fu
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (err : EvmYul.Yul.Exception)
     (hSelector :
@@ -9690,14 +9674,14 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_retrieve_hit_error_fu
 
 def simpleStorageRetrieveHaltProjectedResult
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State) : YulResult :=
   { success := true
     returnValue :=
       if 0 ∈ observableSlots then
-        some (storage 0 % EvmYul.UInt256.size)
+        some (uint256ToNat (storage 0))
       else
         some 0
     finalStorage := projectStorageFromState tx haltState
@@ -9712,7 +9696,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageSelectors_retrieve_hit_projectR
     (storeBody retrieveBody : List EvmYul.Yul.Ast.Stmt)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State)
@@ -9761,7 +9745,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageConcrete_retrieve_hit_projectRe
     (fuel switchId : Nat)
     (contract : EvmYul.Yul.Ast.YulContract)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (observableSlots : List Nat)
     (haltState : EvmYul.Yul.State)
@@ -9806,7 +9790,7 @@ theorem exec_lowerNativeSwitchBlock_simpleStorageConcrete_retrieve_hit_projectRe
 
 @[simp] theorem projectResult_finalMappings
     (tx : YulTransaction)
-    (initialStorage : Nat → Nat)
+    (initialStorage : Nat → IRStorageWord)
     (initialEvents : List (List Nat))
     (result :
       Except EvmYul.Yul.Exception
@@ -9843,7 +9827,7 @@ def interpretRuntimeNative
     (fuel : Nat)
     (runtimeCode : List YulStmt)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (events : List (List Nat))
     (err : AdapterError)
@@ -9857,7 +9841,7 @@ def interpretRuntimeNative
     (fuel : Nat)
     (runtimeCode : List YulStmt)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (events : List (List Nat))
     (contract : EvmYul.Yul.Ast.YulContract)
@@ -9875,7 +9859,7 @@ def interpretRuntimeNative
     (fuel : Nat)
     (runtimeCode : List YulStmt)
     (tx : YulTransaction)
-    (storage : Nat → Nat)
+    (storage : Nat → IRStorageWord)
     (observableSlots : List Nat)
     (events : List (List Nat))
     (contract : EvmYul.Yul.Ast.YulContract)

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSmokeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSmokeTest.lean
@@ -4,6 +4,7 @@ import EvmYul.Yul.Interpreter
 namespace Compiler.Proofs.YulGeneration.Backends
 
 open Compiler.Yul
+open Compiler.Proofs.IRGeneration (IRStorageWord)
 
 private def runNativeProgram (stmts : List YulStmt) : Option EvmYul.Yul.State :=
   match lowerStmtsNative stmts with
@@ -33,10 +34,10 @@ private def sampleTx : Compiler.Proofs.YulGeneration.YulTransaction :=
     functionSelector := 0x01020304
     args := [41] }
 
-private def zeroStorage : Nat → Nat := fun _ => 0
+private def zeroStorage : Nat → IRStorageWord := fun _ => IRStorageWord.ofNat 0
 
-private def seededStorage : Nat → Nat := fun slot =>
-  if slot = 7 then 77 else 0
+private def seededStorage : Nat → IRStorageWord := fun slot =>
+  if slot = 7 then IRStorageWord.ofNat 77 else IRStorageWord.ofNat 0
 
 private def wordByteArray (value : Nat) : ByteArray :=
   ByteArray.ofFn fun i : Fin 32 =>
@@ -53,7 +54,7 @@ private def stateWithLogEntries (entries : List EvmYul.LogEntry) : EvmYul.Yul.St
   .Ok { shared with substate := { shared.substate with logSeries := entries.toArray } } ∅
 
 private def stateWithStorageLogReturn
-    (storage : Nat → Nat) (observableSlots : List Nat)
+    (storage : Nat → IRStorageWord) (observableSlots : List Nat)
     (entries : List EvmYul.LogEntry) (returnWord : Nat) : EvmYul.Yul.State :=
   let shared := StateBridge.toSharedState
     (Compiler.Proofs.YulGeneration.YulState.initial sampleTx storage) observableSlots
@@ -72,7 +73,7 @@ private def nativeStoresBuiltinWithTx
     .let_ "v" (.call builtin []),
     .expr (.call "sstore" [.lit slot, .ident "v"])
   ] tx zeroStorage [slot] with
-  | .ok result => result.success && result.finalStorage slot == expected
+  | .ok result => result.success && result.finalStorage slot == IRStorageWord.ofNat expected
   | .error _ => false
 
 private def nativeStoresBuiltin (builtin : String) (slot expected : Nat) : Bool :=
@@ -150,7 +151,7 @@ private def nativeAllowsUserFunctionNamedChainid : Bool :=
 
 private def referenceRuntimeWithFuel
     (fuel : Nat) (stmts : List YulStmt) (tx : Compiler.Proofs.YulGeneration.YulTransaction)
-    (storage : Nat → Nat) (events : List (List Nat)) :
+    (storage : Nat → IRStorageWord) (events : List (List Nat)) :
     Compiler.Proofs.YulGeneration.YulResult :=
   let initialState := Compiler.Proofs.YulGeneration.YulState.initial tx storage events
   match Compiler.Proofs.YulGeneration.execYulFuel fuel initialState (.stmts stmts) with
@@ -210,7 +211,7 @@ private def nativeCopiesSloadToSlot
   match Native.interpretRuntimeNative 128 [
     .expr (.call "sstore" [.lit 8, .call "sload" [.lit 7]])
   ] sampleTx seededStorage observableSlots with
-  | .ok result => result.success && result.finalStorage 8 == expected
+  | .ok result => result.success && result.finalStorage 8 == IRStorageWord.ofNat expected
   | .error _ => false
 
 private def nativeCopiesTransientLoadToStorage : Bool :=
@@ -218,7 +219,7 @@ private def nativeCopiesTransientLoadToStorage : Bool :=
     .expr (.call "tstore" [.lit 3, .lit 88]),
     .expr (.call "sstore" [.lit 9, .call "tload" [.lit 3]])
   ] sampleTx zeroStorage [9] with
-  | .ok result => result.success && result.finalStorage 9 == 88
+  | .ok result => result.success && result.finalStorage 9 == IRStorageWord.ofNat 88
   | .error _ => false
 
 private def nativeInitialStateInstallsContractAndStorage : Bool :=
@@ -281,12 +282,12 @@ private def nativeStopCommitsStorageAndPreservesEvents : Bool :=
   | .ok result =>
       result.success &&
         result.returnValue.isNone &&
-        result.finalStorage 7 == 99 &&
+        result.finalStorage 7 == IRStorageWord.ofNat 99 &&
         result.events == [[1, 2, 3]]
   | .error _ => false
 
 private def nativeReturnHaltProjectsStorageReturnAndEvents : Bool :=
-  let finalStorage : Nat → Nat := fun slot => if slot = 7 then 99 else 0
+  let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
   let result :=
     Native.projectResult sampleTx seededStorage [[1, 2, 3]]
       (.error (.YulHalt
@@ -294,11 +295,11 @@ private def nativeReturnHaltProjectsStorageReturnAndEvents : Bool :=
         (EvmYul.UInt256.ofNat 1)))
   result.success &&
     result.returnValue == some 44 &&
-    result.finalStorage 7 == 99 &&
+    result.finalStorage 7 == IRStorageWord.ofNat 99 &&
     result.events == [[1, 2, 3], [5, 88]]
 
 private def nativeValueResultProjectsStorageReturnAndEvents : Bool :=
-  let finalStorage : Nat → Nat := fun slot => if slot = 7 then 99 else 0
+  let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
   let result :=
     Native.projectResult sampleTx seededStorage [[1, 2, 3]]
       (.ok
@@ -306,7 +307,7 @@ private def nativeValueResultProjectsStorageReturnAndEvents : Bool :=
           [EvmYul.UInt256.ofNat 44]))
   result.success &&
     result.returnValue == some 44 &&
-    result.finalStorage 7 == 99 &&
+    result.finalStorage 7 == IRStorageWord.ofNat 99 &&
     result.events == [[1, 2, 3], [5, 88]]
 
 private def nativeHardErrorRollsBackStorageAndEvents : Bool :=
@@ -317,7 +318,7 @@ private def nativeHardErrorRollsBackStorageAndEvents : Bool :=
       (.error EvmYul.Yul.Exception.OutOfFuel)
   !result.success &&
     result.returnValue.isNone &&
-    result.finalStorage 7 == 5 &&
+    result.finalStorage 7 == IRStorageWord.ofNat 5 &&
     result.events == [[1, 2, 3]]
 
 private def nativeRevertErrorRollsBackStorageAndEvents : Bool :=
@@ -328,7 +329,7 @@ private def nativeRevertErrorRollsBackStorageAndEvents : Bool :=
       (.error EvmYul.Yul.Exception.Revert)
   !result.success &&
     result.returnValue.isNone &&
-    result.finalStorage 7 == 5 &&
+    result.finalStorage 7 == IRStorageWord.ofNat 5 &&
     result.events == [[1, 2, 3]]
 
 private def dispatchSmokeContract : Compiler.IRContract :=
@@ -833,7 +834,7 @@ example :
       ],
       .expr (.call "sstore" [.lit 7, .call "inc" [.lit 41]])
     ] sampleTx zeroStorage [7] with
-    | .ok result => result.success && result.finalStorage 7 == 42
+    | .ok result => result.success && result.finalStorage 7 == IRStorageWord.ofNat 42
     | .error _ => false) = true := by
   native_decide
 
@@ -841,7 +842,7 @@ example :
     (match Native.interpretRuntimeNative 128
       [.expr (.call "sstore" [.lit 7, .lit 99])]
       sampleTx zeroStorage [7] with
-    | .ok result => result.success && result.finalStorage 7 == 99
+    | .ok result => result.success && result.finalStorage 7 == IRStorageWord.ofNat 99
     | .error _ => false) = true := by
   native_decide
 
@@ -894,14 +895,14 @@ example :
   native_decide
 
 example :
-    (let finalStorage : Nat → Nat := fun slot => if slot = 7 then 99 else 0
+    (let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
      let result :=
       Native.projectResult sampleTx seededStorage [[1, 2, 3]]
         (.ok
           (stateWithStorageLogReturn finalStorage [7] [sampleLogEntry [5] 88] 0,
             [EvmYul.UInt256.ofNat 44]))
      result.finalMappings) =
-    (let finalStorage : Nat → Nat := fun slot => if slot = 7 then 99 else 0
+    (let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
      let result :=
       Native.projectResult sampleTx seededStorage [[1, 2, 3]]
         (.ok
@@ -911,14 +912,14 @@ example :
   rfl
 
 example :
-    (let finalStorage : Nat → Nat := fun slot => if slot = 7 then 99 else 0
+    (let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
      let result :=
       Native.projectResult sampleTx seededStorage [[1, 2, 3]]
         (.error (.YulHalt
           (stateWithStorageLogReturn finalStorage [7] [sampleLogEntry [5] 88] 44)
           (EvmYul.UInt256.ofNat 1)))
      result.finalMappings) =
-    (let finalStorage : Nat → Nat := fun slot => if slot = 7 then 99 else 0
+    (let finalStorage : Nat → IRStorageWord := fun slot => if slot = 7 then IRStorageWord.ofNat 99 else IRStorageWord.ofNat 0
      let result :=
       Native.projectResult sampleTx seededStorage [[1, 2, 3]]
         (.error (.YulHalt
@@ -1164,7 +1165,7 @@ example :
         [[1, 2, 3]]
         (.error EvmYul.Yul.Exception.Revert)
      !result.success &&
-       result.finalStorage 7 == 5 &&
+       result.finalStorage 7 == IRStorageWord.ofNat 5 &&
        result.events == [[1, 2, 3]]) = true := by
   native_decide
 

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanStateBridge.lean
@@ -112,7 +112,7 @@ multiples of `2^256` alias to the same RBMap key via `natToUInt256`. The
 def projectStorage (storage : Nat → IRStorageWord) (slots : List Nat) : EvmYul.Storage :=
   slots.foldl (init := Batteries.RBMap.empty) fun acc slot =>
     let key := natToUInt256 slot
-    let val := natToUInt256 (storage slot)
+    let val := IRStorageWord.toUInt256 (storage slot)
     acc.insert key val
 
 /-! ## Execution Environment Bridge
@@ -467,7 +467,7 @@ def extractStorage (sharedState : SharedState .Yul) (addr : AccountAddress) :
     match sharedState.accountMap.find? addr with
     | some account =>
       match account.storage.find? (natToUInt256 slot) with
-      | some val => uint256ToNat val
+      | some val => val
       | none => 0
     | none => 0
 
@@ -645,7 +645,7 @@ theorem foldl_insert_find_not_mem (storage : Nat → IRStorageWord)
     (hRange : ∀ s ∈ slots, s < UInt256.size)
     (hSlotRange : slot < UInt256.size)
     (acc : EvmYul.Storage) :
-    (slots.foldl (fun m s => m.insert (natToUInt256 s) (natToUInt256 (storage s))) acc).find?
+    (slots.foldl (fun m s => m.insert (natToUInt256 s) (IRStorageWord.toUInt256 (storage s))) acc).find?
       (natToUInt256 slot) = acc.find? (natToUInt256 slot) := by
   induction slots generalizing acc with
   | nil => rfl
@@ -667,8 +667,8 @@ theorem foldl_insert_find (storage : Nat → IRStorageWord)
     (slots : List Nat) (slot : Nat) (hSlot : slot ∈ slots)
     (hRange : ∀ s ∈ slots, s < UInt256.size)
     (acc : EvmYul.Storage) :
-    (slots.foldl (fun m s => m.insert (natToUInt256 s) (natToUInt256 (storage s))) acc).find?
-      (natToUInt256 slot) = some (natToUInt256 (storage slot)) := by
+    (slots.foldl (fun m s => m.insert (natToUInt256 s) (IRStorageWord.toUInt256 (storage s))) acc).find?
+      (natToUInt256 slot) = some (IRStorageWord.toUInt256 (storage slot)) := by
   induction slots generalizing acc with
   | nil => exact absurd hSlot List.not_mem_nil
   | cons hd tl ih =>
@@ -697,11 +697,11 @@ theorem foldl_insert_find (storage : Nat → IRStorageWord)
 theorem storageLookup_projectStorage (storage : Nat → IRStorageWord)
     (slots : List Nat) (slot : Nat) (hSlot : slot ∈ slots)
     (hRange : ∀ s ∈ slots, s < UInt256.size) :
-    uint256ToNat (storageLookup (projectStorage storage slots) (natToUInt256 slot)) =
-      storage slot % UInt256.size := by
+    storageLookup (projectStorage storage slots) (natToUInt256 slot) =
+      storage slot := by
   simp only [storageLookup, projectStorage]
   rw [foldl_insert_find storage slots slot hSlot hRange]
-  simp only [uint256ToNat, natToUInt256, UInt256.toNat, UInt256.ofNat, Id.run, Fin.val_ofNat]
+  rfl
 
 /-- Nat→UInt256→Nat round-trip for values in range.
     Proof: `ofNat n = ⟨Fin.ofNat _ n⟩ = ⟨⟨n % size, _⟩⟩`, and

--- a/Compiler/Proofs/YulGeneration/ReferenceOracle/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/ReferenceOracle/Builtins.lean
@@ -416,7 +416,7 @@ def evalBuiltinCall
 @[simp] theorem evalBuiltinCall_sload_single
     (storage : Nat → IRStorageWord) (sender selector : Nat) (slot : Nat) :
     evalBuiltinCall storage sender selector [] "sload" [slot] =
-      some (Compiler.Proofs.abstractLoadStorageOrMapping storage slot) := by
+      some (Compiler.Proofs.abstractLoadStorageOrMapping storage slot).toNat := by
   simp [evalBuiltinCall, evalBuiltinCallWithContext]
 
 @[simp] theorem evalBuiltinCallWithBackend_sload_single
@@ -429,7 +429,7 @@ def evalBuiltinCall
         []
         "sload"
         [slot] =
-      some (Compiler.Proofs.abstractLoadStorageOrMapping storage slot) := by
+      some (Compiler.Proofs.abstractLoadStorageOrMapping storage slot).toNat := by
   simp [evalBuiltinCallWithBackend, evalBuiltinCallWithBackendContext, evalBuiltinCallWithContext]
 
 end Compiler.Proofs.YulGeneration

--- a/Compiler/Proofs/YulGeneration/ReferenceOracle/Builtins.lean
+++ b/Compiler/Proofs/YulGeneration/ReferenceOracle/Builtins.lean
@@ -55,7 +55,7 @@ def evalBuiltinCallWithContext
     | _ => none
   else if func = "sload" then
     match argVals with
-    | [slot] => some (Compiler.Proofs.abstractLoadStorageOrMapping storage slot)
+    | [slot] => some (Compiler.Proofs.abstractLoadStorageOrMapping storage slot).toNat
     | _ => none
   else if func = "add" then
     match argVals with

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -161,11 +161,11 @@ private def fuzzStorageEntries : List Nat → FuzzRng → FuzzRng × List (Nat �
       let (rng, tail) := fuzzStorageEntries rest rng
       (rng, (slotIdx, value) :: tail)
 
-private def storageOfEntries (entries : List (Nat × Nat)) : Nat → Nat :=
+private def storageOfEntries (entries : List (Nat × Nat)) : Nat → IRStorageWord :=
   fun slotIdx =>
     match entries.find? (fun entry => entry.1 == slotIdx) with
-    | some (_, value) => value
-    | none => 0
+    | some (_, value) => IRStorageWord.ofNat value
+    | none => IRStorageWord.ofNat 0
 
 private def mappingKeySamples (sender : Nat) (args : List Nat) : List Nat :=
   (args ++ [0, 1, sender, 2^160 - 1, 2^256 - 1]).eraseDups

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1886,6 +1886,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/IRGeneration/IRStorageWord.lean
 #print axioms Compiler.Proofs.IRGeneration.IRStorageWord.toNat_ofNat
 #print axioms Compiler.Proofs.IRGeneration.IRStorageWord.ofNat_toNat
+#print axioms Compiler.Proofs.IRGeneration.IRStorageWord.toNat_lt_size
 
 -- Compiler/Proofs/IRGeneration/ParamLoading.lean
 #print axioms Compiler.Proofs.IRGeneration.ParamLoading.uint256_modulus_eq_evm
@@ -3524,4 +3525,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3348 theorems/lemmas (2417 public, 931 private, 0 sorry'd)
+-- Total: 3349 theorems/lemmas (2418 public, 931 private, 0 sorry'd)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -1921,6 +1921,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.exists_writeUnindexedEventScratch_of_length
 #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.exists_writeUnindexedEventScratch_of_length_zero
 #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.exists_eventScratchMemoryAfterEmit?_of_supported_length
+#print axioms Compiler.Proofs.IRGeneration.SourceSemantics.UInt256_size_eq_UINT256_MODULUS
 -- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_literal  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_param  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_localVar  -- private
@@ -3525,4 +3526,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3349 theorems/lemmas (2418 public, 931 private, 0 sorry'd)
+-- Total: 3350 theorems/lemmas (2419 public, 931 private, 0 sorry'd)

--- a/docs/IR_STORAGE_PHASE1_PLAN.md
+++ b/docs/IR_STORAGE_PHASE1_PLAN.md
@@ -42,7 +42,14 @@ flip lands in subsequent commits on this branch.
 
 | Callsite | File:Line | Treatment | Notes |
 |----------|-----------|-----------|-------|
-| _to be filled in during Phase 1 implementation_ |  |  |  |
+| `IRStorageWord` carrier | `Compiler/Proofs/IRGeneration/IRStorageWord.lean` | migrate | Flipped from `abbrev := Nat` to `@[reducible] def := UInt256`. Added `OfNat`, `Inhabited` instances and reproved round-trip lemmas (`toNat_ofNat = n % UInt256.size`, `ofNat_toNat = w`, `toNat_lt_size`). |
+| `abstractStoreMappingEntry` | `Compiler/Proofs/MappingSlot.lean:83` | migrate | Wraps `value : Nat` via `IRStorageWord.ofNat` inside the helper; simp lemma `abstractStoreMappingEntry_eq` updated to match. |
+| `abstractStoreStorageOrMapping` | `Compiler/Proofs/MappingSlot.lean:95` | migrate | Wraps `value : Nat` via `IRStorageWord.ofNat`; simp lemma `abstractStoreStorageOrMapping_eq` updated. |
+| `evalBuiltinCallWithContext` (sload) | `Compiler/Proofs/YulGeneration/ReferenceOracle/Builtins.lean:58` | migrate | Projects `abstractLoadStorageOrMapping storage slot : IRStorageWord` back to `Nat` via `.toNat` for the `Option Nat` return. |
+| `evalBuiltinCallViaEvmYulLean` (sload) | `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean:1064` | migrate | Same `.toNat` projection on the EVMYulLean adapter sload branch. |
+| `IRInterpreter.evalIRStatementWithBackend` | `Compiler/Proofs/IRGeneration/IRInterpreter.lean` | safe | All `state.storage` reads go through `abstractLoadStorageOrMapping`, all writes go through `abstractStoreStorageOrMapping` / `abstractStoreMappingEntry`, so the helper-internal wrapping covers every callsite without changes here. Initial-state literal `fun _ => 0` continues to elaborate via the `OfNat IRStorageWord 0` instance. |
+| `EvmYulLeanBridgeLemmas` | `Compiler/Proofs/YulGeneration/Backends/EvmYulLeanBridgeLemmas.lean` | safe | Builtin-equivalence lemmas thread `storage : Nat → IRStorageWord` as a parameter but never inspect the value; survive carrier flip without edits. |
+| Per-contract specs `Contracts/*/Proofs/` | (across the tree) | safe | Spec-side proofs reason over `IRState`/`abstractLoad…` API surface; no callsite touches the raw carrier. `lake build` + `make check` (600 tests) clean post-flip. |
 
 ## Risks tracked from the parent doc
 
@@ -65,6 +72,9 @@ flip lands in subsequent commits on this branch.
 
 ## Status
 
-Plan-only. Carrier flip not yet implemented. PR is intentionally opened as a
-draft so reviewers can land the audit table incrementally as callsites are
-inspected.
+Carrier flip implemented. `IRStorageWord` is now `@[reducible] def := UInt256`
+with `OfNat` / `Inhabited` instances and the round-trip lemmas restated for the
+new carrier. Downstream callsites have been migrated (helpers wrap `Nat → IRStorageWord`
+internally; sload sites project via `.toNat`). `lake build` clean, `make check`
+green (600 tests). `hRetrieveHit` / `hStoreHit` remain on
+`simpleStorage_endToEnd_native_evmYulLean`; their discharge is Phase 2 / Phase 3.

--- a/docs/IR_STORAGE_PHASE1_PLAN.md
+++ b/docs/IR_STORAGE_PHASE1_PLAN.md
@@ -1,0 +1,70 @@
+# IR Storage Refactor — Phase 1 Plan
+
+Phase 1 of [`IR_STORAGE_UINT256_REFACTOR.md`](IR_STORAGE_UINT256_REFACTOR.md): flip
+`IRStorageWord` from its Phase-0 `abbrev := Nat` surface to a `UInt256`-backed
+representation, and audit every former `Nat → Nat` callsite that flowed through
+`IRState.storage`.
+
+This file is the working scaffold for the Phase 1 PR. It is intentionally a
+plan-only document so the PR opens against a green build; the actual carrier
+flip lands in subsequent commits on this branch.
+
+## Entry state
+
+- `Compiler/Proofs/IRGeneration/IRStorageWord.lean` defines
+  `abbrev IRStorageWord := Nat` plus `ofNat` / `toNat` / `toUInt256` helpers
+  and round-trip lemmas (PR #1753, Phase 0).
+- `IRState.storage : Nat → IRStorageWord` is rfl-identical to `Nat → Nat`
+  under the abbrev, so the Phase 0 retype required no callsite changes.
+- The public theorem `simpleStorage_endToEnd_native_evmYulLean` retains
+  `hRetrieveHit` and `hStoreHit` as explicit hypotheses (#1743 commit
+  `fe63b826`).
+
+## Phase 1 deliverables
+
+1. Replace `abbrev IRStorageWord := Nat` with a structurally-bounded
+   representation — preferred form: `def IRStorageWord := UInt256` (or
+   a single-field structure wrapping `UInt256` if `def` opacity proves
+   awkward in proof contexts).
+2. Update `IRStorageWord.ofNat` / `toNat` so that `ofNat n = ofNat (n % UInt256.size)`
+   holds definitionally on the new carrier; expose the masking lemma.
+3. Update the IR interpreter `sload` / `sstore` semantics in
+   `Compiler/Proofs/IRGeneration/IRInterpreter.lean` to read and write through
+   the typed helpers rather than treating the carrier as raw `Nat`.
+4. Audit log (table below) — every callsite that used to touch
+   `IRState.storage : Nat → Nat` must be inspected, marked `safe` (no value
+   semantics affected) or `migrate` (needs an explicit `ofNat` / `toNat` call),
+   and its outcome recorded.
+5. Confirm `lake build` clean and every existing per-contract spec proof in
+   `Contracts/<Name>/Proofs/` still passes (no spec regressions).
+
+## Audit log
+
+| Callsite | File:Line | Treatment | Notes |
+|----------|-----------|-----------|-------|
+| _to be filled in during Phase 1 implementation_ |  |  |  |
+
+## Risks tracked from the parent doc
+
+- Spec drift on `decide`-style spec proofs that pattern-matched on raw `Nat`
+  storage values. Mitigation: keep helper API stable, expose `Nat`-shaped
+  re-exports at the spec boundary if needed.
+- `UInt256` arithmetic is heavier than `Nat` for kernel reduction. If a
+  benchmark regresses, expose dedicated `simp` lemmas before relaxing the
+  carrier.
+
+## Exit criteria
+
+- `IRStorageWord` is no longer an `abbrev` for `Nat`.
+- `lake build` clean.
+- `make check` clean.
+- Every `Contracts/*/Proofs/` spec theorem unchanged (no signature drift).
+- Public theorem `simpleStorage_endToEnd_native_evmYulLean` still carries
+  `hRetrieveHit` and `hStoreHit` premises — Phase 1 does not yet discharge
+  them. That work is Phase 2 / Phase 3.
+
+## Status
+
+Plan-only. Carrier flip not yet implemented. PR is intentionally opened as a
+draft so reviewers can land the audit table incrementally as callsites are
+inspected.


### PR DESCRIPTION
## Summary
- Adds `docs/IR_STORAGE_PHASE1_PLAN.md` — the Phase 1 working scaffold (audit table, deliverables, exit criteria).
- **No Lean code changes yet.** The carrier flip from `abbrev IRStorageWord := Nat` to a `UInt256`-backed representation lands in subsequent commits on this branch.

## Replaces #1754
PR #1754 was auto-closed when its base branch (`codex/ir-storage-uint256-refactor-skeleton`, the head of the now-merged Phase 0 PR #1753) was deleted on squash-merge. This PR is the same branch retargeted to `main`.

## Phase 1 scope
See [`docs/IR_STORAGE_PHASE1_PLAN.md`](../blob/codex/ir-storage-phase1-carrier-flip/docs/IR_STORAGE_PHASE1_PLAN.md). High-level:
1. Replace `abbrev IRStorageWord := Nat` with a `UInt256`-backed representation.
2. Update `IRStorageWord.ofNat` / `toNat` round-trip semantics.
3. Update IR interpreter `sload` / `sstore` to flow through the typed helpers.
4. Audit every former `Nat → Nat` callsite (table inside the doc).
5. `lake build`, `make check`, and all `Contracts/*/Proofs/` spec theorems remain green.

## Why
Closes the structural gap that prevents discharging `simpleStorageNativeRetrieveHitBridge` and `simpleStorageNativeStoreHitBridge` inside the public theorem signature — see [`docs/IR_STORAGE_UINT256_REFACTOR.md`](../blob/main/docs/IR_STORAGE_UINT256_REFACTOR.md). Phase 1 is the only structural step; Phases 2/3 then drop the explicit `hRetrieveHit` / `hStoreHit` premises.

## Test plan
- [ ] `lake build` clean after carrier flip.
- [ ] `make check` clean.
- [ ] Every `Contracts/*/Proofs/` spec theorem still passes.
- [ ] Audit table in `IR_STORAGE_PHASE1_PLAN.md` populated.
- [ ] Public theorem `simpleStorage_endToEnd_native_evmYulLean` still carries `hRetrieveHit` + `hStoreHit` (Phase 1 does not yet discharge them).

## Status
**Draft.** Plan-only; carrier flip pending.

Refs #1743. Refs #1753. Replaces #1754.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad, cross-cutting change to the IR storage representation and many proof signatures/lemmas; mistakes could invalidate semantics or break downstream proofs despite being proof-layer only.
> 
> **Overview**
> **Flips the IR storage value carrier to a bounded `UInt256` representation** by redefining `IRStorageWord` and tightening its API (`ofNat` modulo `UInt256.size`, `toNat`, `OfNat`/`Inhabited`, and new boundedness/round-trip lemmas).
> 
> Propagates this new storage type through the proof stack: `IRState.storage`/`IRResult.finalStorage`/`finalMappings` and numerous end-to-end/native-dispatch theorems now take `Nat → IRStorageWord`, `sload` in the EvmYulLean adapter projects via `.toNat`, and mapping/storage write helpers now store `IRStorageWord.ofNat` instead of raw `Nat`.
> 
> Updates affected correctness lemmas to account for the new modulo behavior (e.g., `sload` results, congruence proofs, and packed-word write proofs), and adds a small bridge lemma equating `EvmYul.UInt256.size` with Verity’s `UINT256_MODULUS` to simplify modulo reasoning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d9ff0c60393c60a68460ba025258dcb56939452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->