### PR TITLE
proofs: add native block preservation constructors

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -4288,6 +4288,16 @@ theorem NativeBlockPreservesWord_cons_stmt
     NativeBlockPreservesWord name value (stmt :: rest) codeOverride :=
   NativeBlockPreservesWord_cons name value stmt rest codeOverride hHead hRest
 
+theorem NativeBlockPreservesWord_singleton
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (stmt : EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hStmt : NativeStmtPreservesWord name value stmt codeOverride) :
+    NativeBlockPreservesWord name value [stmt] codeOverride := by
+  exact NativeBlockPreservesWord_cons_stmt name value stmt [] codeOverride
+    hStmt (NativeBlockPreservesWord_nil name value codeOverride)
+
 theorem NativeBlockPreservesWord_of_forall_stmt
     (name : EvmYul.Identifier)
     (value : EvmYul.Literal)
@@ -4307,6 +4317,15 @@ theorem NativeBlockPreservesWord_of_forall_stmt
       · exact ih (by
           intro stmt' hmem
           exact hPreserves stmt' (by simp [hmem]))
+
+theorem NativeStmtPreservesWord_block
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (body : List EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hBody : NativeBlockPreservesWord name value body codeOverride) :
+    NativeStmtPreservesWord name value (.Block body) codeOverride :=
+  hBody
 
 theorem NativeStmtPreservesWord_lowerAssignNative_lit_of_ne
     (name target : EvmYul.Identifier)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3108,7 +3108,9 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_nil
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_cons
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_cons_stmt
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_singleton
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_forall_stmt
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_lit_of_ne
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_let_none_of_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_let_var_of_not_mem
@@ -3590,4 +3592,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3414 theorems/lemmas (2470 public, 944 private, 0 sorry'd)
+-- Total: 3416 theorems/lemmas (2472 public, 944 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
+++ b/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
@@ -131,9 +131,10 @@ N8 public Layer 3 theorem flip
 - **Urgency**: P0, highest current bottleneck
 - **Depends on**: N0, N3
 - **Blocks**: N5, N6
-- **Status**: `NativeBlockPreservesWord`, list-level composition from
-  per-statement preservation, and selected freshness projection lemmas exist;
-  general preservation from `nativeStmtsWriteNames` freshness is not complete.
+- **Status**: `NativeBlockPreservesWord`, singleton/block-lift composition,
+  list-level composition from per-statement preservation, and selected
+  freshness projection lemmas exist; general preservation from
+  `nativeStmtsWriteNames` freshness is not complete.
 - **Definition of done**:
   - If a generated native body does not write a dispatcher temp, native
     execution preserves that temp.

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -320,7 +320,9 @@ scope so the native path does not look more complete than it is:
   `nativeSwitchPrefixFinalState_discr`,
   `nativeSwitchPrefixFinalState_marked`, `NativeBlockPreservesWord_nil`,
   `NativeBlockPreservesWord_cons`,
+  `NativeBlockPreservesWord_singleton`,
   `NativeBlockPreservesWord_of_forall_stmt`,
+  `NativeStmtPreservesWord_block`,
   `nativeSwitchTempsFreshForNativeBodies_find_hit_matched_not_mem`, and
   `nativeSwitchTempsFreshForNativeBodies_default_matched_not_mem`; the next
   proof step is the statement induction that derives those preservation

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -200,7 +200,9 @@ def check_public_theorem_target(
         "def generatedRuntimeFunctionNamesUnique",
         "def generatedRuntimeDispatcherHasNoFuncDefs",
         "def generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs",
+        "theorem NativeBlockPreservesWord_singleton",
         "theorem NativeBlockPreservesWord_of_forall_stmt",
+        "theorem NativeStmtPreservesWord_block",
     ):
         if required_native_entrypoint not in normalized_native_harness:
             errors.append(


### PR DESCRIPTION
## Summary
- add singleton/block-lift constructors for native matched-temp word preservation
- pin the new N4 preservation surface in transition docs and the native transition guard
- regenerate PrintAxioms

## Validation
- lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness
- lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanRetarget
- lake build Compiler.Proofs.EndToEnd
- lake build Compiler
- lake build Contracts
- lake build PrintAxioms
- python3 scripts/generate_print_axioms.py --check
- python3 scripts/check_native_transition_doc.py
- python3 scripts/check_bridge_coverage_sync.py
- python3 scripts/check_evmyullean_capability_boundary.py
- make check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f6a8ca782e9e50cfe3384acdc65f6aa90debb85f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->