### PR TITLE
proofs: gate native runtime on generated fragment

### DIFF
--- a/Compiler/Proofs/EndToEnd.lean
+++ b/Compiler/Proofs/EndToEnd.lean
@@ -666,9 +666,10 @@ theorem nativeIRRuntimeAgreesWithInterpreter_of_lowered_callDispatcher_agree
     {fuel : Nat} {contract : IRContract} {tx : IRTransaction}
     {state : IRState} {observableSlots : List Nat}
     {nativeContract : EvmYul.Yul.Ast.YulContract}
-    (hLower :
-      Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
-        (Compiler.emitYul contract).runtimeCode = .ok nativeContract)
+    (hFragment : Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeNativeFragment
+      (Compiler.emitYul contract).runtimeCode = true)
+    (hLower : Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
+      (Compiler.emitYul contract).runtimeCode = .ok nativeContract)
     (hEnv :
       Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
         (Compiler.emitYul contract).runtimeCode (YulTransaction.ofIR tx) = .ok ())
@@ -679,7 +680,7 @@ theorem nativeIRRuntimeAgreesWithInterpreter_of_lowered_callDispatcher_agree
   apply nativeIRRuntimeAgreesWithInterpreter_of_ok_agree
   · exact
       (Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative_eq_callDispatcher_of_lowerRuntimeContractNative
-        fuel contract tx state observableSlots nativeContract hLower hEnv)
+        fuel contract tx state observableSlots nativeContract hFragment hLower hEnv)
   · exact hAgree
 
 /-! ## Layer 3: IR → Yul (Generic) -/
@@ -908,14 +909,10 @@ theorem layer3_contract_preserves_semantics
     (hmemory : initialState.memory = fun _ => 0)
     (htransient : initialState.transientStorage = fun _ => 0)
     (hreturn : initialState.returnValue = none)
-    (hparamErase : ∀ fn, fn ∈ contract.functions →
-      paramLoadErasure fn tx (initialState.withTx tx))
-    (hdispatchGuardSafe : ∀ fn, fn ∈ contract.functions →
-      DispatchGuardsSafe fn tx)
-    (hNoHasSelector : ∀ fn, fn ∈ contract.functions →
-      yulStmtsNoRef "__has_selector" fn.body)
-    (hHasSelectorDead : ∀ fn, fn ∈ contract.functions →
-      HasSelectorDeadBridge fn.body)
+    (hparamErase : ∀ fn, fn ∈ contract.functions → paramLoadErasure fn tx (initialState.withTx tx))
+    (hdispatchGuardSafe : ∀ fn, fn ∈ contract.functions → DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ contract.functions → yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ contract.functions → HasSelectorDeadBridge fn.body)
     (hLoopFree : ∀ fn, fn ∈ contract.functions →
       yulStmtsLoopFree fn.body = true)
     (hWF : ContractWF contract)
@@ -1018,14 +1015,10 @@ theorem layer3_contract_preserves_semantics_evmYulLean
     (hmemory : initialState.memory = fun _ => 0)
     (htransient : initialState.transientStorage = fun _ => 0)
     (hreturn : initialState.returnValue = none)
-    (hparamErase : ∀ fn, fn ∈ contract.functions →
-      paramLoadErasure fn tx (initialState.withTx tx))
-    (hdispatchGuardSafe : ∀ fn, fn ∈ contract.functions →
-      DispatchGuardsSafe fn tx)
-    (hNoHasSelector : ∀ fn, fn ∈ contract.functions →
-      yulStmtsNoRef "__has_selector" fn.body)
-    (hHasSelectorDead : ∀ fn, fn ∈ contract.functions →
-      HasSelectorDeadBridge fn.body)
+    (hparamErase : ∀ fn, fn ∈ contract.functions → paramLoadErasure fn tx (initialState.withTx tx))
+    (hdispatchGuardSafe : ∀ fn, fn ∈ contract.functions → DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ contract.functions → yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ contract.functions → HasSelectorDeadBridge fn.body)
     (hLoopFree : ∀ fn, fn ∈ contract.functions →
       yulStmtsLoopFree fn.body = true)
     (hWF : ContractWF contract)
