### PR TITLE
Add dynamic struct-array ABI head-word lowering

### DIFF
--- a/Compiler/CompilationModel/AbiTypeLayout.lean
+++ b/Compiler/CompilationModel/AbiTypeLayout.lean
@@ -59,16 +59,31 @@ def eventIsDynamicType := isDynamicParamType
 
 def eventHeadWordSize := paramHeadSize
 
-/-- Number of 32-byte words in the local head of an ABI value once its dynamic
-tail has been entered. Dynamic children occupy one offset word in that head. -/
-partial def paramLocalHeadWords : ParamType → Nat
-  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address
-  | ParamType.bool | ParamType.bytes32 | ParamType.string | ParamType.bytes
-  | ParamType.array _ => 1
-  | ParamType.fixedArray elemTy n => n * paramLocalHeadWords elemTy
-  | ParamType.tuple elemTys => elemTys.foldl (fun acc ty => acc + paramLocalHeadWords ty) 0
-  | ParamType.adt _ maxFields => 1 + maxFields
-  | ParamType.newtypeOf _ baseType => paramLocalHeadWords baseType
+mutual
+  /-- Number of 32-byte words an ABI value contributes to its parent's head.
+  Dynamic children occupy one offset word in the parent head. -/
+  partial def paramParentHeadWords : ParamType → Nat
+    | ParamType.string | ParamType.bytes | ParamType.array _ => 1
+    | ParamType.tuple elemTys =>
+        if isDynamicParamTypeList elemTys then 1 else paramLocalHeadWords (ParamType.tuple elemTys)
+    | ParamType.fixedArray elemTy n =>
+        if isDynamicParamType (ParamType.fixedArray elemTy n) then 1 else n * paramParentHeadWords elemTy
+    | ParamType.newtypeOf _ baseType => paramParentHeadWords baseType
+    | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address
+    | ParamType.bool | ParamType.bytes32 => 1
+    | ParamType.adt _ maxFields => 1 + maxFields
+
+  /-- Number of 32-byte words in the local head of an ABI value once its dynamic
+  tail has been entered. Dynamic children occupy one offset word in that head. -/
+  partial def paramLocalHeadWords : ParamType → Nat
+    | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address
+    | ParamType.bool | ParamType.bytes32 | ParamType.string | ParamType.bytes
+    | ParamType.array _ => 1
+    | ParamType.fixedArray elemTy n => n * paramParentHeadWords elemTy
+    | ParamType.tuple elemTys => elemTys.foldl (fun acc ty => acc + paramParentHeadWords ty) 0
+    | ParamType.adt _ maxFields => 1 + maxFields
+    | ParamType.newtypeOf _ baseType => paramLocalHeadWords baseType
+end
 
 /-- Whether a parameter type is ABI-encoded as exactly one 32-byte word without
 needing offset-based dynamic handling. -/

--- a/Compiler/CompilationModel/AbiTypeLayout.lean
+++ b/Compiler/CompilationModel/AbiTypeLayout.lean
@@ -59,6 +59,17 @@ def eventIsDynamicType := isDynamicParamType
 
 def eventHeadWordSize := paramHeadSize
 
+/-- Number of 32-byte words in the local head of an ABI value once its dynamic
+tail has been entered. Dynamic children occupy one offset word in that head. -/
+partial def paramLocalHeadWords : ParamType → Nat
+  | ParamType.uint256 | ParamType.int256 | ParamType.uint8 | ParamType.address
+  | ParamType.bool | ParamType.bytes32 | ParamType.string | ParamType.bytes
+  | ParamType.array _ => 1
+  | ParamType.fixedArray elemTy n => n * paramLocalHeadWords elemTy
+  | ParamType.tuple elemTys => elemTys.foldl (fun acc ty => acc + paramLocalHeadWords ty) 0
+  | ParamType.adt _ maxFields => 1 + maxFields
+  | ParamType.newtypeOf _ baseType => paramLocalHeadWords baseType
+
 /-- Whether a parameter type is ABI-encoded as exactly one 32-byte word without
 needing offset-based dynamic handling. -/
 def isSingleWordStaticParamType (ty : ParamType) : Bool :=

--- a/Compiler/CompilationModel/Dispatch.lean
+++ b/Compiler/CompilationModel/Dispatch.lean
@@ -412,6 +412,8 @@ def compileValidatedCore (spec : CompilationModel) (selectors : List Nat) : Exce
     (if arrayElementWordHelpersRequired then
       [ checkedArrayElementWordCalldataHelper
       , checkedArrayElementWordMemoryHelper
+      , checkedArrayElementDynamicWordCalldataHelper
+      , checkedArrayElementDynamicWordMemoryHelper
       ]
     else
       [])

--- a/Compiler/CompilationModel/DynamicData.lean
+++ b/Compiler/CompilationModel/DynamicData.lean
@@ -26,6 +26,12 @@ def checkedArrayElementWordCalldataHelperName : String :=
 def checkedArrayElementWordMemoryHelperName : String :=
   "__verity_array_element_word_memory_checked"
 
+def checkedArrayElementDynamicWordCalldataHelperName : String :=
+  "__verity_array_element_dynamic_word_calldata_checked"
+
+def checkedArrayElementDynamicWordMemoryHelperName : String :=
+  "__verity_array_element_dynamic_word_memory_checked"
+
 def checkedStorageArrayElementHelperName : String :=
   "__verity_storage_array_element_checked"
 
@@ -82,6 +88,48 @@ def checkedArrayElementWordCalldataHelper : YulStmt :=
 
 def checkedArrayElementWordMemoryHelper : YulStmt :=
   checkedArrayElementWordHelper checkedArrayElementWordMemoryHelperName "mload"
+
+private def checkedArrayElementDynamicWordHelper (helperName loadOp : String) (sizeExpr? : Option YulExpr) : YulStmt :=
+  let offsetTableBytes := YulExpr.call "mul" [YulExpr.ident "length", YulExpr.lit 32]
+  let elementOffsetSlot := YulExpr.call "add" [
+    YulExpr.ident "data_offset",
+    YulExpr.call "mul" [YulExpr.ident "index", YulExpr.lit 32]
+  ]
+  let wordPos := YulExpr.call "add" [
+    YulExpr.call "add" [YulExpr.ident "data_offset", YulExpr.ident "__element_rel_offset"],
+    YulExpr.call "mul" [YulExpr.ident "word_offset", YulExpr.lit 32]
+  ]
+  let sizeCheck :=
+    match sizeExpr? with
+    | some sizeExpr =>
+        [YulStmt.if_ (YulExpr.call "gt" [
+          YulExpr.ident "__element_word_pos",
+          YulExpr.call "sub" [sizeExpr, YulExpr.lit 32]
+        ]) [
+          YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+        ]]
+    | none => []
+  YulStmt.funcDef helperName ["data_offset", "length", "index", "word_offset"] ["word"] (
+    [
+      YulStmt.if_ (YulExpr.call "iszero" [
+        YulExpr.call "lt" [YulExpr.ident "index", YulExpr.ident "length"]
+      ]) [
+        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      ],
+      YulStmt.let_ "__element_rel_offset" (YulExpr.call loadOp [elementOffsetSlot]),
+      YulStmt.if_ (YulExpr.call "lt" [YulExpr.ident "__element_rel_offset", offsetTableBytes]) [
+        YulStmt.expr (YulExpr.call "revert" [YulExpr.lit 0, YulExpr.lit 0])
+      ],
+      YulStmt.let_ "__element_word_pos" wordPos
+    ] ++ sizeCheck ++ [
+      YulStmt.assign "word" (YulExpr.call loadOp [YulExpr.ident "__element_word_pos"])
+    ])
+
+def checkedArrayElementDynamicWordCalldataHelper : YulStmt :=
+  checkedArrayElementDynamicWordHelper checkedArrayElementDynamicWordCalldataHelperName "calldataload" (some (YulExpr.call "calldatasize" []))
+
+def checkedArrayElementDynamicWordMemoryHelper : YulStmt :=
+  checkedArrayElementDynamicWordHelper checkedArrayElementDynamicWordMemoryHelperName "mload" none
 
 def checkedStorageArrayElementHelper : YulStmt :=
   YulStmt.funcDef checkedStorageArrayElementHelperName ["slot", "index"] ["word"] [

--- a/Compiler/CompilationModel/ExpressionCompile.lean
+++ b/Compiler/CompilationModel/ExpressionCompile.lean
@@ -274,6 +274,17 @@ def compileExpr (fields : List Field)
           YulExpr.lit elementWords,
           YulExpr.lit wordOffset
         ])
