### PR TITLE
Support Int256 storage fields in verity_contract

### DIFF
--- a/Contracts/MacroTranslateInvariantTest.lean
+++ b/Contracts/MacroTranslateInvariantTest.lean
@@ -407,7 +407,7 @@ private def expectedExternalSignatures : List (String × List String) :=
       "signedGt(uint256,uint256)", "arithmeticShift(uint256,uint256)", "signExtended()", "shiftedMask()",
       "signedDivSurface(int256,int256)", "signedModSurface(int256,int256)", "signedDivViaLocal(uint256,int256)",
       "castToInt(uint256)", "castToUint(int256)", "minusOne()", "bitAndSignBit(int256,int256)",
-      "minSignBit(int256)"])
+      "minSignBit(int256)", "storeSigned(int256)", "loadSigned()"])
   , ("StatelessSmoke", ["echoWord(uint256)", "whoAmI()"])
   , ("MutabilitySmoke", ["deposit()", "currentOwner()"])
   , ("SpecialEntrypointSmoke", ["getReceiveCount()", "getFallbackCount()"])
@@ -524,7 +524,7 @@ private def expectedExternalSelectors : List (String × List String) :=
   , ("CustomErrorSmoke", ["0x6279e43c"])
   , ("SignedBuiltinSmoke", ["0x5aafa47b", "0x1c781eb5", "0x2ff7ce03", "0x5f28fa76", "0x49795601",
       "0xcc634d7f", "0x7c4ab1e5", "0x44b95b1e", "0x17ea5a3e", "0x6344ce8c", "0xf6814165", "0xae1a9a3e",
-      "0x6622d274", "0x176a2ce1", "0x504d2488"])
+      "0x6622d274", "0x176a2ce1", "0x504d2488", "0xd5451d16", "0x22cfe3c6"])
   , ("StatelessSmoke", ["0x26534f53", "0xda91254c"])
   , ("MutabilitySmoke", ["0xd0e30db0", "0xb387ef92"])
   , ("SpecialEntrypointSmoke", ["0x931999fb", "0x74b204a4"])
@@ -778,6 +778,8 @@ private def checkSignedBuiltinSmoke : IO Unit := do
   let minusOne? := functions.find? (·.name == "minusOne")
   let bitAndSignBit? := functions.find? (·.name == "bitAndSignBit")
   let minSignBit? := functions.find? (·.name == "minSignBit")
+  let storeSigned? := functions.find? (·.name == "storeSigned")
+  let loadSigned? := functions.find? (·.name == "loadSigned")
   let signedDiv := signedDiv?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
   let signedMod := signedMod?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
   let signedLt := signedLt?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
@@ -793,6 +795,12 @@ private def checkSignedBuiltinSmoke : IO Unit := do
   let minusOne := minusOne?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
   let bitAndSignBit := bitAndSignBit?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
   let minSignBit := minSignBit?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  let storeSigned := storeSigned?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  let loadSigned := loadSigned?.getD { name := "", params := [], returnType := none, returns := [], body := [] }
+  expectTrue "SignedBuiltinSmoke: Int256 storage is modeled as a word slot"
+    (match Contracts.Smoke.SignedBuiltinSmoke.spec.fields with
+    | [{ name := "signedSlot", ty := FieldType.uint256, slot := some 0 }] => true
+    | _ => false)
   expectTrue "SignedBuiltinSmoke: signedDiv body uses Expr.sdiv"
     (bodyUsesSignedBuiltin signedDiv.body "Expr.sdiv")
   expectTrue "SignedBuiltinSmoke: signedMod body uses Expr.smod"
@@ -825,6 +833,10 @@ private def checkSignedBuiltinSmoke : IO Unit := do
   expectTrue "SignedBuiltinSmoke: minSignBit keeps signed comparison over min"
     (bodyUsesSignedBuiltin minSignBit.body "Expr.min" &&
       bodyUsesSignedBuiltin minSignBit.body "Expr.lt")
+  expectTrue "SignedBuiltinSmoke: storeSigned writes the signed storage slot"
+    (bodyUsesSignedBuiltin storeSigned.body "Stmt.setStorage")
+  expectTrue "SignedBuiltinSmoke: loadSigned reads the signed storage slot"
+    (bodyUsesSignedBuiltin loadSigned.body "Expr.storage")
 
 private def checkLowLevelTryCatchSmoke : IO Unit := do
   let functions := Contracts.Smoke.LowLevelTryCatchSmoke.spec.functions

--- a/Contracts/Smoke.lean
+++ b/Contracts/Smoke.lean
@@ -316,6 +316,7 @@ verity_contract CustomErrorSmoke where
 
 verity_contract SignedBuiltinSmoke where
   storage
