### PR TITLE
proofs: add native block write-freshness plumbing

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -4318,6 +4318,23 @@ theorem NativeBlockPreservesWord_of_forall_stmt
           intro stmt' hmem
           exact hPreserves stmt' (by simp [hmem]))
 
+theorem NativeBlockPreservesWord_of_forall_stmt_write_not_mem
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (body : List EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hFresh :
+      ∀ stmt, stmt ∈ body → name ∉ Backends.nativeStmtWriteNames stmt)
+    (hPreserves :
+      ∀ stmt, stmt ∈ body →
+        name ∉ Backends.nativeStmtWriteNames stmt →
+          NativeStmtPreservesWord name value stmt codeOverride) :
+    NativeBlockPreservesWord name value body codeOverride :=
+  NativeBlockPreservesWord_of_forall_stmt name value body codeOverride
+    (by
+      intro stmt hmem
+      exact hPreserves stmt hmem (hFresh stmt hmem))
+
 theorem NativeStmtPreservesWord_block
     (name : EvmYul.Identifier)
     (value : EvmYul.Literal)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3110,6 +3110,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_cons_stmt
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_singleton
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_forall_stmt
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_forall_stmt_write_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_self
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_lit_of_ne
@@ -3596,4 +3597,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3420 theorems/lemmas (2476 public, 944 private, 0 sorry'd)
+-- Total: 3421 theorems/lemmas (2477 public, 944 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -322,6 +322,7 @@ scope so the native path does not look more complete than it is:
   `NativeBlockPreservesWord_cons`,
   `NativeBlockPreservesWord_singleton`,
   `NativeBlockPreservesWord_of_forall_stmt`,
+  `NativeBlockPreservesWord_of_forall_stmt_write_not_mem`,
   `NativeStmtPreservesWord_block`,
   `NativeStmtPreservesWord_if_of_eval_self`,
   `NativeStmtPreservesWord_lowerAssignNative_lit_of_ne`,

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -202,6 +202,7 @@ def check_public_theorem_target(
         "def generatedRuntimeFunctionBodiesHaveNoNestedFuncDefs",
         "theorem NativeBlockPreservesWord_singleton",
         "theorem NativeBlockPreservesWord_of_forall_stmt",
+        "theorem NativeBlockPreservesWord_of_forall_stmt_write_not_mem",
         "theorem NativeStmtPreservesWord_block",
         "theorem NativeStmtPreservesWord_if_of_eval_self",
         "theorem NativeStmtPreservesWord_lowerAssignNative_lit_of_ne",


### PR DESCRIPTION
## Summary

- add `NativeBlockPreservesWord_of_forall_stmt_write_not_mem`, a block-level N4 preservation combinator that threads per-statement native write-freshness into `NativeBlockPreservesWord`
- pin the new native preservation surface in the transition doc and transition doc checker
- regenerate `PrintAxioms.lean`

## Validation

- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness Compiler.Proofs.YulGeneration.Backends.EvmYulLeanRetarget Compiler.Proofs.EndToEnd`
- `lake build Compiler Contracts PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `make check` (600 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small, additive lemma and updates documentation/check scripts; no runtime or code generation behavior changes.
> 
> **Overview**
> Adds `NativeBlockPreservesWord_of_forall_stmt_write_not_mem`, a new proof combinator that derives block-level word preservation by threading a per-statement “does not write `name`” freshness premise into existing `NativeBlockPreservesWord_of_forall_stmt`.
> 
> Updates the native transition surface bookkeeping to include this theorem (docs, `check_native_transition_doc.py`), and regenerates `PrintAxioms.lean` to print the new axiom set/count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561040ee6ca9c6fa6524478d6039d9f5dfd4ac86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->