### PR TITLE
Support qualified verity_contract helper calls

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -903,6 +903,19 @@ verity_contract QualifiedLibraryPureExprRejected where
     let ignored := TermMaxCurve.buyXt nif daysToMaturity oriXtReserve debtTokenAmtIn
     return nif
 
+/--
+error: tuple destructuring binds 3 names, but qualified helper 'TermMaxCurve.buyXt' returns 2 values
+-/
+#guard_msgs in
+verity_contract QualifiedLibraryTupleArityRejected where
+  storage
+
+  function badTupleBind (nif : Uint256, daysToMaturity : Uint256,
+      oriXtReserve : Uint256, debtTokenAmtIn : Uint256) : Uint256 := do
+    let (tokenAmtOut, deltaFt, extra) ←
+      TermMaxCurve.buyXt nif daysToMaturity oriXtReserve debtTokenAmtIn
+    return tokenAmtOut
+
 end MacroQualifiedLibraryCallSmoke
 
 namespace MacroStatelessSmoke

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -852,6 +852,19 @@ verity_contract TermMaxOrderV2 where
   function TermMaxCurve_buyXt (value : Uint256) : Uint256 := do
     return value
 
+verity_contract QualifiedPrimitiveLibrary where
+  storage
+
+  function uintIsAccepted (value : Uint256) : Bool := do
+    return value == value
+
+verity_contract QualifiedPrimitiveCaller where
+  storage
+
+  function callBoolHelper (value : Uint256) : Bool := do
+    let result ← QualifiedPrimitiveLibrary.uintIsAccepted value
+    return result
+
 private def qualifiedBuyXtInternalName : String :=
   "internal_qualified_12_TermMaxCurve_5_buyXt"
 
@@ -891,6 +904,14 @@ def qualifiedLibraryExecutableCallRuns : Bool :=
 
 example : qualifiedLibraryExecutableCallRuns = true := by native_decide
 
+def qualifiedLibraryBoolBindRuns : Bool :=
+  match QualifiedPrimitiveCaller.callBoolHelper 7 Verity.defaultState with
+  | .success result state =>
+      result == true && state.sender == Verity.defaultState.sender
+  | .revert _ _ => false
+
+example : qualifiedLibraryBoolBindRuns = true := by native_decide
+
 /--
 error: qualified library helper call 'TermMaxCurve.buyXt' is only supported as a monadic bind source; use `let x ← TermMaxCurve.buyXt ...` or tuple destructuring bind syntax
 -/
@@ -913,6 +934,19 @@ verity_contract QualifiedLibraryTupleArityRejected where
   function badTupleBind (nif : Uint256, daysToMaturity : Uint256,
       oriXtReserve : Uint256, debtTokenAmtIn : Uint256) : Uint256 := do
     let (tokenAmtOut, deltaFt, extra) ←
+      TermMaxCurve.buyXt nif daysToMaturity oriXtReserve debtTokenAmtIn
+    return tokenAmtOut
+
+/--
+error: qualified helper 'TermMaxCurve.buyXt' returns multiple values; use tuple destructuring
+-/
+#guard_msgs in
+verity_contract QualifiedLibraryTupleSimpleBindRejected where
+  storage
+
+  function badSimpleBind (nif : Uint256, daysToMaturity : Uint256,
+      oriXtReserve : Uint256, debtTokenAmtIn : Uint256) : Uint256 := do
+    let tokenAmtOut ←
       TermMaxCurve.buyXt nif daysToMaturity oriXtReserve debtTokenAmtIn
     return tokenAmtOut
 

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -849,7 +849,13 @@ verity_contract TermMaxOrderV2 where
       TermMaxCurve.buyXt nif daysToMaturity oriXtReserve debtTokenAmtIn
     return (tokenAmtOut, deltaFt)
 
-private def qualifiedBuyXtInternalName : String := "internal_TermMaxCurve_buyXt"
+  function TermMaxCurve_buyXt (value : Uint256) : Uint256 := do
+    return value
+
+private def qualifiedBuyXtInternalName : String :=
+  "internal_qualified_12_TermMaxCurve_5_buyXt"
+
+private def localUnderscoreInternalName : String := "internal_TermMaxCurve_buyXt"
 
 def buyXtStepModelUsesQualifiedInternalCall : Bool :=
   match TermMaxOrderV2.buyXtStep_modelBody with
@@ -867,6 +873,15 @@ def callerSpecIncludesQualifiedLibraryModel : Bool :=
     fn.name == qualifiedBuyXtInternalName && fn.isInternal
 
 example : callerSpecIncludesQualifiedLibraryModel = true := by native_decide
+
+def qualifiedHelperAvoidsLocalUnderscoreCollision : Bool :=
+  qualifiedBuyXtInternalName != localUnderscoreInternalName &&
+    TermMaxOrderV2.spec.functions.any (fun fn =>
+      fn.name == qualifiedBuyXtInternalName && fn.isInternal) &&
+    TermMaxOrderV2.spec.functions.any (fun fn =>
+      fn.name == localUnderscoreInternalName && fn.isInternal)
+
+example : qualifiedHelperAvoidsLocalUnderscoreCollision = true := by native_decide
 
 def qualifiedLibraryExecutableCallRuns : Bool :=
   match TermMaxOrderV2.buyXtStep 10 3 20 7 Verity.defaultState with

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -824,6 +824,60 @@ example : storeHelperPairTailNameCollisionExecutablePreservesParam = true := by 
 
 end MacroTupleDestructuringSmoke
 
