### PR TITLE
macro: inline pure Lean def helpers

### DIFF
--- a/Compiler/CompilationModelFeatureTest.lean
+++ b/Compiler/CompilationModelFeatureTest.lean
@@ -1116,6 +1116,34 @@ example : signedLiteralUsesInt256Overload = true := by native_decide
 
 end MacroNumericLiteralHelperSmoke
 
+namespace MacroLeanDefHelperSmoke
+
+open Contracts.Smoke
+
+def leanDefHelperLowersToPureExpr : Bool :=
+  match LeanDefHelperSmoke.addOffset_modelBody with
+  | [Stmt.return
+      (Expr.ite
+        (Expr.slt (Expr.param "y") (Expr.literal 0))
+        (Expr.sub (Expr.param "x") (Expr.sub (Expr.literal 0) (Expr.param "y")))
+        (Expr.add (Expr.param "x") (Expr.param "y")))] => true
+  | _ => false
+
+example : leanDefHelperLowersToPureExpr = true := by native_decide
+
+def leanDefHelperEqualityLowersToPureExpr : Bool :=
+  match LeanDefHelperSmoke.sameWord_modelBody with
+  | [Stmt.return
+      (Expr.ite
+        (Expr.eq (Expr.param "x") (Expr.param "y"))
+        (Expr.literal 1)
+        (Expr.literal 0))] => true
+  | _ => false
+
+example : leanDefHelperEqualityLowersToPureExpr = true := by native_decide
+
+end MacroLeanDefHelperSmoke
+
 namespace MacroPayableConstructorSmoke
 
 open Contracts

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -301,6 +301,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.StatelessSmoke.spec
   , Contracts.Smoke.MutabilitySmoke.spec
   , Contracts.Smoke.SpecialEntrypointSmoke.spec
+  , Contracts.Smoke.LeanDefHelperSmoke.spec
   , Contracts.Smoke.DirectHelperCallSmoke.spec
   , Contracts.Smoke.InitializerSmoke.spec
   , Contracts.Smoke.ConstantSmoke.spec
@@ -407,6 +408,7 @@ private def expectedExternalSignatures : List (String × List String) :=
   , ("StatelessSmoke", ["echoWord(uint256)", "whoAmI()"])
   , ("MutabilitySmoke", ["deposit()", "currentOwner()"])
   , ("SpecialEntrypointSmoke", ["getReceiveCount()", "getFallbackCount()"])
+  , ("LeanDefHelperSmoke", ["addOffset(uint256,int256)", "sameWord(uint256,uint256)"])
   , ("DirectHelperCallSmoke", ["addToTotal(uint256)", "readTotalPlus(uint256)", "pairWithTotal(uint256)",
       "runHelpers(uint256,uint256,uint256)", "snapshot()"])
   , ("InitializerSmoke", ["initOwner(address)", "upgradeToV2()"])
@@ -518,6 +520,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("StatelessSmoke", ["0x26534f53", "0xda91254c"])
   , ("MutabilitySmoke", ["0xd0e30db0", "0xb387ef92"])
   , ("SpecialEntrypointSmoke", ["0x931999fb", "0x74b204a4"])
+  , ("LeanDefHelperSmoke", ["0x42dbad08", "0x9ca603a4"])
   , ("DirectHelperCallSmoke", ["0x623f577a", "0xe9696d56", "0xe176587e", "0xa392867e", "0x9711715a"])
   , ("InitializerSmoke", ["0x0d009297", "0xcc01053e"])
   , ("ConstantSmoke", ["0x9c421eb5", "0x30d9a62a"])

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -61,6 +61,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.StatelessSmoke.spec
   , Contracts.Smoke.MutabilitySmoke.spec
   , Contracts.Smoke.SpecialEntrypointSmoke.spec
+  , Contracts.Smoke.LeanDefHelperSmoke.spec
   , Contracts.Smoke.DirectHelperCallSmoke.spec
   , Contracts.Smoke.InitializerSmoke.spec
   , Contracts.Smoke.ConstantSmoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -20,6 +20,12 @@ open Verity hiding pure bind
 open Verity.EVM.Uint256
 open Verity.Stdlib.Math
 
