### PR TITLE
macro: support named struct parameters

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -311,6 +311,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.StringEqSmoke.spec
   , Contracts.BytesEqSmoke.spec
   , Contracts.Smoke.TupleSmoke.spec
+  , Contracts.Smoke.NamedStructParamSmoke.spec
   , Contracts.Smoke.CurveCutArraySmoke.spec
   , Contracts.Smoke.PackedStorageWriteSmoke.spec
   , Contracts.Smoke.PackedAddressStorageWriteSmoke.spec
@@ -419,6 +420,8 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("StringEqSmoke", ["same(string,string)", "different(string,string)", "choose(string,string)"])
   , ("BytesEqSmoke", ["same(bytes,bytes)", "different(bytes,bytes)", "choose(bytes,bytes)"])
   , ("TupleSmoke", ["setFromPair((uint256,uint256))", "getPair(uint256)", "processConfig((address,address,uint256))"])
+  , ("NamedStructParamSmoke", ["readBorrowFee((uint256,uint256))", "storeNestedFee(((uint256,uint256),address),uint256)",
+      "readNestedMaker(((uint256,uint256),address))"])
   , ("CurveCutArraySmoke", ["firstCutXt((uint256,uint256,int256)[])", "returnCut((uint256,uint256,int256)[],uint256)",
       "storeCut((uint256,uint256,int256)[],uint256)", "storeTwoCuts((uint256,uint256,int256)[],uint256,uint256)"])
   , ("PackedStorageWriteSmoke", ["writeSlot0(bool,uint256)", "writeSlot1(uint256,uint256)"])
@@ -525,6 +528,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("StringEqSmoke", ["0x6df1667c", "0x1ce8f655", "0xc9e9b0e3"])
   , ("BytesEqSmoke", ["0xfc39552e", "0x2c16057d", "0x3eb6f0de"])
   , ("TupleSmoke", ["0x712ea680", "0xbdf391cc", "0x01b427d2"])
+  , ("NamedStructParamSmoke", ["0xa01f780b", "0x38946c6d", "0x596635bb"])
   , ("CurveCutArraySmoke", ["0xefca8f0f", "0x6f413e6b", "0x0d7610a3", "0xbea7dfd2"])
   , ("PackedStorageWriteSmoke", ["0xa0522387", "0x233ab149"])
   , ("PackedAddressStorageWriteSmoke", ["0xd59c874d"])
@@ -864,6 +868,20 @@ private def checkDirectHelperCallSmoke : IO Unit := do
     (contains (reprStr runHelpers.body) "Stmt.internalCallAssign" &&
       contains (reprStr runHelpers.body) "\"internal_pairWithTotal\"")
 
+private def checkNamedStructParamSmoke : IO Unit := do
+  expectTrue
+    "NamedStructParamSmoke: nested struct leaf projection uses recursive tuple binding"
+    (match Contracts.Smoke.NamedStructParamSmoke.storeNestedFee_modelBody with
+    | [ Stmt.setMappingUint "values" (Expr.param "key") (Expr.param "config_0_0")
+      , Stmt.stop
+      ] => true
+    | _ => false)
+  expectTrue
+    "NamedStructParamSmoke: sibling field after nested struct uses top-level tuple binding"
+    (match Contracts.Smoke.NamedStructParamSmoke.readNestedMaker_modelBody with
+    | [Stmt.return (Expr.param "config_1")] => true
+    | _ => false)
+
 private def curveCutArrayStoreMemoizesIndex : Bool :=
   match Contracts.Smoke.CurveCutArraySmoke.storeCut_modelBody with
   | Stmt.letVar "arrayElement_index" (Expr.param "idx") ::
@@ -1025,6 +1043,7 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
   checkLowLevelTryCatchSmoke
   checkSpecialEntrypointSmoke
   checkDirectHelperCallSmoke
+  checkNamedStructParamSmoke
   checkCurveCutArraySmoke
   for spec in macroSpecs do
     checkSpec spec

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -67,6 +67,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.ImmutableSmoke.spec
   , Contracts.Smoke.TypedImmutableSmoke.spec
   , Contracts.Smoke.TupleSmoke.spec
+  , Contracts.Smoke.NamedStructParamSmoke.spec
   , Contracts.Smoke.CurveCutArraySmoke.spec
   , Contracts.Smoke.PackedStorageWriteSmoke.spec
   , Contracts.Smoke.PackedAddressStorageWriteSmoke.spec
