### PR TITLE
proofs: compose native block append preservation

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -6499,6 +6499,27 @@ theorem nativeStmtsWriteNames_right_not_mem_of_append_not_mem
   rw [nativeStmtsWriteNames_append]
   exact List.mem_append_right _ hMem
 
+theorem NativeBlockPreservesWord_append_of_forall_stmt
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (left right : List EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hLeft :
+      ∀ stmt, stmt ∈ left →
+        NativeStmtPreservesWord name value stmt codeOverride)
+    (hRight :
+      ∀ stmt, stmt ∈ right →
+        NativeStmtPreservesWord name value stmt codeOverride) :
+    NativeBlockPreservesWord name value (left ++ right) codeOverride :=
+  NativeBlockPreservesWord_of_forall_stmt name value (left ++ right)
+    codeOverride
+    (by
+      intro stmt hMem
+      rw [List.mem_append] at hMem
+      rcases hMem with hMem | hMem
+      · exact hLeft stmt hMem
+      · exact hRight stmt hMem)
+
 theorem NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem
     (name : EvmYul.Identifier)
     (value : EvmYul.Literal)
@@ -6541,6 +6562,38 @@ theorem NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem
   NativeStmtPreservesWord_block name value body codeOverride
     (NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem
       name value body codeOverride hFresh hPreserves)
+
+theorem NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (left right : List EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hLeftFresh : name ∉ Backends.nativeStmtsWriteNames left)
+    (hRightFresh : name ∉ Backends.nativeStmtsWriteNames right)
+    (hLeft :
+      ∀ stmt, stmt ∈ left →
+        name ∉ Backends.nativeStmtWriteNames stmt →
+          NativeStmtPreservesWord name value stmt codeOverride)
+    (hRight :
+      ∀ stmt, stmt ∈ right →
+        name ∉ Backends.nativeStmtWriteNames stmt →
+          NativeStmtPreservesWord name value stmt codeOverride) :
+    NativeBlockPreservesWord name value (left ++ right) codeOverride :=
+  NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem name value
+    (left ++ right) codeOverride
+    (by
+      rw [nativeStmtsWriteNames_append]
+      intro hMem
+      rw [List.mem_append] at hMem
+      rcases hMem with hMem | hMem
+      · exact hLeftFresh hMem
+      · exact hRightFresh hMem)
+    (by
+      intro stmt hMem hFresh
+      rw [List.mem_append] at hMem
+      rcases hMem with hMem | hMem
+      · exact hLeft stmt hMem hFresh
+      · exact hRight stmt hMem hFresh)
 
 theorem NativeStmtPreservesWord_if_of_eval_self
     (name : EvmYul.Identifier)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3276,9 +3276,11 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.nativeStmtsWriteNames_append
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.nativeStmtsWriteNames_left_not_mem_of_append_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.nativeStmtsWriteNames_right_not_mem_of_append_not_mem
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_append_of_forall_stmt
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_self
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_preserves
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_preserves_and_nativeStmtsWriteNames_not_mem
@@ -3826,4 +3828,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3650 theorems/lemmas (2704 public, 946 private, 0 sorry'd)
+-- Total: 3652 theorems/lemmas (2706 public, 946 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -474,6 +474,8 @@ scope so the native path does not look more complete than it is:
   `nativeStmtsWriteNames_left_not_mem_of_append_not_mem`,
   `nativeStmtsWriteNames_right_not_mem_of_append_not_mem`,
   `NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem`,
+  `NativeBlockPreservesWord_append_of_forall_stmt`,
+  `NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem`,
   `NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem`,
   `NativeStmtPreservesWord_if_of_eval_preserves_and_nativeStmtsWriteNames_not_mem`,
   `NativeStmtPreservesWord_if_of_cond_preserves_and_nativeStmtsWriteNames_not_mem`,

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -349,6 +349,8 @@ def check_public_theorem_target(
         "theorem nativeStmtsWriteNames_left_not_mem_of_append_not_mem",
         "theorem nativeStmtsWriteNames_right_not_mem_of_append_not_mem",
         "theorem NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem",
+        "theorem NativeBlockPreservesWord_append_of_forall_stmt",
+        "theorem NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem",
         "theorem NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem",
         "theorem NativeStmtPreservesWord_if_of_eval_preserves_and_nativeStmtsWriteNames_not_mem",
         "theorem NativeStmtPreservesWord_if_of_cond_preserves_and_nativeStmtsWriteNames_not_mem",


### PR DESCRIPTION
## Summary
- add native block preservation wrappers for appended statement lists
- add a split write-name freshness wrapper for appended native blocks
- pin the new theorem names in the native transition doc/checker and regenerate `PrintAxioms.lean`

## Validation
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `git diff --check`
- `lake build PrintAxioms`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds Lean proof helper theorems and updates documentation/axiom listings; it does not change runtime compiler or EVM semantics.
> 
> **Overview**
> Adds two new wrapper theorems (`NativeBlockPreservesWord_append_of_forall_stmt` and `NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem`) to compose `NativeBlockPreservesWord` across appended statement lists, including a split freshness assumption for write-name sets.
> 
> Updates `PrintAxioms.lean`, the native transition documentation, and the doc checker script to include/pin these new theorem names (increasing the printed theorem count accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91cb2c87cc2796c4712e7fada249545a2d79efe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->