+  | Expr.arrayElementDynamicWord name index wordOffset => do
+      let indexExpr ← compileExpr fields dynamicSource index
+      let helperName := match dynamicSource with
+        | .calldata => checkedArrayElementDynamicWordCalldataHelperName
+        | .memory => checkedArrayElementDynamicWordMemoryHelperName
+      pure (YulExpr.call helperName [
+        YulExpr.ident s!"{name}_data_offset",
+        YulExpr.ident s!"{name}_length",
+        indexExpr,
+        YulExpr.lit wordOffset
+      ])
   | Expr.storageArrayLength field =>
       match findFieldWithResolvedSlot fields field with
       | some (f, slot) =>

--- a/Compiler/CompilationModel/LogicalPurity.lean
+++ b/Compiler/CompilationModel/LogicalPurity.lean
@@ -20,7 +20,8 @@ partial def exprContainsCallLike (expr : Expr) : Bool :=
       exprContainsCallLike key1 || exprContainsCallLike key2
   | Expr.storageArrayElement _ index
   | Expr.arrayElement _ index
-  | Expr.arrayElementWord _ index _ _ =>
+  | Expr.arrayElementWord _ index _ _
+  | Expr.arrayElementDynamicWord _ index _ =>
       exprContainsCallLike index
   | Expr.dynamicBytesEq _ _ =>
       false
@@ -112,7 +113,8 @@ def exprContainsUnsafeLogicalCallLike (expr : Expr) : Bool :=
   | Expr.structMember2 _ key1 key2 _ =>
       exprContainsUnsafeLogicalCallLike key1 || exprContainsUnsafeLogicalCallLike key2
   | Expr.storageArrayElement _ index | Expr.arrayElement _ index
-  | Expr.arrayElementWord _ index _ _ | Expr.returndataOptionalBoolAt index =>
+  | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _
+  | Expr.returndataOptionalBoolAt index =>
       exprContainsUnsafeLogicalCallLike index
   | Expr.dynamicBytesEq _ _ =>
       false

--- a/Compiler/CompilationModel/ScopeValidation.lean
+++ b/Compiler/CompilationModel/ScopeValidation.lean
@@ -141,7 +141,7 @@ def validateScopedExprIdentifiers
           if isDynamicParamType elemTy then
             throw s!"Compilation error: {context} Expr.arrayElementWord '{name}' requires an array parameter with static ABI-word elements, got {repr ty}"
           else
-            let expectedWords := paramHeadSize elemTy / 32
+            let expectedWords := paramLocalHeadWords elemTy
             if elementWords == expectedWords then
               pure ()
             else
@@ -150,6 +150,22 @@ def validateScopedExprIdentifiers
           throw s!"Compilation error: {context} Expr.arrayElementWord '{name}' requires array parameter, got {repr ty}"
       | none =>
           throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayElementWord"
+      validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
+  | Expr.arrayElementDynamicWord name index wordOffset => do
+      match findParamType params name with
+      | some ty@(ParamType.array elemTy) =>
+          if isDynamicParamType elemTy then
+            let expectedWords := paramLocalHeadWords elemTy
+            if wordOffset < expectedWords then
+              pure ()
+            else
+              throw s!"Compilation error: {context} Expr.arrayElementDynamicWord '{name}' wordOffset {wordOffset} is outside dynamic element head width {expectedWords} for {repr ty}"
+          else
+            throw s!"Compilation error: {context} Expr.arrayElementDynamicWord '{name}' requires an array parameter with dynamic ABI elements, got {repr ty}"
+      | some ty =>
+          throw s!"Compilation error: {context} Expr.arrayElementDynamicWord '{name}' requires array parameter, got {repr ty}"
+      | none =>
+          throw s!"Compilation error: {context} references unknown parameter '{name}' in Expr.arrayElementDynamicWord"
       validateScopedExprIdentifiers context params paramScope dynamicParams localScope constructorArgCount index
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ =>

--- a/Compiler/CompilationModel/TrustSurface.lean
+++ b/Compiler/CompilationModel/TrustSurface.lean
@@ -59,7 +59,8 @@ private partial def collectLowLevelExprMechanics : Expr → List String
   | .mappingUint _ key
   | .storageArrayElement _ key
   | .arrayElement _ key
-  | .arrayElementWord _ key _ _ =>
+  | .arrayElementWord _ key _ _
+  | .arrayElementDynamicWord _ key _ =>
       collectLowLevelExprMechanics key
   | .mload key =>
       ["mload"] ++ collectLowLevelExprMechanics key
@@ -123,7 +124,8 @@ private partial def collectAxiomatizedExprPrimitives : Expr → List String
   | .mappingUint _ key
   | .storageArrayElement _ key
   | .arrayElement _ key
-  | .arrayElementWord _ key _ _ =>
+  | .arrayElementWord _ key _ _
+  | .arrayElementDynamicWord _ key _ =>
       collectAxiomatizedExprPrimitives key
   | .externalCall _ args
   | .internalCall _ args =>
@@ -452,7 +454,8 @@ private partial def collectEventEmissionExprMechanics : Expr → List String
       keys.flatMap collectEventEmissionExprMechanics
   | .mappingUint _ key
   | .arrayElement _ key
-  | .arrayElementWord _ key _ _ =>
+  | .arrayElementWord _ key _ _
+  | .arrayElementDynamicWord _ key _ =>
       collectEventEmissionExprMechanics key
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .shl a b | .shr a b | .sar a b | .signextend a b
@@ -613,7 +616,8 @@ private partial def collectRuntimeIntrospectionExprMechanics : Expr → List Str
       keys.flatMap collectRuntimeIntrospectionExprMechanics
   | .mappingUint _ key
   | .arrayElement _ key
-  | .arrayElementWord _ key _ _ =>
+  | .arrayElementWord _ key _ _
+  | .arrayElementDynamicWord _ key _ =>
       collectRuntimeIntrospectionExprMechanics key
   | .add a b | .sub a b | .mul a b | .div a b | .sdiv a b | .mod a b | .smod a b
   | .bitAnd a b | .bitOr a b | .bitXor a b | .shl a b | .shr a b | .sar a b | .signextend a b
@@ -762,7 +766,8 @@ private partial def collectExternalExprNames : Expr → List String
       keys.flatMap collectExternalExprNames
   | .mappingUint _ key
   | .arrayElement _ key
-  | .arrayElementWord _ key _ _ =>
+  | .arrayElementWord _ key _ _
+  | .arrayElementDynamicWord _ key _ =>
       collectExternalExprNames key
   | .internalCall _ args =>
       args.flatMap collectExternalExprNames

--- a/Compiler/CompilationModel/Types.lean
+++ b/Compiler/CompilationModel/Types.lean
@@ -342,6 +342,11 @@ inductive Expr
       static ABI word width of one element and `wordOffset` is the word inside
       that element.  This supports arrays of static tuple/struct-like values. -/
   | arrayElementWord (name : String) (index : Expr) (elementWords wordOffset : Nat)