+namespace MacroQualifiedLibraryCallSmoke
+
+open Contracts
+open Verity hiding pure bind
+open Verity.EVM.Uint256
+
+verity_contract TermMaxCurve where
+  storage
+
+  function buyXt (nif : Uint256, daysToMaturity : Uint256,
+      oriXtReserve : Uint256, debtTokenAmtIn : Uint256) :
+      Tuple [Uint256, Uint256] := do
+    return (add nif daysToMaturity, add oriXtReserve debtTokenAmtIn)
+
+verity_contract TermMaxOrderV2 where
+  storage
+    sentinel : Uint256 := slot 0
+
+  function buyXtStep (nif : Uint256, daysToMaturity : Uint256,
+      oriXtReserve : Uint256, debtTokenAmtIn : Uint256) :
+      Tuple [Uint256, Uint256] := do
+    let (tokenAmtOut, deltaFt) ←
+      TermMaxCurve.buyXt nif daysToMaturity oriXtReserve debtTokenAmtIn
+    return (tokenAmtOut, deltaFt)
+
+private def qualifiedBuyXtInternalName : String := "internal_TermMaxCurve_buyXt"
+
+def buyXtStepModelUsesQualifiedInternalCall : Bool :=
+  match TermMaxOrderV2.buyXtStep_modelBody with
+  | [Stmt.internalCallAssign ["tokenAmtOut", "deltaFt"] helperName
+        [Expr.param "nif", Expr.param "daysToMaturity",
+         Expr.param "oriXtReserve", Expr.param "debtTokenAmtIn"],
+      Stmt.returnValues [Expr.localVar "tokenAmtOut", Expr.localVar "deltaFt"]] =>
+      helperName == qualifiedBuyXtInternalName
+  | _ => false
+
+example : buyXtStepModelUsesQualifiedInternalCall = true := by native_decide
+
+def callerSpecIncludesQualifiedLibraryModel : Bool :=
+  TermMaxOrderV2.spec.functions.any fun fn =>
+    fn.name == qualifiedBuyXtInternalName && fn.isInternal
+
+example : callerSpecIncludesQualifiedLibraryModel = true := by native_decide
+
+def qualifiedLibraryExecutableCallRuns : Bool :=
+  match TermMaxOrderV2.buyXtStep 10 3 20 7 Verity.defaultState with
+  | .success (tokenAmtOut, deltaFt) state =>
+      tokenAmtOut == 13 && deltaFt == 27 && state.sender == Verity.defaultState.sender
+  | .revert _ _ => false
+
+example : qualifiedLibraryExecutableCallRuns = true := by native_decide
+
+end MacroQualifiedLibraryCallSmoke
+
 namespace MacroStatelessSmoke
 
 open Contracts

--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -891,6 +891,18 @@ def qualifiedLibraryExecutableCallRuns : Bool :=
 
 example : qualifiedLibraryExecutableCallRuns = true := by native_decide
 
+/--
+error: qualified library helper call 'TermMaxCurve.buyXt' is only supported as a monadic bind source; use `let x ← TermMaxCurve.buyXt ...` or tuple destructuring bind syntax
+-/
+#guard_msgs in
+verity_contract QualifiedLibraryPureExprRejected where
+  storage
+
+  function badPureCall (nif : Uint256, daysToMaturity : Uint256,
+      oriXtReserve : Uint256, debtTokenAmtIn : Uint256) : Uint256 := do
+    let ignored := TermMaxCurve.buyXt nif daysToMaturity oriXtReserve debtTokenAmtIn
+    return nif
+
 end MacroQualifiedLibraryCallSmoke
 
 namespace MacroStatelessSmoke

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -225,9 +225,25 @@ private def qualifiedFunctionModelName (name : Name) : Name :=
 private def qualifiedFunctionDisplayName (name : Name) : String :=
   String.intercalate "." (nameComponents name)
 
-private def qualifiedInternalHelperName (name : Name) : String :=
+private def internalHelperSpecNameFor (fn : FunctionDecl) : String :=
+  Compiler.CompilationModel.internalFunctionPrefix ++ toString fn.ident.getId
+
+private def qualifiedInternalHelperBaseName (name : Name) : String :=
+  let encodedComponents :=
+    nameComponents name |>.map fun component =>
+      s!"{component.length}_{component}"
   Compiler.CompilationModel.internalFunctionPrefix ++
-    String.intercalate "_" (nameComponents name)
+    "qualified_" ++ String.intercalate "_" encodedComponents
+
+private def qualifiedInternalHelperName (functions : Array FunctionDecl) (name : Name) : String :=
+  Compiler.CompilationModel.pickFreshName
+    (qualifiedInternalHelperBaseName name)
+    ((functions.map internalHelperSpecNameFor).toList)
+
+private def qualifiedInternalHelperNameFromUsed
+    (usedNames : List String)
+    (name : Name) : String :=
+  Compiler.CompilationModel.pickFreshName (qualifiedInternalHelperBaseName name) usedNames
 
 private partial def qualifiedFunctionAppSyntax? (stx : Term) : Option (Name × Array Term) :=
   match stx.raw with