@@ -1106,20 +1099,19 @@ theorem layer3_contract_preserves_semantics_native_of_lowered_callDispatcher_bri
     (hvars : initialState.vars = []) (hmemory : initialState.memory = fun _ => 0)
     (htransient : initialState.transientStorage = fun _ => 0)
     (hreturn : initialState.returnValue = none)
-    (hparamErase : ∀ fn, fn ∈ contract.functions →
-      paramLoadErasure fn tx (initialState.withTx tx))
-    (hdispatchGuardSafe : ∀ fn, fn ∈ contract.functions →
-      DispatchGuardsSafe fn tx)
-    (hNoHasSelector : ∀ fn, fn ∈ contract.functions →
-      yulStmtsNoRef "__has_selector" fn.body)
-    (hHasSelectorDead : ∀ fn, fn ∈ contract.functions →
-      HasSelectorDeadBridge fn.body)
+    (hparamErase : ∀ fn, fn ∈ contract.functions → paramLoadErasure fn tx (initialState.withTx tx))
+    (hdispatchGuardSafe : ∀ fn, fn ∈ contract.functions → DispatchGuardsSafe fn tx)
+    (hNoHasSelector : ∀ fn, fn ∈ contract.functions → yulStmtsNoRef "__has_selector" fn.body)
+    (hHasSelectorDead : ∀ fn, fn ∈ contract.functions → HasSelectorDeadBridge fn.body)
     (hLoopFree : ∀ fn, fn ∈ contract.functions → yulStmtsLoopFree fn.body = true)
     (hWF : ContractWF contract) (hNoFallback : contract.fallbackEntrypoint = none)
     (hNoReceive : contract.receiveEntrypoint = none)
     (hFunctions : ∀ fn, fn ∈ contract.functions →
       Compiler.Proofs.YulGeneration.Backends.BridgedStmts fn.body)
     (hFuel : fuel = sizeOf (Compiler.emitYul contract).runtimeCode + 1)
+    (hFragment :
+      Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeNativeFragment
+        (Compiler.emitYul contract).runtimeCode = true)
     (hLower :
       Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
         (Compiler.emitYul contract).runtimeCode = .ok nativeContract)
@@ -1138,7 +1130,7 @@ theorem layer3_contract_preserves_semantics_native_of_lowered_callDispatcher_bri
     hdispatchGuardSafe hNoHasSelector hHasSelectorDead hLoopFree hWF hNoFallback
     hNoReceive hFunctions hFuel
     (nativeIRRuntimeAgreesWithInterpreter_of_lowered_callDispatcher_agree
-      hLower hEnv hNativeCallDispatcher)
+      hFragment hLower hEnv hNativeCallDispatcher)
 
 /-! ## Layers 2+3 Composition -/
 
@@ -1349,6 +1341,9 @@ theorem layers2_3_ir_matches_native_evmYulLean_of_lowered_callDispatcher_bridge
     (hWF : ContractWF irContract) (hNoFallback : irContract.fallbackEntrypoint = none)
     (hNoReceive : irContract.receiveEntrypoint = none)
     (hFuel : fuel = sizeOf (Compiler.emitYul irContract).runtimeCode + 1)
+    (hFragment :
+      Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeNativeFragment
+        (Compiler.emitYul irContract).runtimeCode = true)
     (hLower : Compiler.Proofs.YulGeneration.Backends.lowerRuntimeContractNative
       (Compiler.emitYul irContract).runtimeCode = .ok nativeContract)
     (hEnv : Compiler.Proofs.YulGeneration.Backends.Native.validateNativeRuntimeEnvironment
@@ -1367,7 +1362,7 @@ theorem layers2_3_ir_matches_native_evmYulLean_of_lowered_callDispatcher_bridge
       (Compiler.Proofs.IRGeneration.Contract.compile_ok_yields_compiled_functions
         spec selectors hSupported irContract hCompile)
       hStaticParams hSafeBodies)
-    hFuel hLower hEnv hNativeCallDispatcher
+    hFuel hFragment hLower hEnv hNativeCallDispatcher
 
 /-! ## Concrete Instantiation: SimpleStorage -/
 
