### PR TITLE
proofs: add native if preservation constructor

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -4327,6 +4327,36 @@ theorem NativeStmtPreservesWord_block
     NativeStmtPreservesWord name value (.Block body) codeOverride :=
   hBody
 
+theorem NativeStmtPreservesWord_if_of_eval_self
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (cond : EvmYul.Yul.Ast.Expr)
+    (body : List EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hCond :
+      ∀ fuel state,
+        state[name]! = value →
+          ∃ condValue,
+            EvmYul.Yul.eval fuel cond codeOverride state =
+              .ok (state, condValue))
+    (hBody : NativeBlockPreservesWord name value body codeOverride) :
+    NativeStmtPreservesWord name value (.If cond body) codeOverride := by
+  intro fuel state final hLookup hExec
+  cases fuel with
+  | zero =>
+      simp [EvmYul.Yul.exec] at hExec
+  | succ fuel' =>
+      rcases hCond fuel' state hLookup with ⟨condValue, hEval⟩
+      simp [EvmYul.Yul.exec, hEval] at hExec
+      by_cases hCondNonzero : condValue ≠ ⟨0⟩
+      · simp [hCondNonzero] at hExec
+        exact hBody fuel' state final hLookup hExec
+      · have hCondZero : condValue = ⟨0⟩ := by
+          exact Decidable.not_not.mp hCondNonzero
+        simp [hCondZero] at hExec
+        cases hExec
+        exact hLookup
+
 theorem NativeStmtPreservesWord_lowerAssignNative_lit_of_ne
     (name target : EvmYul.Identifier)
     (expected : EvmYul.Literal)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3111,6 +3111,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_singleton
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_forall_stmt
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_self
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_lit_of_ne
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_let_none_of_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_let_var_of_not_mem
@@ -3592,4 +3593,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3416 theorems/lemmas (2472 public, 944 private, 0 sorry'd)
+-- Total: 3417 theorems/lemmas (2473 public, 944 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
+++ b/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
@@ -131,7 +131,7 @@ N8 public Layer 3 theorem flip
 - **Urgency**: P0, highest current bottleneck
 - **Depends on**: N0, N3
 - **Blocks**: N5, N6
-- **Status**: `NativeBlockPreservesWord`, singleton/block-lift composition,
+- **Status**: `NativeBlockPreservesWord`, singleton/block-lift/if composition,
   list-level composition from per-statement preservation, and selected
   freshness projection lemmas exist; general preservation from
   `nativeStmtsWriteNames` freshness is not complete.

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -323,6 +323,7 @@ scope so the native path does not look more complete than it is:
   `NativeBlockPreservesWord_singleton`,
   `NativeBlockPreservesWord_of_forall_stmt`,
   `NativeStmtPreservesWord_block`,
+  `NativeStmtPreservesWord_if_of_eval_self`,
   `nativeSwitchTempsFreshForNativeBodies_find_hit_matched_not_mem`, and
   `nativeSwitchTempsFreshForNativeBodies_default_matched_not_mem`; the next
   proof step is the statement induction that derives those preservation

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -203,6 +203,7 @@ def check_public_theorem_target(
         "theorem NativeBlockPreservesWord_singleton",
         "theorem NativeBlockPreservesWord_of_forall_stmt",
         "theorem NativeStmtPreservesWord_block",
+        "theorem NativeStmtPreservesWord_if_of_eval_self",
     ):
         if required_native_entrypoint not in normalized_native_harness:
             errors.append(


### PR DESCRIPTION
## Summary
- add `NativeStmtPreservesWord_if_of_eval_self` to compose if-statement preservation from condition evaluation that leaves the state unchanged plus body preservation
- pin the new N4 proof surface in the native transition docs and doc guard
- regenerate `PrintAxioms.lean`

## Validation
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanRetarget Compiler.Proofs.EndToEnd Compiler Contracts PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only changes plus doc/guard updates; no runtime code paths or semantics are modified beyond adding a new lemma for composition.
> 
> **Overview**
> Adds `NativeStmtPreservesWord_if_of_eval_self`, a new harness lemma that proves `NativeStmtPreservesWord` for `.If` statements when the condition `eval` returns successfully without changing state and the `then` body satisfies `NativeBlockPreservesWord`.
> 
> Updates the native transition documentation and its Python guard (`check_native_transition_doc.py`) to require this new proof surface, and regenerates `PrintAxioms.lean` to include the new theorem/updated counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d89b3030c2c7158bdb31fc94ea393cca52bc8520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->