@@ -1778,9 +1794,6 @@ private def internalHelperSpecName
     (Compiler.CompilationModel.internalFunctionPrefix ++ fnName)
     (functions.map (·.name)).toList
 
-private def internalHelperSpecNameFor (fn : FunctionDecl) : String :=
-  Compiler.CompilationModel.internalFunctionPrefix ++ toString fn.ident.getId
-
 private partial def hasDynamicInternalHelperType (ty : ValueType) : Bool :=
   match ty with
   | .string | .bytes | .array _ => true
@@ -3116,7 +3129,7 @@ private def tupleInternalCallAssignStmt?
             (translatePureExprWithTypes fields constDecls immutableDecls params locals)
           pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
             [ $[$resultNameTerms],* ]
-            $(strTerm (qualifiedInternalHelperName qualifiedName))
+            $(strTerm (qualifiedInternalHelperName functions qualifiedName))
             [ $[$argExprs],* ])))
       | none =>
           pure none
@@ -3402,7 +3415,7 @@ private def translateBindSource
               let argExprs ← argTerms.mapM
                 (translatePureExprWithTypes fields constDecls immutableDecls params locals)
               `(Compiler.CompilationModel.Expr.internalCall
-                  $(strTerm (qualifiedInternalHelperName qualifiedName))
+                  $(strTerm (qualifiedInternalHelperName functions qualifiedName))
                   [ $[$argExprs],* ])
           | none =>
               throwErrorAt rhs
@@ -4924,10 +4937,12 @@ private def collectQualifiedFunctionAppsFromFunction (fn : FunctionDecl) : Array
 private def collectQualifiedFunctionAppsFromConstructor (ctor : ConstructorDecl) : Array Name :=
   collectQualifiedFunctionAppsFromSyntax ctor.body.raw
 
-private def mkQualifiedInternalFunctionTerm (name : Name) : CommandElabM Term := do
+private def mkQualifiedInternalFunctionTerm
+    (usedNames : List String)
+    (name : Name) : CommandElabM Term := do
   let modelIdent : Ident := mkIdent (qualifiedFunctionModelName name)
   `(({ $modelIdent with
-        name := $(strTerm (qualifiedInternalHelperName name))
+        name := $(strTerm (qualifiedInternalHelperNameFromUsed usedNames name))
         isInternal := true } : Compiler.CompilationModel.FunctionSpec))
 
 private def mkSpecCommand
