### PR TITLE
docs: guard native let preservation surface

### DIFF
--- a/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
+++ b/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
@@ -133,8 +133,9 @@ N8 public Layer 3 theorem flip
 - **Blocks**: N5, N6
 - **Status**: `NativeBlockPreservesWord`, singleton/block-lift/if composition,
   list-level composition from per-statement preservation, selected freshness
-  projection lemmas, and assignment constructors for literal/hex/identifier
-  RHS forms exist; general preservation from `nativeStmtsWriteNames`
+  projection lemmas, assignment constructors for literal/hex/identifier/string
+  RHS forms, and generated `let` constructors for omitted, variable, and literal
+  initializers exist; general preservation from `nativeStmtsWriteNames`
   freshness is not complete.
 - **Definition of done**:
   - If a generated native body does not write a dispatcher temp, native

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -324,9 +324,13 @@ scope so the native path does not look more complete than it is:
   `NativeBlockPreservesWord_of_forall_stmt`,
   `NativeStmtPreservesWord_block`,
   `NativeStmtPreservesWord_if_of_eval_self`,
+  `NativeStmtPreservesWord_lowerAssignNative_lit_of_ne`,
   `NativeStmtPreservesWord_lowerAssignNative_hex_of_ne`,
   `NativeStmtPreservesWord_lowerAssignNative_ident_of_ne`,
   `NativeStmtPreservesWord_lowerAssignNative_str_of_ne`,
+  `NativeStmtPreservesWord_let_none_of_not_mem`,
+  `NativeStmtPreservesWord_let_var_of_not_mem`,
+  `NativeStmtPreservesWord_let_lit_of_not_mem`,
   `nativeSwitchTempsFreshForNativeBodies_find_hit_matched_not_mem`, and
   `nativeSwitchTempsFreshForNativeBodies_default_matched_not_mem`; the next
   proof step is the statement induction that derives those preservation

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -204,9 +204,13 @@ def check_public_theorem_target(
         "theorem NativeBlockPreservesWord_of_forall_stmt",
         "theorem NativeStmtPreservesWord_block",
         "theorem NativeStmtPreservesWord_if_of_eval_self",
+        "theorem NativeStmtPreservesWord_lowerAssignNative_lit_of_ne",
         "theorem NativeStmtPreservesWord_lowerAssignNative_hex_of_ne",
         "theorem NativeStmtPreservesWord_lowerAssignNative_ident_of_ne",
         "theorem NativeStmtPreservesWord_lowerAssignNative_str_of_ne",
+        "theorem NativeStmtPreservesWord_let_none_of_not_mem",
+        "theorem NativeStmtPreservesWord_let_var_of_not_mem",
+        "theorem NativeStmtPreservesWord_let_lit_of_not_mem",
     ):
         if required_native_entrypoint not in normalized_native_harness:
             errors.append(


### PR DESCRIPTION
## Summary

- Pin the already-proved native preservation constructors for literal assignments and generated `let` statements in the native transition checker.
- Update the native transition docs / done graph so N4 status reflects the current preservation surface.

## Validation

- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_docs_workflow_sync.py`
- `make check` (600/600)

## Transition scope

This is a narrow native EVMYulLean transition doc/CI guard PR. It does not change public theorem hypotheses or route any proof through the custom interpreter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/CI-guard only; it tightens required text/symbol checks without changing runtime behavior or proof logic.
> 
> **Overview**
> Updates the native EVMYulLean transition docs to reflect newly available preservation constructors, expanding N4 status to include string RHS assignments and generated `let` initializers.
> 
> Strengthens `check_native_transition_doc.py` to require the native harness expose the corresponding preservation theorems (including `NativeStmtPreservesWord_lowerAssignNative_lit_of_ne` and `NativeStmtPreservesWord_let_*_of_not_mem`), preventing doc/CI drift as the native transition proof surface evolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20873d807f095058f11770339056bad90b724a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->