+    signedSlot : Int256 := slot 0
 
   constants
     extendedByte : Uint256 := (signextend 0 255)
@@ -367,6 +368,15 @@ verity_contract SignedBuiltinSmoke where
 
   function minSignBit (lhs : Int256) : Bool := do
     return (min lhs 0 < 0)
+
+  function storeSigned (value : Int256) : Int256 := do
+    setStorage signedSlot value
+    let saved ← getStorage signedSlot
+    return saved
+
+  function loadSigned () : Int256 := do
+    let saved ← getStorage signedSlot
+    return saved
 
 verity_contract StatelessSmoke where
   storage

--- a/Verity/Macro/Translate.lean
+++ b/Verity/Macro/Translate.lean
@@ -475,7 +475,7 @@ private def modelStructMemberTerm (member : StructMemberDecl) : CommandElabM Ter
 private def modelFieldTypeTerm (ty : StorageType) : CommandElabM Term :=
   match ty with
   | .scalar .uint256 => `(Compiler.CompilationModel.FieldType.uint256)
-  | .scalar .int256 => throwError "storage fields cannot be Int256; use Uint256 encoding"
+  | .scalar .int256 => `(Compiler.CompilationModel.FieldType.uint256)
   | .scalar .uint8 => throwError "storage fields cannot be Uint8; use Uint256 encoding"
   | .scalar .address => `(Compiler.CompilationModel.FieldType.address)
   | .scalar .bytes32 => throwError "storage fields cannot be Bytes32; use Uint256 encoding"
@@ -2392,6 +2392,7 @@ private partial def inferBindSourceType
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
       | .scalar .uint256 => pure .uint256
+      | .scalar .int256 => pure .int256
       | .scalar (.newtype ntName (.uint256)) => pure (.newtype ntName .uint256)
       | .scalar (.adt name maxFields) => pure (.adt name maxFields)
       | .scalar (.newtype _ (.address)) => throwErrorAt rhs s!"field '{f.name}' is Address-based newtype; use getStorageAddr"
@@ -3731,7 +3732,7 @@ private def translateBindSource
   | `(term| getStorage $field:ident) =>
       let f ← lookupStorageField fields (toString field.getId)
       match f.ty with
-      | .scalar .uint256 | .scalar (.newtype _ .uint256) | .scalar (.adt _ _) =>
+      | .scalar .uint256 | .scalar .int256 | .scalar (.newtype _ .uint256) | .scalar (.adt _ _) =>
           `(Compiler.CompilationModel.Expr.storage $(strTerm f.name))
       | .scalar .bool => throwErrorAt rhs s!"field '{f.name}' is Bool; encode as Uint256 and use getStorage"
       | .scalar .address | .scalar (.newtype _ .address) =>
@@ -4468,7 +4469,7 @@ private def translateEffectStmt
               $(← translateAdtConstructForStorage fields constDecls immutableDecls params locals adtName value))
       | none =>
           match f.ty with
-          | .scalar .uint256 | .scalar (.newtype _ .uint256) =>
+          | .scalar .uint256 | .scalar .int256 | .scalar (.newtype _ .uint256) =>
               `(Compiler.CompilationModel.Stmt.setStorage $(strTerm f.name) $(← translatePureExprWithTypes fields constDecls immutableDecls params locals value))
           | .scalar (.adt adtName _) =>
               `(Compiler.CompilationModel.Stmt.setStorage
@@ -5218,7 +5219,7 @@ private def mkStorageDefCommand (field : StorageFieldDecl) : CommandElabM Cmd :=
   let storageTy ←
     match field.ty with
     | .scalar .uint256 => `(Uint256)
-    | .scalar .int256 => throwError "storage field cannot be Int256; use Uint256 encoding"
+    | .scalar .int256 => `(Uint256)
     | .scalar .uint8 => throwError "storage field cannot be Uint8; use Uint256 encoding"
     | .scalar .address => `(Address)
     | .scalar .bytes32 => throwError "storage field cannot be Bytes32; use Uint256 encoding"

--- a/artifacts/macro_property_tests/PropertySignedBuiltinSmoke.t.sol
+++ b/artifacts/macro_property_tests/PropertySignedBuiltinSmoke.t.sol
@@ -152,4 +152,24 @@ contract PropertySignedBuiltinSmokeTest is YulTestBase {
         bool actual = abi.decode(ret, (bool));
         assertEq(actual, (((int256(1) < 0) ? int256(1) : 0) < 0), "minSignBit should return the declared constant");
     }
