### PR TITLE
Expose native write-name block freshness

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanAdapter.lean
@@ -246,41 +246,56 @@ mutual
     stmts.foldl (fun acc stmt => acc ++ yulStmtIdentifierNames stmt) []
 end
 
-mutual
-  partial def yulStmtWriteNames : YulStmt → List String
-    | .comment _ | .expr _ | .leave => []
-    | .let_ name _ => [name]
-    | .letMany names _ => names
-    | .assign name _ => [name]
-    | .if_ _ body => yulStmtsWriteNames body
-    | .for_ init _ post body =>
-        yulStmtsWriteNames init ++
-          yulStmtsWriteNames post ++
-          yulStmtsWriteNames body
-    | .switch _ cases defaultBody =>
-        cases.foldl (fun acc (_, body) => acc ++ yulStmtsWriteNames body) [] ++
-          yulStmtsWriteNames (defaultBody.getD [])
-    | .block stmts => yulStmtsWriteNames stmts
-    | .funcDef _ params rets body => params ++ rets ++ yulStmtsWriteNames body
+def collectYulStmtWriteNames
+    (writeStmt : YulStmt → List String) : List YulStmt → List String
+  | [] => []
+  | stmt :: rest => writeStmt stmt ++ collectYulStmtWriteNames writeStmt rest
 
-  partial def yulStmtsWriteNames (stmts : List YulStmt) : List String :=
-    stmts.foldl (fun acc stmt => acc ++ yulStmtWriteNames stmt) []
-end
+partial def yulStmtWriteNames : YulStmt → List String
+  | .comment _ | .expr _ | .leave => []
+  | .let_ name _ => [name]
+  | .letMany names _ => names
+  | .assign name _ => [name]
+  | .if_ _ body => collectYulStmtWriteNames yulStmtWriteNames body
+  | .for_ init _ post body =>
+      collectYulStmtWriteNames yulStmtWriteNames init ++
+        collectYulStmtWriteNames yulStmtWriteNames post ++
+        collectYulStmtWriteNames yulStmtWriteNames body
+  | .switch _ cases defaultBody =>
+      cases.foldl
+          (fun acc (_, body) =>
+            acc ++ collectYulStmtWriteNames yulStmtWriteNames body) [] ++
+        collectYulStmtWriteNames yulStmtWriteNames (defaultBody.getD [])
+  | .block stmts => collectYulStmtWriteNames yulStmtWriteNames stmts
+  | .funcDef _ params rets body =>
+      params ++ rets ++ collectYulStmtWriteNames yulStmtWriteNames body
 
-mutual
-  partial def nativeStmtWriteNames : EvmYul.Yul.Ast.Stmt → List String
-    | .Block stmts => nativeStmtsWriteNames stmts
-    | .Let names _ => names
-    | .ExprStmtCall _ | .Continue | .Break | .Leave => []
-    | .Switch _ cases defaultBody =>
-        cases.foldl (fun acc (_, body) => acc ++ nativeStmtsWriteNames body) [] ++
-          nativeStmtsWriteNames defaultBody
-    | .For _ post body => nativeStmtsWriteNames post ++ nativeStmtsWriteNames body
-    | .If _ body => nativeStmtsWriteNames body
+def yulStmtsWriteNames (stmts : List YulStmt) : List String :=
+  collectYulStmtWriteNames yulStmtWriteNames stmts
 
-  partial def nativeStmtsWriteNames (stmts : List EvmYul.Yul.Ast.Stmt) : List String :=
-    stmts.foldl (fun acc stmt => acc ++ nativeStmtWriteNames stmt) []
-end
+def collectNativeStmtWriteNames
+    (writeStmt : EvmYul.Yul.Ast.Stmt → List String) :
+    List EvmYul.Yul.Ast.Stmt → List String
+  | [] => []
+  | stmt :: rest =>
+      writeStmt stmt ++ collectNativeStmtWriteNames writeStmt rest
+
+partial def nativeStmtWriteNames : EvmYul.Yul.Ast.Stmt → List String
+  | .Block stmts => collectNativeStmtWriteNames nativeStmtWriteNames stmts
+  | .Let names _ => names
+  | .ExprStmtCall _ | .Continue | .Break | .Leave => []
+  | .Switch _ cases defaultBody =>
+      cases.foldl
+          (fun acc (_, body) =>
+            acc ++ collectNativeStmtWriteNames nativeStmtWriteNames body) [] ++
+        collectNativeStmtWriteNames nativeStmtWriteNames defaultBody
+  | .For _ post body =>
+      collectNativeStmtWriteNames nativeStmtWriteNames post ++
+        collectNativeStmtWriteNames nativeStmtWriteNames body
+  | .If _ body => collectNativeStmtWriteNames nativeStmtWriteNames body
+
+def nativeStmtsWriteNames (stmts : List EvmYul.Yul.Ast.Stmt) : List String :=
+  collectNativeStmtWriteNames nativeStmtWriteNames stmts
 
 def nativeSwitchDiscrTempName (switchId : Nat) : String :=
   s!"__verity_native_switch_discr_{switchId}"

