### PR TITLE
proofs: generalize native if word preservation

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -4374,6 +4374,38 @@ theorem NativeStmtPreservesWord_if_of_eval_self
         cases hExec
         exact hLookup
 
+theorem NativeStmtPreservesWord_if_of_eval_preserves
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (cond : EvmYul.Yul.Ast.Expr)
+    (body : List EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hCond :
+      ∀ fuel state,
+        state[name]! = value →
+          ∃ condState condValue,
+            EvmYul.Yul.eval fuel cond codeOverride state =
+              .ok (condState, condValue) ∧
+            condState[name]! = value)
+    (hBody : NativeBlockPreservesWord name value body codeOverride) :
+    NativeStmtPreservesWord name value (.If cond body) codeOverride := by
+  intro fuel state final hLookup hExec
+  cases fuel with
+  | zero =>
+      simp [EvmYul.Yul.exec] at hExec
+  | succ fuel' =>
+      rcases hCond fuel' state hLookup with
+        ⟨condState, condValue, hEval, hCondLookup⟩
+      simp [EvmYul.Yul.exec, hEval] at hExec
+      by_cases hCondNonzero : condValue ≠ ⟨0⟩
+      · simp [hCondNonzero] at hExec
+        exact hBody fuel' condState final hCondLookup hExec
+      · have hCondZero : condValue = ⟨0⟩ := by
+          exact Decidable.not_not.mp hCondNonzero
+        simp [hCondZero] at hExec
+        cases hExec
+        exact hCondLookup
+
 theorem NativeStmtPreservesWord_lowerAssignNative_lit_of_ne
     (name target : EvmYul.Identifier)
     (expected : EvmYul.Literal)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3113,6 +3113,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_forall_stmt_write_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_self
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_preserves
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_lit_of_ne
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_hex_of_ne
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_lowerAssignNative_ident_of_ne
@@ -3597,4 +3598,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3421 theorems/lemmas (2477 public, 944 private, 0 sorry'd)
+-- Total: 3422 theorems/lemmas (2478 public, 944 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
+++ b/docs/NATIVE_EVMYULLEAN_DONE_GRAPH.md
@@ -131,8 +131,9 @@ N8 public Layer 3 theorem flip
 - **Urgency**: P0, highest current bottleneck
 - **Depends on**: N0, N3
 - **Blocks**: N5, N6
-- **Status**: `NativeBlockPreservesWord`, singleton/block-lift/if composition,
-  list-level composition from per-statement preservation, selected freshness
+- **Status**: `NativeBlockPreservesWord`, singleton/block-lift/if composition
+  including condition evaluations that preserve the tracked word, list-level
+  composition from per-statement preservation, selected freshness
   projection lemmas, assignment constructors for literal/hex/identifier/string
   RHS forms, and generated `let` constructors for omitted, variable, and literal
   initializers exist; general preservation from `nativeStmtsWriteNames`

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -325,6 +325,7 @@ scope so the native path does not look more complete than it is:
   `NativeBlockPreservesWord_of_forall_stmt_write_not_mem`,
   `NativeStmtPreservesWord_block`,
   `NativeStmtPreservesWord_if_of_eval_self`,
+  `NativeStmtPreservesWord_if_of_eval_preserves`,
   `NativeStmtPreservesWord_lowerAssignNative_lit_of_ne`,
   `NativeStmtPreservesWord_lowerAssignNative_hex_of_ne`,
   `NativeStmtPreservesWord_lowerAssignNative_ident_of_ne`,

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -205,6 +205,7 @@ def check_public_theorem_target(
         "theorem NativeBlockPreservesWord_of_forall_stmt_write_not_mem",
         "theorem NativeStmtPreservesWord_block",
         "theorem NativeStmtPreservesWord_if_of_eval_self",
+        "theorem NativeStmtPreservesWord_if_of_eval_preserves",
         "theorem NativeStmtPreservesWord_lowerAssignNative_lit_of_ne",
         "theorem NativeStmtPreservesWord_lowerAssignNative_hex_of_ne",
         "theorem NativeStmtPreservesWord_lowerAssignNative_ident_of_ne",


### PR DESCRIPTION
## Summary

- Add `NativeStmtPreservesWord_if_of_eval_preserves`, a native N4 preservation constructor for `if` statements whose condition evaluation may return a different state while preserving the tracked word.
- Pin the new theorem in the native transition doc guard and transition docs.
- Regenerate `PrintAxioms.lean`.

## Validation

- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanRetarget`
- `lake build Compiler.Proofs.EndToEnd`
- `lake build Compiler`
- `lake build Contracts`
- `lake build PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `make check` (600 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean proof and documentation/verification-script updates only; no runtime semantics or codegen behavior changes.
> 
> **Overview**
> Adds `NativeStmtPreservesWord_if_of_eval_preserves`, a new N4 proof constructor for native `if` statements that allows the condition evaluation to return a *different* intermediate state while still preserving the tracked identifier’s value (and threads that state into the body proof).
> 
> Updates `PrintAxioms.lean`, the native transition docs/graph, and `check_native_transition_doc.py` to include and verify the new theorem as part of the required native preservation algebra.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e50616aee659bbfa22fbd9b901756f225eb1ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->