@@ -5574,6 +5569,7 @@ theorem simpleStorage_endToEnd_native_evmYulLean_of_callDispatcher_bridge
     rfl
     simpleStorage_functions_bridged
     rfl
+    Compiler.SimpleStorageNativeWitness.generatedRuntimeNativeFragment_eq
     Compiler.SimpleStorageNativeWitness.lowerRuntimeContractNative_eq
     hEnv
     hNativeCallDispatcher

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -233,6 +233,30 @@ def generatedRuntimeNativeFragment (runtimeCode : List YulStmt) : Bool :=
     generatedRuntimeDispatcherHasNoFuncDefs runtimeCode &&
     generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs runtimeCode
 
+def unsupportedGeneratedRuntimeNativeFragmentError : AdapterError :=
+  "native EVMYulLean generated runtime fragment check failed"
+
+def validateGeneratedRuntimeNativeFragment
+    (runtimeCode : List YulStmt) :
+    Except AdapterError Unit :=
+  if generatedRuntimeNativeFragment runtimeCode then
+    .ok ()
+  else
+    .error unsupportedGeneratedRuntimeNativeFragmentError
+
+@[simp] theorem validateGeneratedRuntimeNativeFragment_ok
+    (runtimeCode : List YulStmt)
+    (hFragment : generatedRuntimeNativeFragment runtimeCode = true) :
+    validateGeneratedRuntimeNativeFragment runtimeCode = .ok () := by
+  simp [validateGeneratedRuntimeNativeFragment, hFragment]
+
+@[simp] theorem validateGeneratedRuntimeNativeFragment_error
+    (runtimeCode : List YulStmt)
+    (hFragment : generatedRuntimeNativeFragment runtimeCode = false) :
+    validateGeneratedRuntimeNativeFragment runtimeCode =
+      .error unsupportedGeneratedRuntimeNativeFragmentError := by
+  simp [validateGeneratedRuntimeNativeFragment, hFragment]
+
 def selectorExprMatchesGeneratedDispatcher : YulExpr → Bool
   | .call "shr" [.lit shift, .call "calldataload" [.lit 0]] =>
       shift == Compiler.Constants.selectorShift
@@ -9950,6 +9974,7 @@ def interpretRuntimeNative
     (observableSlots : List Nat)
     (events : List (List Nat) := []) :
     Except AdapterError YulResult := do
+  validateGeneratedRuntimeNativeFragment runtimeCode
   let contract ← lowerRuntimeContractNative runtimeCode
   validateNativeRuntimeEnvironment runtimeCode tx
   let initial :=
@@ -9966,10 +9991,24 @@ def interpretRuntimeNative
     (observableSlots : List Nat)
     (events : List (List Nat))
     (err : AdapterError)
+    (hFragment : generatedRuntimeNativeFragment runtimeCode = true)
     (hLower : lowerRuntimeContractNative runtimeCode = .error err) :
     interpretRuntimeNative fuel runtimeCode tx storage observableSlots events =
       .error err := by
-  rw [interpretRuntimeNative, hLower]
+  rw [interpretRuntimeNative, validateGeneratedRuntimeNativeFragment_ok runtimeCode hFragment, hLower]
+  rfl
+
+@[simp] theorem interpretRuntimeNative_generatedFragmentError
+    (fuel : Nat)
+    (runtimeCode : List YulStmt)
+    (tx : YulTransaction)
+    (storage : IRStorageSlot → IRStorageWord)
+    (observableSlots : List Nat)
+    (events : List (List Nat))
+    (hFragment : generatedRuntimeNativeFragment runtimeCode = false) :
+    interpretRuntimeNative fuel runtimeCode tx storage observableSlots events =
+      .error unsupportedGeneratedRuntimeNativeFragmentError := by
+  rw [interpretRuntimeNative, validateGeneratedRuntimeNativeFragment_error runtimeCode hFragment]
   rfl
 
 @[simp] theorem interpretRuntimeNative_eq_callDispatcher_of_lowerRuntimeContractNative
@@ -9980,6 +10019,7 @@ def interpretRuntimeNative
     (observableSlots : List Nat)
     (events : List (List Nat))
     (contract : EvmYul.Yul.Ast.YulContract)