+  /-- Checked word access inside the head of a dynamically-sized array element.
+      This supports arrays of tuple/struct-like values whose element contains
+      nested dynamic members; `wordOffset` indexes the element head after the
+      ABI element offset has been resolved. -/
+  | arrayElementDynamicWord (name : String) (index : Expr) (wordOffset : Nat)
   | storageArrayLength (field : String)  -- Read the length word of a storage dynamic array (#1571)
   | storageArrayElement (field : String) (index : Expr)  -- Checked element access of a storage dynamic array (#1571)
   /-- Equality on direct `bytes` / `string` parameters loaded from calldata or memory.

--- a/Compiler/CompilationModel/UsageAnalysis.lean
+++ b/Compiler/CompilationModel/UsageAnalysis.lean
@@ -98,6 +98,9 @@ def exprUsesArrayElementKind (includePlain includeWord : Bool) : Expr → Bool
   | Expr.arrayElementWord _ index _ _ =>
       let nested := exprUsesArrayElementKind includePlain includeWord index
       if nested then true else includeWord
+  | Expr.arrayElementDynamicWord _ index _ =>
+      let nested := exprUsesArrayElementKind includePlain includeWord index
+      if nested then true else includeWord
   | Expr.mapping _ key => exprUsesArrayElementKind includePlain includeWord key
   | Expr.mappingWord _ key _ => exprUsesArrayElementKind includePlain includeWord key
   | Expr.mappingPackedWord _ key _ _ => exprUsesArrayElementKind includePlain includeWord key
@@ -289,7 +292,7 @@ attribute [simp] exprUsesArrayElementKind exprListUsesArrayElementKind
 
 mutual
 def exprUsesArrayElement : Expr → Bool
-  | Expr.arrayElement _ _ | Expr.arrayElementWord _ _ _ _ =>
+  | Expr.arrayElement _ _ | Expr.arrayElementWord _ _ _ _ | Expr.arrayElementDynamicWord _ _ _ =>
       true
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _
   | Expr.mappingUint _ key | Expr.structMember _ key _ =>
@@ -544,7 +547,7 @@ def exprUsesStorageArrayElement : Expr → Bool
   | Expr.calldatasize | Expr.returndataSize | Expr.localVar _ | Expr.arrayLength _ | Expr.storageArrayLength _
   | Expr.adtTag _ _ =>
       false
-  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ =>
+  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _ =>
       exprUsesStorageArrayElement index
 termination_by e => sizeOf e
 decreasing_by all_goals simp_wf; all_goals omega
@@ -663,7 +666,7 @@ def exprUsesDynamicBytesEq : Expr → Bool
   | Expr.externalCall _ args | Expr.internalCall _ args =>
       exprListUsesDynamicBytesEq args
   | Expr.storageArrayElement _ index | Expr.arrayElement _ index
-  | Expr.arrayElementWord _ index _ _ => exprUsesDynamicBytesEq index
+  | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _ => exprUsesDynamicBytesEq index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
   | Expr.mod a b | Expr.smod a b
   | Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b

--- a/Compiler/CompilationModel/Validation.lean
+++ b/Compiler/CompilationModel/Validation.lean
@@ -273,7 +273,7 @@ def exprReadsStateOrEnv : Expr → Bool
   | Expr.arrayLength _ => false
   | Expr.storageArrayLength _ => true
   | Expr.storageArrayElement _ index => true || exprReadsStateOrEnv index
-  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ => exprReadsStateOrEnv index
+  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _ => exprReadsStateOrEnv index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b
   | Expr.mod a b | Expr.smod a b |
     Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b
@@ -345,7 +345,7 @@ def exprWritesState : Expr → Bool
       false
   | Expr.storageArrayElement _ index =>
       exprWritesState index
-  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ =>
+  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _ =>
       exprWritesState index
   | _ =>
       false
@@ -487,6 +487,7 @@ def exprHasUntrackableWrites : Expr → Bool
       exprHasUntrackableWrites cond || exprHasUntrackableWrites thenVal || exprHasUntrackableWrites elseVal
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
+  | Expr.arrayElementDynamicWord _ key _
   | Expr.storageArrayElement _ key =>
       exprHasUntrackableWrites key
   | Expr.mappingChain _ keys =>
@@ -608,6 +609,7 @@ def exprContainsExternalCall : Expr → Bool
       exprContainsExternalCall cond || exprContainsExternalCall thenVal || exprContainsExternalCall elseVal
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
+  | Expr.arrayElementDynamicWord _ key _
   | Expr.storageArrayElement _ key =>
       exprContainsExternalCall key
   | Expr.mappingChain _ keys =>
@@ -662,6 +664,7 @@ def exprMayContainExternalCall : Expr → Bool
       exprMayContainExternalCall cond || exprMayContainExternalCall thenVal || exprMayContainExternalCall elseVal
   | Expr.mapping _ key | Expr.mappingWord _ key _ | Expr.mappingPackedWord _ key _ _ | Expr.mappingUint _ key
   | Expr.structMember _ key _ | Expr.arrayElement _ key | Expr.arrayElementWord _ key _ _
+  | Expr.arrayElementDynamicWord _ key _
   | Expr.storageArrayElement _ key =>
       exprMayContainExternalCall key
   | Expr.mappingChain _ keys =>
@@ -1096,7 +1099,8 @@ def exprContainsAdtConstruct : Expr → Bool
   | Expr.bitNot a | Expr.logicalNot a | Expr.extcodesize a
   | Expr.mload a | Expr.tload a | Expr.calldataload a
   | Expr.returndataOptionalBoolAt a
-  | Expr.storageArrayElement _ a | Expr.arrayElement _ a | Expr.arrayElementWord _ a _ _ =>
+  | Expr.storageArrayElement _ a | Expr.arrayElement _ a | Expr.arrayElementWord _ a _ _
+  | Expr.arrayElementDynamicWord _ a _ =>
       exprContainsAdtConstruct a
   | Expr.ite cond thenVal elseVal =>
       exprContainsAdtConstruct cond || exprContainsAdtConstruct thenVal ||

--- a/Compiler/CompilationModel/ValidationCalls.lean
+++ b/Compiler/CompilationModel/ValidationCalls.lean
@@ -26,6 +26,8 @@ def reservedExternalNames
     if arrayElementWordHelpersRequired then
       [ checkedArrayElementWordCalldataHelperName
       , checkedArrayElementWordMemoryHelperName
+      , checkedArrayElementDynamicWordCalldataHelperName
+      , checkedArrayElementDynamicWordMemoryHelperName
       ]
     else
       []
@@ -140,7 +142,8 @@ def validateInternalCallShapesInExpr
       validateInternalCallShapesInExpr functions callerName key
   | Expr.storageArrayElement _ index
   | Expr.arrayElement _ index
-  | Expr.arrayElementWord _ index _ _ =>
+  | Expr.arrayElementWord _ index _ _
+  | Expr.arrayElementDynamicWord _ index _ =>
       validateInternalCallShapesInExpr functions callerName index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b | Expr.mod a b | Expr.smod a b |
     Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b |
@@ -372,7 +375,8 @@ def validateExternalCallTargetsInExpr
       validateExternalCallTargetsInExprList externals context args
   | Expr.storageArrayElement _ index
   | Expr.arrayElement _ index
-  | Expr.arrayElementWord _ index _ _ =>
+  | Expr.arrayElementWord _ index _ _
+  | Expr.arrayElementDynamicWord _ index _ =>
       validateExternalCallTargetsInExpr externals context index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b | Expr.mod a b | Expr.smod a b |
     Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b |

--- a/Compiler/CompilationModel/ValidationHelpers.lean
+++ b/Compiler/CompilationModel/ValidationHelpers.lean
@@ -77,7 +77,8 @@ def collectExprNames : Expr → List String
   | Expr.externalCall name args => name :: collectExprListNames args
   | Expr.internalCall name args => name :: collectExprListNames args
   | Expr.arrayLength name => [name]
-  | Expr.arrayElement name index | Expr.arrayElementWord name index _ _ =>
+  | Expr.arrayElement name index | Expr.arrayElementWord name index _ _
+  | Expr.arrayElementDynamicWord name index _ =>
       name :: collectExprNames index
   | Expr.storageArrayLength field => [field]
   | Expr.storageArrayElement field index => field :: collectExprNames index

--- a/Compiler/CompilationModel/ValidationInterop.lean
+++ b/Compiler/CompilationModel/ValidationInterop.lean
@@ -83,7 +83,7 @@ def validateInteropExpr (context : String) : Expr → Except String Unit
       validateInteropExprList context args
   | Expr.storageArrayElement _ index =>
       validateInteropExpr context index
-  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ =>
+  | Expr.arrayElement _ index | Expr.arrayElementWord _ index _ _ | Expr.arrayElementDynamicWord _ index _ =>
       validateInteropExpr context index
   | Expr.add a b | Expr.sub a b | Expr.mul a b | Expr.div a b | Expr.sdiv a b | Expr.mod a b | Expr.smod a b |
     Expr.bitAnd a b | Expr.bitOr a b | Expr.bitXor a b | Expr.shl a b | Expr.shr a b |

--- a/Compiler/Proofs/IRGeneration/ExprCore.lean
+++ b/Compiler/Proofs/IRGeneration/ExprCore.lean
@@ -37,7 +37,8 @@ def exprBoundNames : Expr → List String
   | .externalCall _ args | .internalCall _ args | .adtConstruct _ _ args => exprListBoundNames args
   | .adtTag _ field => [field]
   | .adtField _ _ _ _ storageField => [storageField]
-  | .arrayElement name index | .arrayElementWord name index _ _ => name :: exprBoundNames index
+  | .arrayElement name index | .arrayElementWord name index _ _
+  | .arrayElementDynamicWord name index _ => name :: exprBoundNames index
   | .arrayLength name => [name]
   | .storageArrayLength name => [name]
   | .storageArrayElement name index => name :: exprBoundNames index

--- a/Compiler/Proofs/IRGeneration/SourceSemantics.lean
+++ b/Compiler/Proofs/IRGeneration/SourceSemantics.lean
@@ -1346,6 +1346,14 @@ private theorem evalExpr_arrayElementWord
     (elementWords wordOffset : Nat) :
     evalExpr fields state (.arrayElementWord name index elementWords wordOffset) = none := rfl
 
+private theorem evalExpr_arrayElementDynamicWord
+    (fields : List Field)
+    (state : RuntimeState)
+    (name : String)
+    (index : Expr)
+    (wordOffset : Nat) :
+    evalExpr fields state (.arrayElementDynamicWord name index wordOffset) = none := rfl
+
 private theorem evalExpr_mappingWord
     (fields : List Field)
     (state : RuntimeState)
@@ -3671,6 +3679,8 @@ mutual
         simp [evalExprWithHelpers, evalExpr_arrayElement]
     | arrayElementWord _ b _ _ =>
         simp [evalExprWithHelpers, evalExpr_arrayElementWord]
+    | arrayElementDynamicWord _ b _ =>
+        simp [evalExprWithHelpers, evalExpr_arrayElementDynamicWord]
     | mappingWord _ b _ | mappingPackedWord _ b _ _ | structMember _ b _ =>
         simp only [exprTouchesUnsupportedHelperSurface] at hsurface
         have hb :=

--- a/Compiler/Proofs/IRGeneration/SupportedSpec.lean
+++ b/Compiler/Proofs/IRGeneration/SupportedSpec.lean
@@ -565,6 +565,7 @@ def exprTouchesUnsupportedConstructorRawCalldataSurface : Expr → Bool
   | .mapping _ a | .mappingWord _ a _ | .mappingPackedWord _ a _ _
   | .mappingUint _ a | .structMember _ a _ | .arrayElement _ a
   | .arrayElementWord _ a _ _
+  | .arrayElementDynamicWord _ a _
   | .storageArrayElement _ a =>
       exprTouchesUnsupportedConstructorRawCalldataSurface a
   | .add a b | .sub a b | .mul a b | .div a b | .mod a b
@@ -710,6 +711,7 @@ def exprTouchesUnsupportedCoreSurface : Expr → Bool
   | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
+  | .arrayElementDynamicWord _ _ _
   | .storageArrayLength _ | .storageArrayElement _ _
   | .dynamicBytesEq _ _
   | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => true
@@ -747,6 +749,7 @@ def exprTouchesUnsupportedStateSurface : Expr → Bool
   | .calldatasize | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
+  | .arrayElementDynamicWord _ _ _
   | .dynamicBytesEq _ _ => false
   | .mload a | .tload a | .calldataload a => exprTouchesUnsupportedStateSurface a
   | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => true
@@ -772,6 +775,7 @@ def exprTouchesUnsupportedCallSurface : Expr → Bool
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesUnsupportedCallSurface a || exprTouchesUnsupportedCallSurface b
   | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .arrayElementDynamicWord _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedCallSurface b
   | .mappingChain _ _ => true
@@ -813,6 +817,7 @@ def exprTouchesUnsupportedHelperSurface : Expr → Bool
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesUnsupportedHelperSurface a || exprTouchesUnsupportedHelperSurface b
   | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .arrayElementDynamicWord _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedHelperSurface b
   | .mappingChain _ _ => true
@@ -862,6 +867,7 @@ def exprTouchesInternalHelperSurface : Expr → Bool
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesInternalHelperSurface a || exprTouchesInternalHelperSurface b
   | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .arrayElementDynamicWord _ b _
   | .storageArrayElement _ b =>
       exprTouchesInternalHelperSurface b
   | .mappingChain _ [] => false
@@ -905,6 +911,7 @@ def exprTouchesUnsupportedForeignSurface : Expr → Bool
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesUnsupportedForeignSurface a || exprTouchesUnsupportedForeignSurface b
   | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .arrayElementDynamicWord _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedForeignSurface b
   | .mappingChain _ _ => true
@@ -945,6 +952,7 @@ def exprTouchesUnsupportedLowLevelSurface : Expr → Bool
   | .min a b | .max a b | .wMulDown a b | .wDivUp a b | .ceilDiv a b =>
       exprTouchesUnsupportedLowLevelSurface a || exprTouchesUnsupportedLowLevelSurface b
   | .mapping _ b | .mappingUint _ b | .arrayElement _ b | .arrayElementWord _ b _ _
+  | .arrayElementDynamicWord _ b _
   | .storageArrayElement _ b =>
       exprTouchesUnsupportedLowLevelSurface b
   | .mappingChain _ _ => true
@@ -1002,6 +1010,7 @@ def exprTouchesUnsupportedContractSurface (expr : Expr) : Bool :=
   | .returndataSize | .extcodesize _
   | .returndataOptionalBoolAt _ | .externalCall _ _ | .internalCall _ _
   | .arrayLength _ | .arrayElement _ _ | .arrayElementWord _ _ _ _
+  | .arrayElementDynamicWord _ _ _
   | .storageArrayLength _ | .storageArrayElement _ _
   | .dynamicBytesEq _ _
   | .adtConstruct _ _ _ | .adtTag _ _ | .adtField _ _ _ _ _ => true
@@ -1604,6 +1613,7 @@ mutual
     | .mapping _ key | .mappingWord _ key _ | .mappingPackedWord _ key _ _
     | .mappingUint _ key | .structMember _ key _ | .arrayElement _ key
     | .arrayElementWord _ key _ _
+    | .arrayElementDynamicWord _ key _
     | .storageArrayElement _ key | .mload key | .tload key | .calldataload key
     | .extcodesize key | .returndataOptionalBoolAt key =>
         exprInternalHelperCallNames key
@@ -3129,6 +3139,7 @@ mutual
         simp [exprTouchesInternalHelperSurface,
           exprTouchesInternalHelperSurface_eq_false_of_helperSurfaceClosed hsurface]
     | mapping _ b | mappingUint _ b | arrayElement _ b | arrayElementWord _ b _ _
+    | arrayElementDynamicWord _ b _
     | storageArrayElement _ b
     | mappingWord _ b _ | mappingPackedWord _ b _ _ | structMember _ b _ =>
         simp only [exprTouchesUnsupportedHelperSurface] at hsurface
@@ -3516,6 +3527,10 @@ private theorem exprTouchesUnsupportedCallSurface_eq_featureOr
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
         exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
       exact exprTouchesUnsupportedCallSurface_eq_featureOr b
+  | arrayElementDynamicWord _ b _ =>
+      simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
+        exprTouchesUnsupportedForeignSurface, exprTouchesUnsupportedLowLevelSurface]
+      exact exprTouchesUnsupportedCallSurface_eq_featureOr b
   | mappingWord _ a _ | mappingPackedWord _ a _ _
   | structMember _ a _ =>
       simp only [exprTouchesUnsupportedCallSurface, exprTouchesUnsupportedHelperSurface,
@@ -3748,7 +3763,8 @@ private theorem exprTouchesUnsupportedContractSurface_eq_false_of_featureClosed
   | mapping _ _ | mappingWord _ _ _ | mappingPackedWord _ _ _ _
   | mapping2 _ _ _ | mapping2Word _ _ _ _ | mappingUint _ _
   | mappingChain _ _ | structMember _ _ _ | structMember2 _ _ _ _
-  | arrayElement _ _ | arrayElementWord _ _ _ _ | storageArrayElement _ _
+  | arrayElement _ _ | arrayElementWord _ _ _ _ | arrayElementDynamicWord _ _ _
+  | storageArrayElement _ _
   | call _ _ _ _ _ _ _ | staticcall _ _ _ _ _ _ | delegatecall _ _ _ _ _ _
   | externalCall _ _ | internalCall _ _ =>
       cases hcore
@@ -4046,7 +4062,8 @@ theorem exprTouchesUnsupportedHelperSurface_eq_false_of_contractSurfaceClosed
   | mapping _ _ | mappingWord _ _ _ | mappingPackedWord _ _ _ _
   | mapping2 _ _ _ | mapping2Word _ _ _ _ | mappingUint _ _
   | structMember _ _ _ | structMember2 _ _ _ _
-  | arrayElement _ _ | arrayElementWord _ _ _ _ | storageArrayElement _ _
+  | arrayElement _ _ | arrayElementWord _ _ _ _ | arrayElementDynamicWord _ _ _
+  | storageArrayElement _ _
   | mappingChain _ _ =>
       simp [exprTouchesUnsupportedContractSurface] at hsurface
   | tload a | calldataload a | mload a =>

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -314,6 +314,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.TupleSmoke.spec
   , Contracts.Smoke.NamedStructParamSmoke.spec
   , Contracts.Smoke.CurveCutArraySmoke.spec
+  , Contracts.Smoke.DynamicStructArraySmoke.spec
   , Contracts.Smoke.PackedStorageWriteSmoke.spec
   , Contracts.Smoke.PackedAddressStorageWriteSmoke.spec
   , Contracts.Smoke.Uint8Smoke.spec
@@ -426,6 +427,9 @@ private def expectedExternalSignatures : List (String × List String) :=
       "readNestedMaker(((uint256,uint256),address))"])
   , ("CurveCutArraySmoke", ["firstCutXt((uint256,uint256,int256)[])", "returnCut((uint256,uint256,int256)[],uint256)",
       "storeCut((uint256,uint256,int256)[],uint256)", "storeTwoCuts((uint256,uint256,int256)[],uint256,uint256)"])