+def plusInt256Helper (a : Uint256) (b : Int256) : Uint256 :=
+  if b < 0 then sub a (toUint256 (-b)) else add a (toUint256 b)
+
+def eqWordHelper (a : Uint256) (b : Uint256) : Uint256 :=
+  if a = b then 1 else 0
+
 private def genericECMEffectDemoModule : Compiler.ECM.ExternalCallModule where
   name := "genericEffectDemo"
   numArgs := 2
@@ -1096,6 +1102,29 @@ def packedStorageExecutableUpdatesAddressMirror : Bool :=
   | _ => false
 
 example : packedStorageExecutableUpdatesAddressMirror = true := by decide
+
+verity_contract LeanDefHelperSmoke where
+  storage
+
+  function addOffset (x : Uint256, y : Int256) : Uint256 := do
+    return (plusInt256Helper x y)
+
+  function sameWord (x : Uint256, y : Uint256) : Uint256 := do
+    return (eqWordHelper x y)
+
+def leanDefHelperExecutableAddsPositiveOffset : Bool :=
+  match LeanDefHelperSmoke.addOffset 10 3 Verity.defaultState with
+  | .success value _ => value == 13
+  | _ => false
+
+example : leanDefHelperExecutableAddsPositiveOffset = true := by decide
+
+def leanDefHelperExecutableUsesEquality : Bool :=
+  match LeanDefHelperSmoke.sameWord 7 7 Verity.defaultState with
+  | .success value _ => value == 1
+  | _ => false
+
+example : leanDefHelperExecutableUsesEquality = true := by decide
 
 verity_contract DirectHelperCallSmoke where
   storage

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1894,6 +1894,143 @@ private def throwPureContextAccessorError (stx : Syntax) (name : String) : Comma
     s!"context accessor '{name}' is monadic; use `let x ← {name}` before using it in a pure expression"
 
 mutual
