### PR TITLE
proofs: pin native generated runtime fragment

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -178,6 +178,61 @@ def yulFunctionBodies (runtimeCode : List YulStmt) : List (String × List YulStm
     | .funcDef name _ _ body => some (name, body)
     | _ => none
 
+/-! ## Generated Native Runtime Fragment -/
+
+mutual
+  partial def yulStmtContainsFuncDef : YulStmt → Bool
+    | .funcDef _ _ _ _ => true
+    | .if_ _ body => yulStmtsContainFuncDef body
+    | .for_ init _ post body =>
+        yulStmtsContainFuncDef init ||
+          yulStmtsContainFuncDef post ||
+          yulStmtsContainFuncDef body
+    | .switch _ cases defaultBody =>
+        cases.any (fun entry => yulStmtsContainFuncDef entry.2) ||
+          defaultBody.any yulStmtsContainFuncDef
+    | .block stmts => yulStmtsContainFuncDef stmts
+    | .comment _ | .let_ _ _ | .letMany _ _ | .assign _ _ | .expr _ | .leave => false
+
+  partial def yulStmtsContainFuncDef (stmts : List YulStmt) : Bool :=
+    stmts.any yulStmtContainsFuncDef
+end
+
+def yulRuntimeTopLevelFunctionNames (runtimeCode : List YulStmt) : List String :=
+  runtimeCode.filterMap fun
+    | .funcDef name _ _ _ => some name
+    | _ => none
+
+def yulRuntimeDispatcherStmts (runtimeCode : List YulStmt) : List YulStmt :=
+  runtimeCode.filter fun
+    | .funcDef _ _ _ _ => false
+    | _ => true
+
+def stringListHasDuplicate : List String → Bool
+  | [] => false
+  | name :: rest => rest.contains name || stringListHasDuplicate rest
+
+def generatedRuntimeFunctionNamesUnique (runtimeCode : List YulStmt) : Bool :=
+  !stringListHasDuplicate (yulRuntimeTopLevelFunctionNames runtimeCode)
+
+def generatedRuntimeDispatcherHasNoFuncDefs (runtimeCode : List YulStmt) : Bool :=
+  !yulStmtsContainFuncDef (yulRuntimeDispatcherStmts runtimeCode)
+
+def generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs
+    (runtimeCode : List YulStmt) :
+    Bool :=
+  (yulFunctionBodies runtimeCode).all fun entry => !yulStmtsContainFuncDef entry.2
+
+/-- Executable characterization for the generated runtime shape that the
+    native EVMYulLean lowering path currently accepts: top-level `funcDef`
+    statements are helpers, dispatcher statements contain no nested function
+    definitions, helper names are unique, and helper bodies themselves contain
+    no nested function definitions. -/
+def generatedRuntimeNativeFragment (runtimeCode : List YulStmt) : Bool :=
+  generatedRuntimeFunctionNamesUnique runtimeCode &&
+    generatedRuntimeDispatcherHasNoFuncDefs runtimeCode &&
+    generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs runtimeCode
+
 def selectorExprMatchesGeneratedDispatcher : YulExpr → Bool
   | .call "shr" [.lit shift, .call "calldataload" [.lit 0]] =>
       shift == Compiler.Constants.selectorShift

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSmokeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSmokeTest.lean
@@ -703,6 +703,30 @@ private def nestedNativeFunctionDefinitionsFailClosed : Bool :=
   | .ok _ => false
   | .error _ => true)
 