+  , ("DynamicStructArraySmoke", ["tokenOf((uint256[],(address,uint256,bytes32),(uint256[],bytes32)[],address,uint256)[],uint256)",
+      "feeOf((uint256[],(address,uint256,bytes32),(uint256[],bytes32)[],address,uint256)[],uint256)",
+      "storeTokenAndFee((uint256[],(address,uint256,bytes32),(uint256[],bytes32)[],address,uint256)[],uint256)"])
   , ("PackedStorageWriteSmoke", ["writeSlot0(bool,uint256)", "writeSlot1(uint256,uint256)"])
   , ("PackedAddressStorageWriteSmoke", ["writeOwnerWord(uint256)"])
   , ("Uint8Smoke", ["acceptSig((uint8,bytes32,bytes32))", "sigV()"])
@@ -533,6 +537,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("TupleSmoke", ["0x712ea680", "0xbdf391cc", "0x01b427d2"])
   , ("NamedStructParamSmoke", ["0xa01f780b", "0x38946c6d", "0x596635bb"])
   , ("CurveCutArraySmoke", ["0xefca8f0f", "0x6f413e6b", "0x0d7610a3", "0xbea7dfd2"])
+  , ("DynamicStructArraySmoke", ["0xcbe2b47b", "0x587d08b7", "0x1fae5c19"])
   , ("PackedStorageWriteSmoke", ["0xa0522387", "0x233ab149"])
   , ("PackedAddressStorageWriteSmoke", ["0xd59c874d"])
   , ("Uint8Smoke", ["0xc233eaa7", "0x62fc458b"])