@@ -209,7 +210,7 @@ private def shardSpecs (specs : List CompilationModel) (shardIndex shardCount : 
     throw <| IO.userError
       s!"MACRO_FUZZ_SHARD_INDEX must be less than MACRO_FUZZ_SHARD_COUNT ({shardIndex} >= {shardCount})"
   let sharded :=
-    specs.enum.filterMap fun (idx, spec) =>
+    specs.zipIdx.filterMap fun (spec, idx) =>
       if idx % shardCount == shardIndex then some spec else none
   if sharded.isEmpty then
     throw <| IO.userError

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -914,6 +914,90 @@ verity_contract TupleSmoke where
     let flag := cfg_2
     setMapping authorized owner flag
 
+verity_contract NamedStructParamSmoke where
+  storage
+    values : Uint256 → Uint256 := slot 0
+
+  struct FeeConfig where
+    borrowTakerFeeRatio : Uint256,
+    lendMakerFeeRatio : Uint256
+
+  struct OrderConfig where
+    feeConfig : FeeConfig,
+    maker : Address
+
+  function readBorrowFee (feeConfig : FeeConfig) : Uint256 := do
+    return feeConfig.borrowTakerFeeRatio
+
+  function storeNestedFee (config : OrderConfig, key : Uint256) : Unit := do
+    setMappingUint values key config.feeConfig.borrowTakerFeeRatio
+
+  function readNestedMaker (config : OrderConfig) : Address := do
+    return config.maker
+
+/--
+error: non-leaf struct parameter projection is not supported; project a scalar or static single-word leaf field instead
+-/
+#guard_msgs in
+verity_contract NamedStructNonLeafProjectionRejected where
+  storage
+
+  struct FeeConfig where
+    borrowTakerFeeRatio : Uint256,
+    lendMakerFeeRatio : Uint256
+
+  struct OrderConfig where
+    feeConfig : FeeConfig,
+    maker : Address
+
+  function bad (config : OrderConfig) : Uint256 := do
+    let feeConfig := config.feeConfig
+    return feeConfig.borrowTakerFeeRatio
+
+/--
+error: non-leaf struct parameter projection is not supported; project a scalar or static single-word leaf field instead
+-/
+#guard_msgs in
+verity_contract NamedStructTupleProjectionRejected where
+  storage
+
+  struct TupleConfig where
+    pair : Tuple [Uint256, Uint256],
+    maker : Address
+
+  function badTuple (config : TupleConfig) : Uint256 := do
+    let pair := config.pair
+    return pair_0
+
+/--
+error: non-leaf struct parameter projection is not supported; project a scalar or static single-word leaf field instead
+-/
+#guard_msgs in
+verity_contract NamedStructDynamicProjectionRejected where
+  storage
+
+  struct DynamicConfig where
+    notes : Array Uint256,
+    maker : Address
+
+  function badDynamic (config : DynamicConfig) : Uint256 := do
+    let notes := config.notes
+    return 0
+
+/--
+error: function return types cannot be named structs; return an explicit Tuple [...] instead
+-/
+#guard_msgs in
+verity_contract NamedStructReturnRejected where
+  storage
+
+  struct FeeConfig where
+    borrowTakerFeeRatio : Uint256,
+    lendMakerFeeRatio : Uint256
+
+  function badReturn (feeConfig : FeeConfig) : FeeConfig := do
+    return feeConfig
+
 verity_contract CurveCutArraySmoke where
   storage
     lastXt : Uint256 := slot 0
@@ -1600,6 +1684,7 @@ end SpecGenSmoke
 #check_contract StatelessSmoke
 #check_contract SpecialEntrypointSmoke
 #check_contract TupleSmoke
+#check_contract NamedStructParamSmoke
 #check_contract CurveCutArraySmoke
 #check_contract PackedStorageWriteSmoke
 #check_contract DirectHelperCallSmoke
@@ -1621,6 +1706,22 @@ example : TupleSmoke.getPair = (TupleSmoke.getPair : Uint256 → Verity.Contract
 example :
     TupleSmoke.processConfig =
       (TupleSmoke.processConfig : (Address × Address × Uint256) → Verity.Contract Unit) := rfl
+
+example :
+    NamedStructParamSmoke.readBorrowFee =
+      (NamedStructParamSmoke.readBorrowFee :
+        NamedStructParamSmoke.FeeConfig → Verity.Contract Uint256) := rfl
+
+def namedStructExecutableReadsField : Bool :=
+  let feeConfig : NamedStructParamSmoke.FeeConfig := {
+    borrowTakerFeeRatio := 11
+    lendMakerFeeRatio := 13
+  }
+  match NamedStructParamSmoke.readBorrowFee feeConfig Verity.defaultState with
+  | .success value _ => value == 11
+  | _ => false
+
+example : namedStructExecutableReadsField = true := by decide
 example : Uint8Smoke.acceptSig = (Uint8Smoke.acceptSig : (Uint256 × Uint256 × Uint256) → Verity.Contract Unit) := rfl
 example : ExternalCallSmoke.storeEcho = (ExternalCallSmoke.storeEcho : Uint256 → Verity.Contract Unit) := rfl
 

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -985,6 +985,20 @@ verity_contract NamedStructDynamicProjectionRejected where
     return 0
 
 /--
+error: struct parameter projection from an ABI-dynamic root is not supported; use a static struct parameter or wait for nested-dynamic ABI decoding
+-/
+#guard_msgs in
+verity_contract NamedStructDynamicRootLeafProjectionRejected where
+  storage
+
+  struct DynamicConfig where
+    notes : Array Uint256,
+    maker : Address
+
+  function badDynamicLeaf (config : DynamicConfig) : Address := do
+    return config.maker
+
+/--
 error: function return types cannot be named structs; return an explicit Tuple [...] instead
 -/
 #guard_msgs in

--- a/Verity/Macro/Elaborate.lean
+++ b/Verity/Macro/Elaborate.lean
@@ -13,7 +13,7 @@ set_option hygiene false
 
 @[command_elab verityContractCmd]
 def elabVerityContract : CommandElab := fun stx => do
-  let (contractName, _newtypeDecls, adtDecls, fields, errorDecls, constDecls, immutableDecls, externalDecls, ctor, functions, storageNamespace) ← parseContractSyntax stx
+  let (contractName, _newtypeDecls, structDecls, adtDecls, fields, errorDecls, constDecls, immutableDecls, externalDecls, ctor, functions, storageNamespace) ← parseContractSyntax stx
 
   validateGeneratedDefNamesPublic fields constDecls immutableDecls functions
   validateConstantDeclsPublic constDecls
@@ -25,6 +25,9 @@ def elabVerityContract : CommandElab := fun stx => do
   try
     for constant in constDecls do
       elabCommand (← mkConstantDefCommandPublic constant)
+
+    for structDecl in structDecls do
+      elabCommand (← mkStructDefCommandPublic structDecl)
 
     for field in fields do
       elabCommand (← mkStorageDefCommandPublic field)

--- a/Verity/Macro/Syntax.lean
+++ b/Verity/Macro/Syntax.lean
@@ -19,6 +19,7 @@ declare_syntax_cat verityInitGuard
 declare_syntax_cat verityModifies
 declare_syntax_cat verityRequiresRole
 declare_syntax_cat verityNewtype
+declare_syntax_cat verityStructDecl
 declare_syntax_cat verityAdtVariant
 declare_syntax_cat verityAdtDecl
 declare_syntax_cat verityNamespaceSpec
@@ -46,6 +47,7 @@ syntax "cei_safe" : verityMutability
 syntax "modifies(" sepBy1(ident, ",") ")" : verityModifies
 syntax "requires(" ident ")" : verityRequiresRole
 syntax ident " : " term:max : verityNewtype
+syntax "struct " ident " where " sepBy1(verityParam, ",") : verityStructDecl
 syntax "| " ident "(" sepBy(verityParam, ",") ")" : verityAdtVariant
 syntax "| " ident : verityAdtVariant
 syntax ident " := " verityAdtVariant+ : verityAdtDecl
@@ -78,6 +80,7 @@ syntax (name := verityContractCmd)
   ("inductive " verityAdtDecl+)?
   (verityNamespaceSpec)?
   "storage " verityStorageField*
+  (verityStructDecl)*
   ("errors " verityError+)?
   ("constants " verityConstant+)?
   ("immutables " verityImmutable+)?

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -31,6 +31,7 @@ inductive ValueType where
   | tuple (elemTys : List ValueType)
   | unit
   | newtype (name : String) (baseType : ValueType)  -- Semantic newtype; erased to baseType (#1727 Steps 3b/3c)
+  | struct (name : String) (fields : List (String × ValueType)) -- Named ABI tuple with executable field access (#1750)
   | adt (name : String) (maxFields : Nat)  -- User-defined ADT (tagged union); maxFields = max variant field count (#1727 Step 5b)
   deriving Repr, BEq
 
@@ -99,6 +100,14 @@ structure NewtypeDecl where
   ident : Ident
   name : String
   baseType : ValueType
+
+/-- A named ABI struct declared in the `verity_contract` body.
+    It elaborates to a Lean `structure` for executable tests, while the compiler
+    lowers it as an ABI tuple with named projection support. -/
+structure StructDecl where
+  ident : Ident
+  name : String
+  fields : Array ParamDecl
 
 /-- A single variant (constructor) of a user-defined algebraic data type.
     E.g. `| Ok(value : Uint256)` or `| None`.
@@ -175,6 +184,9 @@ private partial def valueTypeSignatureComponent : ValueType → String
   | .array ty => "array_" ++ valueTypeSignatureComponent ty
   | .tuple tys => "tuple" ++ toString tys.length ++ "_" ++ String.intercalate "__" (tys.map valueTypeSignatureComponent)
   | .newtype name baseType => "newtype_" ++ name ++ "_" ++ valueTypeSignatureComponent baseType
+  | .struct name fields =>
+      "struct_" ++ name ++ "_" ++
+        String.intercalate "__" (fields.map (fun field => field.fst ++ "_" ++ valueTypeSignatureComponent field.snd))
   | .adt name _ => "adt_" ++ name
 
 private def functionSignatureKey (fn : FunctionDecl) : String :=
@@ -184,6 +196,8 @@ private partial def valueTypeAbiSignatureComponent : ValueType → String
   | .newtype _ baseType => valueTypeAbiSignatureComponent baseType
   | .array ty => "array_" ++ valueTypeAbiSignatureComponent ty
   | .tuple tys => "tuple" ++ toString tys.length ++ "_" ++ String.intercalate "__" (tys.map valueTypeAbiSignatureComponent)
+  | .struct _ fields =>
+      "tuple" ++ toString fields.length ++ "_" ++ String.intercalate "__" (fields.map (fun field => valueTypeAbiSignatureComponent field.snd))
   | .adt _ maxFields =>
       "tuple" ++ toString (maxFields + 1) ++ "_" ++
         String.intercalate "__" ("scalar_uint8" :: List.replicate maxFields "scalar_uint256")
@@ -260,7 +274,14 @@ private partial def stripParens (stx : Term) : Term :=
   | `(term| ($inner)) => stripParens inner
   | _ => stx
 
-private partial def valueTypeFromSyntax (newtypes : Array NewtypeDecl) (adtDecls : Array AdtDecl) (ty : Term) : CommandElabM ValueType := do
+private def structValueTypeFields (decl : StructDecl) : List (String × ValueType) :=
+  decl.fields.toList.map fun field => (field.name, field.ty)
+
+private partial def valueTypeFromSyntax
+    (newtypes : Array NewtypeDecl)
+    (structDecls : Array StructDecl)
+    (adtDecls : Array AdtDecl)
+    (ty : Term) : CommandElabM ValueType := do
   let ty := stripParens ty
   match ty with
   | `(term| Uint256) => pure .uint256
@@ -272,13 +293,13 @@ private partial def valueTypeFromSyntax (newtypes : Array NewtypeDecl) (adtDecls
   | `(term| String) => pure .string
   | `(term| Bytes) => pure .bytes
   | `(term| Array $elemTy:term) =>
-      let elem ← valueTypeFromSyntax newtypes adtDecls elemTy
+      let elem ← valueTypeFromSyntax newtypes structDecls adtDecls elemTy
       match elem with
       | .unit => throwErrorAt ty "unsupported type '{ty}'; Array Unit is not allowed"
       | .array _ => throwErrorAt ty "unsupported type '{ty}'; nested arrays are not supported"
       | _ => pure (.array elem)
   | `(term| Tuple [ $[$elemTys:term],* ]) =>
-      let elems ← elemTys.mapM (valueTypeFromSyntax newtypes adtDecls)
+      let elems ← elemTys.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
       if elems.size < 2 then
         throwErrorAt ty "tuple types must have at least 2 elements"
       pure (.tuple elems.toList)
@@ -290,15 +311,18 @@ private partial def valueTypeFromSyntax (newtypes : Array NewtypeDecl) (adtDecls
       | some nt => pure (.newtype nt.name nt.baseType)
       | none =>
         -- Try resolving as a user-defined ADT (#1727, Axis 1 Step 5b)
-        match adtDecls.find? (fun a => a.name == tyName) with
-        | some decl =>
-            let maxFields := decl.variants.foldl (fun acc v => max acc v.fields.size) 0
-            pure (.adt decl.name maxFields)
-        | none => throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Int256, Uint8, Address, Bytes32, Bool, String, Bytes, Array <type>, Tuple [...], Unit, or a user-defined type from the `types` or `inductive` section"
+        match structDecls.find? (fun s => s.name == tyName) with
+        | some decl => pure (.struct decl.name (structValueTypeFields decl))
+        | none =>
+          match adtDecls.find? (fun a => a.name == tyName) with
+          | some decl =>
+              let maxFields := decl.variants.foldl (fun acc v => max acc v.fields.size) 0
+              pure (.adt decl.name maxFields)
+          | none => throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Int256, Uint8, Address, Bytes32, Bool, String, Bytes, Array <type>, Tuple [...], Unit, a user-defined struct, or a user-defined type from the `types` or `inductive` section"
   | _ =>
-      throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Int256, Uint8, Address, Bytes32, Bool, String, Bytes, Array <type>, Tuple [...], Unit, or a user-defined type from the `types` or `inductive` section"
+      throwErrorAt ty "unsupported type '{ty}'; expected Uint256, Int256, Uint8, Address, Bytes32, Bool, String, Bytes, Array <type>, Tuple [...], Unit, a user-defined struct, or a user-defined type from the `types` or `inductive` section"
 
-private def storageTypeFromSyntax (newtypes : Array NewtypeDecl) (adtDecls : Array AdtDecl := #[]) (ty : Term) : CommandElabM StorageType := do
+private def storageTypeFromSyntax (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl := #[]) (adtDecls : Array AdtDecl := #[]) (ty : Term) : CommandElabM StorageType := do
   let keyTypeFromSyntax (stx : Term) : CommandElabM MappingKeyType := do
     match stx with
     | `(term| Address) => pure .address
@@ -354,10 +378,11 @@ private def storageTypeFromSyntax (newtypes : Array NewtypeDecl) (adtDecls : Arr
         (← keyTypeFromSyntax innerKey)
         ((← members.mapM structMemberFromSyntax).toList)
   | _ => do
-      let vt ← valueTypeFromSyntax newtypes adtDecls ty
+      let vt ← valueTypeFromSyntax newtypes structDecls adtDecls ty
       match vt with
       | .array elemTy => pure (.dynamicArray (← storageArrayElemTypeFromValueType elemTy))
       | .tuple _ => throwErrorAt ty "storage fields cannot be Tuple; use mapping encodings"
+      | .struct _ _ => throwErrorAt ty "storage fields cannot be named structs; use mapping encodings"
       | _ => pure (.scalar vt)
 
 private def modelMappingKeyTypeTerm : MappingKeyType → CommandElabM Term
@@ -401,6 +426,7 @@ private def modelFieldTypeTerm (ty : StorageType) : CommandElabM Term :=
   | .scalar .bytes => throwError "storage fields cannot be Bytes; use Uint256 encoding"
   | .scalar (.array _) => throwError "storage fields cannot be Array; use mapping encodings"
   | .scalar (.tuple _) => throwError "storage fields cannot be Tuple; use mapping encodings"
+  | .scalar (.struct _ _) => throwError "storage fields cannot be named structs; use mapping encodings"
   | .scalar .unit => throwError "storage fields cannot be Unit"
   | .scalar (.newtype _ baseType) => modelFieldTypeTerm (.scalar baseType)  -- Erased to base type
   | .scalar (.adt name maxFields) =>
@@ -450,6 +476,9 @@ private partial def modelParamTypeTerm (ty : ValueType) : CommandElabM Term :=
   | .tuple elemTys => do
       let elemTerms ← elemTys.mapM modelParamTypeTerm
       `(Compiler.CompilationModel.ParamType.tuple [ $[$elemTerms.toArray],* ])
+  | .struct _ fields => do
+      let elemTerms ← fields.mapM (fun field => modelParamTypeTerm field.snd)
+      `(Compiler.CompilationModel.ParamType.tuple [ $[$elemTerms.toArray],* ])
   | .unit => throwError "function parameters cannot be Unit"
   | .newtype name baseType => do
       let baseTerm ← modelParamTypeTerm baseType
@@ -470,6 +499,7 @@ private def modelReturnTypeTerm (ty : ValueType) : CommandElabM Term :=
   | .bytes => `(none)
   | .array _ => `(none)
   | .tuple _ => `(none)
+  | .struct _ _ => `(none)
   | .newtype _ baseType => modelReturnTypeTerm baseType
   | .adt _ _ => `(none)  -- ADTs are not directly returnable as single FieldType
 
@@ -488,6 +518,9 @@ private partial def modelReturnsTerm (ty : ValueType) : CommandElabM Term :=
       `([Compiler.CompilationModel.ParamType.array $(← modelParamTypeTerm elemTy)])
   | .tuple elemTys => do
       let elemTerms ← elemTys.mapM modelParamTypeTerm
+      `([ $[$elemTerms.toArray],* ])
+  | .struct _ fields => do
+      let elemTerms ← fields.mapM (fun field => modelParamTypeTerm field.snd)
       `([ $[$elemTerms.toArray],* ])
   | .newtype name baseType => do
       let baseTerm ← modelParamTypeTerm baseType
@@ -519,13 +552,14 @@ private partial def contractValueTypeTerm (ty : ValueType) : CommandElabM Term :
   | .tuple elemTys => mkTupleContractType elemTys
   | .unit => `(Unit)
   | .newtype _ baseType => contractValueTypeTerm baseType  -- Erased to base type at contract level
+  | .struct name _ => pure (mkIdent (Name.mkSimple name))
   | .adt _ _ => `(Uint256)  -- ADTs represented as tag value at contract level
 end
 
-private def parseStorageField (newtypes : Array NewtypeDecl) (adtDecls : Array AdtDecl := #[]) (stx : Syntax) : CommandElabM StorageFieldDecl := do
+private def parseStorageField (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl := #[]) (adtDecls : Array AdtDecl := #[]) (stx : Syntax) : CommandElabM StorageFieldDecl := do
   match stx with
   | `(verityStorageField| $name:ident : $ty:term := slot $slotNum:num) =>
-      let parsedTy ← storageTypeFromSyntax newtypes adtDecls ty
+      let parsedTy ← storageTypeFromSyntax newtypes structDecls adtDecls ty
       let adtInfo? :=
         match parsedTy with
         | .scalar (.adt adtName maxFields) => some (adtName, maxFields)
@@ -539,20 +573,20 @@ private def parseStorageField (newtypes : Array NewtypeDecl) (adtDecls : Array A
       }
   | _ => throwErrorAt stx "invalid storage field declaration"
 
-private def parseParam (newtypes : Array NewtypeDecl) (adtDecls : Array AdtDecl) (stx : Syntax) : CommandElabM ParamDecl := do
+private def parseParam (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl) (adtDecls : Array AdtDecl) (stx : Syntax) : CommandElabM ParamDecl := do
   match stx with
   | `(verityParam| $name:ident : $ty:term) =>
       pure {
         ident := name
         name := toString name.getId
-        ty := ← valueTypeFromSyntax newtypes adtDecls ty
+        ty := ← valueTypeFromSyntax newtypes structDecls adtDecls ty
       }
   | _ => throwErrorAt stx "invalid parameter declaration"
 
 private def parseNewtype (stx : Syntax) : CommandElabM NewtypeDecl := do
   match stx with
   | `(verityNewtype| $name:ident : $ty:term) =>
-      let baseType ← valueTypeFromSyntax #[] #[] ty
+      let baseType ← valueTypeFromSyntax #[] #[] #[] ty
       -- Validate: newtypes must be based on scalar types (not arrays, tuples, or unit)
       match baseType with
       | .array _ => throwErrorAt ty "newtype base type must be a scalar type, not an array"
@@ -566,12 +600,26 @@ private def parseNewtype (stx : Syntax) : CommandElabM NewtypeDecl := do
       }
   | _ => throwErrorAt stx "invalid type declaration"
 
+private def parseStructDecl (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl) (stx : Syntax) : CommandElabM StructDecl := do
+  match stx with
+  | `(verityStructDecl| struct $name:ident where $[$fields:verityParam],*) =>
+      let parsedFields ← fields.mapM (parseParam newtypes structDecls #[])
+      if parsedFields.isEmpty then
+        throwErrorAt name s!"struct '{toString name.getId}' must have at least one field"
+      let mut seenFieldNames : Array String := #[]
+      for field in parsedFields do
+        if seenFieldNames.contains field.name then
+          throwErrorAt field.ident s!"duplicate field '{field.name}' in struct '{toString name.getId}'"
+        seenFieldNames := seenFieldNames.push field.name
+      pure { ident := name, name := toString name.getId, fields := parsedFields }
+  | _ => throwErrorAt stx "invalid struct declaration"
+
 /-- Parse a single ADT variant: `| Name(field1 : Type1, field2 : Type2)` or `| Name`.
     (#1727, Axis 1 Step 5a) -/
 private def parseAdtVariant (newtypes : Array NewtypeDecl) (stx : Syntax) : CommandElabM AdtVariantDecl := do
   match stx with
   | `(verityAdtVariant| | $name:ident ($[$params:verityParam],*)) =>
-      let parsedParams ← params.mapM (parseParam newtypes #[])
+      let parsedParams ← params.mapM (parseParam newtypes #[] #[])
       pure { ident := name, name := toString name.getId, fields := parsedParams }
   | `(verityAdtVariant| | $name:ident) =>
       pure { ident := name, name := toString name.getId, fields := #[] }
@@ -597,13 +645,13 @@ private def parseAdtDecl (newtypes : Array NewtypeDecl) (stx : Syntax) : Command
       pure { ident := name, name := toString name.getId, variants := parsedVariants }
   | _ => throwErrorAt stx "invalid ADT declaration"
 
-private def parseError (newtypes : Array NewtypeDecl) (adtDecls : Array AdtDecl) (stx : Syntax) : CommandElabM ErrorDecl := do
+private def parseError (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl) (adtDecls : Array AdtDecl) (stx : Syntax) : CommandElabM ErrorDecl := do
   match stx with
   | `(verityError| error $name:ident ($[$params:term],*)) =>
       pure {
         ident := name
         name := toString name.getId
-        params := ← params.mapM (valueTypeFromSyntax newtypes adtDecls)
+        params := ← params.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
       }
   | _ => throwErrorAt stx "invalid custom error declaration"
 
@@ -613,7 +661,7 @@ private def parseConstant (newtypes : Array NewtypeDecl) (stx : Syntax) : Comman
       pure {
         ident := name
         name := toString name.getId
-        ty := ← valueTypeFromSyntax newtypes #[] ty
+        ty := ← valueTypeFromSyntax newtypes #[] #[] ty
         body := body
       }
   | _ => throwErrorAt stx "invalid constant declaration"
@@ -624,25 +672,25 @@ private def parseImmutable (newtypes : Array NewtypeDecl) (stx : Syntax) : Comma
       pure {
         ident := name
         name := toString name.getId
-        ty := ← valueTypeFromSyntax newtypes #[] ty
+        ty := ← valueTypeFromSyntax newtypes #[] #[] ty
         body := body
       }
   | _ => throwErrorAt stx "invalid immutable declaration"
 
-private def parseExternal (newtypes : Array NewtypeDecl) (adtDecls : Array AdtDecl) (stx : Syntax) : CommandElabM ExternalDecl := do
+private def parseExternal (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl) (adtDecls : Array AdtDecl) (stx : Syntax) : CommandElabM ExternalDecl := do
   match stx with
   | `(verityExternal| external $name:ident ($[$params:term],*) -> ($[$returnTys:term],*)) =>
       pure {
         ident := name
         name := toString name.getId
-        params := ← params.mapM (valueTypeFromSyntax newtypes adtDecls)
-        returnTys := ← returnTys.mapM (valueTypeFromSyntax newtypes adtDecls)
+        params := ← params.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
+        returnTys := ← returnTys.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
       }
   | `(verityExternal| external $name:ident ($[$params:term],*)) =>
       pure {
         ident := name
         name := toString name.getId
-        params := ← params.mapM (valueTypeFromSyntax newtypes adtDecls)
+        params := ← params.mapM (valueTypeFromSyntax newtypes structDecls adtDecls)
         returnTys := #[]
       }
   | _ => throwErrorAt stx "invalid external declaration"
@@ -776,12 +824,16 @@ private def parseSpecialEntrypoint (stx : Syntax) : CommandElabM FunctionDecl :=
       }
   | _ => throwErrorAt stx "invalid special entrypoint declaration"
 
-private def parseFunction (newtypes : Array NewtypeDecl) (adtDecls : Array AdtDecl := #[]) (stx : Syntax) : CommandElabM FunctionDecl := do
+private def parseFunction (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl := #[]) (adtDecls : Array AdtDecl := #[]) (stx : Syntax) : CommandElabM FunctionDecl := do
   match stx with
   | `(verityFunction| function $[$mods:verityMutability]* $name:ident ($[$params:verityParam],*) $[$guard?:verityInitGuard]? $[$requiresRoleClause?:verityRequiresRole]? $[$modifiesClause?:verityModifies]? $[$localObligations?:verityLocalObligations]? : $retTy:term := $body:term) => do
       let mut_ ← parseMutabilityModifiers mods stx
-      let parsedParams ← params.mapM (parseParam newtypes adtDecls)
-      let parsedReturnTy ← valueTypeFromSyntax newtypes adtDecls retTy
+      let parsedParams ← params.mapM (parseParam newtypes structDecls adtDecls)
+      let parsedReturnTy ← valueTypeFromSyntax newtypes structDecls adtDecls retTy
+      match parsedReturnTy with
+      | .struct _ _ =>
+          throwErrorAt retTy "function return types cannot be named structs; return an explicit Tuple [...] instead"
+      | _ => pure ()
       let parsedGuard? ←
         match guard? with
         | some guard => pure (some (← parseInitGuard guard))
@@ -820,30 +872,30 @@ private def parseFunction (newtypes : Array NewtypeDecl) (adtDecls : Array AdtDe
       }
   | _ => throwErrorAt stx "invalid function declaration"
 
-private def parseConstructor (newtypes : Array NewtypeDecl) (adtDecls : Array AdtDecl := #[]) (stx : Syntax) : CommandElabM ConstructorDecl := do
+private def parseConstructor (newtypes : Array NewtypeDecl) (structDecls : Array StructDecl := #[]) (adtDecls : Array AdtDecl := #[]) (stx : Syntax) : CommandElabM ConstructorDecl := do
   match stx with
   | `(verityConstructor| constructor ($[$params:verityParam],*) payable local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
       pure {
-        params := ← params.mapM (parseParam newtypes adtDecls)
+        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         isPayable := true
         localObligations := ← obligations.mapM parseLocalObligation
         body := body
       }
   | `(verityConstructor| constructor ($[$params:verityParam],*) payable := $body:term) =>
       pure {
-        params := ← params.mapM (parseParam newtypes adtDecls)
+        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         isPayable := true
         body := body
       }
   | `(verityConstructor| constructor ($[$params:verityParam],*) local_obligations [ $[$obligations:verityLocalObligation],* ] := $body:term) =>
       pure {
-        params := ← params.mapM (parseParam newtypes adtDecls)
+        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         localObligations := ← obligations.mapM parseLocalObligation
         body := body
       }
   | `(verityConstructor| constructor ($[$params:verityParam],*) := $body:term) =>
       pure {
-        params := ← params.mapM (parseParam newtypes adtDecls)
+        params := ← params.mapM (parseParam newtypes structDecls adtDecls)
         body := body
       }
   | _ => throwErrorAt stx "invalid constructor declaration"
@@ -902,6 +954,7 @@ private partial def containsAdtValueType : ValueType → Bool
   | .newtype _ baseType => containsAdtValueType baseType
   | .array elemTy => containsAdtValueType elemTy
   | .tuple elemTys => elemTys.any containsAdtValueType
+  | .struct _ fields => fields.any (fun field => containsAdtValueType field.snd)
   | _ => false
 
 private def rejectExecutableBoundaryAdt
@@ -1275,6 +1328,13 @@ private partial def staticAbiWordCount? : ValueType → Option Nat
           | some n, some m => some (n + m)
           | _, _ => none)
         (some 0)
+  | .struct _ fields =>
+      fields.foldl
+        (fun acc field =>
+          match acc, staticAbiWordCount? field.snd with
+          | some n, some m => some (n + m)
+          | _, _ => none)
+        (some 0)
   | .newtype _ baseType => staticAbiWordCount? baseType
   | _ => none
 
@@ -1356,6 +1416,85 @@ private def tupleParamElemType? (params : Array ParamDecl) (name : String) : Opt
               none
       | none => none
   | _ => none
+
+private partial def structProjectionPath? (stx : Term) : Option (Term × List String) :=
+  match stripParens stx with
+  | `(term| $id:ident) =>
+      match (toString id.getId).splitOn "." with
+      | root :: field :: rest =>
+          some (mkIdent (Name.mkSimple root), field :: rest)
+      | _ => none
+  | `(term| $base:term.$field:ident) =>
+      let fieldName := toString field.getId
+      match structProjectionPath? base with
+      | some (root, path) => some (root, path ++ [fieldName])
+      | none => some (base, [fieldName])
+  | _ => none
+
+private partial def structFieldPath?
+    (ty : ValueType)
+    (path : List String)
+    (indices : List Nat := []) : Option (ValueType × List Nat) :=
+  -- The returned indices are the recursive tuple binding path used by
+  -- ParamLoading.staticParamBindingNames, not flattened ABI word offsets.
+  match path with
+  | [] => some (ty, indices)
+  | fieldName :: rest =>
+      match ty with
+      | .struct _ fields =>
+          fields.zipIdx.findSome? fun (field, idx) =>
+            if field.fst == fieldName then
+              structFieldPath? field.snd rest (indices ++ [idx])
+            else
+              none
+      | _ => none
+
+private def paramStructProjectionResolved?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × ValueType) := do
+  let resolve (rootName : String) (path : List String) := do
+    let param ← params.find? (fun p => p.name == rootName)
+    let (fieldTy, indices) ← structFieldPath? param.ty path
+    if indices.isEmpty then
+      none
+    else
+      some (String.intercalate "_" (rootName :: indices.map toString), fieldTy)
+  match (stripParens stx).raw with
+  | .ident _ raw _ _ =>
+      let parts := raw.toString.splitOn "."
+      let rec findParamPath : List String → Option (String × List String)
+        | [] | [_] => none
+        | rootName :: fieldName :: rest =>
+            if params.any (fun p => p.name == rootName) then
+              some (rootName, fieldName :: rest)
+            else
+              findParamPath (fieldName :: rest)
+      match findParamPath parts with
+      | some (rootName, path) => resolve rootName path
+      | none => none
+  | _ =>
+      let (root, path) ← structProjectionPath? stx
+      match stripParens root with
+      | `(term| $id:ident) => resolve (toString id.getId) path
+      | _ => none
+
+private def paramStructProjection?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × ValueType) := do
+  let (paramName, fieldTy) ← paramStructProjectionResolved? params stx
+  if isSingleWordStaticValueType fieldTy then
+    some (paramName, fieldTy)
+  else
+    none
+
+private def isParamStructNonLeafProjection (params : Array ParamDecl) (stx : Term) : Bool :=
+  match paramStructProjectionResolved? params stx with
+  | some (_, fieldTy) => !isSingleWordStaticValueType fieldTy
+  | none => false
+
+private def throwStructNonLeafProjectionError (stx : Term) : CommandElabM α :=
+  throwErrorAt stx
+    "non-leaf struct parameter projection is not supported; project a scalar or static single-word leaf field instead"
 
 private def renderValueType (ty : ValueType) : String :=
   reprStr ty
@@ -1506,6 +1645,7 @@ private def requireDeclaredValueType
 private partial def localBindingUsesDynamicData : ValueType → Bool
   | .string | .bytes | .array _ => true
   | .tuple elemTys => elemTys.any localBindingUsesDynamicData
+  | .struct _ fields => fields.any (fun field => localBindingUsesDynamicData field.snd)
   | .newtype _ baseType => localBindingUsesDynamicData baseType
   | .adt _ _ => false  -- ADTs are stored as tag + fixed-width slots, not dynamic
   | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool | .unit => false
@@ -1591,6 +1731,7 @@ private partial def hasDynamicInternalHelperType (ty : ValueType) : Bool :=
   match ty with
   | .string | .bytes | .array _ => true
   | .tuple elemTys => elemTys.any hasDynamicInternalHelperType
+  | .struct _ fields => fields.any (fun field => hasDynamicInternalHelperType field.snd)
   | _ => false
 
 private def supportsInternalHelperSpec (fn : FunctionDecl) : Bool :=
@@ -1628,6 +1769,12 @@ private partial def inferPureExprType
           if matchesBareName p.name name then some p.ty else none) with
     | some ty => pure ty
     | none => throwPureContextAccessorError stx name
+  if isParamStructNonLeafProjection params stx then
+    throwStructNonLeafProjectionError stx
+  else
+  if let some (_, ty) := paramStructProjection? params stx then
+    pure ty
+  else
   match stx with
   | `(term| true) | `(term| false) => pure .bool
   | `(term| constructorArg $idx:num) =>
@@ -2257,6 +2404,12 @@ partial def translatePureExprWithTypes
     (visitingConstants : List String := []) : CommandElabM Term := do
   let stx := stripParens stx
   let localNames := typedLocalNames locals
+  if isParamStructNonLeafProjection params stx then
+    throwStructNonLeafProjectionError stx
+  else
+  if let some (paramName, _ty) := paramStructProjection? params stx then
+    `(Compiler.CompilationModel.Expr.param $(strTerm paramName))
+  else
   match stx with
   | `(term| true) => `(Compiler.CompilationModel.Expr.literal 1)
   | `(term| false) => `(Compiler.CompilationModel.Expr.literal 0)
@@ -4416,6 +4569,7 @@ private def mkStorageDefCommand (field : StorageFieldDecl) : CommandElabM Cmd :=
     | .scalar .bytes => throwError "storage field cannot be Bytes; use Uint256 encoding"
     | .scalar (.array _) => throwError "storage field cannot be Array; use mapping encodings"
     | .scalar (.tuple _) => throwError "storage field cannot be Tuple; use mapping encodings"
+    | .scalar (.struct _ _) => throwError "storage field cannot be named struct; use mapping encodings"
     | .scalar .unit => throwError "storage field cannot be Unit"
     | .scalar (.newtype _ baseType) =>
         -- Newtypes erased to base type for storage (#1727 Step 3b)
@@ -4796,9 +4950,9 @@ def computeStorageNamespaceKey (key : String) : Nat :=
 def parseContractSyntax
     (stx : Syntax)
     : CommandElabM
-        (Ident × Array NewtypeDecl × Array AdtDecl × Array StorageFieldDecl × Array ErrorDecl × Array ConstantDecl × Array ImmutableDecl × Array ExternalDecl × Option ConstructorDecl × Array FunctionDecl × Option Nat) := do
+        (Ident × Array NewtypeDecl × Array StructDecl × Array AdtDecl × Array StorageFieldDecl × Array ErrorDecl × Array ConstantDecl × Array ImmutableDecl × Array ExternalDecl × Option ConstructorDecl × Array FunctionDecl × Option Nat) := do
   match stx with
-  | `(command| verity_contract $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageFields:verityStorageField]* $[errors $[$errorDecls:verityError]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$functions:verityFunction]*) =>
+  | `(command| verity_contract $contractName:ident where $[types $[$newtypeDecls:verityNewtype]*]? $[inductive $[$adtDecls:verityAdtDecl]*]? $[$nsSpec:verityNamespaceSpec]? storage $[$storageFields:verityStorageField]* $[$structDecls:verityStructDecl]* $[errors $[$errorDecls:verityError]*]? $[constants $[$constantDecls:verityConstant]*]? $[immutables $[$immutableDecls:verityImmutable]*]? $[linked_externals $[$externalDecls:verityExternal]*]? $[$ctor:verityConstructor]? $[$entrypoints:veritySpecialEntrypoint]* $[$functions:verityFunction]*) =>
       -- Parse newtypes first — they are needed by all downstream type resolution
       let parsedNewtypes ←
         match newtypeDecls with
@@ -4815,6 +4969,15 @@ def parseContractSyntax
       for nt in parsedNewtypes do
         if builtinTypeNames.contains nt.name then
           throwErrorAt nt.ident s!"type name '{nt.name}' shadows a built-in type"
+      let mut parsedStructs : Array StructDecl := #[]
+      for structStx in structDecls do
+        let parsedStruct ← parseStructDecl parsedNewtypes parsedStructs structStx
+        if seenNames.contains parsedStruct.name then
+          throwErrorAt parsedStruct.ident s!"duplicate type name '{parsedStruct.name}'"
+        if builtinTypeNames.contains parsedStruct.name then
+          throwErrorAt parsedStruct.ident s!"struct name '{parsedStruct.name}' shadows a built-in type"
+        seenNames := seenNames.push parsedStruct.name
+        parsedStructs := parsedStructs.push parsedStruct
       -- Parse ADT declarations (#1727, Axis 1 Step 5a)
       let parsedAdts ←
         match adtDecls with
@@ -4851,7 +5014,7 @@ def parseContractSyntax
         | none => pure 0
       let parsedErrors ←
         match errorDecls with
-        | some decls => decls.mapM (parseError parsedNewtypes parsedAdts)
+        | some decls => decls.mapM (parseError parsedNewtypes parsedStructs parsedAdts)
         | none => pure #[]
       let parsedConstants ←
         match constantDecls with
@@ -4863,10 +5026,10 @@ def parseContractSyntax
         | none => pure #[]
       let parsedExternals ←
         match externalDecls with
-        | some decls => decls.mapM (parseExternal parsedNewtypes parsedAdts)
+        | some decls => decls.mapM (parseExternal parsedNewtypes parsedStructs parsedAdts)
         | none => pure #[]
       -- Apply namespace offset to parsed storage fields (#1730, Axis 4 Step 4b)
-      let parsedFields ← storageFields.mapM (parseStorageField parsedNewtypes parsedAdts)
+      let parsedFields ← storageFields.mapM (parseStorageField parsedNewtypes parsedStructs parsedAdts)
       let parsedFields := parsedFields.map fun field =>
         { field with slotNum := field.slotNum + namespaceOffset }
       -- Compute the Option Nat for the spec's storageNamespace field (#1730, Axis 4 Step 4d)
@@ -4875,16 +5038,17 @@ def parseContractSyntax
       pure
         ( contractName
         , parsedNewtypes
+        , parsedStructs
         , parsedAdts
         , parsedFields
         , parsedErrors
         , parsedConstants
         , parsedImmutables
         , parsedExternals
-        , (← ctor.mapM (parseConstructor parsedNewtypes parsedAdts))
+        , (← ctor.mapM (parseConstructor parsedNewtypes parsedStructs parsedAdts))
           , assignOverloadInternalIdents
               ((← entrypoints.mapM parseSpecialEntrypoint) ++
-                (← functions.mapM (parseFunction parsedNewtypes parsedAdts)))
+                (← functions.mapM (parseFunction parsedNewtypes parsedStructs parsedAdts)))
           , namespaceOpt
           )
   | _ => throwErrorAt stx "invalid verity_contract declaration"
@@ -4897,6 +5061,14 @@ def mkStorageDefCommandPublic (field : StorageFieldDecl) : CommandElabM Cmd :=
 
 def mkConstantDefCommandPublic (constant : ConstantDecl) : CommandElabM Cmd :=
   mkConstantDefCommand constant
+
+def mkStructDefCommandPublic (decl : StructDecl) : CommandElabM Cmd := do
+  let structId := decl.ident
+  let fieldIds := decl.fields.map (·.ident)
+  let fieldTys ← decl.fields.mapM (fun field => contractValueTypeTerm field.ty)
+  `(command| structure $structId where
+      $[$fieldIds:ident : $fieldTys:term]*
+      deriving Repr)
 
 /-- Generate a `def storageNamespace : Nat := <keccak-value>` command for
     the current contract.  Uses the resolved namespace value from

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1338,6 +1338,14 @@ private partial def staticAbiWordCount? : ValueType → Option Nat
   | .newtype _ baseType => staticAbiWordCount? baseType
   | _ => none
 
+private partial def valueTypeUsesDynamicData : ValueType → Bool
+  | .string | .bytes | .array _ => true
+  | .tuple elemTys => elemTys.any valueTypeUsesDynamicData
+  | .struct _ fields => fields.any (fun field => valueTypeUsesDynamicData field.snd)
+  | .newtype _ baseType => valueTypeUsesDynamicData baseType
+  | .adt _ _ => false  -- ADTs are stored as tag + fixed-width slots, not dynamic
+  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool | .unit => false
+
 private def classifyWordArithmeticResultType
     (stx : Syntax)
     (context : String)
@@ -1451,14 +1459,14 @@ private partial def structFieldPath?
 
 private def paramStructProjectionResolved?
     (params : Array ParamDecl)
-    (stx : Term) : Option (String × ValueType) := do
+    (stx : Term) : Option (String × ValueType × ValueType) := do
   let resolve (rootName : String) (path : List String) := do
     let param ← params.find? (fun p => p.name == rootName)
     let (fieldTy, indices) ← structFieldPath? param.ty path
     if indices.isEmpty then
       none
     else
-      some (String.intercalate "_" (rootName :: indices.map toString), fieldTy)
+      some (String.intercalate "_" (rootName :: indices.map toString), fieldTy, param.ty)
   match (stripParens stx).raw with
   | .ident _ raw _ _ =>
       let parts := raw.toString.splitOn "."
@@ -1481,20 +1489,29 @@ private def paramStructProjectionResolved?
 private def paramStructProjection?
     (params : Array ParamDecl)
     (stx : Term) : Option (String × ValueType) := do
-  let (paramName, fieldTy) ← paramStructProjectionResolved? params stx
-  if isSingleWordStaticValueType fieldTy then
+  let (paramName, fieldTy, rootTy) ← paramStructProjectionResolved? params stx
+  if isSingleWordStaticValueType fieldTy && !valueTypeUsesDynamicData rootTy then
     some (paramName, fieldTy)
   else
     none
 
 private def isParamStructNonLeafProjection (params : Array ParamDecl) (stx : Term) : Bool :=
   match paramStructProjectionResolved? params stx with
-  | some (_, fieldTy) => !isSingleWordStaticValueType fieldTy
+  | some (_, fieldTy, _) => !isSingleWordStaticValueType fieldTy
+  | none => false
+
+private def isParamStructDynamicRootProjection (params : Array ParamDecl) (stx : Term) : Bool :=
+  match paramStructProjectionResolved? params stx with
+  | some (_, fieldTy, rootTy) => isSingleWordStaticValueType fieldTy && valueTypeUsesDynamicData rootTy
   | none => false
 
 private def throwStructNonLeafProjectionError (stx : Term) : CommandElabM α :=
   throwErrorAt stx
     "non-leaf struct parameter projection is not supported; project a scalar or static single-word leaf field instead"
+
+private def throwStructDynamicRootProjectionError (stx : Term) : CommandElabM α :=
+  throwErrorAt stx
+    "struct parameter projection from an ABI-dynamic root is not supported; use a static struct parameter or wait for nested-dynamic ABI decoding"
 
 private def renderValueType (ty : ValueType) : String :=
   reprStr ty
@@ -1642,13 +1659,8 @@ private def requireDeclaredValueType
     throwErrorAt stx
       s!"{context} expects {renderValueType expectedTy}, got {renderValueType actualTy}"
 
-private partial def localBindingUsesDynamicData : ValueType → Bool
-  | .string | .bytes | .array _ => true
-  | .tuple elemTys => elemTys.any localBindingUsesDynamicData
-  | .struct _ fields => fields.any (fun field => localBindingUsesDynamicData field.snd)
-  | .newtype _ baseType => localBindingUsesDynamicData baseType
-  | .adt _ _ => false  -- ADTs are stored as tag + fixed-width slots, not dynamic
-  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool | .unit => false
+private def localBindingUsesDynamicData : ValueType → Bool :=
+  valueTypeUsesDynamicData
 
 private def requireSupportedLocalBindingType
     (stx : Syntax)
@@ -1769,6 +1781,9 @@ private partial def inferPureExprType
           if matchesBareName p.name name then some p.ty else none) with
     | some ty => pure ty
     | none => throwPureContextAccessorError stx name
+  if isParamStructDynamicRootProjection params stx then
+    throwStructDynamicRootProjectionError stx
+  else
   if isParamStructNonLeafProjection params stx then
     throwStructNonLeafProjectionError stx
   else
@@ -2404,6 +2419,9 @@ partial def translatePureExprWithTypes
     (visitingConstants : List String := []) : CommandElabM Term := do
   let stx := stripParens stx
   let localNames := typedLocalNames locals
+  if isParamStructDynamicRootProjection params stx then
+    throwStructDynamicRootProjectionError stx
+  else
   if isParamStructNonLeafProjection params stx then
     throwStructNonLeafProjectionError stx
   else

--- a/artifacts/macro_property_tests/PropertyNamedStructParamSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyNamedStructParamSmoke.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyNamedStructParamSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyNamedStructParamSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("NamedStructParamSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `readBorrowFee` result
+    function testTODO_ReadBorrowFee_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("readBorrowFee((uint256,uint256))", abi.decode(abi.encode(uint256(1), uint256(1)), (uint256, uint256))));
+        require(ok, "readBorrowFee reverted unexpectedly");
+        assertEq(ret.length, 32, "readBorrowFee ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: storeNestedFee has no unexpected revert
+    function testAuto_StoreNestedFee_NoUnexpectedRevert() public {
+        vm.prank(alice);
+        (bool ok,) = target.call(abi.encodeWithSignature("storeNestedFee(((uint256,uint256),address),uint256)", abi.decode(abi.encode(abi.decode(abi.encode(uint256(1), uint256(1)), (uint256, uint256)), alice), ((uint256,uint256), address)), uint256(1)));
+        require(ok, "storeNestedFee reverted unexpectedly");
+    }
+    // Property 3: TODO decode and assert `readNestedMaker` result
+    function testTODO_ReadNestedMaker_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("readNestedMaker(((uint256,uint256),address))", abi.decode(abi.encode(abi.decode(abi.encode(uint256(1), uint256(1)), (uint256, uint256)), alice), ((uint256,uint256), address))));
+        require(ok, "readNestedMaker reverted unexpectedly");
+        assertEq(ret.length, 32, "readNestedMaker ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,6 +87,7 @@ Recent progress for low-level calls + returndata handling (`#622`):
 
 Recent progress for dynamic ABI-shaped parameters:
 - `verity_contract` now accepts dynamic array parameters whose element type is a static tuple of ABI words, e.g. `Array (Tuple [Uint256, Uint256, Int256])`, on tuple destructuring and tuple-return `arrayElement` paths. Those paths lower to checked word reads with the tuple element stride, which covers Solidity memory arrays of small fixed-size structs such as `CurveCut[]`; plain scalar `arrayElement` remains limited to single-word static element arrays.
+- `verity_contract` now accepts named `struct` declarations for function parameters as ABI tuple aliases. Executable contracts get Lean structures and field projection syntax, while the compilation model keeps the existing tuple ABI lowering. Nested static struct fields are supported for parameter field reads, covering the #1750 TermMax-style `config.feeConfig.borrowTakerFeeRatio` shape.
 - ABI artifact emission now reflects explicit function mutability markers (`isView`, `isPure`) as `stateMutability: "view" | "pure"` in generated JSON.
 
 Recent progress for custom errors (`#586`):

--- a/scripts/generate_macro_property_tests.py
+++ b/scripts/generate_macro_property_tests.py
@@ -29,6 +29,7 @@ PARAM_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$")
 NEWTYPE_RE = re.compile(
     r"^\s*([A-Z][A-Za-z0-9_]*)\s*:\s*([A-Za-z0-9_]+)\s*$",
 )
+STRUCT_RE = re.compile(r"^\s*struct\s+([A-Za-z_][A-Za-z0-9_]*)\s+where\s*(.*?)\s*$")
 STORAGE_RE = re.compile(
     r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*:=\s*slot\s+([0-9]+)\s*$",
 )
@@ -158,6 +159,29 @@ def _normalize_type(type_src: str) -> str:
     return " ".join(type_src.strip().split())
 
 
+def _strip_lean_comments(src: str, in_block_comment: bool = False) -> tuple[str, bool]:
+    """Strip Lean line and block comments from a struct field list fragment."""
+    out: list[str] = []
+    i = 0
+    while i < len(src):
+        if in_block_comment:
+            end = src.find("-/", i)
+            if end == -1:
+                return "".join(out).rstrip(), True
+            i = end + 2
+            in_block_comment = False
+            continue
+        if src.startswith("--", i):
+            break
+        if src.startswith("/-", i):
+            in_block_comment = True
+            i += 2
+            continue
+        out.append(src[i])
+        i += 1
+    return "".join(out).rstrip(), in_block_comment
+
+
 def _split_params(params_src: str) -> tuple[ParamDecl, ...]:
     if not params_src.strip():
         return ()
@@ -191,21 +215,36 @@ def _split_params(params_src: str) -> tuple[ParamDecl, ...]:
     return tuple(out)
 
 
-def _resolve_newtypes_in_params(
-    params: tuple[ParamDecl, ...], newtypes: dict[str, str]
-) -> tuple[ParamDecl, ...]:
-    """Replace newtype names with their base types in param declarations."""
-    if not newtypes:
-        return params
-    return tuple(
-        ParamDecl(name=p.name, lean_type=newtypes.get(p.lean_type, p.lean_type))
-        for p in params
-    )
-
-
 def _resolve_newtype(ty: str, newtypes: dict[str, str]) -> str:
     """Replace a newtype name with its base type if found."""
     return newtypes.get(ty, ty)
+
+
+def _resolve_decl_type(ty: str, newtypes: dict[str, str], structs: dict[str, tuple[ParamDecl, ...]]) -> str:
+    """Resolve macro-local aliases into the tuple-shaped type syntax used by this generator."""
+    normalized = _resolve_newtype(_normalize_type(ty), newtypes)
+    if normalized in structs:
+        elems = [_resolve_decl_type(field.lean_type, newtypes, structs) for field in structs[normalized]]
+        return f"Tuple [{', '.join(elems)}]"
+    if normalized.startswith("Array "):
+        elem = normalized[len("Array ") :].strip()
+        return f"Array {_resolve_decl_type(elem, newtypes, structs)}"
+    if normalized.startswith("Tuple [") and normalized.endswith("]"):
+        inner = normalized[len("Tuple [") : -1]
+        elems = [_resolve_decl_type(elem, newtypes, structs) for elem in _parse_tuple_elements(inner)]
+        return f"Tuple [{', '.join(elems)}]"
+    return normalized
+
+
+def _resolve_decl_types_in_params(
+    params: tuple[ParamDecl, ...],
+    newtypes: dict[str, str],
+    structs: dict[str, tuple[ParamDecl, ...]],
+) -> tuple[ParamDecl, ...]:
+    return tuple(
+        ParamDecl(name=p.name, lean_type=_resolve_decl_type(p.lean_type, newtypes, structs))
+        for p in params
+    )
 
 
 def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
@@ -215,6 +254,10 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
     current_storage_slots: dict[str, int] = {}
     current_storage_types: dict[str, str] = {}
     current_newtypes: dict[str, str] = {}
+    current_structs: dict[str, tuple[ParamDecl, ...]] = {}
+    current_struct_name: str | None = None
+    current_struct_fields: list[ParamDecl] = []
+    current_struct_block_comment = False
     current_constants: dict[str, ValueDecl] = {}
     current_immutables: dict[str, ValueDecl] = {}
     current_functions: list[FunctionDecl] = []
@@ -226,6 +269,15 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
     in_constants_block = False
     in_immutables_block = False
     pending_storage_lines: list[str] = []
+
+    def flush_struct() -> None:
+        nonlocal current_struct_name, current_struct_fields, current_struct_block_comment
+        if current_struct_name is None:
+            return
+        current_structs[current_struct_name] = tuple(current_struct_fields)
+        current_struct_name = None
+        current_struct_fields = []
+        current_struct_block_comment = False
 
     def flush_function() -> None:
         nonlocal current_function, current_body
@@ -243,9 +295,10 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
         current_body = []
 
     def flush_current() -> None:
-        nonlocal current_name, current_constructor, current_storage_slots, current_storage_types, current_newtypes, current_constants, current_immutables, current_functions, in_types_block, in_storage_block, in_constants_block, in_immutables_block, pending_storage_lines
+        nonlocal current_name, current_constructor, current_storage_slots, current_storage_types, current_newtypes, current_structs, current_constants, current_immutables, current_functions, in_types_block, in_storage_block, in_constants_block, in_immutables_block, pending_storage_lines, current_struct_block_comment
         if current_name is None:
             return
+        flush_struct()
         flush_function()
         contracts[current_name] = ContractDecl(
             name=current_name,
@@ -263,9 +316,11 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
         current_storage_slots = {}
         current_storage_types = {}
         current_newtypes = {}
+        current_structs = {}
         current_constants = {}
         current_immutables = {}
         current_functions = []
+        current_struct_block_comment = False
         in_types_block = False
         in_storage_block = False
         in_constants_block = False
@@ -294,6 +349,21 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
         if current_name is None:
             continue
 
+        if current_struct_name is not None:
+            field_src, current_struct_block_comment = _strip_lean_comments(
+                line.strip(), current_struct_block_comment
+            )
+            if not field_src.strip():
+                continue
+            try:
+                fields = _split_params(field_src)
+            except ValueError:
+                fields = ()
+            if fields:
+                current_struct_fields.extend(fields)
+                continue
+            flush_struct()
+
         if current_function is not None and line.strip() and not line.startswith("    "):
             flush_function()
 
@@ -316,6 +386,7 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
                 # fall through to check other sections
 
         if line.strip() == "storage":
+            flush_struct()
             in_types_block = False
             in_storage_block = True
             in_constants_block = False
@@ -324,6 +395,7 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
             continue
 
         if line.strip() == "constants":
+            flush_struct()
             in_storage_block = False
             in_constants_block = True
             in_immutables_block = False
@@ -331,18 +403,46 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
             continue
 
         if line.strip() == "immutables":
+            flush_struct()
             in_storage_block = False
             in_constants_block = False
             in_immutables_block = True
             pending_storage_lines = []
             continue
 
+        sm = STRUCT_RE.match(line)
+        if sm:
+            flush_function()
+            flush_struct()
+            inline_fields, current_struct_block_comment = _strip_lean_comments(sm.group(2).strip())
+            if inline_fields:
+                current_struct_fields = list(_split_params(inline_fields))
+                if current_struct_block_comment:
+                    current_struct_name = sm.group(1)
+                else:
+                    current_structs[sm.group(1)] = tuple(current_struct_fields)
+                    current_struct_fields = []
+            else:
+                current_struct_name = sm.group(1)
+                current_struct_fields = []
+            in_types_block = False
+            in_storage_block = False
+            in_constants_block = False
+            in_immutables_block = False
+            pending_storage_lines = []
+            continue
+
         ctor = CONSTRUCTOR_RE.match(line)
         if ctor:
             flush_function()
+            flush_struct()
             if current_constructor is not None:
                 raise ValueError(f"duplicate constructor in contract '{current_name}'")
-            current_constructor = ConstructorDecl(params=_resolve_newtypes_in_params(_split_params(ctor.group(1)), current_newtypes))
+            current_constructor = ConstructorDecl(
+                params=_resolve_decl_types_in_params(
+                    _split_params(ctor.group(1)), current_newtypes, current_structs
+                )
+            )
             in_types_block = False
             in_storage_block = False
             in_constants_block = False
@@ -352,12 +452,15 @@ def parse_contracts(text: str, source: Path) -> dict[str, ContractDecl]:
         fm = FUNCTION_RE.match(line)
         if fm:
             flush_function()
+            flush_struct()
             fn_name = fm.group(1)
             params_src = fm.group(2)
-            ret_ty = _resolve_newtype(_normalize_type(fm.group(3)), current_newtypes)
+            ret_ty = _resolve_decl_type(fm.group(3), current_newtypes, current_structs)
             current_function = FunctionDecl(
                 name=fn_name,
-                params=_resolve_newtypes_in_params(_split_params(params_src), current_newtypes),
+                params=_resolve_decl_types_in_params(
+                    _split_params(params_src), current_newtypes, current_structs
+                ),
                 return_type=ret_ty,
             )
             in_storage_block = False

--- a/scripts/test_generate_macro_property_tests.py
+++ b/scripts/test_generate_macro_property_tests.py
@@ -47,6 +47,62 @@ class ParseContractsTests(unittest.TestCase):
         out = gen._split_params("to : Address, amount : Uint256")
         self.assertEqual([(p.name, p.lean_type) for p in out], [("to", "Address"), ("amount", "Uint256")])
 
+    def test_parse_inline_struct_param_as_tuple(self) -> None:
+        src = textwrap.dedent(
+            """
+            verity_contract StructConsumer where
+              storage
+
+              struct feeConfig where borrowTakerFeeRatio : Uint256, /- inline block comment -/ lendMakerFeeRatio : Uint256 -- inline comment
+
+              function readBorrowFee (feeConfig : feeConfig) : Uint256 := do
+                return feeConfig.borrowTakerFeeRatio
+            """
+        )
+        parsed = gen.parse_contracts(src, Path("dummy.lean"))
+        fn = parsed["StructConsumer"].functions[0]
+        self.assertEqual(
+            [(p.name, p.lean_type) for p in fn.params],
+            [("feeConfig", "Tuple [Uint256, Uint256]")],
+        )
+
+    def test_parse_nested_multiline_struct_param_as_tuple(self) -> None:
+        src = textwrap.dedent(
+            """
+            verity_contract StructConsumer where
+              storage
+
+              struct FeeConfig where
+                borrowTakerFeeRatio : Uint256, rebateRatio : Uint256, -- inline comment
+                -- comments inside struct declarations should not end the struct
+                /-- block comments inside struct declarations should not end the struct -/
+                /-
+                multiline block comments should be skipped as well
+                -/ makerFeeRatio : Uint256,
+                /- inline block comment -/ lenderRebateRatio : Uint256, /- between fields -/ borrowerRebateRatio : Uint256,
+                lendMakerFeeRatio : Uint256
+
+              struct OrderConfig where
+                feeConfig : FeeConfig,
+                maker : Address
+
+              function storeNestedFee (config : OrderConfig, key : Uint256) : Unit := do
+                pure ()
+            """
+        )
+        parsed = gen.parse_contracts(src, Path("dummy.lean"))
+        fn = parsed["StructConsumer"].functions[0]
+        self.assertEqual(
+            [(p.name, p.lean_type) for p in fn.params],
+            [
+                (
+                    "config",
+                    "Tuple [Tuple [Uint256, Uint256, Uint256, Uint256, Uint256, Uint256], Address]",
+                ),
+                ("key", "Uint256"),
+            ],
+        )
+
     def test_parse_constructor(self) -> None:
         src = textwrap.dedent(
             """


### PR DESCRIPTION
## Summary
- add contract-local `struct` declarations to `verity_contract` and lower them as ABI tuple aliases
- generate Lean structures for executable contract bodies and support direct/nested field projections on struct parameters
- add NamedStructParamSmoke coverage, macro signature/selector snapshots, round-trip fuzz coverage, generated Foundry property artifact, and roadmap note

Closes #1750.
Advances #1760.

## Validation
- `lake build Verity.Macro.Translate Verity.Macro.Elaborate`
- `lake build Contracts.Smoke`
- `lake build Contracts.MacroTranslateInvariantTest`
- `lake build Contracts.MacroTranslateRoundTripFuzz`
- `lake build Contracts Compiler PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_macro_health.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core macro elaboration/type parsing and expression translation, so regressions could affect ABI typing or parameter lowering across many contracts despite added smoke/fuzz coverage.
> 
> **Overview**
> `verity_contract` now supports contract-local `struct` declarations that elaborate to Lean `structure`s for executable use while compiling as ABI tuple aliases, including support for direct and nested *leaf* field projections on struct parameters.
> 
> The macro/type system is extended with a `ValueType.struct` branch, updated signature/ABI key generation, parsing/validation (duplicate names, shadowing), and explicit restrictions (no struct-typed storage fields, no struct return types, and clear errors for non-leaf or ABI-dynamic-root projections).
> 
> Test coverage is expanded with a new `NamedStructParamSmoke` contract plus invariant and round-trip fuzz inclusion, pinned signature/selector snapshots, an auto-generated Foundry property-test stub, and updates to the property-test generator to parse `struct ... where ...` blocks (including comment handling) and resolve struct types into tuple-shaped ABI types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef553e7b4652f323ed2ac8f4d140ba231dad1f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->