@@ -5015,8 +5030,9 @@ private def mkSpecCommand
       (match ctor with
       | some ctorDecl => collectQualifiedFunctionAppsFromConstructor ctorDecl
       | none => #[])
+  let localInternalFunctionNames := (functions.map internalHelperSpecNameFor).toList
   let qualifiedInternalFunctionTerms ←
-    qualifiedFunctionNames.mapM mkQualifiedInternalFunctionTerm
+    qualifiedFunctionNames.mapM (mkQualifiedInternalFunctionTerm localInternalFunctionNames)
   let adtTypeTerms ← adtDecls.mapM mkAdtTypeDefTerm
   let functionModelTerms : Array Term := functionModelIds.map fun id => ⟨id.raw⟩
   let allFunctionTerms := functionModelTerms ++ internalFunctionTerms ++ qualifiedInternalFunctionTerms

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -206,6 +206,48 @@ private partial def valueTypeAbiSignatureComponent : ValueType → String
 private def functionAbiSignatureKey (fn : FunctionDecl) : String :=
   fn.name ++ "(" ++ String.intercalate "," (fn.params.toList.map (fun p => valueTypeAbiSignatureComponent p.ty)) ++ ")"
 
+private def nameComponents : Name → List String
+  | .anonymous => []
+  | .str parent part => nameComponents parent ++ [part]
+  | .num parent n => nameComponents parent ++ [toString n]
+
+private def mapNameLastComponent (f : String → String) : Name → Name
+  | .anonymous => .anonymous
+  | .str parent part => .str parent (f part)
+  | .num parent n => .str parent (f (toString n))
+
+private def isQualifiedFunctionName (name : Name) : Bool :=
+  (nameComponents name).length == 2
+
+private def qualifiedFunctionModelName (name : Name) : Name :=
+  mapNameLastComponent (fun part => part ++ "_model") name
+
+private def qualifiedFunctionDisplayName (name : Name) : String :=
+  String.intercalate "." (nameComponents name)
+
+private def qualifiedInternalHelperName (name : Name) : String :=
+  Compiler.CompilationModel.internalFunctionPrefix ++
+    String.intercalate "_" (nameComponents name)
+
+private partial def qualifiedFunctionAppSyntax? (stx : Term) : Option (Name × Array Term) :=
+  match stx.raw with
+  | .node _ `Lean.Parser.Term.doExpr args =>
+      match args.getD 0 Syntax.missing with
+      | inner => qualifiedFunctionAppSyntax? ⟨inner⟩
+  | .node _ `Lean.Parser.Term.paren args =>
+      match args.getD 1 Syntax.missing with
+      | inner => qualifiedFunctionAppSyntax? ⟨inner⟩
+  | .node _ `Lean.Parser.Term.app args =>
+      match args.getD 0 Syntax.missing with
+      | .ident _ _ raw _ =>
+          if isQualifiedFunctionName raw then
+            let argTerms := (args.getD 1 Syntax.missing).getArgs.map (fun syn => ⟨syn⟩)
+            some (raw, argTerms)
+          else
+            none
+      | _ => none
+  | _ => none
+
 private def overloadedFunctionIdentName (fn : FunctionDecl) : String :=
   -- Length-prefix each component so the suffix encoding is injective.
   -- Component strings can contain `_` (e.g. `newtype_Foo_scalar_uint256`,
@@ -1985,7 +2027,12 @@ private partial def inferPureExprType
       requireWordLikeType key1 "structMember2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key1 visitingConstants)
       requireWordLikeType key2 "structMember2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key2 visitingConstants)
       pure .uint256
-  | _ => throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
+  | _ =>
+      match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals stx with
+      | some _ =>
+          pure .uint256
+      | none =>
+          throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
 
 private partial def lookupNamedValueType?
     (constDecls : Array ConstantDecl)
@@ -2194,8 +2241,12 @@ private partial def inferBindSourceType
           | retTy =>
               pure retTy
       | none =>
-          throwErrorAt rhs
-            "unsupported bind source; expected getStorage/getStorageAddr/getStorageArrayLength/getStorageArrayElement/getMapping/getMappingAddr/getMappingUint/getMappingUintAddr/getMappingWord/getMapping2/getMappingN/structMember/structMember2/msgSender/msgValue/tload/ecrecover/ecmCall or a direct internal helper call"
+          match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
+          | some _ =>
+              pure .uint256
+          | none =>
+              throwErrorAt rhs
+                "unsupported bind source; expected getStorage/getStorageAddr/getStorageArrayLength/getStorageArrayElement/getMapping/getMappingAddr/getMappingUint/getMappingUintAddr/getMappingWord/getMapping2/getMappingN/structMember/structMember2/msgSender/msgValue/tload/ecrecover/ecmCall, a direct internal helper call, or a qualified library helper call"
 
 private partial def inferTupleSourceTypes?
     (fields : Array StorageFieldDecl)
@@ -2266,7 +2317,10 @@ private partial def inferTupleSourceTypes?
               match fn.returnTy with
               | .tuple elemTys => pure (some elemTys.toArray)
               | _ => pure none
-          | none => pure none
+          | none =>
+              match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals other with
+              | some _ => pure none
+              | none => pure none
 
 private partial def resolveLocalFunctionApp?
     (fields : Array StorageFieldDecl)
@@ -2304,6 +2358,24 @@ private partial def resolveLocalFunctionApp?
     | _ =>
         throwErrorAt stx
           s!"ambiguous overload resolution for '{fnName}'"
+
+private partial def resolveQualifiedFunctionApp?
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term) : CommandElabM (Option (Name × Array Term)) := do
+  let some (fnName, argTerms) := qualifiedFunctionAppSyntax? stx
+    | pure none
+  if (nameComponents fnName).head? == some "Verity" then
+    pure none
+  else
+    for arg in argTerms do
+      requireWordLikeType arg s!"qualified helper '{qualifiedFunctionDisplayName fnName}' argument"
+        (← inferPureExprType fields constDecls immutableDecls externalDecls params locals arg)
+    pure (some (fnName, argTerms))
 end
 
 mutual
@@ -3041,7 +3113,16 @@ private def tupleInternalCallAssignStmt?
         $(strTerm (internalHelperSpecNameFor fn))
         [ $[$argExprs],* ])))
   | none =>
-      pure none
+      match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
+      | some (qualifiedName, argTerms) =>
+          let argExprs ← argTerms.mapM
+            (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+          pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
+            [ $[$resultNameTerms],* ]
+            $(strTerm (qualifiedInternalHelperName qualifiedName))
+            [ $[$argExprs],* ])))
+      | none =>
+          pure none
 
 /-- Try to translate a tuple‐destructured `tryExternalCall "name" [args]` RHS into
     a `Stmt.tryExternalCallBind` term.  Returns `none` when the RHS is not a
@@ -3319,8 +3400,16 @@ private def translateBindSource
               $(strTerm (internalHelperSpecNameFor fn))
               [ $[$argExprs],* ])
       | none =>
-          throwErrorAt rhs
-            "unsupported bind source; expected getStorage/getStorageAddr/getStorageArrayLength/getStorageArrayElement/getMapping/getMappingAddr/getMappingUint/getMappingUintAddr/getMappingWord/getMapping2/getMappingN/structMember/structMember2/msgSender/msgValue/tload/ecrecover or a direct internal helper call"
+          match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
+          | some (qualifiedName, argTerms) =>
+              let argExprs ← argTerms.mapM
+                (translatePureExprWithTypes fields constDecls immutableDecls params locals)
+              `(Compiler.CompilationModel.Expr.internalCall
+                  $(strTerm (qualifiedInternalHelperName qualifiedName))
+                  [ $[$argExprs],* ])
+          | none =>
+              throwErrorAt rhs
+                "unsupported bind source; expected getStorage/getStorageAddr/getStorageArrayLength/getStorageArrayElement/getMapping/getMappingAddr/getMappingUint/getMappingUintAddr/getMappingWord/getMapping2/getMappingN/structMember/structMember2/msgSender/msgValue/tload/ecrecover, a direct internal helper call, or a qualified library helper call"
 
 private def translateSafeRequireBind
     (fields : Array StorageFieldDecl)
@@ -3417,32 +3506,48 @@ private partial def validateDoElemExprTypes
       match tupleBinderNames? patDecl[0] with
       | some names =>
           let rhs : Term := ⟨patDecl[4]⟩
-          match (← inferTupleSourceTypes? fields constDecls immutableDecls externalDecls functions params locals rhs) with
-          | some valueTys =>
-              if names.size != valueTys.size then
-                throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueTys.size} values"
-              for (name?, ty) in names.zip valueTys do
-                if let some name := name? then
-                  requireSupportedLocalBindingType patDecl s!"local binding '{name}'" ty
-              let typedNames := (names.zip valueTys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
+          match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
+          | some _ =>
+              let valueTys := Array.replicate names.size ValueType.uint256
+              let typedNames := (names.zip valueTys).filterMap fun (name?, ty) =>
+                name?.map (fun name => (name, ty))
               pure (some (locals ++ typedNames))
-          | none => pure none
+          | none =>
+              match (← inferTupleSourceTypes? fields constDecls immutableDecls externalDecls functions params locals rhs) with
+              | some valueTys =>
+                  if names.size != valueTys.size then
+                    throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueTys.size} values"
+                  for (name?, ty) in names.zip valueTys do
+                    if let some name := name? then
+                      requireSupportedLocalBindingType patDecl s!"local binding '{name}'" ty
+                  let typedNames := (names.zip valueTys).filterMap fun (name?, ty) =>
+                    name?.map (fun name => (name, ty))
+                  pure (some (locals ++ typedNames))
+              | none => pure none
       | none => pure none
     else if stx.getKind == `Lean.Parser.Term.doLetArrow then
       let patDecl := stx[2]
       match tupleBinderNames? patDecl[0] with
       | some names =>
           let rhs : Term := ⟨patDecl[2][0]⟩
-          match (← inferTupleSourceTypes? fields constDecls immutableDecls externalDecls functions params locals rhs) with
-          | some valueTys =>
-              if names.size != valueTys.size then
-                throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueTys.size} values"
-              for (name?, ty) in names.zip valueTys do
-                if let some name := name? then
-                  requireSupportedLocalBindingType patDecl s!"local binding '{name}'" ty
-              let typedNames := (names.zip valueTys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
+          match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
+          | some _ =>
+              let valueTys := Array.replicate names.size ValueType.uint256
+              let typedNames := (names.zip valueTys).filterMap fun (name?, ty) =>
+                name?.map (fun name => (name, ty))
               pure (some (locals ++ typedNames))
-          | none => pure none
+          | none =>
+              match (← inferTupleSourceTypes? fields constDecls immutableDecls externalDecls functions params locals rhs) with
+              | some valueTys =>
+                  if names.size != valueTys.size then
+                    throwErrorAt patDecl s!"tuple destructuring binds {names.size} names, but the source provides {valueTys.size} values"
+                  for (name?, ty) in names.zip valueTys do
+                    if let some name := name? then
+                      requireSupportedLocalBindingType patDecl s!"local binding '{name}'" ty
+                  let typedNames := (names.zip valueTys).filterMap fun (name?, ty) =>
+                    name?.map (fun name => (name, ty))
+                  pure (some (locals ++ typedNames))
+              | none => pure none
       | none => pure none
     else
       pure none
@@ -4200,7 +4305,13 @@ private partial def translateDoElem
                       | some tys =>
                           let typedPairs := (names.zip tys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
                           pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
-                      | none => throwErrorAt rhs "unable to infer tuple local types"
+                      | none =>
+                          match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
+                          | some _ =>
+                              let tys := Array.replicate names.size ValueType.uint256
+                              let typedPairs := (names.zip tys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
+                              pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
+                          | none => throwErrorAt rhs "unable to infer tuple local types"
                   | none =>
                       match (← tryExternalCallBindStmt? fields constDecls immutableDecls externalDecls params locals rhs names) with
                       | some (stmt, tys) =>
@@ -4239,7 +4350,13 @@ private partial def translateDoElem
                           | some tys =>
                               let typedPairs := (names.zip tys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
                               pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
-                          | none => throwErrorAt rhs "unable to infer tuple local types"
+                          | none =>
+                              match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
+                              | some _ =>
+                                  let tys := Array.replicate names.size ValueType.uint256
+                                  let typedPairs := (names.zip tys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
+                                  pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
+                              | none => throwErrorAt rhs "unable to infer tuple local types"
                       | none =>
                           match (← tryExternalCallBindStmt? fields constDecls immutableDecls externalDecls params locals rhs names) with
                           | some (stmt, tys) =>
@@ -4273,7 +4390,13 @@ private partial def translateDoElem
               | some tys =>
                   let typedPairs := (names.zip tys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
                   pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
-              | none => throwErrorAt rhs "unable to infer tuple local types"
+              | none =>
+                  match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
+                  | some _ =>
+                      let tys := Array.replicate names.size ValueType.uint256
+                      let typedPairs := (names.zip tys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
+                      pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
+                  | none => throwErrorAt rhs "unable to infer tuple local types"
           | none =>
               match (← tryExternalCallBindStmt? fields constDecls immutableDecls externalDecls params locals rhs names) with
               | some (stmt, tys) =>
@@ -4776,6 +4899,40 @@ private def mkAdtTypeDefTerm (adtDecl : AdtDecl) : CommandElabM Term := do
       $(strTerm adtDecl.name)
       [ $[$variantTerms],* ])
 
+private partial def collectQualifiedFunctionAppsFromSyntax (stx : Syntax) : Array Name :=
+  let fromChildren : Array Name :=
+    match stx with
+    | .node _ _ args =>
+        args.foldl (fun acc child => acc ++ collectQualifiedFunctionAppsFromSyntax child) #[]
+    | _ => #[]
+  match stx with
+  | .node _ `Lean.Parser.Term.app args =>
+      match args.getD 0 Syntax.missing with
+      | .ident _ _ raw _ =>
+          if isQualifiedFunctionName raw && (nameComponents raw).head? != some "Verity" then
+            fromChildren.push raw
+          else
+            fromChildren
+      | _ => fromChildren
+  | _ => fromChildren
+
+private def uniqueNames (names : Array Name) : Array Name :=
+  names.foldl
+    (fun acc name => if acc.any (· == name) then acc else acc.push name)
+    #[]
+
+private def collectQualifiedFunctionAppsFromFunction (fn : FunctionDecl) : Array Name :=
+  collectQualifiedFunctionAppsFromSyntax fn.body.raw
+
+private def collectQualifiedFunctionAppsFromConstructor (ctor : ConstructorDecl) : Array Name :=
+  collectQualifiedFunctionAppsFromSyntax ctor.body.raw
+
+private def mkQualifiedInternalFunctionTerm (name : Name) : CommandElabM Term := do
+  let modelIdent : Ident := mkIdent (qualifiedFunctionModelName name)
+  `(({ $modelIdent with
+        name := $(strTerm (qualifiedInternalHelperName name))
+        isInternal := true } : Compiler.CompilationModel.FunctionSpec))
+
 private def mkSpecCommand
     (contractName : String)
     (fields : Array StorageFieldDecl)
@@ -4855,7 +5012,17 @@ private def mkSpecCommand
       } : Compiler.CompilationModel.FunctionSpec) ))
     else
       pure none
+  let qualifiedFunctionNames :=
+    uniqueNames <|
+      (functions.foldl (fun acc fn => acc ++ collectQualifiedFunctionAppsFromFunction fn) #[]) ++
+      (match ctor with
+      | some ctorDecl => collectQualifiedFunctionAppsFromConstructor ctorDecl
+      | none => #[])
+  let qualifiedInternalFunctionTerms ←
+    qualifiedFunctionNames.mapM mkQualifiedInternalFunctionTerm
   let adtTypeTerms ← adtDecls.mapM mkAdtTypeDefTerm
+  let functionModelTerms : Array Term := functionModelIds.map fun id => ⟨id.raw⟩
+  let allFunctionTerms := functionModelTerms ++ internalFunctionTerms ++ qualifiedInternalFunctionTerms
   let namespaceTerm ← match storageNamespace with
     | some ns => `(some $(natTerm ns))
     | none => `(none)
@@ -4864,7 +5031,7 @@ private def mkSpecCommand
     fields := [ $[$fieldTerms],* ]
     «errors» := [ $[$errorTerms],* ]
     «constructor» := $constructorTerm
-    functions := [ $[$functionModelIds],*, $[$internalFunctionTerms],* ]
+    functions := [ $[$allFunctionTerms],* ]
     «externals» := [ $[$externalTerms],* ]
     adtTypes := [ $[$adtTypeTerms],* ]
     storageNamespace := $namespaceTerm

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2317,10 +2317,7 @@ private partial def inferTupleSourceTypes?
               match fn.returnTy with
               | .tuple elemTys => pure (some elemTys.toArray)
               | _ => pure none
-          | none =>
-              match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals other with
-              | some _ => pure none
-              | none => pure none
+          | none => pure none
 
 private partial def resolveLocalFunctionApp?
     (fields : Array StorageFieldDecl)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -2041,9 +2041,13 @@ private partial def inferPureExprType
       requireWordLikeType key2 "structMember2 key" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals key2 visitingConstants)
       pure .uint256
   | _ =>
-      match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals stx with
-      | some _ =>
-          pure .uint256
+      match qualifiedFunctionAppSyntax? stx with
+      | some (fnName, _) =>
+          if (nameComponents fnName).head? == some "Verity" then
+            throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
+          else
+            throwErrorAt stx
+              s!"qualified library helper call '{qualifiedFunctionDisplayName fnName}' is only supported as a monadic bind source; use `let x ← {qualifiedFunctionDisplayName fnName} ...` or tuple destructuring bind syntax"
       | none =>
           throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
 

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -586,6 +586,53 @@ private partial def modelReturnsTerm (ty : ValueType) : CommandElabM Term :=
   | .adt name maxFields => do
       `([Compiler.CompilationModel.ParamType.adt $(Lean.quote name) $(Lean.quote maxFields)])
 