--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -4335,6 +4335,43 @@ theorem NativeBlockPreservesWord_of_forall_stmt_write_not_mem
       intro stmt hmem
       exact hPreserves stmt hmem (hFresh stmt hmem))
 
+theorem nativeStmtWriteNames_not_mem_of_nativeStmtsWriteNames_not_mem
+    (name : EvmYul.Identifier)
+    (body : List EvmYul.Yul.Ast.Stmt)
+    (stmt : EvmYul.Yul.Ast.Stmt)
+    (hFresh : name ∉ Backends.nativeStmtsWriteNames body)
+    (hMem : stmt ∈ body) :
+    name ∉ Backends.nativeStmtWriteNames stmt := by
+  induction body with
+  | nil =>
+      simp at hMem
+  | cons head tail ih =>
+      simp [Backends.nativeStmtsWriteNames,
+        Backends.collectNativeStmtWriteNames] at hFresh hMem
+      rcases hMem with hEq | hTail
+      · subst stmt
+        exact hFresh.1
+      · exact ih hFresh.2 hTail
+
+theorem NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (body : List EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hFresh : name ∉ Backends.nativeStmtsWriteNames body)
+    (hPreserves :
+      ∀ stmt, stmt ∈ body →
+        name ∉ Backends.nativeStmtWriteNames stmt →
+          NativeStmtPreservesWord name value stmt codeOverride) :
+    NativeBlockPreservesWord name value body codeOverride :=
+  NativeBlockPreservesWord_of_forall_stmt_write_not_mem name value body
+    codeOverride
+    (by
+      intro stmt hMem
+      exact nativeStmtWriteNames_not_mem_of_nativeStmtsWriteNames_not_mem
+        name body stmt hFresh hMem)
+    hPreserves
+
 theorem NativeStmtPreservesWord_block
     (name : EvmYul.Identifier)
     (value : EvmYul.Literal)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3111,6 +3111,8 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_singleton
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_forall_stmt
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_forall_stmt_write_not_mem
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.nativeStmtWriteNames_not_mem_of_nativeStmtsWriteNames_not_mem
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_self
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_preserves
@@ -3598,4 +3600,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3422 theorems/lemmas (2478 public, 944 private, 0 sorry'd)
+-- Total: 3424 theorems/lemmas (2480 public, 944 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -333,6 +333,8 @@ scope so the native path does not look more complete than it is:
   `NativeStmtPreservesWord_let_none_of_not_mem`,
   `NativeStmtPreservesWord_let_var_of_not_mem`,
   `NativeStmtPreservesWord_let_lit_of_not_mem`,
+  `nativeStmtWriteNames_not_mem_of_nativeStmtsWriteNames_not_mem`,
+  `NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem`,
   `nativeSwitchTempsFreshForNativeBodies_find_hit_matched_not_mem`, and
   `nativeSwitchTempsFreshForNativeBodies_default_matched_not_mem`; the next
   proof step is the statement induction that derives those preservation

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -213,6 +213,8 @@ def check_public_theorem_target(
         "theorem NativeStmtPreservesWord_let_none_of_not_mem",
         "theorem NativeStmtPreservesWord_let_var_of_not_mem",
         "theorem NativeStmtPreservesWord_let_lit_of_not_mem",
+        "theorem nativeStmtWriteNames_not_mem_of_nativeStmtsWriteNames_not_mem",
+        "theorem NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem",
     ):
         if required_native_entrypoint not in normalized_native_harness:
             errors.append(


### PR DESCRIPTION
## Summary

- make the Yul/native statement write-name list collectors unfold through transparent list helpers while preserving the existing statement-level collection semantics
- add `nativeStmtWriteNames_not_mem_of_nativeStmtsWriteNames_not_mem` and `NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem` so N4 preservation proofs can consume whole-body native write freshness directly
- update the native transition doc guard and regenerate `PrintAxioms.lean`

## Validation

- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanRetarget Compiler.Proofs.EndToEnd Compiler Contracts PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `make check`

## Native transition status

This advances N4 body temp/write preservation plumbing only. The generic public theorem still targets `interpretYulRuntimeWithBackend .evmYulLean`; the full native EVMYulLean transition remains incomplete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to Lean proof infrastructure and documentation, with no impact on runtime compiler behavior; risk is mainly proof breakage due to unfolding/lemma plumbing changes.
> 
> **Overview**
> Refactors `yulStmtsWriteNames`/`nativeStmtsWriteNames` collection to go through new explicit list-recursion helpers (`collectYulStmtWriteNames`, `collectNativeStmtWriteNames`), making write-name aggregation unfold more predictably in proofs while preserving per-statement semantics.
> 
> Adds two new native harness theorems—`nativeStmtWriteNames_not_mem_of_nativeStmtsWriteNames_not_mem` and `NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem`—so preservation proofs can assume whole-body `nativeStmtsWriteNames` freshness instead of threading per-statement freshness.
> 
> Updates the native transition doc + guard script to require these entrypoints, and regenerates `PrintAxioms.lean` to include the new theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4441a8a4f6ce35c5f662422b04e09dbe97e71c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->