@@ -926,6 +931,18 @@ private def checkCurveCutArraySmoke : IO Unit := do
   expectTrue "CurveCutArraySmoke: repeated tuple arrayElement destructures use fresh synthetic indexes"
     curveCutArrayRepeatedDestructuresUseFreshSyntheticIndexes
 
+private def checkDynamicStructArraySmoke : IO Unit := do
+  expectTrue
+    "DynamicStructArraySmoke: dynamic struct array leaf projection lowers through dynamic element head word"
+    (match Contracts.Smoke.DynamicStructArraySmoke.tokenOf_modelBody with
+    | [Stmt.return (Expr.arrayElementDynamicWord "txs" (Expr.param "idx") 5)] => true
+    | _ => false)
+  expectTrue
+    "DynamicStructArraySmoke: later static leaf in dynamic struct array uses flattened head offset"
+    (match Contracts.Smoke.DynamicStructArraySmoke.feeOf_modelBody with
+    | [Stmt.return (Expr.arrayElementDynamicWord "txs" (Expr.param "idx") 6)] => true
+    | _ => false)
+
 private def checkSpec (spec : CompilationModel) : IO Unit := do
   let extFns := externalFunctions spec
   let fnNames := extFns.map (·.name)
@@ -1048,6 +1065,7 @@ private def checkSpec (spec : CompilationModel) : IO Unit := do
   checkDirectHelperCallSmoke
   checkNamedStructParamSmoke
   checkCurveCutArraySmoke
+  checkDynamicStructArraySmoke
   for spec in macroSpecs do
     checkSpec spec
 

--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -429,6 +429,7 @@ private def expectedExternalSignatures : List (String × List String) :=
       "storeCut((uint256,uint256,int256)[],uint256)", "storeTwoCuts((uint256,uint256,int256)[],uint256,uint256)"])
   , ("DynamicStructArraySmoke", ["tokenOf((uint256[],(address,uint256,bytes32),(uint256[],bytes32)[],address,uint256)[],uint256)",
       "feeOf((uint256[],(address,uint256,bytes32),(uint256[],bytes32)[],address,uint256)[],uint256)",
+      "wrappedTokenOf(((uint256[],bytes32),address,uint256)[],uint256)",
       "storeTokenAndFee((uint256[],(address,uint256,bytes32),(uint256[],bytes32)[],address,uint256)[],uint256)"])
   , ("PackedStorageWriteSmoke", ["writeSlot0(bool,uint256)", "writeSlot1(uint256,uint256)"])
   , ("PackedAddressStorageWriteSmoke", ["writeOwnerWord(uint256)"])
@@ -537,7 +538,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("TupleSmoke", ["0x712ea680", "0xbdf391cc", "0x01b427d2"])
   , ("NamedStructParamSmoke", ["0xa01f780b", "0x38946c6d", "0x596635bb"])
   , ("CurveCutArraySmoke", ["0xefca8f0f", "0x6f413e6b", "0x0d7610a3", "0xbea7dfd2"])
-  , ("DynamicStructArraySmoke", ["0xcbe2b47b", "0x587d08b7", "0x1fae5c19"])
+  , ("DynamicStructArraySmoke", ["0xcbe2b47b", "0x587d08b7", "0x0b7d2799", "0x1fae5c19"])
   , ("PackedStorageWriteSmoke", ["0xa0522387", "0x233ab149"])
   , ("PackedAddressStorageWriteSmoke", ["0xd59c874d"])
   , ("Uint8Smoke", ["0xc233eaa7", "0x62fc458b"])
@@ -941,6 +942,11 @@ private def checkDynamicStructArraySmoke : IO Unit := do
     "DynamicStructArraySmoke: later static leaf in dynamic struct array uses flattened head offset"
     (match Contracts.Smoke.DynamicStructArraySmoke.feeOf_modelBody with
     | [Stmt.return (Expr.arrayElementDynamicWord "txs" (Expr.param "idx") 6)] => true
+    | _ => false)
+  expectTrue
+    "DynamicStructArraySmoke: dynamic child struct contributes one parent head word"
+    (match Contracts.Smoke.DynamicStructArraySmoke.wrappedTokenOf_modelBody with
+    | [Stmt.return (Expr.arrayElementDynamicWord "items" (Expr.param "idx") 1)] => true
     | _ => false)
 
 private def checkSpec (spec : CompilationModel) : IO Unit := do

--- a/Contracts/MacroTranslateRoundTripFuzz.lean
+++ b/Contracts/MacroTranslateRoundTripFuzz.lean
@@ -70,6 +70,7 @@ private def macroSpecs : List CompilationModel :=
   , Contracts.Smoke.TupleSmoke.spec
   , Contracts.Smoke.NamedStructParamSmoke.spec
   , Contracts.Smoke.CurveCutArraySmoke.spec
+  , Contracts.Smoke.DynamicStructArraySmoke.spec
   , Contracts.Smoke.PackedStorageWriteSmoke.spec
   , Contracts.Smoke.PackedAddressStorageWriteSmoke.spec
   , Contracts.Smoke.Uint8Smoke.spec

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1062,6 +1062,56 @@ def curveCutArrayExecutableReadsTupleElement : Bool :=
 
 example : curveCutArrayExecutableReadsTupleElement = true := by decide
 