+private partial def leanExprAppFnArgs (expr : Expr) : Expr × Array Expr :=
+  let rec go (fn : Expr) (argsRev : Array Expr) : Expr × Array Expr :=
+    match fn.consumeMData with
+    | .app f arg => go f (argsRev.push arg)
+    | other => (other, argsRev.reverse)
+  go expr #[]
+
+private partial def leanConstName? (expr : Expr) : Option Name :=
+  match expr.consumeMData with
+  | .const name _ => some name
+  | _ => none
+
+private partial def leanConstNameMatches (expr : Expr) (names : List Name) : Bool :=
+  match leanConstName? expr with
+  | some name => names.contains name
+  | none => false
+
+private partial def leanConstNameMatchesStringOrSuffix
+    (expr : Expr)
+    (names : List String)
+    (suffixes : List String) : Bool :=
+  match leanConstName? expr with
+  | some name =>
+      let nameString := name.toString
+      names.contains nameString || suffixes.any (fun suffix => nameString.endsWith s!".{suffix}")
+  | none => false
+
+private partial def valueTypeFromLeanTypeExpr? (expr : Expr) : Option ValueType :=
+  match expr.consumeMData with
+  | .const name _ =>
+      let nameString := name.toString
+      if nameString == "Verity.Uint256" || nameString == "Verity.Core.Uint256" ||
+          nameString.endsWith ".Uint256" then
+        some .uint256
+      else if nameString == "Verity.Int256" || nameString == "Verity.Core.Int256" ||
+          nameString.endsWith ".Int256" then
+        some .int256
+      else if nameString == "Verity.Address" || nameString == "Verity.Core.Address" ||
+          nameString.endsWith ".Address" then
+        some .address
+      else if nameString == "Bool" then
+        some .bool
+      else if nameString == "String" then
+        some .string
+      else if nameString == "ByteArray" then
+        some .bytes
+      else
+        none
+  | _ => none
+
+private partial def peelForallTypes (type : Expr) : List Expr × Expr :=
+  let rec go (remaining : Expr) (acc : List Expr) : List Expr × Expr :=
+    match remaining.consumeMData with
+    | .forallE _ domain body _ => go body (domain :: acc)
+    | other => (acc.reverse, other)
+  go type []
+
+private partial def peelLambdaBody (value : Expr) (arity : Nat) : Option Expr :=
+  match arity with
+  | 0 => some value
+  | n + 1 =>
+      match value.consumeMData with
+      | .lam _ _ body _ => peelLambdaBody body n
+      | _ => none
+
+private partial def leanDefAppSyntax? (stx : Term) : Option (Syntax × String × Array Term) :=
+  let stx := stripParens stx
+  match stx.raw with
+  | .node _ `Lean.Parser.Term.app args =>
+      match args.getD 0 Syntax.missing with
+      | head@(.ident _ _ raw _) =>
+          if isQualifiedFunctionName raw then
+            none
+          else
+            let argTerms := (args.getD 1 Syntax.missing).getArgs.map (fun syn => ⟨syn⟩)
+            some (head, raw.toString, argTerms)
+      | _ => none
+  | _ => none
+
+private partial def resolveLeanDefName? (head : Syntax) : CommandElabM (Option Name) := do
+  try
+    pure (some (← liftCoreM <| Lean.Elab.realizeGlobalConstNoOverloadWithInfo head none))
+  catch _ =>
+    pure none
+
+private partial def leanDefInfo? (name : Name) : CommandElabM (Option DefinitionVal) := do
+  match (← getEnv).find? name with
+  | some (.defnInfo info) => pure (some info)
+  | _ => pure none
+
+private partial def checkLeanDefCallArgs
+    (stx : Syntax)
+    (fnDisplay : String)
+    (argTerms : Array Term)
+    (paramTypeExprs : List Expr)
+    (argTypes : Array ValueType) : CommandElabM Unit := do
+  unless argTerms.size == paramTypeExprs.length do
+    throwErrorAt stx
+      s!"Lean helper '{fnDisplay}' expects {paramTypeExprs.length} argument(s), got {argTerms.size}"
+  for ((argTerm, argTy), expectedExpr) in argTerms.zip argTypes |>.zip paramTypeExprs.toArray do
+    let expectedTy ←
+      match valueTypeFromLeanTypeExpr? expectedExpr with
+      | some ty => pure ty
+      | none =>
+          throwErrorAt stx
+            s!"Lean helper '{fnDisplay}' uses an unsupported parameter type; supported pure helper parameters are Uint256, Int256, Address, Bytes32/Uint256, Bool, String, and Bytes"
+    unless argTy == expectedTy || (isNatLiteralTerm argTerm && numericLiteralCompatibleValueType expectedTy) do
+      throwErrorAt argTerm
+        s!"Lean helper '{fnDisplay}' argument expects {renderValueType expectedTy}, got {renderValueType argTy}"
+
+private partial def inferLeanDefCallType?
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term)
+    (visitingConstants : List String) : CommandElabM (Option ValueType) := do
+  let some (head, fnDisplay, argTerms) := leanDefAppSyntax? stx
+    | pure none
+  let some fnName ← resolveLeanDefName? head
+    | pure none
+  let some info ← leanDefInfo? fnName
+    | pure none
+  let (paramTypeExprs, resultTypeExpr) := peelForallTypes info.type
+  let argTypes ← argTerms.mapM
+    (inferPureExprType fields constDecls immutableDecls externalDecls params locals · visitingConstants)
+  checkLeanDefCallArgs stx.raw fnDisplay argTerms paramTypeExprs argTypes
+  match valueTypeFromLeanTypeExpr? resultTypeExpr with
+  | some ty =>
+      requireSupportedLocalBindingType stx.raw s!"Lean helper '{fnDisplay}' return" ty
+      pure (some ty)
+  | none =>
+      throwErrorAt stx
+        s!"Lean helper '{fnDisplay}' uses an unsupported return type; supported pure helper returns are Uint256, Int256, Address, Bytes32/Uint256, and Bool"
+
 private partial def inferPureExprType
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -2124,7 +2261,9 @@ private partial def inferPureExprType
             throwErrorAt stx
               s!"qualified library helper call '{qualifiedFunctionDisplayName fnName}' is only supported as a monadic bind source; use `let x ← {qualifiedFunctionDisplayName fnName} ...` or tuple destructuring bind syntax"
       | none =>
-          throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
+          match ← inferLeanDefCallType? fields constDecls immutableDecls externalDecls params locals stx visitingConstants with
+          | some ty => pure ty
+          | none => throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
 
 private partial def lookupNamedValueType?
     (constDecls : Array ConstantDecl)
@@ -2570,6 +2709,150 @@ private partial def translateConstantExpr
         throwError s!"constant '{name}' depends on itself recursively"
       translatePureExprWithTypes fields constDecls immutableDecls #[] #[] constant.body (name :: visiting)
 
+private partial def translateLeanExprFromDef
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (origin : Syntax)
+    (fnDisplay : String)
+    (argExprs : Array Term)
+    (expr : Expr) : CommandElabM Term := do
+  match expr.consumeMData with
+  | .bvar idx =>
+      if idx < argExprs.size then
+        let argIdx := argExprs.size - 1 - idx
+        match argExprs[argIdx]? with
+        | some arg => pure arg
+        | none => throwErrorAt origin s!"Lean helper '{fnDisplay}' body references an out-of-scope argument"
+      else
+        throwErrorAt origin s!"Lean helper '{fnDisplay}' body references an out-of-scope argument"
+  | .lit (.natVal n) =>
+      `(Compiler.CompilationModel.Expr.literal $(natTerm n))
+  | .const ``Bool.true _ =>
+      `(Compiler.CompilationModel.Expr.literal 1)
+  | .const ``Bool.false _ =>
+      `(Compiler.CompilationModel.Expr.literal 0)
+  | other =>
+      let (fn, args) := leanExprAppFnArgs other
+      if leanConstNameMatches fn [``OfNat.ofNat] then
+        match args.toList with
+        | [_ty, .lit (.natVal n), _inst] =>
+            `(Compiler.CompilationModel.Expr.literal $(natTerm n))
+        | _ =>
+            throwErrorAt origin s!"Lean helper '{fnDisplay}' contains an unsupported numeric literal form"
+      else if leanConstNameMatches fn [``ite] then
+        match args.toList with
+        | [_ty, cond, _dec, thenExpr, elseExpr] =>
+            `(Compiler.CompilationModel.Expr.ite
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs cond)
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs thenExpr)
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs elseExpr))
+        | _ =>
+            throwErrorAt origin s!"Lean helper '{fnDisplay}' contains an unsupported if/ite form"
+      else if leanConstNameMatchesStringOrSuffix fn
+          ["Verity.toInt256", "Verity.toUint256", "Verity.wordToAddress", "Verity.addressToWord"]
+          ["toInt256", "toUint256", "wordToAddress", "addressToWord"] then
+        match args.toList with
+        | [arg] => translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs arg
+        | _ => throwErrorAt origin s!"Lean helper '{fnDisplay}' contains an unsupported cast form"
+      else if leanConstNameMatches fn [``Neg.neg] then
+        match args.toList with
+        | [_ty, _inst, arg] =>
+            `(Compiler.CompilationModel.Expr.sub
+                (Compiler.CompilationModel.Expr.literal 0)
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs arg))
+        | _ => throwErrorAt origin s!"Lean helper '{fnDisplay}' contains an unsupported negation form"
+      else if leanConstNameMatches fn [``Eq] then
+        match args.toList with
+        | [_tyExpr, lhs, rhs] =>
+            `(Compiler.CompilationModel.Expr.eq
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs lhs)
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs rhs))
+        | _ => throwErrorAt origin s!"Lean helper '{fnDisplay}' contains an unsupported equality form"
+      else if leanConstNameMatches fn [``LT.lt, ``LE.le] then
+        match args.toList with
+        | [tyExpr, _inst, lhs, rhs] =>
+            let lhsExpr ← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs lhs
+            let rhsExpr ← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs rhs
+            match leanConstName? fn with
+            | some ``LT.lt =>
+                if valueTypeFromLeanTypeExpr? tyExpr == some .int256 then
+                  `(Compiler.CompilationModel.Expr.slt $lhsExpr $rhsExpr)
+                else
+                  `(Compiler.CompilationModel.Expr.lt $lhsExpr $rhsExpr)
+            | _ =>
+                if valueTypeFromLeanTypeExpr? tyExpr == some .int256 then
+                  `(Compiler.CompilationModel.Expr.logicalNot
+                      (Compiler.CompilationModel.Expr.sgt $lhsExpr $rhsExpr))
+                else
+                  `(Compiler.CompilationModel.Expr.le $lhsExpr $rhsExpr)
+        | _ => throwErrorAt origin s!"Lean helper '{fnDisplay}' contains an unsupported comparison form"
+      else if leanConstNameMatchesStringOrSuffix fn
+          ["Verity.EVM.Uint256.add", "Verity.EVM.Int256.add",
+           "Verity.Core.Uint256.add", "Verity.Core.Int256.add"]
+          ["add"] then
+        match args.toList with
+        | [lhs, rhs] =>
+            `(Compiler.CompilationModel.Expr.add
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs lhs)
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs rhs))
+        | _ => throwErrorAt origin s!"Lean helper '{fnDisplay}' contains an unsupported add form"
+      else if leanConstNameMatchesStringOrSuffix fn
+          ["Verity.EVM.Uint256.sub", "Verity.EVM.Int256.sub",
+           "Verity.Core.Uint256.sub", "Verity.Core.Int256.sub"]
+          ["sub"] then
+        match args.toList with
+        | [lhs, rhs] =>
+            `(Compiler.CompilationModel.Expr.sub
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs lhs)
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs rhs))
+        | _ => throwErrorAt origin s!"Lean helper '{fnDisplay}' contains an unsupported sub form"
+      else if leanConstNameMatchesStringOrSuffix fn
+          ["Verity.EVM.Uint256.mul", "Verity.EVM.Int256.mul",
+           "Verity.Core.Uint256.mul", "Verity.Core.Int256.mul"]
+          ["mul"] then
+        match args.toList with
+        | [lhs, rhs] =>
+            `(Compiler.CompilationModel.Expr.mul
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs lhs)
+                $(← translateLeanExprFromDef fields constDecls immutableDecls params locals origin fnDisplay argExprs rhs))
+        | _ => throwErrorAt origin s!"Lean helper '{fnDisplay}' contains an unsupported mul form"
+      else
+        throwErrorAt origin
+          s!"Lean helper '{fnDisplay}' body contains unsupported expression '{fn}'; inline it or rewrite the helper using supported pure Verity operations"
+
+private partial def translateLeanDefCall?
+    (fields : Array StorageFieldDecl)
+    (constDecls : Array ConstantDecl)
+    (immutableDecls : Array ImmutableDecl)
+    (externalDecls : Array ExternalDecl)
+    (params : Array ParamDecl)
+    (locals : Array TypedLocal)
+    (stx : Term)
+    (visitingConstants : List String) : CommandElabM (Option Term) := do
+  let some (head, fnDisplay, argTerms) := leanDefAppSyntax? stx
+    | pure none
+  let some fnName ← resolveLeanDefName? head
+    | pure none
+  let some info ← leanDefInfo? fnName
+    | pure none
+  let (paramTypeExprs, resultTypeExpr) := peelForallTypes info.type
+  let argTypes ← argTerms.mapM
+    (inferPureExprType fields constDecls immutableDecls externalDecls params locals · visitingConstants)
+  checkLeanDefCallArgs stx.raw fnDisplay argTerms paramTypeExprs argTypes
+  match valueTypeFromLeanTypeExpr? resultTypeExpr with
+  | some ty => requireSupportedLocalBindingType stx.raw s!"Lean helper '{fnDisplay}' return" ty
+  | none =>
+      throwErrorAt stx
+        s!"Lean helper '{fnDisplay}' uses an unsupported return type; supported pure helper returns are Uint256, Int256, Address, Bytes32/Uint256, and Bool"
+  let some body := peelLambdaBody info.value argTerms.size
+    | throwErrorAt stx s!"Lean helper '{fnDisplay}' body is not a transparent function definition"
+  let argExprs ← argTerms.mapM
+    (translatePureExprWithTypes fields constDecls immutableDecls params locals · visitingConstants)
+  pure (some (← translateLeanExprFromDef fields constDecls immutableDecls params locals stx.raw fnDisplay argExprs body))
+
 partial def translatePureExprWithTypes
     (fields : Array StorageFieldDecl)
     (constDecls : Array ConstantDecl)
@@ -2853,7 +3136,10 @@ partial def translatePureExprWithTypes
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key1 visitingConstants)
           $(← translatePureExprWithTypes fields constDecls immutableDecls params locals key2 visitingConstants)
           $(strTerm memberName))
-  | _ => throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
+  | _ =>
+      match ← translateLeanDefCall? fields constDecls immutableDecls #[] params locals stx visitingConstants with
+      | some expr => pure expr
+      | none => throwErrorAt stx "unsupported expression in verity_contract body (see #1003 for planned macro support expansions)"
 end
 
 partial def translatePureExpr

--- a/artifacts/macro_property_tests/PropertyLeanDefHelperSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertyLeanDefHelperSmoke.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+import "./yul/YulTestBase.sol";
+
+/**
+ * @title PropertyLeanDefHelperSmokeTest
+ * @notice Auto-generated baseline property stubs from `verity_contract` declarations.
+ * @dev Source: Contracts/Smoke.lean
+ */
+contract PropertyLeanDefHelperSmokeTest is YulTestBase {
+    address target;
+    address alice = address(0x1111);
+
+    function setUp() public {
+        target = deployYul("LeanDefHelperSmoke");
+        require(target != address(0), "Deploy failed");
+    }
+
+    // Property 1: TODO decode and assert `addOffset` result
+    function testTODO_AddOffset_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("addOffset(uint256,int256)", uint256(1), int256(1)));
+        require(ok, "addOffset reverted unexpectedly");
+        assertEq(ret.length, 32, "addOffset ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+    // Property 2: TODO decode and assert `sameWord` result
+    function testTODO_SameWord_DecodeAndAssert() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("sameWord(uint256,uint256)", uint256(1), uint256(1)));
+        require(ok, "sameWord reverted unexpectedly");
+        assertEq(ret.length, 32, "sameWord ABI return length mismatch (expected 32 bytes)");
+        // TODO(#1011): decode `ret` and assert the concrete postcondition from Lean theorem.
+        ret;
+    }
+}


### PR DESCRIPTION
## Summary
- inline transparent pure Lean `def` helpers when called from `verity_contract` pure expressions
- support the static value-type helper subset needed for arithmetic/branching helper calls, with unsupported bodies failing closed at macro elaboration
- add LeanDefHelperSmoke coverage across executable smoke, model-body regression, macro invariant snapshots, round-trip fuzz coverage, and generated macro property artifacts

Closes #1749.
Advances #1760.

## Validation
- `lake build Verity.Macro.Translate Contracts.Smoke Compiler.CompilationModelFeatureTest Contracts.MacroTranslateInvariantTest`
- `lake build Contracts`
- `lake build Compiler`
- `lake build PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `make check` (602 Python tests)

No new `sorry`, `admit`, `axiom`, unchecked declaration, or trust boundary is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core macro translation/type inference paths, so incorrect lowering could change generated models/Yul or diagnostics; scope is constrained by a strict supported-expression whitelist and fail-closed errors.
> 
> **Overview**
> Adds macro support to **inline transparent, pure Lean `def` helpers** when they are called from `verity_contract` *pure* expressions. The translator now recognizes unqualified Lean function applications, type-checks arguments/return types against a supported `ValueType` subset, and lowers a small set of Lean constructs (e.g. `if/ite`, literals, casts, `+/-/*`, comparisons, equality) into `CompilationModel.Expr`, rejecting anything else at elaboration time.
> 
> Introduces `LeanDefHelperSmoke` plus helper defs in `Contracts/Smoke.lean`, and wires this contract into model-body regression checks, macro invariant/selector snapshots, round-trip fuzz coverage, and an auto-generated Solidity property-test stub artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2bd04e33851d557e23678a1d48a274aa8d23089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->