### PR TITLE
proofs: add native assignment preservation constructors

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -4376,6 +4376,63 @@ theorem NativeStmtPreservesWord_lowerAssignNative_lit_of_ne
         (EvmYul.UInt256.ofNat assigned) hne]
       exact hLookup
 
+theorem NativeStmtPreservesWord_lowerAssignNative_hex_of_ne
+    (name target : EvmYul.Identifier)
+    (expected : EvmYul.Literal)
+    (assigned : Nat)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hne : name ≠ target) :
+    NativeStmtPreservesWord name expected
+      (Backends.lowerAssignNative target (.hex assigned)) codeOverride := by
+  intro fuel state final hLookup hExec
+  cases fuel with
+  | zero =>
+      simp [EvmYul.Yul.exec] at hExec
+  | succ fuel' =>
+      simp [Backends.lowerAssignNative, Backends.lowerExprNative] at hExec
+      cases hExec
+      rw [state_getElem_insert_of_ne state name target
+        (EvmYul.UInt256.ofNat assigned) hne]
+      exact hLookup
+
+theorem NativeStmtPreservesWord_lowerAssignNative_ident_of_ne
+    (name target source : EvmYul.Identifier)
+    (expected : EvmYul.Literal)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hne : name ≠ target) :
+    NativeStmtPreservesWord name expected
+      (Backends.lowerAssignNative target (.ident source)) codeOverride := by
+  intro fuel state final hLookup hExec
+  cases fuel with
+  | zero =>
+      simp [EvmYul.Yul.exec] at hExec
+  | succ fuel' =>
+      have hFinal : state.insert target state[source]! = final := by
+        simpa [Backends.lowerAssignNative, Backends.lowerExprNative,
+          EvmYul.Yul.exec] using hExec
+      subst final
+      rw [state_getElem_insert_of_ne state name target state[source]! hne]
+      exact hLookup
+
+theorem NativeStmtPreservesWord_lowerAssignNative_str_of_ne
+    (name target source : EvmYul.Identifier)
+    (expected : EvmYul.Literal)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hne : name ≠ target) :
+    NativeStmtPreservesWord name expected
+      (Backends.lowerAssignNative target (.str source)) codeOverride := by
+  intro fuel state final hLookup hExec
+  cases fuel with
+  | zero =>
+      simp [EvmYul.Yul.exec] at hExec
+  | succ fuel' =>
+      have hFinal : state.insert target state[source]! = final := by
+        simpa [Backends.lowerAssignNative, Backends.lowerExprNative,
+          EvmYul.Yul.exec] using hExec
+      subst final
+      rw [state_getElem_insert_of_ne state name target state[source]! hne]
+      exact hLookup
+
 theorem NativeStmtPreservesWord_let_none_of_not_mem
     (name : EvmYul.Identifier)
     (expected : EvmYul.Literal)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3113,6 +3113,9 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_self
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_lit_of_ne
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_hex_of_ne
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_ident_of_ne
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_str_of_ne
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_let_none_of_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_let_var_of_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_let_lit_of_not_mem
@@ -3593,4 +3596,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3417 theorems/lemmas (2473 public, 944 private, 0 sorry'd)
+-- Total: 3420 theorems/lemmas (2476 public, 944 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
+++ b/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
@@ -132,9 +132,10 @@ N8 public Layer 3 theorem flip
 - **Depends on**: N0, N3
 - **Blocks**: N5, N6
 - **Status**: `NativeBlockPreservesWord`, singleton/block-lift/if composition,
-  list-level composition from per-statement preservation, and selected
-  freshness projection lemmas exist; general preservation from
-  `nativeStmtsWriteNames` freshness is not complete.
+  list-level composition from per-statement preservation, selected freshness
+  projection lemmas, and assignment constructors for literal/hex/identifier
+  RHS forms exist; general preservation from `nativeStmtsWriteNames`
+  freshness is not complete.
 - **Definition of done**:
   - If a generated native body does not write a dispatcher temp, native
     execution preserves that temp.

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -324,6 +324,9 @@ scope so the native path does not look more complete than it is:
   `NativeBlockPreservesWord_of_forall_stmt`,
   `NativeStmtPreservesWord_block`,
   `NativeStmtPreservesWord_if_of_eval_self`,
+  `NativeStmtPreservesWord_lowerAssignNative_hex_of_ne`,
+  `NativeStmtPreservesWord_lowerAssignNative_ident_of_ne`,
+  `NativeStmtPreservesWord_lowerAssignNative_str_of_ne`,
   `nativeSwitchTempsFreshForNativeBodies_find_hit_matched_not_mem`, and
   `nativeSwitchTempsFreshForNativeBodies_default_matched_not_mem`; the next
   proof step is the statement induction that derives those preservation

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -204,6 +204,9 @@ def check_public_theorem_target(
         "theorem NativeBlockPreservesWord_of_forall_stmt",
         "theorem NativeStmtPreservesWord_block",
         "theorem NativeStmtPreservesWord_if_of_eval_self",
+        "theorem NativeStmtPreservesWord_lowerAssignNative_hex_of_ne",
+        "theorem NativeStmtPreservesWord_lowerAssignNative_ident_of_ne",
+        "theorem NativeStmtPreservesWord_lowerAssignNative_str_of_ne",
     ):
         if required_native_entrypoint not in normalized_native_harness:
             errors.append(


### PR DESCRIPTION
## Summary
- add N4 `NativeStmtPreservesWord` constructors for native assignment lowering with hex, identifier, and string RHS forms
- pin the new native proof surface in the transition docs and doc checker
- regenerate `PrintAxioms.lean`

## Validation
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanRetarget`
- `lake build Compiler.Proofs.EndToEnd`
- `lake build Compiler`
- `lake build Contracts`
- `lake build PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a918fa3378fb31cb43677ed6be7d9f0e5fd05e45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->