### PR TITLE
proofs: compose native block cons preservation

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -6568,6 +6568,28 @@ theorem NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem
         name body stmt hFresh hMem)
     hPreserves
 
+theorem NativeBlockPreservesWord_cons_of_nativeStmtsWriteNames_not_mem
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (stmt : EvmYul.Yul.Ast.Stmt)
+    (rest : List EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hFresh : name ∉ Backends.nativeStmtsWriteNames (stmt :: rest))
+    (hHead :
+      name ∉ Backends.nativeStmtWriteNames stmt →
+        NativeStmtPreservesWord name value stmt codeOverride)
+    (hRest :
+      name ∉ Backends.nativeStmtsWriteNames rest →
+        NativeBlockPreservesWord name value rest codeOverride) :
+    NativeBlockPreservesWord name value (stmt :: rest) codeOverride :=
+  NativeBlockPreservesWord_cons_stmt name value stmt rest codeOverride
+    (hHead
+      (nativeStmtsWriteNames_head_not_mem_of_cons_not_mem
+        name stmt rest hFresh))
+    (hRest
+      (nativeStmtsWriteNames_tail_not_mem_of_cons_not_mem
+        name stmt rest hFresh))
+
 theorem NativeStmtPreservesWord_block
     (name : EvmYul.Identifier)
     (value : EvmYul.Literal)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3281,6 +3281,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.nativeStmtsWriteNames_right_not_mem_of_append_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_append_of_forall_stmt
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_cons_of_nativeStmtsWriteNames_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem
@@ -3835,4 +3836,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3659 theorems/lemmas (2713 public, 946 private, 0 sorry'd)
+-- Total: 3660 theorems/lemmas (2714 public, 946 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -477,6 +477,7 @@ scope so the native path does not look more complete than it is:
   `nativeStmtsWriteNames_left_not_mem_of_append_not_mem`,
   `nativeStmtsWriteNames_right_not_mem_of_append_not_mem`,
   `NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem`,
+  `NativeBlockPreservesWord_cons_of_nativeStmtsWriteNames_not_mem`,
   `NativeBlockPreservesWord_append_of_forall_stmt`,
   `NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem`,
   `NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem`,

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -352,6 +352,7 @@ def check_public_theorem_target(
         "theorem nativeStmtsWriteNames_left_not_mem_of_append_not_mem",
         "theorem nativeStmtsWriteNames_right_not_mem_of_append_not_mem",
         "theorem NativeBlockPreservesWord_of_nativeStmtsWriteNames_not_mem",
+        "theorem NativeBlockPreservesWord_cons_of_nativeStmtsWriteNames_not_mem",
         "theorem NativeBlockPreservesWord_append_of_forall_stmt",
         "theorem NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem",
         "theorem NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem",


### PR DESCRIPTION
## Summary

- add `NativeBlockPreservesWord_cons_of_nativeStmtsWriteNames_not_mem`
- package cons-level `nativeStmtsWriteNames` freshness projections into block preservation
- pin the theorem in the native transition doc checker and regenerate `PrintAxioms.lean`

## Validation

- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `python3 scripts/generate_print_axioms.py --check`
- `lake build PrintAxioms`
- `git diff --check`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small compositional proof lemma and updates associated axiom-printing and documentation/checker lists without affecting runtime/compiler behavior.
> 
> **Overview**
> Adds a new theorem `NativeBlockPreservesWord_cons_of_nativeStmtsWriteNames_not_mem` that packages the head/tail freshness projections for `nativeStmtsWriteNames` into a single cons-case block-preservation proof.
> 
> Updates the native transition documentation and its checker to require this new lemma, and regenerates `PrintAxioms.lean` to include it (bumping the printed theorem count).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c819852ff8d2e08805eba831973ec219312dca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->