### PR TITLE
proofs: derive append preservation from whole freshness

### DIFF
--- a/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
+++ b/Compiler/Proofs/YulGeneration/Backends/EvmYulLeanNativeHarness.lean
@@ -6646,6 +6646,29 @@ theorem NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem
       · exact hLeft stmt hMem hFresh
       · exact hRight stmt hMem hFresh)
 
+theorem NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_append_not_mem
+    (name : EvmYul.Identifier)
+    (value : EvmYul.Literal)
+    (left right : List EvmYul.Yul.Ast.Stmt)
+    (codeOverride : Option EvmYul.Yul.Ast.YulContract)
+    (hFresh : name ∉ Backends.nativeStmtsWriteNames (left ++ right))
+    (hLeft :
+      ∀ stmt, stmt ∈ left →
+        name ∉ Backends.nativeStmtWriteNames stmt →
+          NativeStmtPreservesWord name value stmt codeOverride)
+    (hRight :
+      ∀ stmt, stmt ∈ right →
+        name ∉ Backends.nativeStmtWriteNames stmt →
+          NativeStmtPreservesWord name value stmt codeOverride) :
+    NativeBlockPreservesWord name value (left ++ right) codeOverride :=
+  NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem
+    name value left right codeOverride
+    (nativeStmtsWriteNames_left_not_mem_of_append_not_mem
+      name left right hFresh)
+    (nativeStmtsWriteNames_right_not_mem_of_append_not_mem
+      name left right hFresh)
+    hLeft hRight
+
 theorem NativeStmtPreservesWord_if_of_eval_self
     (name : EvmYul.Identifier)
     (value : EvmYul.Literal)

--- a/PrintAxioms.lean
+++ b/PrintAxioms.lean
@@ -3285,6 +3285,7 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem
+#print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_append_not_mem
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_self
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_preserves
 #print axioms Compiler.Proofs.YulGeneration.Backends.Native.NativeStmtPreservesWord_if_of_eval_preserves_and_nativeStmtsWriteNames_not_mem
@@ -3836,4 +3837,4 @@ import Compiler.Proofs.YulGeneration.ReferenceOracle.Semantics
 -- Compiler/Proofs/YulGeneration/ReferenceOracle/Semantics.lean
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_sender
 #print axioms Compiler.Proofs.YulGeneration.YulTransaction.ofIR_args
--- Total: 3660 theorems/lemmas (2714 public, 946 private, 0 sorry'd)
+-- Total: 3661 theorems/lemmas (2715 public, 946 private, 0 sorry'd)

--- a/docs/NATIVE_EVMYULLEAN_TRANSITION.md
+++ b/docs/NATIVE_EVMYULLEAN_TRANSITION.md
@@ -480,6 +480,7 @@ scope so the native path does not look more complete than it is:
   `NativeBlockPreservesWord_cons_of_nativeStmtsWriteNames_not_mem`,
   `NativeBlockPreservesWord_append_of_forall_stmt`,
   `NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem`,
+  `NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_append_not_mem`,
   `NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem`,
   `NativeStmtPreservesWord_if_of_eval_preserves_and_nativeStmtsWriteNames_not_mem`,
   `NativeStmtPreservesWord_if_of_cond_preserves_and_nativeStmtsWriteNames_not_mem`,

--- a/scripts/check_native_transition_doc.py
+++ b/scripts/check_native_transition_doc.py
@@ -355,6 +355,7 @@ def check_public_theorem_target(
         "theorem NativeBlockPreservesWord_cons_of_nativeStmtsWriteNames_not_mem",
         "theorem NativeBlockPreservesWord_append_of_forall_stmt",
         "theorem NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_not_mem",
+        "theorem NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_append_not_mem",
         "theorem NativeStmtPreservesWord_block_of_nativeStmtsWriteNames_not_mem",
         "theorem NativeStmtPreservesWord_if_of_eval_preserves_and_nativeStmtsWriteNames_not_mem",
         "theorem NativeStmtPreservesWord_if_of_cond_preserves_and_nativeStmtsWriteNames_not_mem",


### PR DESCRIPTION
## Summary
- add `NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_append_not_mem`
- let callers derive left/right generated write-name freshness from freshness of the appended native block
- pin the theorem in the native transition doc/checker and regenerate `PrintAxioms.lean`

## Validation
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanNativeHarness`
- `python3 scripts/generate_print_axioms.py --check`
- `python3 scripts/check_native_transition_doc.py`
- `python3 scripts/check_bridge_coverage_sync.py`
- `python3 scripts/check_evmyullean_capability_boundary.py`
- `git diff --check`
- `lake build PrintAxioms`
- `lake build Compiler.Proofs.YulGeneration.Backends.EvmYulLeanRetarget Compiler.Proofs.EndToEnd Compiler Contracts`
- `make check`

## Notes
- Stacked on #1788 / `codex/native-block-cons-preservation`.
- This is N4/N5 prep work; it does not flip the public theorem target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a derived helper theorem and updates documentation/axiom listings without changing executable compiler logic.
> 
> **Overview**
> Adds `NativeBlockPreservesWord_append_of_nativeStmtsWriteNames_append_not_mem`, a helper lemma that derives left/right write-name freshness from freshness of `nativeStmtsWriteNames (left ++ right)` when proving `NativeBlockPreservesWord` for appended blocks.
> 
> Updates the native transition documentation/checker to include the new theorem and regenerates `PrintAxioms.lean` to reflect the additional public lemma count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872bc977317a3678b69f41c1a3a76140063d650e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->