+private partial def valueTypeFromModelParamType? : Compiler.CompilationModel.ParamType → Option ValueType
+  | .uint256 => some .uint256
+  | .int256 => some .int256
+  | .uint8 => some .uint8
+  | .address => some .address
+  | .bool => some .bool
+  | .bytes32 => some .bytes32
+  | .string => some .string
+  | .bytes => some .bytes
+  | .array elemTy => do
+      let elem ← valueTypeFromModelParamType? elemTy
+      some (.array elem)
+  | .tuple elemTys => do
+      let elems ← elemTys.mapM valueTypeFromModelParamType?
+      some (.tuple elems)
+  | .newtypeOf name baseType => do
+      let base ← valueTypeFromModelParamType? baseType
+      some (.newtype name base)
+  | .adt name maxFields => some (.adt name maxFields)
+  | .fixedArray _ _ => none
+
+private unsafe def evalQualifiedFunctionSpec
+    (fnName : Name) : CommandElabM Compiler.CompilationModel.FunctionSpec := do
+  let modelTerm : Term := ⟨(mkIdent (qualifiedFunctionModelName fnName)).raw⟩
+  liftTermElabM do
+    let expectedType := mkConst ``Compiler.CompilationModel.FunctionSpec
+    let expr ← Lean.Elab.Term.elabTermEnsuringType modelTerm expectedType
+    Lean.Meta.evalExpr Compiler.CompilationModel.FunctionSpec expectedType expr .unsafe
+
+private unsafe def qualifiedFunctionReturnTypes
+    (stx : Syntax)
+    (fnName : Name) : CommandElabM (Array ValueType) := do
+  let spec ←
+    try
+      unsafe evalQualifiedFunctionSpec fnName
+    catch _ =>
+      throwErrorAt stx
+        s!"unable to inspect qualified helper '{qualifiedFunctionDisplayName fnName}'; expected generated model '{qualifiedFunctionModelName fnName}' to be in scope"
+  let mut result := #[]
+  for returnTy in spec.returns do
+    match valueTypeFromModelParamType? returnTy with
+    | some ty => result := result.push ty
+    | none =>
+        throwErrorAt stx
+          s!"qualified helper '{qualifiedFunctionDisplayName fnName}' returns unsupported value type {repr returnTy}"
+  pure result
+
 mutual
 private partial def mkTupleContractType (elemTys : List ValueType) : CommandElabM Term := do
   let rec go : List ValueType → CommandElabM Term