+    (hFragment : generatedRuntimeNativeFragment runtimeCode = true)
     (hLower : lowerRuntimeContractNative runtimeCode = .ok contract)
     (hEnv : validateNativeRuntimeEnvironment runtimeCode tx = .ok ()) :
     interpretRuntimeNative fuel runtimeCode tx storage observableSlots events =
@@ -9987,7 +10027,8 @@ def interpretRuntimeNative
         (EvmYul.Yul.callDispatcher fuel (some contract)
           (initialState contract tx storage
             (materializedStorageSlots runtimeCode observableSlots)))) := by
-  rw [interpretRuntimeNative, hLower, hEnv]
+  rw [interpretRuntimeNative, validateGeneratedRuntimeNativeFragment_ok runtimeCode hFragment,
+    hLower, hEnv]
   rfl
 
 @[simp] theorem interpretRuntimeNative_environmentError
@@ -9999,11 +10040,13 @@ def interpretRuntimeNative
     (events : List (List Nat))
     (contract : EvmYul.Yul.Ast.YulContract)
     (err : AdapterError)
+    (hFragment : generatedRuntimeNativeFragment runtimeCode = true)
     (hLower : lowerRuntimeContractNative runtimeCode = .ok contract)
     (hEnv : validateNativeRuntimeEnvironment runtimeCode tx = .error err) :
     interpretRuntimeNative fuel runtimeCode tx storage observableSlots events =
       .error err := by
-  rw [interpretRuntimeNative, hLower, hEnv]
+  rw [interpretRuntimeNative, validateGeneratedRuntimeNativeFragment_ok runtimeCode hFragment,
+    hLower, hEnv]
   rfl
 
 /-- Native EVMYulLean execution target for emitted IR-contract runtime Yul.
@@ -10046,10 +10089,29 @@ def interpretIRRuntimeNative
     (state : Compiler.Proofs.IRGeneration.IRState)
     (observableSlots : List Nat)
     (err : AdapterError)
+    (hFragment :
+      generatedRuntimeNativeFragment (Compiler.emitYul contract).runtimeCode = true)
     (hLower : lowerRuntimeContractNative (Compiler.emitYul contract).runtimeCode =
       .error err) :
     interpretIRRuntimeNative fuel contract tx state observableSlots = .error err := by
-  rw [interpretIRRuntimeNative, interpretRuntimeNative, hLower]
+  rw [interpretIRRuntimeNative, interpretRuntimeNative,
+    validateGeneratedRuntimeNativeFragment_ok (Compiler.emitYul contract).runtimeCode
+      hFragment, hLower]
+  rfl
+
+@[simp] theorem interpretIRRuntimeNative_generatedFragmentError
+    (fuel : Nat)
+    (contract : Compiler.IRContract)
+    (tx : Compiler.Proofs.IRGeneration.IRTransaction)
+    (state : Compiler.Proofs.IRGeneration.IRState)
+    (observableSlots : List Nat)
+    (hFragment :
+      generatedRuntimeNativeFragment (Compiler.emitYul contract).runtimeCode = false) :
+    interpretIRRuntimeNative fuel contract tx state observableSlots =
+      .error unsupportedGeneratedRuntimeNativeFragmentError := by
+  rw [interpretIRRuntimeNative, interpretRuntimeNative,
+    validateGeneratedRuntimeNativeFragment_error (Compiler.emitYul contract).runtimeCode
+      hFragment]
   rfl
 
 @[simp] theorem interpretIRRuntimeNative_eq_callDispatcher_of_lowerRuntimeContractNative
@@ -10059,6 +10121,8 @@ def interpretIRRuntimeNative
     (state : Compiler.Proofs.IRGeneration.IRState)
     (observableSlots : List Nat)
     (nativeContract : EvmYul.Yul.Ast.YulContract)
+    (hFragment :
+      generatedRuntimeNativeFragment (Compiler.emitYul irContract).runtimeCode = true)
     (hLower : lowerRuntimeContractNative (Compiler.emitYul irContract).runtimeCode =
       .ok nativeContract)
     (hEnv :
@@ -10070,7 +10134,9 @@ def interpretIRRuntimeNative
           (initialState nativeContract (YulTransaction.ofIR tx) state.storage
             (materializedStorageSlots (Compiler.emitYul irContract).runtimeCode
               observableSlots)))) := by