+    // Property 16: storeSigned decodes and matches the inferred straight-line result
+    function testAuto_StoreSigned_ReturnsInferredStraightLineResult() public {
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("storeSigned(int256)", int256(1)));
+        require(ok, "storeSigned reverted unexpectedly");
+        assertEq(ret.length, 32, "storeSigned ABI return length mismatch (expected 32 bytes)");
+        int256 actual = abi.decode(ret, (int256));
+        assertEq(actual, int256(1), "storeSigned should preserve the inferred result");
+    }
+    // Property 17: loadSigned reads storage slot 0 and decodes the result
+    function testAuto_LoadSigned_ReadsConfiguredStorage() public {
+        int256 expected = int256(1);
+        vm.store(target, bytes32(uint256(0)), bytes32(uint256(expected)));
+        vm.prank(alice);
+        (bool ok, bytes memory ret) = target.call(abi.encodeWithSignature("loadSigned()"));
+        require(ok, "loadSigned reverted unexpectedly");
+        assertEq(ret.length, 32, "loadSigned ABI return length mismatch (expected 32 bytes)");
+        int256 actual = abi.decode(ret, (int256));
+        assertEq(actual, expected, "loadSigned should return storage slot 0");
+    }
 }

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,9 +10,9 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 110000,
-    "foundry_functions": 567,
+    "foundry_functions": 522,
     "property_functions": 239,
-    "suites": 67
+    "suites": 50
   },
   "theorems": {
     "categories": 11,

--- a/artifacts/verification_status.json
+++ b/artifacts/verification_status.json
@@ -10,9 +10,9 @@
   "schema_version": 1,
   "tests": {
     "differential_total": 110000,
-    "foundry_functions": 522,
+    "foundry_functions": 567,
     "property_functions": 239,
-    "suites": 50
+    "suites": 67
   },
   "theorems": {
     "categories": 11,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -77,6 +77,7 @@ Recent progress for storage layout controls (`#623`):
 - `CompilationModel.Field` now supports packed subfield placement (`packedBits := some { offset := o, width := w }`) so multiple fields can share a slot with disjoint bit ranges; codegen performs masked read-modify-write updates and masked reads directly from layout metadata.
 - `FieldType.mappingStruct` / `FieldType.mappingStruct2` plus `Expr.structMember` / `Stmt.setStructMember` now make struct-valued mappings and packed submembers first-class in the CompilationModel surface, and `verity_contract` now exposes matching `MappingStruct(...)` / `MappingStruct2(...)` storage declarations so Morpho-style layouts no longer require handwritten CompilationModel shims.
 - Migration-faithful packed-slot writes can now be expressed without unsafe raw Yul: build the packed word with first-class word operations and call `setPackedStorage root offset word`, which lowers through `Stmt.setStorageWord` to an explicit full-word write at `root.slot + offset`.
+- `verity_contract` now accepts scalar `Int256` storage fields as signed views over normal 256-bit storage words. The compiler-facing model stays word-level (`FieldType.uint256`), while macro typechecking preserves signed reads/writes at the DSL boundary.
 
 Recent progress for low-level calls + returndata handling (`#622`):
 - `CompilationModel.Expr` now supports first-class low-level call primitives (`call`, `staticcall`, `delegatecall`) with explicit gas/value/target/input/output operands and deterministic Yul lowering.


### PR DESCRIPTION
## Summary

Closes #1751.

- allow `verity_contract` scalar `Int256` storage declarations
- keep compiler-facing storage layout word-level by lowering signed storage fields to `FieldType.uint256`
- preserve signed macro typechecking for `getStorage`/`setStorage` reads and writes
- add `SignedBuiltinSmoke` storage read/write coverage plus generated macro property coverage

## Validation

- `lake build Contracts.Smoke Contracts.MacroTranslateInvariantTest Contracts.MacroTranslateRoundTripFuzz`
- `lake build`
- `python3 scripts/check_macro_health.py`
- `python3 scripts/generate_print_axioms.py --check`
- `git diff --check`
- `make check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the macro/typechecker and storage-field modeling rules to accept `Int256` in storage, which can affect compilation-model generation and `getStorage`/`setStorage` typing for any contract using signed storage views.
> 
> **Overview**
> `verity_contract` now allows scalar `Int256` storage declarations by treating them as signed views over a normal 256-bit word slot (lowered to `FieldType.uint256` in the compilation model) while preserving `Int256` typing for `getStorage`/`setStorage` at the DSL boundary.
> 
> Adds SignedBuiltinSmoke coverage for signed storage reads/writes (`storeSigned`, `loadSigned`) across Lean macro invariants and generated Foundry property tests, and updates pinned selector/signature snapshots plus verification status counts/docs to reflect the new entrypoints and capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c821d1675bf79b231e249fb0ec25c5fd7341dd9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->