@@ -1727,6 +1774,20 @@ private def requireSupportedLocalBindingType
   if localBindingUsesDynamicData ty then
     throwErrorAt stx
       s!"{context} currently cannot bind dynamic values ({renderValueType ty}) to local variables on the compilation-model path; use the parameter directly"
+
+private unsafe def qualifiedTupleBindTypedLocals
+    (stx : Syntax)
+    (fnName : Name)
+    (names : Array (Option String)) : CommandElabM (Array TypedLocal) := do
+  let valueTys ← unsafe qualifiedFunctionReturnTypes stx fnName
+  if names.size != valueTys.size then
+    throwErrorAt stx
+      s!"tuple destructuring binds {names.size} names, but qualified helper '{qualifiedFunctionDisplayName fnName}' returns {valueTys.size} values"
+  for (name?, ty) in names.zip valueTys do
+    if let some name := name? then
+      requireSupportedLocalBindingType stx s!"local binding '{name}'" ty
+  pure <| (names.zip valueTys).filterMap fun (name?, ty) =>
+    name?.map (fun name => (name, ty))
 
 private def customErrorRequiresDirectParamRef : ValueType → Bool
   | .uint256 | .int256 | .uint8 | .address | .bool | .bytes32 => false
@@ -3129,6 +3190,7 @@ private def tupleInternalCallAssignStmt?
   | none =>
       match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
       | some (qualifiedName, argTerms) =>