-  rw [interpretIRRuntimeNative, interpretRuntimeNative, hLower, hEnv]
+  rw [interpretIRRuntimeNative, interpretRuntimeNative,
+    validateGeneratedRuntimeNativeFragment_ok (Compiler.emitYul irContract).runtimeCode
+      hFragment, hLower, hEnv]
   rfl
 
 end Compiler.Proofs.YulGeneration.Backends.Native

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSmokeTest.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeSmokeTest.lean
@@ -727,6 +727,20 @@ private def nestedHelperFuncDefRejectedByGeneratedNativeFragment : Bool :=
     ]
   ]
 
+private def nativeRuntimeFragmentGateRejectsDuplicateHelper : Bool :=
+  match Native.interpretRuntimeNative 128 [
+    .funcDef "dup" [] [] [],
+    .funcDef "dup" [] [] []
+  ] sampleTx zeroStorage [] with
+  | .error err => err == Native.unsupportedGeneratedRuntimeNativeFragmentError
+  | .ok _ => false
+
+private def nativeIRRuntimeFragmentGateRejectsDuplicateHelper : Bool :=
+  match Native.interpretIRRuntimeNative 128 duplicateHelperIRContract sampleIRTx
+    sampleIRState [] with
+  | .error err => err == Native.unsupportedGeneratedRuntimeNativeFragmentError
+  | .ok _ => false
+
 private def emittedDispatchLowersNativeSelectorCases : Bool :=
   match lowerRuntimeContractNative (Compiler.emitYul dispatchSmokeContract).runtimeCode with
   | .ok contract =>
@@ -1154,6 +1168,14 @@ example :
 
 example :
     nestedHelperFuncDefRejectedByGeneratedNativeFragment = true := by
+  native_decide
+
+example :
+    nativeRuntimeFragmentGateRejectsDuplicateHelper = true := by
+  native_decide
+
+example :
+    nativeIRRuntimeFragmentGateRejectsDuplicateHelper = true := by
   native_decide
 
 example :

--- a/Compiler/SimpleStorageNativeWitness.lean
+++ b/Compiler/SimpleStorageNativeWitness.lean
@@ -32,6 +32,11 @@ theorem lowerRuntimeContractNative_ok :
       rw [hLower] at this
       cases this
 
+@[simp] theorem generatedRuntimeNativeFragment_eq :
+    Compiler.Proofs.YulGeneration.Backends.Native.generatedRuntimeNativeFragment
+      (Compiler.emitYul simpleStorageIRContract).runtimeCode = true := by
+  native_decide
+
 /-- The concrete lowered native contract for `simpleStorage`.
 
 Keeping this definition executable lets downstream concrete proofs reduce the

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2903,6 +2903,8 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.evalBuiltinCallWithBackendContext_evmYulLean_pure_bridge
 
 -- Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.validateGeneratedRuntimeNativeFragment_ok
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.validateGeneratedRuntimeNativeFragment_error
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.selectorExprMatchesGeneratedDispatcher_selectorExpr
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.selectedSwitchBody_hit
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.selectedSwitchBody_miss
@@ -3287,10 +3289,12 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.exec_lowerNativeSwitchBlock_simpleStorageConcrete_retrieve_hit_projectResult_eq
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.projectResult_finalMappings
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.interpretRuntimeNative_loweringError
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.interpretRuntimeNative_generatedFragmentError
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.interpretRuntimeNative_eq_callDispatcher_of_lowerRuntimeContractNative
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.interpretRuntimeNative_environmentError
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative_eq_interpretRuntimeNative
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative_loweringError
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative_generatedFragmentError
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.interpretIRRuntimeNative_eq_callDispatcher_of_lowerRuntimeContractNative
 
 -- Compiler/Proofs/YulGeneration/Backends/EvmYulLeanRetarget.lean