+private def emittedRuntimeSatisfiesGeneratedNativeFragment : Bool :=
+  Native.generatedRuntimeNativeFragment
+    (Compiler.emitYul dispatchSmokeContract).runtimeCode
+
+private def duplicateHelpersRejectedByGeneratedNativeFragment : Bool :=
+  !Native.generatedRuntimeNativeFragment [
+    .funcDef "dup" [] [] [],
+    .funcDef "dup" [] [] []
+  ]
+
+private def nestedDispatcherFuncDefRejectedByGeneratedNativeFragment : Bool :=
+  !Native.generatedRuntimeNativeFragment [
+    .block [
+      .funcDef "nested_dispatcher" [] [] []
+    ]
+  ]
+
+private def nestedHelperFuncDefRejectedByGeneratedNativeFragment : Bool :=
+  !Native.generatedRuntimeNativeFragment [
+    .funcDef "outer" [] [] [
+      .funcDef "nested_helper" [] [] []
+    ]
+  ]
+
 private def emittedDispatchLowersNativeSelectorCases : Bool :=
   match lowerRuntimeContractNative (Compiler.emitYul dispatchSmokeContract).runtimeCode with
   | .ok contract =>
@@ -1114,6 +1138,22 @@ example :
 
 example :
     nestedNativeFunctionDefinitionsFailClosed = true := by
+  native_decide
+
+example :
+    emittedRuntimeSatisfiesGeneratedNativeFragment = true := by
+  native_decide
+
+example :
+    duplicateHelpersRejectedByGeneratedNativeFragment = true := by
+  native_decide
+
+example :
+    nestedDispatcherFuncDefRejectedByGeneratedNativeFragment = true := by
+  native_decide
+
+example :
+    nestedHelperFuncDefRejectedByGeneratedNativeFragment = true := by
   native_decide
 
 example :

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -194,6 +194,10 @@ def check_public_theorem_target(
         "def interpretRuntimeNative",
         "def interpretIRRuntimeNative",
         "EvmYul.Yul.callDispatcher",
+        "def generatedRuntimeNativeFragment",
+        "def generatedRuntimeFunctionNamesUnique",
+        "def generatedRuntimeDispatcherHasNoFuncDefs",
+        "def generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs",
     ):
         if required_native_entrypoint not in normalized_native_harness:
             errors.append(
@@ -229,6 +233,10 @@ def check_native_switch_lowering_boundary(native_adapter_text: str, native_smoke
         "nativeSwitchTempNamesAvoidUserNames = true",
         "nativeFunctionSwitchTempNamesAvoidLocalUserNames = true",
         "nativeSwitchExecutesOnlyFirstMatchingNonHaltingCase = true",
+        "emittedRuntimeSatisfiesGeneratedNativeFragment = true",
+        "duplicateHelpersRejectedByGeneratedNativeFragment = true",
+        "nestedDispatcherFuncDefRejectedByGeneratedNativeFragment = true",
+        "nestedHelperFuncDefRejectedByGeneratedNativeFragment = true",
     ):
         if required_smoke not in normalized_smoke:
             errors.append(


### PR DESCRIPTION
## Summary

- add `Native.generatedRuntimeNativeFragment` as the executable top-level runtime fragment predicate for native EVMYulLean lowering
- characterize unique helper names, dispatcher `funcDef` exclusion, and nested helper `funcDef` rejection
- pin emitted-good and rejected-bad fragment cases in native smoke coverage and in the native transition checker

## Validation

- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `lake env lean Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSmokeTest.lean`
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanRetarget`
- `lake build Compiler.Proofs.EndToEnd`
- `lake build Compiler Contracts PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `python3 scripts/check_docs_workflow_sync.py`
- `make check` (600/600 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an executable shape predicate and corresponding smoke/doc checks without changing compiler output or runtime semantics, but it can cause CI failures if generated Yul structure changes unexpectedly.
> 
> **Overview**
> Adds `Native.generatedRuntimeNativeFragment`, an executable predicate that characterizes the Yul runtime shape accepted by the native EVMYulLean lowering (unique top-level helper names, no `funcDef` in dispatcher statements, and no nested `funcDef` inside helper bodies).
> 
> Extends native smoke tests to assert the emitted runtime satisfies this predicate and to pin rejection of duplicate helpers and nested function definitions. Updates `check_native_transition_doc.py` to require these new harness/smoke entrypoints so the native transition documentation stays in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334e8cb7960d6e2ebe665218951174e7e4b00984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->