+          let _ ← unsafe qualifiedTupleBindTypedLocals rhs.raw qualifiedName names
           let argExprs ← argTerms.mapM
             (translatePureExprWithTypes fields constDecls immutableDecls params locals)
           pure (some (← `(Compiler.CompilationModel.Stmt.internalCallAssign
@@ -3521,10 +3583,8 @@ private partial def validateDoElemExprTypes
       | some names =>
           let rhs : Term := ⟨patDecl[4]⟩
           match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
-          | some _ =>
-              let valueTys := Array.replicate names.size ValueType.uint256
-              let typedNames := (names.zip valueTys).filterMap fun (name?, ty) =>
-                name?.map (fun name => (name, ty))
+          | some (qualifiedName, _) =>
+              let typedNames ← unsafe qualifiedTupleBindTypedLocals patDecl qualifiedName names
               pure (some (locals ++ typedNames))
           | none =>
               match (← inferTupleSourceTypes? fields constDecls immutableDecls externalDecls functions params locals rhs) with
@@ -3545,10 +3605,8 @@ private partial def validateDoElemExprTypes
       | some names =>
           let rhs : Term := ⟨patDecl[2][0]⟩
           match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
-          | some _ =>
-              let valueTys := Array.replicate names.size ValueType.uint256
-              let typedNames := (names.zip valueTys).filterMap fun (name?, ty) =>
-                name?.map (fun name => (name, ty))
+          | some (qualifiedName, _) =>
+              let typedNames ← unsafe qualifiedTupleBindTypedLocals patDecl qualifiedName names
               pure (some (locals ++ typedNames))
           | none =>
               match (← inferTupleSourceTypes? fields constDecls immutableDecls externalDecls functions params locals rhs) with
@@ -4321,9 +4379,8 @@ private partial def translateDoElem
                           pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
                       | none =>
                           match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
-                          | some _ =>
-                              let tys := Array.replicate names.size ValueType.uint256
-                              let typedPairs := (names.zip tys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
+                          | some (qualifiedName, _) =>
+                              let typedPairs ← unsafe qualifiedTupleBindTypedLocals patDecl qualifiedName names
                               pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
                           | none => throwErrorAt rhs "unable to infer tuple local types"
                   | none =>
@@ -4366,9 +4423,8 @@ private partial def translateDoElem
                               pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
                           | none =>
                               match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
-                              | some _ =>
-                                  let tys := Array.replicate names.size ValueType.uint256
-                                  let typedPairs := (names.zip tys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
+                              | some (qualifiedName, _) =>
+                                  let typedPairs ← unsafe qualifiedTupleBindTypedLocals patDecl qualifiedName names
                                   pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
                               | none => throwErrorAt rhs "unable to infer tuple local types"
                       | none =>
@@ -4406,9 +4462,8 @@ private partial def translateDoElem
                   pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
               | none =>
                   match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
-                  | some _ =>
-                      let tys := Array.replicate names.size ValueType.uint256
-                      let typedPairs := (names.zip tys).filterMap fun (name?, ty) => name?.map (fun name => (name, ty))
+                  | some (qualifiedName, _) =>
+                      let typedPairs ← unsafe qualifiedTupleBindTypedLocals patDecl qualifiedName names
                       pure (some (#[(stmt)], locals ++ typedPairs, mutableLocals))
                   | none => throwErrorAt rhs "unable to infer tuple local types"
           | none =>

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1789,6 +1789,20 @@ private unsafe def qualifiedTupleBindTypedLocals
   pure <| (names.zip valueTys).filterMap fun (name?, ty) =>
     name?.map (fun name => (name, ty))
 
+private unsafe def qualifiedSingleBindType
+    (stx : Syntax)
+    (fnName : Name) : CommandElabM ValueType := do
+  let valueTys ← unsafe qualifiedFunctionReturnTypes stx fnName
+  match valueTys.toList with
+  | [] =>
+      throwErrorAt stx
+        s!"qualified helper '{qualifiedFunctionDisplayName fnName}' returns Unit and cannot be bound"
+  | [retTy] =>
+      pure retTy
+  | _ =>
+      throwErrorAt stx
+        s!"qualified helper '{qualifiedFunctionDisplayName fnName}' returns multiple values; use tuple destructuring"
+
 private def customErrorRequiresDirectParamRef : ValueType → Bool
   | .uint256 | .int256 | .uint8 | .address | .bool | .bytes32 => false
   | .newtype _ baseType => customErrorRequiresDirectParamRef baseType
@@ -2320,8 +2334,8 @@ private partial def inferBindSourceType
               pure retTy
       | none =>
           match ← resolveQualifiedFunctionApp? fields constDecls immutableDecls externalDecls params locals rhs with
-          | some _ =>
-              pure .uint256
+          | some (qualifiedName, _) =>
+              unsafe qualifiedSingleBindType rhs.raw qualifiedName
           | none =>
               throwErrorAt rhs
                 "unsupported bind source; expected getStorage/getStorageAddr/getStorageArrayLength/getStorageArrayElement/getMapping/getMappingAddr/getMappingUint/getMappingUintAddr/getMappingWord/getMapping2/getMappingN/structMember/structMember2/msgSender/msgValue/tload/ecrecover/ecmCall, a direct internal helper call, or a qualified library helper call"


### PR DESCRIPTION
## Summary
- recognize two-part qualified calls like `TermMaxCurve.buyXt` inside `verity_contract` bodies
- lower qualified calls to internal helper-call models named with the compiler internal prefix, and include copied helper specs in the caller contract spec
- add a TermMax-style smoke test covering tuple destructuring, spec inclusion, and executable behavior

Closes #1748.
Advances #1760.

## Validation
- `lake build Verity.Macro.Translate`
- `lake build Compiler.CompilationModelFeatureTest`
- `lake build Contracts`
- `lake build Compiler`
- `lake build PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core macro translation/type inference and uses unsafe evaluation of referenced helper models, so mis-resolution or naming collisions could affect compilation outputs across contracts that use helper calls.
> 
> **Overview**
> `verity_contract` translation now recognizes two-part qualified function applications (e.g. `TermMaxCurve.buyXt`) and treats them as *library helper calls* rather than unsupported expressions.
> 
> Qualified helper calls are lowered to fresh internal helper names with a `internal_qualified_<len>_<component>...` encoding to avoid collisions with local/internal helper names, and the caller’s generated `spec` is extended to include copied `FunctionSpec`s for each referenced qualified helper.
> 
> Typechecking for binds/tuple destructuring was extended to infer qualified helper return arity/types by evaluating the referenced helper’s generated `<name>_model` spec (rejecting unsupported return types), and new smoke tests validate model lowering, spec inclusion, runtime execution, and expected diagnostics for invalid qualified usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f324d7b36129c4ad9b97ce7dd0d560e877ab932c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->