@@ -3585,4 +3589,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3409 theorems/lemmas (2465 public, 944 private, 0 sorry'd)
+-- Total: 3413 theorems/lemmas (2469 public, 944 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -185,7 +185,13 @@ scope so the native path does not look more complete than it is:
      `lowerExprNative_call_userFunction`,
    - duplicate helper definitions fail closed.
 
-   Progress: `EvmYul.Yul.callDispatcher` now unfolds through
+   Progress: `generatedRuntimeNativeFragment` is the executable native runtime
+   shape boundary, and `interpretRuntimeNative`/`interpretIRRuntimeNative` now
+   fail closed before lowering when emitted runtime code violates that boundary.
+   It currently pins unique top-level helper names, no nested dispatcher
+   `funcDef`s, and no nested helper-body `funcDef`s.
+
+   `EvmYul.Yul.callDispatcher` now unfolds through
    `callDispatcher_succ_eq_callDispatcherBlockResult` to the named
    `callDispatcherBlockResult`, then rewrites initial-state execution to
    `contractDispatcherBlockResult`, then peels the block wrapper to
@@ -370,7 +376,9 @@ scope so the native path does not look more complete than it is:
    dispatcher/helper
    partitioning that keeps helper definitions in the function map while
    dispatcher calls remain native user-function calls, fail-closed rejection
-   of nested native function definitions in dispatcher/helper bodies, the named
+   of nested native function definitions in dispatcher/helper bodies, exact
+   generated-fragment gate failures at the native runtime and IR-runtime
+   entrypoints, the named
    `lowerExprNative_call_runtimePrimOp` and
    `lowerExprNative_call_userFunction` lemmas for native expression-call
    lowering,

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -195,6 +195,8 @@ def check_public_theorem_target(
         "def interpretIRRuntimeNative",
         "EvmYul.Yul.callDispatcher",
         "def generatedRuntimeNativeFragment",
+        "def validateGeneratedRuntimeNativeFragment",
+        "unsupportedGeneratedRuntimeNativeFragmentError",
         "def generatedRuntimeFunctionNamesUnique",
         "def generatedRuntimeDispatcherHasNoFuncDefs",
         "def generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs",
@@ -237,6 +239,8 @@ def check_native_switch_lowering_boundary(native_adapter_text: str, native_smoke
         "duplicateHelpersRejectedByGeneratedNativeFragment = true",
         "nestedDispatcherFuncDefRejectedByGeneratedNativeFragment = true",
         "nestedHelperFuncDefRejectedByGeneratedNativeFragment = true",
+        "nativeRuntimeFragmentGateRejectsDuplicateHelper = true",
+        "nativeIRRuntimeFragmentGateRejectsDuplicateHelper = true",
     ):
         if required_smoke not in normalized_smoke:
             errors.append(


### PR DESCRIPTION
## Summary
- make `interpretRuntimeNative` / `interpretIRRuntimeNative` fail closed on `generatedRuntimeNativeFragment` before native lowering
- thread the generated-fragment fact through the native EndToEnd unwrap seams and pin SimpleStorage emitted-runtime witness
- add smoke/doc guard coverage for exact fragment-gate failures and regenerate `PrintAxioms`

## Validation
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanRetarget`
- `lake build Compiler.Proofs.EndToEnd`
- `lake build Compiler`
- `lake build Contracts`
- `lake build PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `make check` (600/600 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new fail-closed validation step in the native execution entrypoints, which can change runtime behavior by rejecting previously-accepted Yul runtimes; proof seams are updated accordingly to carry the new precondition.
> 
> **Overview**
> Native EVMYulLean execution now **fails closed** unless emitted runtime Yul satisfies `generatedRuntimeNativeFragment`, via a new `validateGeneratedRuntimeNativeFragment` check and a dedicated `unsupportedGeneratedRuntimeNativeFragmentError`.
> 
> Theorems and end-to-end proof seams are updated to thread the new fragment hypothesis through `interpretRuntimeNative`/`interpretIRRuntimeNative` rewrite lemmas and higher-level EndToEnd/native preservation results, with `SimpleStorageNativeWitness` pinning the fragment fact and smoke tests/docs/scripts extended to assert the exact new gate failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a62fe13cc5e86fa9999a2128a4052fcf6672aef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->