+verity_contract DynamicStructArraySmoke where
+  storage
+    lastToken : Address := slot 0
+    lastAmount : Uint256 := slot 1
+
+  struct Note where
+    owner : Address,
+    amount : Uint256,
+    nullifier : Bytes32
+
+  struct Ciphertext where
+    data : Array Uint256,
+    nonce : Bytes32
+
+  struct Transaction where
+    proof : Array Uint256,
+    note : Note,
+    ciphertexts : Array Ciphertext,
+    token : Address,
+    fee : Uint256
+
+  function tokenOf (txs : Array Transaction, idx : Uint256) : Address := do
+    return (arrayElement txs idx).token
+
+  function feeOf (txs : Array Transaction, idx : Uint256) : Uint256 := do
+    return (arrayElement txs idx).fee
+
+  function storeTokenAndFee (txs : Array Transaction, idx : Uint256) : Unit := do
+    setStorageAddr lastToken (arrayElement txs idx).token
+    setStorage lastAmount (arrayElement txs idx).fee
+
+def dynamicStructArrayExecutableReadsStaticLeaves : Bool :=
+  let note : DynamicStructArraySmoke.Note := {
+    owner := 0x1234,
+    amount := 99,
+    nullifier := 7
+  }
+  let tx : DynamicStructArraySmoke.Transaction := {
+    proof := #[1, 2, 3],
+    note := note,
+    ciphertexts := #[],
+    token := 0xabcd,
+    fee := 5
+  }
+  match DynamicStructArraySmoke.feeOf #[tx] 0 Verity.defaultState with
+  | .success value _ => value == 5
+  | _ => false
+
+example : dynamicStructArrayExecutableReadsStaticLeaves = true := by decide
+
 verity_contract PackedStorageWriteSmoke where
   storage
     stateRoot : Uint256 := slot 0
@@ -1729,6 +1779,7 @@ end SpecGenSmoke
 #check_contract TupleSmoke
 #check_contract NamedStructParamSmoke
 #check_contract CurveCutArraySmoke
+#check_contract DynamicStructArraySmoke
 #check_contract PackedStorageWriteSmoke
 #check_contract DirectHelperCallSmoke
 #check_contract Uint8Smoke

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -1083,11 +1083,19 @@ verity_contract DynamicStructArraySmoke where
     token : Address,
     fee : Uint256
 
+  struct WrappedCiphertext where
+    ciphertext : Ciphertext,
+    token : Address,
+    fee : Uint256
+
   function tokenOf (txs : Array Transaction, idx : Uint256) : Address := do
     return (arrayElement txs idx).token
 
   function feeOf (txs : Array Transaction, idx : Uint256) : Uint256 := do
     return (arrayElement txs idx).fee
+
+  function wrappedTokenOf (items : Array WrappedCiphertext, idx : Uint256) : Address := do
+    return (arrayElement items idx).token
 
   function storeTokenAndFee (txs : Array Transaction, idx : Uint256) : Unit := do
     setStorageAddr lastToken (arrayElement txs idx).token

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -2023,6 +2023,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mappingUint  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElement  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementWord  -- private
+-- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_arrayElementDynamicWord  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mappingWord  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_mappingPackedWord  -- private
 -- #print axioms Compiler.Proofs.IRGeneration.SourceSemantics.evalExpr_structMember  -- private
@@ -3689,4 +3690,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3513 theorems/lemmas (2569 public, 944 private, 0 sorry'd)
+-- Total: 3514 theorems/lemmas (2569 public, 945 private, 0 sorry'd)

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1443,6 +1443,26 @@ private partial def staticAbiWordCount? : ValueType → Option Nat
   | .newtype _ baseType => staticAbiWordCount? baseType
   | _ => none
 
+private partial def abiLocalHeadWordCount? : ValueType → Option Nat
+  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool
+  | .string | .bytes | .array _ => some 1
+  | .tuple elemTys =>
+      elemTys.foldl
+        (fun acc ty =>
+          match acc, abiLocalHeadWordCount? ty with
+          | some n, some m => some (n + m)
+          | _, _ => none)
+        (some 0)
+  | .struct _ fields =>
+      fields.foldl
+        (fun acc field =>
+          match acc, abiLocalHeadWordCount? field.snd with
+          | some n, some m => some (n + m)
+          | _, _ => none)
+        (some 0)
+  | .newtype _ baseType => abiLocalHeadWordCount? baseType
+  | .adt _ _ | .unit => none
+
 private partial def valueTypeUsesDynamicData : ValueType → Bool
   | .string | .bytes | .array _ => true
   | .tuple elemTys => elemTys.any valueTypeUsesDynamicData
@@ -1562,6 +1582,30 @@ private partial def structFieldPath?
               none
       | _ => none
 
+private partial def structFieldHeadOffset?
+    (ty : ValueType)
+    (path : List String)
+    (baseOffset : Nat := 0) : Option (ValueType × Nat) :=
+  match path with
+  | [] => none
+  | fieldName :: rest =>
+      match ty with
+      | .struct _ fields =>
+          let rec go (remaining : List (String × ValueType)) (curOffset : Nat) : Option (ValueType × Nat) :=
+            match remaining with
+            | [] => none
+            | (name, fieldTy) :: more =>
+                if name == fieldName then
+                  match rest with
+                  | [] => some (fieldTy, curOffset)
+                  | _ => structFieldHeadOffset? fieldTy rest curOffset
+                else
+                  match abiLocalHeadWordCount? fieldTy with
+                  | some n => go more (curOffset + n)
+                  | none => none
+          go fields baseOffset
+      | _ => none
+
 private def paramStructProjectionResolved?
     (params : Array ParamDecl)
     (stx : Term) : Option (String × ValueType × ValueType) := do
@@ -1590,6 +1634,33 @@ private def paramStructProjectionResolved?
       match stripParens root with
       | `(term| $id:ident) => resolve (toString id.getId) path
       | _ => none
+
+private def arrayElementStructProjectionResolved?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × Term × ValueType × ValueType × Nat) := do
+  let (root, path) ← structProjectionPath? stx
+  match stripParens root with
+  | `(term| arrayElement $name:term $index:term) =>
+      let paramName ←
+        match stripParens name with
+        | `(term| $id:ident) => some (toString id.getId)
+        | _ => none
+      let param ← params.find? (fun p => p.name == paramName)
+      let elemTy ← match param.ty with
+        | .array elemTy => some elemTy
+        | _ => none
+      let (fieldTy, wordOffset) ← structFieldHeadOffset? elemTy path
+      some (paramName, index, fieldTy, elemTy, wordOffset)
+  | _ => none
+
+private def arrayElementStructProjection?
+    (params : Array ParamDecl)
+    (stx : Term) : Option (String × Term × ValueType × ValueType × Nat) := do
+  let resolved@(_, _, fieldTy, _, _) ← arrayElementStructProjectionResolved? params stx
+  if isSingleWordStaticValueType fieldTy then
+    some resolved
+  else
+    none
 
 private def paramStructProjection?
     (params : Array ParamDecl)
@@ -1659,6 +1730,13 @@ private def requireSupportedArrayElementTupleSourceType
     (context : String)
     (ty : ValueType) : CommandElabM ValueType := do
   match ty with
+  | .array elemTy@(.tuple _) =>
+      match staticAbiWordCount? elemTy, abiLocalHeadWordCount? elemTy with
+      | some _, _ => pure elemTy
+      | none, some _ => pure elemTy
+      | none, none =>
+          throwErrorAt stx
+            s!"{context} currently supports only arrays with ABI-decodable tuple elements, got {renderValueType ty}"
   | .array elemTy =>
       match staticAbiWordCount? elemTy with
       | some _ => pure elemTy
@@ -2048,6 +2126,10 @@ private partial def inferPureExprType
           if matchesBareName p.name name then some p.ty else none) with
     | some ty => pure ty
     | none => throwPureContextAccessorError stx name
+  if let some (_, index, fieldTy, _, _) := arrayElementStructProjection? params stx then
+    requireWordLikeType index "arrayElement index" (← inferPureExprType fields constDecls immutableDecls externalDecls params locals index visitingConstants)
+    pure fieldTy
+  else
   if isParamStructDynamicRootProjection params stx then
     throwStructDynamicRootProjectionError stx
   else
@@ -2863,6 +2945,24 @@ partial def translatePureExprWithTypes
     (visitingConstants : List String := []) : CommandElabM Term := do
   let stx := stripParens stx
   let localNames := typedLocalNames locals
+  if let some (paramName, index, _fieldTy, elemTy, wordOffset) := arrayElementStructProjection? params stx then
+    let indexExpr ← translatePureExprWithTypes fields constDecls immutableDecls params locals index visitingConstants
+    if valueTypeUsesDynamicData elemTy then
+      `(Compiler.CompilationModel.Expr.arrayElementDynamicWord
+        $(strTerm paramName)
+        $indexExpr
+        $(natTerm wordOffset))
+    else
+      let elementWords ←
+        match staticAbiWordCount? elemTy with
+        | some n => pure n
+        | none => throwErrorAt stx "arrayElement struct projection requires a static or dynamic ABI-decodable element"
+      `(Compiler.CompilationModel.Expr.arrayElementWord
+        $(strTerm paramName)
+        $indexExpr
+        $(natTerm elementWords)
+        $(natTerm wordOffset))
+  else
   if isParamStructDynamicRootProjection params stx then
     throwStructDynamicRootProjectionError stx
   else
@@ -3292,12 +3392,6 @@ private def arrayElementTupleDestructureStmts?
       let paramName := ← expectStringOrIdent name
       match params.find? (fun p => p.name == paramName) with
       | some { ty := .array (.tuple elemTys), .. } =>
-          let elementWords ←
-            match staticAbiWordCount? (.tuple elemTys) with
-            | some n => pure n
-            | none =>
-                throwErrorAt rhs
-                  "arrayElement tuple destructuring requires a static ABI-word tuple element type"
           if names.size != elemTys.length then
             throwErrorAt rhs
               s!"tuple destructuring binds {names.size} names, but the source provides {elemTys.length} values"
@@ -3310,22 +3404,51 @@ private def arrayElementTupleDestructureStmts?
             `(Compiler.CompilationModel.Expr.localVar $(strTerm indexName))
           let mut offset := 0
           let mut valueExprs : Array Term := #[]
-          for elemTy in elemTys do
-            let elemWords ←
-              match staticAbiWordCount? elemTy with
-              | some n => pure n
-              | none =>
+          match staticAbiWordCount? (.tuple elemTys) with
+          | some elementWords =>
+              for elemTy in elemTys do
+                let elemWords ←
+                  match staticAbiWordCount? elemTy with
+                  | some n => pure n
+                  | none =>
+                      throwErrorAt rhs
+                        "arrayElement tuple destructuring requires static ABI-word tuple members"
+                if elemWords != 1 then
                   throwErrorAt rhs
-                    "arrayElement tuple destructuring requires static ABI-word tuple members"
-            if elemWords != 1 then
-              throwErrorAt rhs
-                "arrayElement tuple destructuring currently supports top-level single-word tuple members"
-            valueExprs := valueExprs.push (← `(Compiler.CompilationModel.Expr.arrayElementWord
-              $(strTerm paramName)
-              $indexLocal
-              $(natTerm elementWords)
-              $(natTerm offset)))
-            offset := offset + elemWords
+                    "arrayElement tuple destructuring currently supports top-level single-word tuple members"
+                valueExprs := valueExprs.push (← `(Compiler.CompilationModel.Expr.arrayElementWord
+                  $(strTerm paramName)
+                  $indexLocal
+                  $(natTerm elementWords)
+                  $(natTerm offset)))
+                offset := offset + elemWords
+          | none =>
+              let _ ←
+                match abiLocalHeadWordCount? (.tuple elemTys) with
+                | some n => pure n
+                | none =>
+                    throwErrorAt rhs
+                      "arrayElement tuple destructuring requires an ABI-decodable tuple element type"
+              for (elemTy, name?) in elemTys.zip names.toList do
+                if isSingleWordStaticValueType elemTy then
+                  valueExprs := valueExprs.push (← `(Compiler.CompilationModel.Expr.arrayElementDynamicWord
+                    $(strTerm paramName)
+                    $indexLocal
+                    $(natTerm offset)))
+                else
+                  match name? with
+                  | none =>
+                      valueExprs := valueExprs.push (← `(Compiler.CompilationModel.Expr.literal 0))
+                  | some boundName =>
+                      throwErrorAt rhs
+                        s!"arrayElement tuple destructuring cannot bind dynamic member '{boundName}' yet; use '_' for nested dynamic members"
+                let elemHeadWords ←
+                  match abiLocalHeadWordCount? elemTy with
+                  | some n => pure n
+                  | none =>
+                      throwErrorAt rhs
+                        "arrayElement tuple destructuring requires ABI-decodable tuple members"
+                offset := offset + elemHeadWords
           let boundPairs := (names.zip valueExprs).filterMap fun (name?, valueExpr) =>
             name?.map (fun name => (name, valueExpr))
           let boundStmts ← boundPairs.mapM fun (name, valueExpr) =>
@@ -5625,7 +5748,7 @@ def mkStructDefCommandPublic (decl : StructDecl) : CommandElabM Cmd := do
   let fieldTys ← decl.fields.mapM (fun field => contractValueTypeTerm field.ty)
   `(command| structure $structId where
       $[$fieldIds:ident : $fieldTys:term]*
-      deriving Repr)
+      deriving Repr, Inhabited)
 
 /-- Generate a `def storageNamespace : Nat := <keccak-value>` command for
     the current contract.  Uses the resolved namespace value from

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -1471,6 +1471,18 @@ private partial def valueTypeUsesDynamicData : ValueType → Bool
   | .adt _ _ => false  -- ADTs are stored as tag + fixed-width slots, not dynamic
   | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool | .unit => false
 
+private partial def abiParentHeadWordCount? (ty : ValueType) : Option Nat :=
+  match ty with
+  | .string | .bytes | .array _ => some 1
+  | .tuple _ | .struct _ _ =>
+      if valueTypeUsesDynamicData ty then
+        some 1
+      else
+        abiLocalHeadWordCount? ty
+  | .newtype _ baseType => abiParentHeadWordCount? baseType
+  | .uint256 | .int256 | .uint8 | .address | .bytes32 | .bool => some 1
+  | .adt _ _ | .unit => none
+
 private def classifyWordArithmeticResultType
     (stx : Syntax)
     (context : String)
@@ -1598,9 +1610,13 @@ private partial def structFieldHeadOffset?
                 if name == fieldName then
                   match rest with
                   | [] => some (fieldTy, curOffset)
-                  | _ => structFieldHeadOffset? fieldTy rest curOffset
+                  | _ =>
+                      if valueTypeUsesDynamicData fieldTy then
+                        none
+                      else
+                        structFieldHeadOffset? fieldTy rest curOffset
                 else
-                  match abiLocalHeadWordCount? fieldTy with
+                  match abiParentHeadWordCount? fieldTy with
                   | some n => go more (curOffset + n)
                   | none => none
           go fields baseOffset

--- a/artifacts/interpreter_feature_matrix.json
+++ b/artifacts/interpreter_feature_matrix.json
@@ -331,6 +331,15 @@
       "IRInterpreter": "n/a",
       "EVMYulLean_bridge": "n/a",
       "proof_status": "proved"
+    },
+    {
+      "feature": "arrayElementDynamicWord",
+      "constructor": "Expr.arrayElementDynamicWord",
+      "SpecInterpreter_basic": "unsupported",
+      "SpecInterpreter_fuel": "unsupported",
+      "IRInterpreter": "n/a",
+      "EVMYulLean_bridge": "n/a",
+      "proof_status": "not_modeled"
     }
   ],
   "stmt_features": [

--- a/docs/INTERPRETER_FEATURE_MATRIX.md
+++ b/docs/INTERPRETER_FEATURE_MATRIX.md
@@ -63,6 +63,7 @@ with the existing sync scripts and boundary checks.
 | External call (linked) | `Expr.externalCall` | ok | ok | -- | -- | assumed |
 | Array length | `Expr.arrayLength` | ok | ok | -- | -- | proved |
 | Array element | `Expr.arrayElement` | ok | ok | -- | -- | proved |
+| Dynamic struct-array head word | `Expr.arrayElementDynamicWord` | **0** | **0** | -- | -- | n/m |
 
 Legend: **ok** = supported, **0** = returns 0 (not modeled), **del** = delegated to Verity path, **--** = not applicable at this layer, **n/m** = not modeled in proofs.
 
@@ -161,21 +162,23 @@ Legend: **ok** = native evaluation.
 
 | Category | Proved | Assumed | Partial | Not Modeled |
 |---|---|---|---|---|
-| Expression features | 24 | 1 (`externalCall`) | 5 (`blockNumber`, `contractAddress`, `chainid`, `mload`, `returndataOptionalBoolAt`) | 4 (`keccak256`, `call`, `staticcall`, `delegatecall`) |
+| Expression features | 24 | 1 (`externalCall`) | 5 (`blockNumber`, `contractAddress`, `chainid`, `mload`, `returndataOptionalBoolAt`) | 5 (`keccak256`, `call`, `staticcall`, `delegatecall`, `arrayElementDynamicWord`) |
 | Statement features | 25 | 0 | 1 (`mstore`) | 6 (`calldatacopy`, `returndataCopy`, `revertReturndata`, `rawLog`, `externalCallBind`, `ecm`) |
 | Builtins (agreement) | 36 | 0 | 0 | 0 (delegated) |
 
-Proof-boundary features split across two buckets. Partially modeled features currently include runtime introspection (`blockNumber`, `contractAddress`, `chainid`) and single-word linear-memory forms (`mload`, `mstore`, `returndataOptionalBoolAt`). Fully not-modeled features currently include `keccak256`, low-level call / returndata plumbing (`call`, `staticcall`, `delegatecall`, `calldatacopy`, `returndataCopy`, `revertReturndata`), event emission (`rawLog`), and external call modules (`externalCallBind`, `ecm`). These features are still compiler-supported and are validated by differential testing (70,000+ test vectors against actual EVM execution).
+Proof-boundary features split across two buckets. Partially modeled features currently include runtime introspection (`blockNumber`, `contractAddress`, `chainid`) and single-word linear-memory forms (`mload`, `mstore`, `returndataOptionalBoolAt`). Fully not-modeled features currently include `keccak256`, low-level call / returndata plumbing (`call`, `staticcall`, `delegatecall`, `calldatacopy`, `returndataCopy`, `revertReturndata`), event emission (`rawLog`), and external call modules (`externalCallBind`, `ecm`). Dynamic struct-array head-word decoding (`arrayElementDynamicWord`) is also not modeled by proof interpreters yet. These features are still compiler-supported and are validated by differential testing (70,000+ test vectors against actual EVM execution).
 
 ---
 
 ## Known Limitations
 
-1. **Linear memory**: The IRInterpreter has single-word memory support. `mload`, `mstore`, `calldatacopy`, `returndataCopy`, and `returndataOptionalBoolAt` therefore remain only partially modeled or not modeled in the proof interpreters today. Full linear memory coverage requires EVMYulLean semantic integration.
+1. **Nested dynamic ABI decoding**: The compiler can read checked static leaf words from calldata arrays whose tuple/struct elements contain nested dynamic members via `Expr.arrayElementDynamicWord`. This is a compilation-level ABI decoder surface for Unlink-style transaction arrays; proof interpreters do not model those decoded words yet.
 
-2. **Low-level calls**: `call`/`staticcall`/`delegatecall` and `externalCallBind`/`ecm` are compiler-only features validated by Foundry testing, not modeled in proof interpreters. `delegatecall` additionally remains a dedicated proxy / upgradeability trust boundary; use `--trust-report` / `--deny-proxy-upgradeability` when those semantics must stay outside the selected verification envelope (issue [#1420](https://github.com/lfglabs-dev/verity/issues/1420)).
+2. **Linear memory**: The IRInterpreter has single-word memory support. `mload`, `mstore`, `calldatacopy`, `returndataCopy`, and `returndataOptionalBoolAt` therefore remain only partially modeled or not modeled in the proof interpreters today. Full linear memory coverage requires EVMYulLean semantic integration.
 
-3. **Internal helper compositional proofs**: `Stmt.internalCall` / `Expr.internalCall` execute in the fuel-based interpreter path, but helper-level theorem reuse across callers is not yet surfaced as a first-class proof interface. The `verity_contract` user surface for these is ordinary direct function-name calls; `internalCall` / `internalCallAssign` remain lower-level compilation-model constructors. The current proof-level gap is tracked under the Layer 2 completeness roadmap in [#1630](https://github.com/lfglabs-dev/verity/issues/1630), with the interface/boundary refactor in [#1633](https://github.com/lfglabs-dev/verity/pull/1633).
+3. **Low-level calls**: `call`/`staticcall`/`delegatecall` and `externalCallBind`/`ecm` are compiler-only features validated by Foundry testing, not modeled in proof interpreters. `delegatecall` additionally remains a dedicated proxy / upgradeability trust boundary; use `--trust-report` / `--deny-proxy-upgradeability` when those semantics must stay outside the selected verification envelope (issue [#1420](https://github.com/lfglabs-dev/verity/issues/1420)).
+
+4. **Internal helper compositional proofs**: `Stmt.internalCall` / `Expr.internalCall` execute in the fuel-based interpreter path, but helper-level theorem reuse across callers is not yet surfaced as a first-class proof interface. The `verity_contract` user surface for these is ordinary direct function-name calls; `internalCall` / `internalCallAssign` remain lower-level compilation-model constructors. The current proof-level gap is tracked under the Layer 2 completeness roadmap in [#1630](https://github.com/lfglabs-dev/verity/issues/1630), with the interface/boundary refactor in [#1633](https://github.com/lfglabs-dev/verity/pull/1633).
 
 ---
 

--- a/scripts/check_macro_property_test_generation.py
+++ b/scripts/check_macro_property_test_generation.py
@@ -18,6 +18,12 @@ from property_utils import ROOT
 DEFAULT_SOURCE = ROOT / "Contracts" / "Counter" / "Counter.lean"
 DEFAULT_SOURCE_DIR = ROOT / "Contracts"
 DEFAULT_OUTPUT_DIR = ROOT / "artifacts" / "macro_property_tests"
+EXCLUDED_CONTRACTS = {
+    # The property generator does not yet synthesize Solidity examples for
+    # arrays of tuple/struct values with nested dynamic members. This smoke is
+    # covered by Lean macro invariant and round-trip tests instead.
+    "DynamicStructArraySmoke",
+}
 
 
 def _expected_rendered(
@@ -28,7 +34,7 @@ def _expected_rendered(
     if not contracts:
         raise SystemExit("no verity_contract declarations found")
 
-    names = selected_contracts or sorted(contracts.keys())
+    names = selected_contracts or sorted(name for name in contracts.keys() if name not in EXCLUDED_CONTRACTS)
     unknown = [name for name in names if name not in contracts]
     if unknown:
         known = ", ".join(sorted(contracts.keys()))


### PR DESCRIPTION
## Summary
- add `Expr.arrayElementDynamicWord` plus checked calldata/memory helpers for reading static head words from dynamic ABI array elements
- teach the macro translator to lower `(arrayElement txs idx).field` for named struct arrays with nested dynamic fields, covering an Unlink-shaped `Transaction` smoke
- document the new compiler-supported/proof-not-modeled ABI surface and keep generated axiom/interpreter matrix artifacts in sync

## Validation
- `lake build Contracts.Smoke`
- `lake build Contracts.MacroTranslateInvariantTest`
- `lake build Contracts.MacroTranslateRoundTripFuzz`
- `lake build Compiler Contracts PrintAxioms`
- `python3 scripts/generate_print_axioms.py --check`
- `make check`

Advances #1760. Does not claim the full #1760 nested-dynamic ABI definition of done: full solc differential coverage for all Unlink shapes remains follow-up work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new ABI decoding paths and Yul helper functions for reading words from dynamic array elements, which could affect calldata/memory safety and correctness of generated code. However, the change is scoped to new `Expr.arrayElementDynamicWord` lowering and adds targeted validation and smoke tests.
> 
> **Overview**
> Adds a new compilation-model expression, `Expr.arrayElementDynamicWord`, to read **static head words** from *dynamic ABI array elements* (tuple/struct elements containing nested dynamic members), along with new checked calldata/memory Yul helpers that bounds-check the index and resolved element offsets.
> 
> Extends ABI layout utilities with `paramParentHeadWords`/`paramLocalHeadWords`, updates scope validation to use these word counts for `Expr.arrayElementWord`, and wires the new helpers into dispatch/validation and analysis passes (purity, usage, trust surface, etc.).
> 
> Enhances the macro translator to lower `(arrayElement xs i).field` on struct arrays by computing flattened head offsets; it emits `arrayElementDynamicWord` when the element type is dynamic and expands tuple destructuring to support ABI-decodable tuples with dynamic members (requiring `_` for dynamic binds). Adds a new `DynamicStructArraySmoke` contract plus invariant/round-trip coverage, and updates the interpreter/proof feature matrix and docs to mark `arrayElementDynamicWord` as compiler-supported but not modeled in proof interpreters (and excludes it from property-test generation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd7e566d7c389be0d626fde80a389adb88a3e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->